### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main # Run on pushes to the main branch
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint Code with ESLint


### PR DESCRIPTION
Potential fix for [https://github.com/CyanAutomation/judokon/security/code-scanning/1](https://github.com/CyanAutomation/judokon/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions to `contents: read`, which is the minimum required for the workflow to function. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
