### PR TITLE
Fix portrait element scope

### DIFF
--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -155,25 +155,24 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
   );
   judokaCard.appendChild(topBarElement);
 
-  let portraitHTML = "";
-  try {
-    portraitHTML = generateCardPortrait(judoka);
-  } catch (error) {
-    console.error("Failed to generate portrait:", error);
-  }
-  const portraitElement = document.createElement("div");
-  portraitElement.className = "card-portrait";
-  portraitElement.innerHTML = portraitHTML;
+  const portraitElement = (() => {
+    try {
+      const portraitHTML = generateCardPortrait(judoka);
+      const element = document.createElement("div");
+      element.className = "card-portrait";
+      element.innerHTML = portraitHTML;
 
-  try {
-    const weightClassElement = document.createElement("div");
-    weightClassElement.className = "card-weight-class";
-    weightClassElement.textContent = judoka.weightClass;
-    portraitElement.appendChild(weightClassElement);
-  } catch (error) {
-    console.error("Failed to generate portrait:", error);
-    portraitElement = createNoDataContainer();
-  }
+      const weightClassElement = document.createElement("div");
+      weightClassElement.className = "card-weight-class";
+      weightClassElement.textContent = judoka.weightClass;
+      element.appendChild(weightClassElement);
+
+      return element;
+    } catch (error) {
+      console.error("Failed to generate portrait:", error);
+      return createNoDataContainer();
+    }
+  })();
 
   judokaCard.appendChild(portraitElement);
 


### PR DESCRIPTION
## Summary
- refactor cardBuilder's portrait generation to use `const` inside a closure

## Testing
- `npx prettier . --check`
- `npx eslint src/helpers/cardBuilder.js` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6845bb41c1a48326b307f24889940a65