### PR TITLE
Fix date validation

### DIFF
--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -92,7 +92,7 @@ export function formatDate(dateString) {
   if (typeof dateString !== "string" || !dateString.trim()) {
     return "Invalid Date";
   }
-  const isoMatch = dateString.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  const isoMatch = dateString.match(/^(\d{4})-(\d{2})-(\d{2})(?:$|T)/);
   const date = new Date(dateString);
   if (isNaN(date.getTime())) return "Invalid Date";
 

--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -92,8 +92,21 @@ export function formatDate(dateString) {
   if (typeof dateString !== "string" || !dateString.trim()) {
     return "Invalid Date";
   }
+  const isoMatch = dateString.match(/^(\d{4})-(\d{2})-(\d{2})/);
   const date = new Date(dateString);
   if (isNaN(date.getTime())) return "Invalid Date";
+
+  if (isoMatch) {
+    const [, year, month, day] = isoMatch.map(Number);
+    if (
+      date.getUTCFullYear() !== year ||
+      date.getUTCMonth() + 1 !== month ||
+      date.getUTCDate() !== day
+    ) {
+      return "Invalid Date";
+    }
+  }
+
   return date.toISOString().split("T")[0];
 }
 

--- a/tests/helpers/helpers.test.js
+++ b/tests/helpers/helpers.test.js
@@ -11,6 +11,15 @@ describe("formatDate", () => {
   );
 
   test.each([
+    "2025-02-30",
+    "2025-04-31",
+    "2025-13-01",
+    "2025-00-10"
+  ])('returns "Invalid Date" for impossible calendar date %p', (input) => {
+    expect(formatDate(input)).toBe("Invalid Date");
+  });
+
+  test.each([
     ["2025-04-24", "2025-04-24"],
     ["2025-04-24T15:30:00Z", "2025-04-24"],
     ["2025-04-24T15:30:00+02:00", "2025-04-24"],


### PR DESCRIPTION
## Summary
- handle impossible calendar dates in `formatDate`
- test impossible dates for invalid output

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684008b97f408326b8c4c3e78aea0cd5