### PR TITLE
Fix language toggle text

### DIFF
--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -172,8 +172,8 @@ async function fetchQuote() {
 
     const quotes = await response.json();
     const randomQuote = quotes[Math.floor(Math.random() * quotes.length)];
-    displayQuote(randomQuote);
-    await setupLanguageToggle(quoteElement, randomQuote);
+    displayQuote(randomQuote.story);
+    await setupLanguageToggle(quoteElement, randomQuote.story);
   } catch (error) {
     console.error("Error fetching quote:", error);
     displayFallbackMessage();

--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -172,8 +172,9 @@ async function fetchQuote() {
 
     const quotes = await response.json();
     const randomQuote = quotes[Math.floor(Math.random() * quotes.length)];
-    displayQuote(randomQuote.story);
-    await setupLanguageToggle(quoteElement, randomQuote.story);
+    const { story } = randomQuote;
+    displayQuote(story);
+    await setupLanguageToggle(quoteElement, story);
   } catch (error) {
     console.error("Error fetching quote:", error);
     displayFallbackMessage();


### PR DESCRIPTION
## Summary
- ensure fetchQuote uses the fetched story for language toggling

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6846be23b96c8326a415ede99865d338