### PR TITLE
Add mincho font and toggle styling

### DIFF
--- a/src/helpers/pseudoJapanese.js
+++ b/src/helpers/pseudoJapanese.js
@@ -83,8 +83,8 @@ export async function setupLanguageToggle(element, originalText) {
     element.style.opacity = "0";
     setTimeout(() => {
       element.textContent = showingPseudo ? originalText : pseudoText;
-      element.style.opacity = "1";
       element.classList.toggle("jp-font", !showingPseudo);
+      element.style.opacity = "1";
       showingPseudo = !showingPseudo;
     }, 200);
   });

--- a/src/helpers/pseudoJapanese.js
+++ b/src/helpers/pseudoJapanese.js
@@ -61,7 +61,8 @@ export async function convertToPseudoJapanese(text) {
  * @pseudocode
  * 1. Generate pseudo-Japanese text from `originalText` using `convertToPseudoJapanese`.
  * 2. Find the existing button with id `language-toggle`.
- * 3. Attach a click handler that fades out the element, swaps the text, then fades back in.
+ * 3. Attach a click handler that fades out the element, swaps the text,
+ *    toggles a Japanese font class, then fades back in.
  * 4. Return the button so callers can further manipulate it if needed.
  *
  * @param {HTMLElement} element - The element whose text will be toggled.
@@ -83,6 +84,7 @@ export async function setupLanguageToggle(element, originalText) {
     setTimeout(() => {
       element.textContent = showingPseudo ? originalText : pseudoText;
       element.style.opacity = "1";
+      element.classList.toggle("jp-font", !showingPseudo);
       showingPseudo = !showingPseudo;
     }, 200);
   });

--- a/src/pages/quoteKG.html
+++ b/src/pages/quoteKG.html
@@ -8,6 +8,12 @@
     <link rel="stylesheet" href="../styles/layout.css" />
     <link rel="stylesheet" href="../styles/components.css" />
     <link rel="stylesheet" href="../styles/utilities.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP&display=swap"
+      rel="stylesheet"
+    />
     <!-- Page‑specific styling -->
     <link rel="stylesheet" href="../styles/quote.css" />
   </head>
@@ -59,8 +65,8 @@
             aria-live="polite"
           ></div>
           <button id="language-toggle" class="language-toggle hidden">
-            <span class="jp-flag"></span> 日本語風 / English
-            <span class="uk-flag"></span>
+            <span class="jp-flag flag-icon"></span> 日本語風 / English
+            <span class="uk-flag flag-icon"></span>
           </button>
         </div>
       </section>

--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -152,10 +152,31 @@
   background-color: var(--accent-red);
   color: var(--text-color);
   border: none;
-  border-radius: var(--border-radius-small);
+  border-radius: var(--border-radius-medium);
   padding: 0.5rem 0.75rem;
   margin-top: 0.5rem;
   cursor: pointer;
+  transition:
+    background-color 200ms,
+    color 200ms;
+}
+
+.language-toggle:hover,
+.language-toggle:focus {
+  background-color: var(--accent-red-dark);
+}
+
+.flag-icon {
+  display: inline-block;
+  font-size: 1.25rem;
+  line-height: 1;
+  border-radius: var(--border-radius-small);
+  border: 1px solid #fff;
+  padding: 0 0.1rem;
+}
+
+.jp-font {
+  font-family: "Noto Serif JP", serif;
 }
 
 .language-toggle .jp-flag::before {


### PR DESCRIPTION
## Summary
- style the language toggle button with accent colors, a 200ms transition and matching flag icons
- load a Mincho-style font in `quoteKG.html`
- apply the font when pseudo-Japanese text is displayed

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68468646276c8326ba7b8a114924152e