### PR TITLE
Fix Map caching in data utils

### DIFF
--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -57,8 +57,8 @@ export async function loadJSON(url) {
  */
 export async function fetchDataWithErrorHandling(url) {
   try {
-    if (url in dataCache) {
-      return dataCache[url];
+    if (dataCache.has(url)) {
+      return dataCache.get(url);
     }
 
     const response = await fetch(url);
@@ -68,7 +68,7 @@ export async function fetchDataWithErrorHandling(url) {
     }
 
     const json = await response.json();
-    dataCache[url] = json;
+    dataCache.set(url, json);
     return json;
   } catch (error) {
     console.error(`Error fetching data from ${url}:`, error);


### PR DESCRIPTION
## Summary
- fix Map usage in `fetchDataWithErrorHandling`

## Testing
- `npx prettier . --check` *(fails: code style issues in design docs)*
- `npx eslint .` *(fails to load `@eslint/js`)*
- `npx vitest run` *(fails: 403 Forbidden when downloading vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68458cf406f4832680bcb0e76957861c