### PR TITLE
Update Quick Start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 
 ## Quick Start
 
-1. Clone the repository:
+1. Make sure you have **Node 18+** and `npm` (or another package manager) installed.
+2. Clone the repository, install dependencies, and launch a lightweight local dev server:
    ```bash
    git clone https://github.com/cyanautomation/judokon.git
    cd judokon
-   npx serve
+   npm install
+   npx serve  # lightweight local dev server
    # Then visit: http://localhost:5000
    ```
 


### PR DESCRIPTION
## Summary
- clarify Node 18+ and package manager requirement
- show npm install before starting the lightweight server

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6846abf9ffd88326a1ce8613dd09e5f7