### PR TITLE
Capture screenshots for all site pages

### DIFF
--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -1,6 +1,20 @@
 import { test, expect } from "@playwright/test";
 
-test("homepage screenshot", async ({ page }) => {
-  await page.goto("/");
-  await expect(page).toHaveScreenshot("homepage.png");
-});
+// List of pages to capture screenshots for
+const pages = [
+  "/",
+  "/src/pages/battleJudoka.html",
+  "/src/pages/carouselJudoka.html",
+  "/src/pages/createJudoka.html",
+  "/src/pages/randomJudoka.html",
+  "/src/pages/quoteKG.html",
+  "/src/pages/updateJudoka.html"
+];
+
+for (const url of pages) {
+  test(`screenshot ${url}`, async ({ page }) => {
+    await page.goto(url);
+    const name = url === "/" ? "homepage.png" : url.split("/").pop().replace(".html", ".png");
+    await expect(page).toHaveScreenshot(name);
+  });
+}


### PR DESCRIPTION
## Summary
- update Playwright screenshot test to iterate through each page and save snapshots

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684570389290832684dfde0ac4d68fb1