### PR TITLE
Enhance random judoka view

### DIFF
--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("View Judoka screen", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/src/pages/randomJudoka.html");
+  });
+
+  test("essential elements visible", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /draw card/i })).toBeVisible();
+    await expect(page.getByRole("navigation")).toBeVisible();
+  });
+
+  test("battle link navigates", async ({ page }) => {
+    await page.getByRole("link", { name: /battle!/i }).click();
+    await expect(page).toHaveURL(/battleJudoka\.html/);
+  });
+
+  test("draw button has label", async ({ page }) => {
+    const btn = page.getByRole("button", { name: /draw card/i });
+    await expect(btn).toHaveAttribute("aria-label", /draw a random card/i);
+  });
+});

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -37,13 +37,22 @@
       </header>
 
       <div id="card-container" class="card-container"></div>
+      <button id="draw-card-btn" class="draw-card-btn" aria-label="Draw a random card">
+        Draw Card!
+      </button>
 
       <footer>
         <nav class="bottom-navbar">
           <ul>
-            <li><a href="randomJudoka.html">View Judoka</a></li>
-            <li><a href="updateJudoka.html">Update Judoka</a></li>
-            <li><a href="battleJudoka.html">Battle!</a></li>
+            <li>
+              <a href="randomJudoka.html" aria-label="View Judoka page">View Judoka</a>
+            </li>
+            <li>
+              <a href="updateJudoka.html" aria-label="Update Judoka page">Update Judoka</a>
+            </li>
+            <li>
+              <a href="battleJudoka.html" aria-label="Battle mode page">Battle!</a>
+            </li>
           </ul>
         </nav>
       </footer>
@@ -95,6 +104,8 @@
 
         // Call the function to display a random judoka when the page loads
         displayRandomJudoka();
+
+        document.getElementById("draw-card-btn").addEventListener("click", displayRandomJudoka);
       </script>
       <noscript>
         <p class="noscript-warning">

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -792,3 +792,21 @@ button:focus {
     transform: translate(-50%, -50%) rotate(360deg);
   }
 }
+
+.draw-card-btn {
+  display: block;
+  margin: var(--padding-large) auto;
+  width: min(300px, 80vw);
+  min-height: 64px;
+  padding: var(--padding-medium) var(--padding-large);
+  background-color: var(--primary-bg);
+  color: var(--text-color);
+  border: 2px solid #fff;
+  border-radius: var(--border-radius-medium);
+  font-size: 1.25rem;
+  font-weight: bold;
+}
+
+.draw-card-btn:active {
+  transform: scale(var(--button-scale));
+}


### PR DESCRIPTION
## Summary
- add big **Draw Card** button to random judoka page
- wire button to draw a new card on click
- expose nav links with aria labels
- style the new draw-card button
- add Playwright tests for view judoka screen

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845cf7ca5848326bf39fcea59bd4146