### PR TITLE
Handle whitespace in pseudoJapanese

### DIFF
--- a/src/helpers/pseudoJapanese.js
+++ b/src/helpers/pseudoJapanese.js
@@ -19,10 +19,10 @@ async function loadConverter() {
  * @pseudocode
  * 1. Load the converter JSON once using `loadConverter`.
  *    - If loading fails, return `STATIC_FALLBACK`.
- * 2. Clean the `text` by removing characters other than letters, numbers, and spaces.
+ * 2. Clean the `text` by removing characters other than letters, numbers, and whitespace.
  * 3. Build a list of fallback characters from the mapping values.
  * 4. For each character in the cleaned text:
- *    - Preserve spaces as-is.
+ *    - Preserve whitespace characters as-is.
  *    - Map letters (case-insensitive) using the converter table.
  *    - Replace unmapped characters with a random fallback character.
  * 5. Join and return the converted string.
@@ -43,7 +43,7 @@ export async function convertToPseudoJapanese(text) {
   return cleaned
     .split("")
     .map((char) => {
-      if (char === " ") {
+      if (/\s/.test(char)) {
         return char;
       }
       const letters = mapping[char.toLowerCase()];

--- a/tests/helpers/pseudo-japanese.test.js
+++ b/tests/helpers/pseudo-japanese.test.js
@@ -39,6 +39,16 @@ describe("convertToPseudoJapanese", () => {
     expect(result).toBe("アアバアカア");
   });
 
+  it("preserves newline characters", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => mapping });
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const { convertToPseudoJapanese } = await import("../../src/helpers/pseudoJapanese.js");
+
+    const result = await convertToPseudoJapanese("one\ntwo");
+    expect(result).toBe("アアエ\nアアア");
+  });
+
   it("returns static fallback when the mapping fails to load", async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error("fail"));
 


### PR DESCRIPTION
## Summary
- handle all whitespace when mapping pseudo-Japanese characters
- document new behavior in pseudocode block
- test newline preservation

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6846d4f18c408326926e90e920fc42bb