### PR TITLE
Implement safeGenerate helper

### DIFF
--- a/helpers/cardBuilder.js
+++ b/helpers/cardBuilder.js
@@ -5,6 +5,7 @@ import {
   generateCardStats,
   generateCardSignatureMove
 } from "./cardRender.js";
+import { safeGenerate } from "./errorUtils.js";
 
 /**
  * Generates the "last updated" HTML for a judoka card.
@@ -86,9 +87,9 @@ function validateJudoka(judoka) {
  *    - Ensure all required fields are present using `validateJudoka`.
  *
  * 2. Generate the flag URL:
- *    - Use `getFlagUrl` with the `countryCode` from the `judoka` object.
+ *    - Call `safeGenerate` with `getFlagUrl` and the `countryCode`.
  *    - Default to "vu" if `countryCode` is missing.
- *    - If fetching the flag fails, fallback to the Vanuatu flag.
+ *    - Fallback to the Vanuatu flag when an error occurs.
  *
  * 3. Determine the card type:
  *    - Use the `rarity` field to set the card type (e.g., "common").
@@ -101,20 +102,20 @@ function validateJudoka(judoka) {
  *    - Add a class based on the `gender` field ("female-card" or "male-card").
  *
  * 6. Append the top bar:
- *    - Generate the top bar using `generateCardTopBar` and append it.
- *    - If generation fails, append a "No data available" container instead.
+ *    - Use `safeGenerate` to create the top bar with `generateCardTopBar`.
+ *    - Fallback to `createNoDataContainer` on failure.
  *
  * 7. Append the portrait section:
- *    - Generate portrait HTML using `generateCardPortrait`.
+ *    - Generate portrait HTML using `safeGenerate` and `generateCardPortrait`.
  *    - If generation fails, continue with an empty section.
  *    - Add weight class information to the portrait section.
  *
  * 8. Append the stats section:
- *    - Generate stats HTML using `generateCardStats` and append it.
+ *    - Generate stats HTML using `safeGenerate` and `generateCardStats`.
  *    - If generation fails, append an empty stats container.
  *
  * 9. Append the signature move section:
- *    - Generate signature move HTML using `generateCardSignatureMove` and append it.
+ *    - Generate signature move HTML using `safeGenerate` and `generateCardSignatureMove`.
  *    - If generation fails, append an empty signature move container.
  *
  * 10. Return the complete card container:
@@ -128,13 +129,11 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
   validateJudoka(judoka);
 
   const countryCode = judoka.countryCode;
-  let flagUrl;
-  try {
-    flagUrl = await getFlagUrl(countryCode || "vu"); // Default to "vu" (Vanuatu)
-  } catch (error) {
-    console.error("Failed to resolve flag URL:", error);
-    flagUrl = "https://flagcdn.com/w320/vu.png";
-  }
+  const flagUrl = await safeGenerate(
+    () => getFlagUrl(countryCode || "vu"),
+    "Failed to resolve flag URL:",
+    "https://flagcdn.com/w320/vu.png"
+  );
 
   const cardType = judoka.rarity?.toLowerCase() || "common";
 
@@ -149,21 +148,17 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
   const genderClass = judoka.gender === "female" ? "female-card" : "male-card";
   judokaCard.classList.add(genderClass);
 
-  let topBarElement;
-  try {
-    topBarElement = await generateCardTopBar(judoka, flagUrl);
-  } catch (error) {
-    console.error("Failed to generate top bar:", error);
-    topBarElement = createNoDataContainer();
-  }
+  const topBarElement = await safeGenerate(
+    () => generateCardTopBar(judoka, flagUrl),
+    "Failed to generate top bar:",
+    createNoDataContainer()
+  );
   judokaCard.appendChild(topBarElement);
 
-  let portraitHTML = "";
-  try {
-    portraitHTML = generateCardPortrait(judoka);
-  } catch (error) {
-    console.error("Failed to generate portrait:", error);
-  }
+  const portraitHTML = await safeGenerate(
+    () => generateCardPortrait(judoka),
+    "Failed to generate portrait:"
+  );
   const portraitElement = document.createElement("div");
   portraitElement.className = "card-portrait";
   portraitElement.innerHTML = portraitHTML;
@@ -175,22 +170,18 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
 
   judokaCard.appendChild(portraitElement);
 
-  let statsHTML = "";
-  try {
-    statsHTML = generateCardStats(judoka, cardType);
-  } catch (error) {
-    console.error("Failed to generate stats:", error);
-  }
+  const statsHTML = await safeGenerate(
+    () => generateCardStats(judoka, cardType),
+    "Failed to generate stats:"
+  );
   const statsElement = document.createElement("div");
   statsElement.innerHTML = statsHTML;
   judokaCard.appendChild(statsElement);
 
-  let signatureMoveHTML = "";
-  try {
-    signatureMoveHTML = generateCardSignatureMove(judoka, gokyoLookup, cardType);
-  } catch (error) {
-    console.error("Failed to generate signature move:", error);
-  }
+  const signatureMoveHTML = await safeGenerate(
+    () => generateCardSignatureMove(judoka, gokyoLookup, cardType),
+    "Failed to generate signature move:"
+  );
   const signatureMoveElement = document.createElement("div");
   signatureMoveElement.innerHTML = signatureMoveHTML;
   judokaCard.appendChild(signatureMoveElement);
@@ -205,26 +196,26 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
  *
  * @pseudocode
  * 1. Generate the card HTML:
- *    - Use `generateJudokaCardHTML` with the `judoka` and `gokyoLookup`.
+ *    - Use `safeGenerate` with `generateJudokaCardHTML` and a fallback of `null`.
  *
  * 2. Append the card to the container:
- *    - Use `appendChild` to add the card to the DOM.
+ *    - If a card is returned, append it to the DOM.
  *
  * 3. Handle errors:
- *    - Log an error message if card generation fails.
- *    - Include the judoka's name in the error message for debugging.
+ *    - Error logging is managed by `safeGenerate`.
  *
  * @param {Object} judoka - A judoka object containing data for the card.
  * @param {Object} gokyoLookup - A lookup object for gokyo data.
  * @param {HTMLElement} container - The container to append the card to.
  */
 export async function generateJudokaCard(judoka, gokyoLookup, container) {
-  try {
-    const card = await generateJudokaCardHTML(judoka, gokyoLookup);
+  const card = await safeGenerate(
+    () => generateJudokaCardHTML(judoka, gokyoLookup),
+    `Error generating card for judoka: ${judoka.firstname} ${judoka.surname}`,
+    null
+  );
+  if (card) {
     container.appendChild(card);
-    return card;
-  } catch (error) {
-    console.error(`Error generating card for judoka: ${judoka.firstname} ${judoka.surname}`, error);
-    return null;
   }
+  return card;
 }

--- a/helpers/errorUtils.js
+++ b/helpers/errorUtils.js
@@ -1,0 +1,26 @@
+/**
+ * Executes a (possibly async) generator function and logs errors.
+ *
+ * @pseudocode
+ * 1. Call the provided function `fn` inside a try/catch block.
+ *    - Await the result in case `fn` returns a promise.
+ *
+ * 2. If the call succeeds, return the result.
+ *
+ * 3. If the call throws an error:
+ *    - Log `errorMsg` along with the error to the console.
+ *    - Return the provided `fallback` value.
+ *
+ * @param {Function} fn - Function to execute.
+ * @param {string} errorMsg - Message prefix for `console.error`.
+ * @param {*} [fallback=""] - Value returned if `fn` throws.
+ * @returns {Promise<*>} Result of `fn` or the fallback value.
+ */
+export async function safeGenerate(fn, errorMsg, fallback = "") {
+  try {
+    return await fn();
+  } catch (error) {
+    console.error(errorMsg, error);
+    return fallback;
+  }
+}

--- a/tests/helpers/error-utils.test.js
+++ b/tests/helpers/error-utils.test.js
@@ -1,0 +1,31 @@
+import { describe, test, expect } from "vitest";
+import { safeGenerate } from "../../helpers/errorUtils.js";
+
+describe("safeGenerate", () => {
+  test("returns fallback for synchronous errors", async () => {
+    const result = await safeGenerate(
+      () => {
+        throw new Error("fail");
+      },
+      "error",
+      "fallback"
+    );
+    expect(result).toBe("fallback");
+  });
+
+  test("returns fallback for asynchronous errors", async () => {
+    const result = await safeGenerate(
+      async () => {
+        throw new Error("fail");
+      },
+      "error",
+      42
+    );
+    expect(result).toBe(42);
+  });
+
+  test("returns value when no error is thrown", async () => {
+    const result = await safeGenerate(() => "ok", "error", "fallback");
+    expect(result).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary
- add `safeGenerate` helper for safe function execution
- refactor card builder to use `safeGenerate`
- document new helper in pseudocode
- test `safeGenerate` functionality

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6842099934f48326be30ad878c34b207