### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/runUnitTests.yml
+++ b/.github/workflows/runUnitTests.yml
@@ -21,6 +21,8 @@
 # 4. Run the test suite:
 #    - Execute 'npm run test' to run the project's tests using Vitest.
 name: Run Unit Tests (Vitest)
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CyanAutomation/judokon/security/code-scanning/2](https://github.com/CyanAutomation/judokon/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level (applied to all jobs) to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only needs to read the repository contents to run tests, we will set `contents: read`. This ensures that no unnecessary write permissions are granted.

The `permissions` block will be added immediately after the `name` field (line 23) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
