### PR TITLE
Add homepage navigation test

### DIFF
--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Homepage", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/index.html");
+  });
+
+  test("navigation links visible", async ({ page }) => {
+    await expect(page.getByRole("navigation")).toBeVisible();
+    await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /battle!/i })).toBeVisible();
+  });
+
+  test("view judoka link navigates", async ({ page }) => {
+    await page.getByRole("link", { name: /view judoka/i }).click();
+    await expect(page).toHaveURL(/randomJudoka\.html/);
+  });
+});


### PR DESCRIPTION
## Summary
- test navigation links on homepage via Playwright

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6845d32100208326bbebb9f229f69e4c