### PR TITLE
Add lazy loading to card images

### DIFF
--- a/helpers/cardRender.js
+++ b/helpers/cardRender.js
@@ -37,7 +37,7 @@ export function generateCardPortrait(card) {
   const { id, firstname, surname } = card;
   return `
     <div class="card-portrait">
-      <img src="../assets/judokaPortraits/judokaPortrait-${id}.png" alt="${firstname} ${surname}'s portrait" onerror="this.src='../assets/judokaPortraits/judokaPortrait-${id}.png'">
+      <img src="../assets/judokaPortraits/judokaPortrait-${id}.png" alt="${firstname} ${surname}'s portrait" loading="lazy" onerror="this.src='../assets/judokaPortraits/judokaPortrait-${id}.png'">
     </div>
   `;
 }

--- a/helpers/cardTopBar.js
+++ b/helpers/cardTopBar.js
@@ -170,6 +170,8 @@ export function createFlagImage(finalFlagUrl, countryName) {
 
   flagImg.alt = `${countryName || ""} flag`;
 
+  flagImg.setAttribute("loading", "lazy");
+
   flagImg.setAttribute("onerror", `this.src='${PLACEHOLDER_FLAG_URL}'`);
 
   flagContainer.appendChild(flagImg);

--- a/tests/card/card-builder.test.js
+++ b/tests/card/card-builder.test.js
@@ -113,4 +113,10 @@ describe("generateCardPortrait", () => {
   it("should throw an error if card is undefined", () => {
     expect(() => generateCardPortrait(undefined)).toThrowError("Card object is required");
   });
+
+  it("should include loading attribute on the portrait image", () => {
+    const card = { id: 1, firstname: "John", surname: "Doe" };
+    const result = generateCardPortrait(card);
+    expect(result).toContain('loading="lazy"');
+  });
 });

--- a/tests/card/card-top-bar.test.js
+++ b/tests/card/card-top-bar.test.js
@@ -35,7 +35,7 @@ describe("generateCardTopBar", () => {
           <span class="surname">Doe</span>
         </div>
         <div class="card-flag">
-          <img src="../assets/countryFlags/placeholder-flag.png" alt="Unknown flag" onerror="this.src='../assets/countryFlags/placeholder-flag.png'">
+          <img src="../assets/countryFlags/placeholder-flag.png" alt="Unknown flag" loading="lazy" onerror="this.src='../assets/countryFlags/placeholder-flag.png'">
         </div>
       </div>
     `;
@@ -129,5 +129,6 @@ describe("createFlagImage", () => {
     expect(flagImage.outerHTML).toContain(
       `<img src="https://flagcdn.com/w320/us.png" alt="United States flag"`
     );
+    expect(flagImage.outerHTML).toContain('loading="lazy"');
   });
 });


### PR DESCRIPTION
## Summary
- lazily load portrait images in cardRender
- lazily load flag images in cardTopBar
- update tests for lazy loading attributes

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684046ea58fc8326be552fdd5b78ce1b