### PR TITLE
Update quote toggle initialization

### DIFF
--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -19,6 +19,7 @@
  * @throws {Error} If the fetch request fails or the response is not successful.
  */
 import { DATA_DIR } from "./constants.js";
+import { setupLanguageToggle } from "./pseudoJapanese.js";
 
 async function fetchFables() {
   const response = await fetch(`${DATA_DIR}aesopsFables.json`);
@@ -172,9 +173,11 @@ async function fetchQuote() {
     const quotes = await response.json();
     const randomQuote = quotes[Math.floor(Math.random() * quotes.length)];
     displayQuote(randomQuote);
+    await setupLanguageToggle(quoteElement, randomQuote);
   } catch (error) {
     console.error("Error fetching quote:", error);
     displayFallbackMessage();
+    await setupLanguageToggle(quoteElement, "\u65e5\u672c\u8a9e\u98a8\u30c6\u30ad\u30b9\u30c8");
   }
 }
 


### PR DESCRIPTION
## Summary
- trigger language toggle setup after displaying quotes
- ensure pseudo-Japanese fallback text when fetch fails

## Testing
- `npx prettier src/helpers/quoteBuilder.js --check`
- `npx eslint src/helpers/quoteBuilder.js`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68467f31bd548326b658a4e7e2ed9e04