### PR TITLE
Add fallback handling in cardBuilder

### DIFF
--- a/helpers/cardBuilder.js
+++ b/helpers/cardBuilder.js
@@ -101,21 +101,21 @@ function validateJudoka(judoka) {
  *    - Add a class based on the `gender` field ("female-card" or "male-card").
  *
  * 6. Append the top bar:
- *    - Generate the top bar using `generateCardTopBar` and append it.
+ *    - Generate the top bar using `generateCardTopBar` inside a `try...catch`.
  *    - If generation fails, append a "No data available" container instead.
  *
  * 7. Append the portrait section:
- *    - Generate portrait HTML using `generateCardPortrait`.
- *    - If generation fails, continue with an empty section.
- *    - Add weight class information to the portrait section.
+ *    - Generate portrait HTML using `generateCardPortrait` inside a `try...catch`.
+ *    - If generation fails, append a fallback container from `createNoDataContainer`.
+ *    - When successful, add weight class information to the portrait section.
  *
  * 8. Append the stats section:
- *    - Generate stats HTML using `generateCardStats` and append it.
- *    - If generation fails, append an empty stats container.
+ *    - Generate stats HTML using `generateCardStats` inside a `try...catch`.
+ *    - If generation fails, append a fallback container from `createNoDataContainer`.
  *
  * 9. Append the signature move section:
- *    - Generate signature move HTML using `generateCardSignatureMove` and append it.
- *    - If generation fails, append an empty signature move container.
+ *    - Generate signature move HTML using `generateCardSignatureMove` inside a `try...catch`.
+ *    - If generation fails, append a fallback container from `createNoDataContainer`.
  *
  * 10. Return the complete card container:
  *    - Append the `judoka-card` to the `card-container`.
@@ -158,41 +158,44 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
   }
   judokaCard.appendChild(topBarElement);
 
-  let portraitHTML = "";
+  let portraitElement;
   try {
-    portraitHTML = generateCardPortrait(judoka);
+    const portraitHTML = generateCardPortrait(judoka);
+    portraitElement = document.createElement("div");
+    portraitElement.className = "card-portrait";
+    portraitElement.innerHTML = portraitHTML;
+
+    const weightClassElement = document.createElement("div");
+    weightClassElement.className = "card-weight-class";
+    weightClassElement.textContent = judoka.weightClass;
+    portraitElement.appendChild(weightClassElement);
   } catch (error) {
     console.error("Failed to generate portrait:", error);
+    portraitElement = createNoDataContainer();
   }
-  const portraitElement = document.createElement("div");
-  portraitElement.className = "card-portrait";
-  portraitElement.innerHTML = portraitHTML;
-
-  const weightClassElement = document.createElement("div");
-  weightClassElement.className = "card-weight-class";
-  weightClassElement.textContent = judoka.weightClass;
-  portraitElement.appendChild(weightClassElement);
 
   judokaCard.appendChild(portraitElement);
 
-  let statsHTML = "";
+  let statsElement;
   try {
-    statsHTML = generateCardStats(judoka, cardType);
+    const statsHTML = generateCardStats(judoka, cardType);
+    statsElement = document.createElement("div");
+    statsElement.innerHTML = statsHTML;
   } catch (error) {
     console.error("Failed to generate stats:", error);
+    statsElement = createNoDataContainer();
   }
-  const statsElement = document.createElement("div");
-  statsElement.innerHTML = statsHTML;
   judokaCard.appendChild(statsElement);
 
-  let signatureMoveHTML = "";
+  let signatureMoveElement;
   try {
-    signatureMoveHTML = generateCardSignatureMove(judoka, gokyoLookup, cardType);
+    const signatureMoveHTML = generateCardSignatureMove(judoka, gokyoLookup, cardType);
+    signatureMoveElement = document.createElement("div");
+    signatureMoveElement.innerHTML = signatureMoveHTML;
   } catch (error) {
     console.error("Failed to generate signature move:", error);
+    signatureMoveElement = createNoDataContainer();
   }
-  const signatureMoveElement = document.createElement("div");
-  signatureMoveElement.innerHTML = signatureMoveHTML;
   judokaCard.appendChild(signatureMoveElement);
 
   cardContainer.appendChild(judokaCard);

--- a/helpers/cardBuilder.js
+++ b/helpers/cardBuilder.js
@@ -192,6 +192,7 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
   try {
     const signatureMoveHTML = generateCardSignatureMove(judoka, gokyoLookup, cardType);
     signatureMoveElement = document.createElement("div");
+    signatureMoveElement.className = "card-signature-move";
     signatureMoveElement.innerHTML = signatureMoveHTML;
   } catch (error) {
     console.error("Failed to generate signature move:", error);

--- a/helpers/cardBuilder.js
+++ b/helpers/cardBuilder.js
@@ -180,6 +180,7 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
   try {
     const statsHTML = generateCardStats(judoka, cardType);
     statsElement = document.createElement("div");
+    statsElement.className = "card-stats";
     statsElement.innerHTML = statsHTML;
   } catch (error) {
     console.error("Failed to generate stats:", error);

--- a/tests/card/judoka-card-html-fallback.test.js
+++ b/tests/card/judoka-card-html-fallback.test.js
@@ -1,0 +1,57 @@
+import { vi } from "vitest";
+import { generateJudokaCardHTML } from "../../helpers/cardBuilder.js";
+import * as cardRender from "../../helpers/cardRender.js";
+
+const judoka = {
+  id: 1,
+  firstname: "John",
+  surname: "Doe",
+  country: "USA",
+  countryCode: "us",
+  stats: { power: 5, speed: 5, technique: 5, kumikata: 5, newaza: 5 },
+  weightClass: "-100kg",
+  signatureMoveId: 1,
+  rarity: "common",
+  gender: "male"
+};
+
+const gokyoLookup = {
+  0: { id: 0, name: "Jigoku-guruma" },
+  1: { id: 1, name: "Uchi-mata" }
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("generateJudokaCardHTML fallback containers", () => {
+  it("adds fallback when portrait generation throws", async () => {
+    vi.spyOn(cardRender, "generateCardPortrait").mockImplementation(() => {
+      throw new Error("portrait fail");
+    });
+
+    const card = await generateJudokaCardHTML(judoka, gokyoLookup);
+
+    expect(card.textContent).toContain("No data available");
+  });
+
+  it("adds fallback when stats generation throws", async () => {
+    vi.spyOn(cardRender, "generateCardStats").mockImplementation(() => {
+      throw new Error("stats fail");
+    });
+
+    const card = await generateJudokaCardHTML(judoka, gokyoLookup);
+
+    expect(card.textContent).toContain("No data available");
+  });
+
+  it("adds fallback when signature move generation throws", async () => {
+    vi.spyOn(cardRender, "generateCardSignatureMove").mockImplementation(() => {
+      throw new Error("signature fail");
+    });
+
+    const card = await generateJudokaCardHTML(judoka, gokyoLookup);
+
+    expect(card.textContent).toContain("No data available");
+  });
+});


### PR DESCRIPTION
## Summary
- handle portrait, stats and signature block errors with `createNoDataContainer`
- document fallback behavior in `generateJudokaCardHTML` pseudocode
- test fallback containers for failing portrait, stats or signature move generation
- clarify pseudocode for using try/catch when generating sections

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6842097c50a483269eff2be3bb57147d