### PR TITLE
Add tests for Date input to formatDate

### DIFF
--- a/tests/helpers/helpers.test.js
+++ b/tests/helpers/helpers.test.js
@@ -75,4 +75,12 @@ describe("formatDate", () => {
       expect(formatDate(input)).toBe(expected);
     }
   );
+
+  test.each([
+    [new Date("2025-04-24T00:00:00Z"), "2025-04-24"],
+    [new Date("2024-02-29T23:59:59Z"), "2024-02-29"],
+    [new Date("1970-01-01T00:00:00Z"), "1970-01-01"]
+  ])("formats Date instance %p to %p", (dateObj, expected) => {
+    expect(formatDate(dateObj)).toBe(expected);
+  });
 });


### PR DESCRIPTION
## Summary
- cover `formatDate` when called with JavaScript `Date` objects

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840079b7b648326a804801282ecbee1