### PR TITLE
Add draw card test for random judoka page

### DIFF
--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -19,4 +19,10 @@ test.describe("View Judoka screen", () => {
     const btn = page.getByRole("button", { name: /draw card/i });
     await expect(btn).toHaveAttribute("aria-label", /draw a random card/i);
   });
+
+  test("draw card populates container", async ({ page }) => {
+    await page.click("#draw-card-btn");
+    const card = page.locator("#card-container .judoka-card");
+    await expect(card).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- check that drawing a card inserts a `.judoka-card` element

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6845f612cf288326aee7719fbe499278