### PR TITLE
Fix carousel overflow on mobile

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -528,6 +528,7 @@ button:focus {
   backdrop-filter: blur(10px);
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.5);
   overflow: hidden;
+  width: 100%;
 }
 
 .card-carousel {


### PR DESCRIPTION
## Summary
- constrain `.carousel-container` to the viewport width

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68448510437483268c88fcd3964486b0