### PR TITLE
Update screenshot spec for stable snapshots

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -17,7 +17,7 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("logo has alt text", async ({ page }) => {
-    const logo = page.getByRole('img', { name: 'JU-DO-KON! Logo' });
+    const logo = page.getByRole("img", { name: "JU-DO-KON! Logo" });
     await expect(logo).toBeVisible();
   });
 

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -16,7 +16,7 @@ test.describe("View Judoka screen", () => {
   });
 
   test("logo has alt text", async ({ page }) => {
-    const logo = page.getByRole('img', { name: 'JU-DO-KON! Logo' });
+    const logo = page.getByRole("img", { name: "JU-DO-KON! Logo" });
     await expect(logo).toHaveAttribute("alt", "JU-DO-KON! Logo");
   });
 

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -13,8 +13,8 @@ const pages = [
 
 for (const url of pages) {
   test(`screenshot ${url}`, async ({ page }) => {
-    await page.goto(url);
+    await page.goto(url, { waitUntil: "networkidle" });
     const name = url === "/" ? "homepage.png" : url.split("/").pop().replace(".html", ".png");
-    await expect(page).toHaveScreenshot(name);
+    await expect(page).toHaveScreenshot(name, { fullPage: true });
   });
 }


### PR DESCRIPTION
## Summary
- wait for network idle before capturing screenshots in Playwright
- capture full page screenshots
- run Prettier on Playwright specs for consistency

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6845ff05ffc48326a95f2f33f70f30d2