### PR TITLE
Fix Browse Judoka locator

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -6,7 +6,7 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("essential elements visible", async ({ page }) => {
-    await expect(page.getByLabel("Filter judoka by country")).toBeVisible();
+    await expect(page.getByRole("combobox", { name: /filter judoka by country/i })).toBeVisible();
     await expect(page.getByRole("navigation")).toBeVisible();
     await expect(page.getByRole("link", { name: /battle!/i })).toBeVisible();
   });
@@ -29,7 +29,7 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("country filter updates carousel", async ({ page }) => {
-    const dropdown = page.getByLabel("Filter judoka by country");
+    const dropdown = page.getByRole("combobox", { name: /filter judoka by country/i });
 
     // wait for cards to load
     await page.waitForSelector("#carousel-container .judoka-card");

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -29,7 +29,7 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("country filter updates carousel", async ({ page }) => {
-    const dropdown = page.getByRole("combobox", { name: /filter judoka by country/i });
+    const dropdown = page.getByRole("combobox", { name: FILTER_BY_COUNTRY_LOCATOR });
 
     // wait for cards to load
     await page.waitForSelector("#carousel-container .judoka-card");

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -6,7 +6,7 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("essential elements visible", async ({ page }) => {
-    await expect(page.getByRole("combobox", { name: /filter judoka by country/i })).toBeVisible();
+    await expect(page.getByRole("combobox", { name: FILTER_BY_COUNTRY_LOCATOR })).toBeVisible();
     await expect(page.getByRole("navigation")).toBeVisible();
     await expect(page.getByRole("link", { name: /battle!/i })).toBeVisible();
   });


### PR DESCRIPTION
## Summary
- update Playwright test to use a robust `getByRole` combobox locator

## Testing
- `npx prettier . --check` *(fails: code style issues in unrelated files)*
- `npx eslint .` *(fails to resolve `@eslint/js`)*
- `npx vitest run` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846086342e08326b5abda12deceee41