### PR TITLE
Fix buildCardCarousel bug with returned card element

### DIFF
--- a/helpers/cardBuilder.js
+++ b/helpers/cardBuilder.js
@@ -190,7 +190,9 @@ export async function generateJudokaCard(judoka, gokyoLookup, container) {
   try {
     const card = await generateJudokaCardHTML(judoka, gokyoLookup);
     container.appendChild(card);
+    return card;
   } catch (error) {
     console.error(`Error generating card for judoka: ${judoka.firstname} ${judoka.surname}`, error);
+    return null;
   }
 }

--- a/helpers/carouselBuilder.js
+++ b/helpers/carouselBuilder.js
@@ -298,9 +298,11 @@ export async function buildCardCarousel(judokaList, gokyoData) {
     }
 
     const card = await generateJudokaCard(judoka, gokyoLookup, container);
-    if (card) {
-      handleBrokenImages(card);
+    if (!card) {
+      console.warn("Failed to generate card for judoka:", judoka);
+      continue;
     }
+    handleBrokenImages(card);
   }
 
   clearTimeout(timeoutId);

--- a/helpers/carouselBuilder.js
+++ b/helpers/carouselBuilder.js
@@ -298,7 +298,9 @@ export async function buildCardCarousel(judokaList, gokyoData) {
     }
 
     const card = await generateJudokaCard(judoka, gokyoLookup, container);
-    handleBrokenImages(card);
+    if (card) {
+      handleBrokenImages(card);
+    }
   }
 
   clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary
- return the newly created card element from `generateJudokaCard`
- handle potential null returns in `buildCardCarousel` before fixing broken images

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffa0bcf908326a7c87d61f5d0709a