### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/scripts/playwrightServer.js
+++ b/scripts/playwrightServer.js
@@ -36,7 +36,7 @@ function getContentType(filePath) {
 
 const server = http.createServer((req, res) => {
   let filePath = path.resolve(rootDir, req.url === "/" ? "index.html" : req.url);
-  if (!filePath.startsWith(rootDir)) {
+  if (path.relative(rootDir, filePath).startsWith("..")) {
     res.statusCode = 403;
     res.end("Forbidden");
     return;

--- a/scripts/playwrightServer.js
+++ b/scripts/playwrightServer.js
@@ -35,7 +35,12 @@ function getContentType(filePath) {
 }
 
 const server = http.createServer((req, res) => {
-  let filePath = path.join(rootDir, req.url === "/" ? "index.html" : req.url);
+  let filePath = path.resolve(rootDir, req.url === "/" ? "index.html" : req.url);
+  if (!filePath.startsWith(rootDir)) {
+    res.statusCode = 403;
+    res.end("Forbidden");
+    return;
+  }
   if (existsSync(filePath) && statSync(filePath).isDirectory()) {
     filePath = path.join(filePath, "index.html");
   }


### PR DESCRIPTION
Potential fix for [https://github.com/CyanAutomation/judokon/security/code-scanning/9](https://github.com/CyanAutomation/judokon/security/code-scanning/9)

To fix the issue, we need to ensure that the constructed `filePath` is contained within the `rootDir`. This can be achieved by normalizing the path using `path.resolve` and verifying that the resulting path starts with `rootDir`. Additionally, we should handle cases where the user provides invalid or malicious input by returning a `403 Forbidden` response.

Steps to fix:
1. Use `path.resolve` to normalize the `filePath` and remove any `..` segments.
2. Check if the normalized `filePath` starts with `rootDir`. If not, return a `403 Forbidden` response.
3. Ensure the rest of the logic remains unchanged for valid paths.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
