### PR TITLE
Update grid layout for home screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,11 +87,10 @@
             <h2>Update Judoka</h2>
           </div>
         </a>
-
-        <div class="homeHelperContainer">
-          <img src="./src/assets/actionPortraits/actionPortrait-40.png" />
-        </div>
       </main>
+      <div class="homeHelperContainer">
+        <img src="./src/assets/actionPortraits/actionPortrait-40.png" />
+      </div>
       <footer>
         <nav class="bottom-navbar">
           <ul></ul>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -86,11 +86,17 @@ body {
 
 .game-mode-grid {
   display: grid;
-  grid-template-columns: auto minmax(300px, 25%);
+  grid-template-columns: repeat(2, 1fr);
   gap: 1rem 0;
   padding: 0 10vw;
   flex: 1 1 auto;
   min-height: 85%;
+}
+
+@media (max-width: 768px) {
+  .game-mode-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .game-tile {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -60,20 +60,26 @@ body {
 }
 .game-mode-grid {
   display: grid;
-  grid-template-columns: auto minmax(300px, 25%);
+  grid-template-columns: repeat(2, 1fr);
   gap: 1rem 0;
   padding: 0 10vw;
   flex: 1 1 auto;
   min-height: 85%;
 }
+
+@media (max-width: 768px) {
+  .game-mode-grid {
+    grid-template-columns: 1fr;
+  }
+}
 .homeHelperContainer {
   background: var(--secondary-bg);
   border: 2px solid var(--secondary-bg);
   border-radius: 4px 12px 12px 4px;
-
   text-align: center;
-  grid-row: 1/5;
-  grid-column: 2;
+  position: absolute;
+  right: 0;
+  bottom: 0;
   z-index: 5;
 }
 


### PR DESCRIPTION
## Summary
- adjust `.game-mode-grid` to be 2 columns on large screens and 1 on narrow
- reposition the helper character below the grid
- add responsive rules to layout and components CSS

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6846f703117c8326868da7e7b3b31137