### PR TITLE
Add logo alt text checks

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -16,6 +16,11 @@ test.describe("Browse Judoka screen", () => {
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 
+  test("logo has alt text", async ({ page }) => {
+    const logo = page.locator(".logo-container img");
+    await expect(logo).toHaveAttribute("alt", "JU-DO-KON! Logo");
+  });
+
   test("scroll buttons have labels", async ({ page }) => {
     const left = page.locator(".scroll-button.left");
     const right = page.locator(".scroll-button.right");

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -15,6 +15,11 @@ test.describe("View Judoka screen", () => {
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 
+  test("logo has alt text", async ({ page }) => {
+    const logo = page.locator(".logo-container img");
+    await expect(logo).toHaveAttribute("alt", "JU-DO-KON! Logo");
+  });
+
   test("draw button has label", async ({ page }) => {
     const btn = page.getByRole("button", { name: /draw card/i });
     await expect(btn).toHaveAttribute("aria-label", /draw a random card/i);


### PR DESCRIPTION
## Summary
- verify the logo image has the proper alt text in the random and browse judoka pages

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6845fa1d8ef4832699751c9c328f1fce