### PR TITLE
Fix double carousel container

### DIFF
--- a/pages/carouselJudoka.html
+++ b/pages/carouselJudoka.html
@@ -38,7 +38,7 @@
 
       <main class="kodokan-grid" role="main">
         <div class="helper-container">TEST</div>
-        <div class="carousel-container"></div>
+        <div id="carousel-container"></div>
       </main>
 
       <div class="country-flag-slider">
@@ -70,7 +70,7 @@
 
         document.addEventListener("DOMContentLoaded", async () => {
           // Build the carousel
-          const carouselContainer = document.querySelector(".carousel-container");
+          const carouselContainer = document.getElementById("carousel-container");
 
           try {
             const [judokaData, gokyoData] = await Promise.all([


### PR DESCRIPTION
## Summary
- use a dedicated `#carousel-container` element in `carouselJudoka.html`
- select it by ID in the script

This prevents nested `.carousel-container` divs when rendering the Judoka carousel.

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c5e7f4188326afd4a59a773c8b0d