### PR TITLE
Fix stats element initialization in card builder

### DIFF
--- a/helpers/cardBuilder.js
+++ b/helpers/cardBuilder.js
@@ -177,9 +177,9 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
 
   judokaCard.appendChild(portraitElement);
 
-  let statsHTML = "";
+  let statsElement;
   try {
-    statsHTML = generateCardStats(judoka, cardType);
+    const statsHTML = generateCardStats(judoka, cardType);
     statsElement = document.createElement("div");
     statsElement.className = "card-stats";
     statsElement.innerHTML = statsHTML;
@@ -187,8 +187,6 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
     console.error("Failed to generate stats:", error);
     statsElement = createNoDataContainer();
   }
-  const statsElement = document.createElement("div");
-  statsElement.innerHTML = statsHTML;
   judokaCard.appendChild(statsElement);
 
   let signatureMoveHTML = "";


### PR DESCRIPTION
## Summary
- fix variable scoping when generating stats section

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68421311698083269dd14f7b5ca09af7