### PR TITLE
Fix global fetch restoration in cache test

### DIFF
--- a/tests/helpers/data-utils-caching.test.js
+++ b/tests/helpers/data-utils-caching.test.js
@@ -8,6 +8,7 @@ describe("fetchDataWithErrorHandling caching", () => {
       ok: true,
       json: vi.fn().mockResolvedValue(data)
     });
+    const originalFetch = global.fetch;
     global.fetch = fetchMock;
 
     const url = "/some.json";


### PR DESCRIPTION
## Summary
- store original fetch before mocking
- keep the original fetch after test

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68406379de908326aaa377bfea26af11