### PR TITLE
Enable on-demand screenshot tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ In the browser you can enable it from the console before loading the page:
 window.DEBUG_LOGGING = true;
 ```
 
+## Screenshot Tests (On-Demand)
+
+Run optional Playwright-based screenshot tests with:
+
+```bash
+npm run test:screenshot
+```
+
 ## Project Structure
 
 The repository follows a simple layout. GitHub Pages requires `index.html` to live at the project root.

--- a/design/productRequirementsDocuments/prdCardCarousel.md
+++ b/design/productRequirementsDocuments/prdCardCarousel.md
@@ -4,7 +4,7 @@
 
 As part of the game, certain screens, such as “Browse Judoka,” require an intuitive and interactive way to present judoka cards. With more than 100 cards in the game, it would be cumbersome and frustrating for players to browse through all cards manually without an efficient filtering and navigation system.
 
-Failure to provide an efficient browsing experience may impact core gameplay — players might struggle to find and build optimal teams, leading to frustration and potential churn. 
+Failure to provide an efficient browsing experience may impact core gameplay — players might struggle to find and build optimal teams, leading to frustration and potential churn.
 
 > A smooth and intuitive browsing experience fosters a sense of mastery and control, enhancing overall player satisfaction and engagement.
 

--- a/design/productRequirementsDocuments/prdCardCodeGeneration.md
+++ b/design/productRequirementsDocuments/prdCardCodeGeneration.md
@@ -174,9 +174,9 @@ F7KP-WQ9M-ZD23-HYTR
 - Auto-hyphenates every 4 characters.
 - Invalid input prompts real-time error feedback.
 
-| **Card Code Display and Entry Mockup 1**  | **Card Code Display and Entry Mockup 2** |
-|----|----:|
-|![Card Code Display and Entry Mockup 1](/design/mockups/mockupCardCode1.png)|![Card Code Display and Entry Mockup 2](/design/mockups/mockupCardCode2.png)|
+| **Card Code Display and Entry Mockup 1**                                     |                                     **Card Code Display and Entry Mockup 2** |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------: |
+| ![Card Code Display and Entry Mockup 1](/design/mockups/mockupCardCode1.png) | ![Card Code Display and Entry Mockup 2](/design/mockups/mockupCardCode2.png) |
 
 ---
 

--- a/design/productRequirementsDocuments/prdCountryPickerFilter.md
+++ b/design/productRequirementsDocuments/prdCountryPickerFilter.md
@@ -4,7 +4,7 @@
 
 ## Problem Statement
 
-Each judoka and judoka card is affiliated with a country (e.g., a judoka might be part of the Spanish team). Currently, there is no way for players to browse judoka by country, which frustrates players when searching for their favorite country’s athletes. The lack of an intuitive country filter diminishes user experience, leading to inefficient browsing and potential drop-off. 
+Each judoka and judoka card is affiliated with a country (e.g., a judoka might be part of the Spanish team). Currently, there is no way for players to browse judoka by country, which frustrates players when searching for their favorite country’s athletes. The lack of an intuitive country filter diminishes user experience, leading to inefficient browsing and potential drop-off.
 
 > By including a country picker, we aim to increase session duration and card interaction rates — both critical, as longer, more engaged sessions correlate directly with higher player retention and in-game activity.
 
@@ -109,9 +109,10 @@ Key Details:
   - Flag grid fade-in duration: 200ms.
 
 ### Wireframes
-| **Country Picker Mockup 1** | **Country Picker Mockup 2**                         |
-|---|---:|
-|![Country Picker Mockup 1](/design/mockups/mockupCountryPicker1.png)|![Country Picker Mockup 2](/design/mockups/mockupCountryPicker2.png)|
+
+| **Country Picker Mockup 1**                                          |                                          **Country Picker Mockup 2** |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------: |
+| ![Country Picker Mockup 1](/design/mockups/mockupCountryPicker1.png) | ![Country Picker Mockup 2](/design/mockups/mockupCountryPicker2.png) |
 
 ---
 

--- a/design/productRequirementsDocuments/prdDrawRandomCard.md
+++ b/design/productRequirementsDocuments/prdDrawRandomCard.md
@@ -161,10 +161,9 @@ Without this feature, players would be forced to pre-select cards, leading to pr
 
 ---
 
-
-| **Draw Random Card Mockup 1**  | **Draw Random Card Mockup  2** |
-|----|----:|
-|![Draw Random Card Mockup 1](/design/mockups/mockupDrawCard1.png)|![Draw Random Card Mockup 2](/design/mockups/mockupDrawCard2.png)|
+| **Draw Random Card Mockup 1**                                     |                                     **Draw Random Card Mockup 2** |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------: |
+| ![Draw Random Card Mockup 1](/design/mockups/mockupDrawCard1.png) | ![Draw Random Card Mockup 2](/design/mockups/mockupDrawCard2.png) |
 
 ---
 

--- a/design/productRequirementsDocuments/prdNavigationMap.md
+++ b/design/productRequirementsDocuments/prdNavigationMap.md
@@ -2,7 +2,7 @@
 
 ## Problem Statement
 
-Players have reported that the current navigation menus feel disconnected from the Ju-Do-Kon! theme, which weakens immersion and reduces excitement when switching game modes. A theoretical 10-year-old playtester noted, 
+Players have reported that the current navigation menus feel disconnected from the Ju-Do-Kon! theme, which weakens immersion and reduces excitement when switching game modes. A theoretical 10-year-old playtester noted,
 
 > _"The menu feels boring compared to the rest of the game — can it look more exciting? Maybe like a judo dojo or village?"_
 
@@ -60,9 +60,9 @@ Currently, the menu is purely functional but lacks the thematic cohesion that dr
 - **Performance:** Maintain ≥60fps animations on mid-tier devices.
 - **Responsiveness:** If viewport height <400px or width <640px, hide the map icon and corresponding functionality.
 
-| **Navigation Map Mockup 1** | **Navigation Map Mockup 2**                         |
-|---|---:|
-|![Navigation Map Mockup 1](/design/mockups/mockupNavigationMap2.png)|![Navigation Map Mockup 2](/design/mockups/mockupNavigationMap3.png)|
+| **Navigation Map Mockup 1**                                          |                                          **Navigation Map Mockup 2** |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------: |
+| ![Navigation Map Mockup 1](/design/mockups/mockupNavigationMap2.png) | ![Navigation Map Mockup 2](/design/mockups/mockupNavigationMap3.png) |
 
 ## Accessibility Checklist
 

--- a/design/productRequirementsDocuments/prdPseudoJapanese.md
+++ b/design/productRequirementsDocuments/prdPseudoJapanese.md
@@ -67,9 +67,9 @@ As this game is about a Japanese martial art, authentic cultural immersion is ke
   - Visually consistent with game UI (rounded rectangle, matching color scheme).
 - No plan for real Japanese localization — this feature is purely for stylistic effect.
 
-| **Quote Screen Mockup 3** | **Quote Screen Mockup 4**                         |
-|---|---:|
-|![Quote Screen Mockup 3](/design/mockups/mockupQuoteScreen3.png)|![Quote Screen Mockup 4](/design/mockups/mockupQuoteScreen4.png)|
+| **Quote Screen Mockup 3**                                        |                                        **Quote Screen Mockup 4** |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------: |
+| ![Quote Screen Mockup 3](/design/mockups/mockupQuoteScreen3.png) | ![Quote Screen Mockup 4](/design/mockups/mockupQuoteScreen4.png) |
 
 ### 1. Quote Display + Language Toggle Module
 

--- a/design/productRequirementsDocuments/prdQuoteScreen.md
+++ b/design/productRequirementsDocuments/prdQuoteScreen.md
@@ -10,7 +10,8 @@ Introduce a rewarding quote screen that appears when players achieve a perfect v
 
 ## Problem Statement
 
-Currently, players completing a full sweep of team battles receive no special acknowledgment. Without a distinctive reward, players may lack the emotional closure and reinforcement that drives continued engagement. Providing a “quote reward” with KG taps into the human drive for mastery and recognition. By celebrating this achievement, we encourage players to replay and improve. There is a concern that any lack of reward for challenging play could lead to reduced play time or negative player feedback. 
+Currently, players completing a full sweep of team battles receive no special acknowledgment. Without a distinctive reward, players may lack the emotional closure and reinforcement that drives continued engagement. Providing a “quote reward” with KG taps into the human drive for mastery and recognition. By celebrating this achievement, we encourage players to replay and improve. There is a concern that any lack of reward for challenging play could lead to reduced play time or negative player feedback.
+
 > Full sweeps—winning all matches in a team battle—are likely challenging, and it is estimated that only 20% of players achieve this.
 
 ---
@@ -85,9 +86,9 @@ Players are motivated by meaningful, personalized rewards that mark major achiev
 - Background is neutral and matches the tone of the team battle mode.
 - Quote text uses a legible, sans-serif font, sized 18px minimum.
 
-| **Quote Screen Mockup 3** | **Quote Screen Mockup 4**                         |
-|---|---:|
-|![Quote Screen Mockup 3](/design/mockups/mockupQuoteScreen3.png)|![Quote Screen Mockup 4](/design/mockups/mockupQuoteScreen4.png)|
+| **Quote Screen Mockup 3**                                        |                                        **Quote Screen Mockup 4** |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------: |
+| ![Quote Screen Mockup 3](/design/mockups/mockupQuoteScreen3.png) | ![Quote Screen Mockup 4](/design/mockups/mockupQuoteScreen4.png) |
 
 ### 1. Victory Feedback Module
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "test:screenshot": "playwright test"
   },
   "keywords": [],
   "author": "",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,14 @@
+/* eslint-env node */
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./playwright",
+  use: {
+    baseURL: "http://localhost:5000"
+  },
+  webServer: {
+    command: "node scripts/playwrightServer.js",
+    port: 5000,
+    reuseExistingServer: true
+  }
+});

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -1,0 +1,6 @@
+import { test, expect } from "@playwright/test";
+
+test("homepage screenshot", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveScreenshot("homepage.png");
+});

--- a/scripts/playwrightServer.js
+++ b/scripts/playwrightServer.js
@@ -1,0 +1,52 @@
+/* eslint-env node */
+/**
+ * Simple static file server for Playwright tests.
+ *
+ * @pseudocode
+ * 1. Determine root directory and port.
+ * 2. Create HTTP server to serve files.
+ * 3. Resolve requested paths relative to root.
+ * 4. Stream the file with correct Content-Type.
+ * 5. Return 404 if file not found.
+ */
+import http from "http";
+import { createReadStream, existsSync, statSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+const port = process.env.PORT || 5000;
+
+const mimeTypes = {
+  ".html": "text/html",
+  ".js": "application/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon"
+};
+
+function getContentType(filePath) {
+  return mimeTypes[path.extname(filePath).toLowerCase()] || "application/octet-stream";
+}
+
+const server = http.createServer((req, res) => {
+  let filePath = path.join(rootDir, req.url === "/" ? "index.html" : req.url);
+  if (existsSync(filePath) && statSync(filePath).isDirectory()) {
+    filePath = path.join(filePath, "index.html");
+  }
+  if (existsSync(filePath)) {
+    res.setHeader("Content-Type", getContentType(filePath));
+    createReadStream(filePath).pipe(res);
+  } else {
+    res.statusCode = 404;
+    res.end("Not Found");
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Static server running at http://localhost:${port}`);
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true, // Enables global functions like describe and it
-    environment: "jsdom" // Use jsdom for DOM-related tests
+    environment: "jsdom", // Use jsdom for DOM-related tests
+    exclude: ["playwright/**", "node_modules/**"]
   }
 });


### PR DESCRIPTION
## Summary
- add a simple static server for Playwright
- configure Playwright with a web server
- write a basic screenshot test
- ignore Playwright tests in Vitest
- document how to run screenshot tests
- format design docs so Prettier passes

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68455133a7f883269f863330887c573b