### PR TITLE
Refactor bottom navbar styles

### DIFF
--- a/src/styles/bottom-navbar.css
+++ b/src/styles/bottom-navbar.css
@@ -1,0 +1,34 @@
+.bottom-navbar {
+  min-height: max(7vh, 12px);
+  display: inline-flex;
+  min-width: 100vw;
+  background-color: #22223b;
+  text-align: center;
+  align-items: center;
+  justify-content: space-evenly;
+  box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.2);
+  font-size: max(1.3rem, 1.8vw);
+  /* border: solid 5px red; */
+}
+
+.bottom-navbar ul {
+  display: inline-flex;
+  gap: 2rem;
+  list-style-type: none;
+  text-transform: uppercase;
+}
+
+.bottom-navbar a,
+.top-navbar a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.bottom-navbar a {
+  position: relative;
+  overflow: hidden;
+}
+
+.bottom-navbar a:hover {
+  text-decoration: underline;
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,3 +1,4 @@
+@import "./bottom-navbar.css";
 /* Reset default browser styles for all elements */
 *,
 *::before,
@@ -570,41 +571,6 @@ button:focus {
 
 .top-navbar ul {
   list-style: none;
-}
-
-.bottom-navbar {
-  min-height: max(7vh, 12px);
-  display: inline-flex;
-  min-width: 100vw;
-  background-color: #22223b;
-  text-align: center;
-  align-items: center;
-  justify-content: space-evenly;
-  box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.2);
-  font-size: max(1.3rem, 1.8vw);
-  /* border: solid 5px red; */
-}
-
-.bottom-navbar ul {
-  display: inline-flex;
-  gap: 2rem;
-  list-style-type: none;
-  /* text-transform: uppercase; */
-}
-
-.bottom-navbar a,
-.top-navbar a {
-  color: #fff;
-  text-decoration: none;
-}
-
-.bottom-navbar a {
-  position: relative;
-  overflow: hidden;
-}
-
-.bottom-navbar a:hover {
-  text-decoration: underline;
 }
 
 .country-flag-slider {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,3 +1,4 @@
+@import "./bottom-navbar.css";
 /* General body styles */
 body {
   font-family: "Open Sans", sans-serif;
@@ -103,40 +104,6 @@ body {
   align-items: center;
   padding: 1rem;
   backdrop-filter: blur(10px);
-}
-.bottom-navbar {
-  min-height: max(7vh, 12px);
-  display: inline-flex;
-  min-width: 100vw;
-  background-color: #22223b;
-  text-align: center;
-  align-items: center;
-  justify-content: space-evenly;
-  box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.2);
-  font-size: max(1.3rem, 1.8vw);
-  /* border: solid 5px red; */
-}
-
-.bottom-navbar ul {
-  display: inline-flex;
-  gap: 2rem;
-  list-style-type: none;
-  text-transform: uppercase;
-}
-
-.bottom-navbar a,
-.top-navbar a {
-  color: #fff;
-  text-decoration: none;
-}
-
-.bottom-navbar a {
-  position: relative;
-  overflow: hidden;
-}
-
-.bottom-navbar a:hover {
-  text-decoration: underline;
 }
 .country-flag-slider {
   background: rgba(0, 32, 82, 0.5);


### PR DESCRIPTION
## Summary
- centralize bottom navbar styles in `bottom-navbar.css`
- import the shared styles in `layout.css` and `components.css`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6846092553e483268c9609f563c6fe80