### PR TITLE
Optimize scroll markers

### DIFF
--- a/helpers/carouselBuilder.js
+++ b/helpers/carouselBuilder.js
@@ -82,10 +82,14 @@ function addScrollMarkers(container, wrapper) {
 
   wrapper.appendChild(markers);
 
+  const firstCard = container.querySelector(".judoka-card");
+  const cardWidth = firstCard ? firstCard.offsetWidth : 0;
+
   container.addEventListener("scroll", () => {
     const scrollLeft = container.scrollLeft;
-    const cardWidth = container.querySelector(".judoka-card").offsetWidth;
-    const activeIndex = Math.round(scrollLeft / cardWidth);
+    const activeIndex = cardWidth
+      ? Math.round(scrollLeft / cardWidth)
+      : 0;
 
     markers.querySelectorAll(".scroll-marker").forEach((marker, index) => {
       marker.classList.toggle("active", index === activeIndex);
@@ -321,3 +325,5 @@ export async function buildCardCarousel(judokaList, gokyoData) {
 
   return wrapper;
 }
+
+export { addScrollMarkers };

--- a/tests/helpers/scroll-markers.test.js
+++ b/tests/helpers/scroll-markers.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { addScrollMarkers } from "../../helpers/carouselBuilder.js";
+
+describe("addScrollMarkers", () => {
+  it("reads offsetWidth only once", () => {
+    const container = document.createElement("div");
+    const wrapper = document.createElement("div");
+
+    const card = document.createElement("div");
+    card.className = "judoka-card";
+    container.appendChild(card);
+
+    let readCount = 0;
+    Object.defineProperty(card, "offsetWidth", {
+      get() {
+        readCount += 1;
+        return 100;
+      }
+    });
+
+    addScrollMarkers(container, wrapper);
+
+    container.scrollLeft = 50;
+    container.dispatchEvent(new Event("scroll"));
+
+    expect(readCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- compute `cardWidth` once in `addScrollMarkers`
- expose `addScrollMarkers` for testing
- ensure scroll markers only read offsetWidth a single time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684046ce9d4483269dface330c5aa3d1