### PR TITLE
Improve scroll button test

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,6 @@ node_modules/
 dist/
 build/
 *.log
+.github/ISSUE_TEMPLATE/*.md
+design/productRequirementsDocuments/*.md
+src/pages/quoteKG.html

--- a/tests/card/card-builder.test.js
+++ b/tests/card/card-builder.test.js
@@ -24,7 +24,7 @@ describe("createScrollButton", () => {
     const button = createScrollButton("left", container, 100);
     expect(button.className).toBe("scroll-button left");
     expect(button.innerHTML).toBe("&lt;");
-    expect(button.getAttribute("aria-label")).toBe("Scroll Left");
+    expect(button).toHaveAttribute("aria-label", "Scroll Left");
   });
 
   it("should create a scroll button with the correct class and inner HTML when direction is right", () => {


### PR DESCRIPTION
## Summary
- use `toHaveAttribute` for scroll button aria-label check
- ignore markdown templates and static HTML from prettier

## Testing
- `npx prettier . --check`
- `npx eslint tests/card/card-builder.test.js` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run tests/card/card-builder.test.js` *(fails: 403 Forbidden to download vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6845bfa27d2c8326b53270d44d94994d