### PR TITLE
Add reusable random card generator

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1,6 +1,6 @@
 import { fetchDataWithErrorHandling, validateData } from "./helpers/dataUtils.js";
 import { buildCardCarousel } from "./helpers/carouselBuilder.js";
-import { displayJudokaCard, getRandomJudoka } from "./helpers/cardUtils.js";
+import { generateRandomCard } from "./helpers/randomCard.js";
 import { DATA_DIR } from "./helpers/constants.js";
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -72,18 +72,8 @@ document.addEventListener("DOMContentLoaded", () => {
     showRandom.classList.add("hidden");
     gameArea.innerHTML = "";
 
-    try {
-      const judokaData = await fetchDataWithErrorHandling(`${DATA_DIR}judoka.json`);
-      const gokyoData = await fetchDataWithErrorHandling(`${DATA_DIR}gokyo.json`);
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-      validateData(judokaData, "judoka");
-      validateData(gokyoData, "gokyo");
-
-      const selectedJudoka = getRandomJudoka(judokaData);
-      displayJudokaCard(selectedJudoka, gokyoData, gameArea, showRandom);
-    } catch (error) {
-      console.error("Error loading card:", error);
-      gameArea.innerHTML = `<p>⚠️ Failed to load card. ${error.message}. Please try again later.</p>`;
-    }
+    await generateRandomCard(null, null, gameArea, prefersReducedMotion);
   });
 });

--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -1,0 +1,104 @@
+import { fetchDataWithErrorHandling } from "./dataUtils.js";
+import { createGokyoLookup } from "./utils.js";
+import { generateJudokaCardHTML } from "./cardBuilder.js";
+import { getRandomJudoka } from "./cardUtils.js";
+import { DATA_DIR } from "./constants.js";
+
+/**
+ * Generates a random judoka card and appends it to a container element.
+ *
+ * @pseudocode
+ * 1. Ensure judoka data is available:
+ *    - If `activeCards` is undefined, fetch `judoka.json` and filter out hidden
+ *      or incomplete entries.
+ * 2. Ensure gokyo data is available:
+ *    - Use the provided `gokyoData` or fetch `gokyo.json`.
+ *    - Create a lookup object with `createGokyoLookup`.
+ * 3. Select a random judoka using `getRandomJudoka`.
+ * 4. Generate the card HTML with `generateJudokaCardHTML` and append it to
+ *    `containerEl`.
+ *    - Clear existing content before appending.
+ *    - Apply an animation when `prefersReducedMotion` is false.
+ * 5. On any error, log the issue and display a fallback card (judoka id `0`).
+ *
+ * @param {Judoka[]} [activeCards] - Preloaded judoka data.
+ * @param {GokyoEntry[]} [gokyoData] - Preloaded gokyo data.
+ * @param {HTMLElement} containerEl - Element to contain the card.
+ * @param {boolean} [prefersReducedMotion=false] - Motion preference flag.
+ * @returns {Promise<void>} Resolves when the card is appended.
+ */
+export async function generateRandomCard(
+  activeCards,
+  gokyoData,
+  containerEl,
+  prefersReducedMotion = false
+) {
+  try {
+    const judokaData = activeCards || (await fetchDataWithErrorHandling(`${DATA_DIR}judoka.json`));
+
+    const validJudoka = Array.isArray(judokaData)
+      ? judokaData.filter((j) => {
+          const hasRequired =
+            j.firstname &&
+            j.surname &&
+            j.countryCode &&
+            j.stats &&
+            j.weightClass &&
+            j.signatureMoveId !== undefined &&
+            j.rarity;
+          return !j.isHidden && hasRequired;
+        })
+      : [];
+
+    if (validJudoka.length === 0) {
+      throw new Error("No valid judoka entries found");
+    }
+
+    const gokyo = gokyoData || (await fetchDataWithErrorHandling(`${DATA_DIR}gokyo.json`));
+    const gokyoLookup = createGokyoLookup(gokyo);
+
+    const selectedJudoka = getRandomJudoka(validJudoka);
+    const judokaCard = await generateJudokaCardHTML(selectedJudoka, gokyoLookup);
+
+    containerEl.innerHTML = "";
+    containerEl.appendChild(judokaCard);
+
+    if (!prefersReducedMotion) {
+      requestAnimationFrame(() => {
+        judokaCard.classList.add("animate-card");
+      });
+    }
+  } catch (error) {
+    console.error("Error generating random card:", error);
+
+    const fallbackJudoka = {
+      id: 0,
+      firstname: "Unknown",
+      surname: "Judoka",
+      country: "Unknown",
+      countryCode: "N/A",
+      stats: {
+        power: 0,
+        speed: 0,
+        technique: 0,
+        kumikata: 0,
+        newaza: 0
+      },
+      weightClass: "N/A",
+      signatureMoveId: 0,
+      rarity: "common"
+    };
+
+    try {
+      const gokyo = gokyoData || (await fetchDataWithErrorHandling(`${DATA_DIR}gokyo.json`));
+      const gokyoLookup = createGokyoLookup(gokyo);
+      const fallbackCard = await generateJudokaCardHTML(fallbackJudoka, gokyoLookup);
+
+      containerEl.innerHTML = "";
+      containerEl.appendChild(fallbackCard);
+    } catch (fallbackError) {
+      console.error("Error displaying fallback card:", fallbackError);
+      containerEl.innerHTML = "<p>⚠️ Failed to display card. Please try again later.</p>";
+    }
+  }
+}

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -59,14 +59,11 @@
       </footer>
       <script type="module">
         import { fetchDataWithErrorHandling } from "../helpers/dataUtils.js";
-        import { createGokyoLookup } from "../helpers/utils.js";
-        import { generateJudokaCardHTML } from "../helpers/cardBuilder.js";
+        import { generateRandomCard } from "../helpers/randomCard.js";
         import { DATA_DIR } from "../helpers/constants.js";
 
-        // Check for Reduced Motion preference
         const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-        // Preload and cache data
         let cachedJudokaData = null;
         let cachedGokyoData = null;
 
@@ -79,81 +76,19 @@
           }
         }
 
-        async function displayRandomJudoka() {
+        async function displayCard() {
           const cardContainer = document.getElementById("card-container");
-
-          try {
-            // Use cached data if available
-            const judokaData =
-              cachedJudokaData || (await fetchDataWithErrorHandling(`${DATA_DIR}judoka.json`));
-            const validJudoka = judokaData.filter((j) => {
-              const hasRequiredFields =
-                j.firstname &&
-                j.surname &&
-                j.countryCode &&
-                j.stats &&
-                j.weightClass &&
-                j.signatureMoveId !== undefined &&
-                j.rarity;
-              return !j.isHidden && hasRequiredFields;
-            });
-
-            if (validJudoka.length === 0) {
-              throw new Error("No valid judoka entries found");
-            }
-
-            const randomJudoka = validJudoka[Math.floor(Math.random() * validJudoka.length)];
-
-            // Use cached gokyo data if available
-            const gokyoData =
-              cachedGokyoData || (await fetchDataWithErrorHandling(`${DATA_DIR}gokyo.json`));
-            const gokyoLookup = createGokyoLookup(gokyoData);
-
-            // Generate the judoka card
-            const judokaCard = await generateJudokaCardHTML(randomJudoka, gokyoLookup);
-
-            // Display the card
-            cardContainer.innerHTML = ""; // Clear any existing content
-            cardContainer.appendChild(judokaCard);
-
-            // Skip animations if Reduced Motion is enabled
-            if (!prefersReducedMotion) {
-              requestAnimationFrame(() => {
-                judokaCard.classList.add("animate-card");
-              });
-            }
-          } catch (error) {
-            console.error("Error displaying random judoka:", error);
-
-            // Display fallback card (judoka id=0)
-            const fallbackJudoka = {
-              id: 0,
-              firstname: "Unknown",
-              surname: "Judoka",
-              countryCode: "N/A",
-              stats: { wins: 0, losses: 0 },
-              weightClass: "N/A",
-              signatureMoveId: null,
-              rarity: "common"
-            };
-
-            const gokyoData =
-              cachedGokyoData || (await fetchDataWithErrorHandling(`${DATA_DIR}gokyo.json`));
-            const gokyoLookup = createGokyoLookup(gokyoData);
-            const fallbackCard = await generateJudokaCardHTML(fallbackJudoka, gokyoLookup);
-
-            cardContainer.innerHTML = ""; // Clear any existing content
-            cardContainer.appendChild(fallbackCard);
-          }
+          await generateRandomCard(
+            cachedJudokaData,
+            cachedGokyoData,
+            cardContainer,
+            prefersReducedMotion
+          );
         }
 
-        // Preload data on page load
-        preloadData();
+        preloadData().then(displayCard);
 
-        // Call the function to display a random judoka when the page loads
-        displayRandomJudoka();
-
-        document.getElementById("draw-card-btn").addEventListener("click", displayRandomJudoka);
+        document.getElementById("draw-card-btn").addEventListener("click", displayCard);
       </script>
       <noscript>
         <p class="noscript-warning">

--- a/tests/helpers/random-card.test.js
+++ b/tests/helpers/random-card.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+let getRandomJudokaMock;
+let generateJudokaCardHTMLMock;
+
+vi.mock("../../src/helpers/cardUtils.js", () => ({
+  getRandomJudoka: (...args) => getRandomJudokaMock(...args)
+}));
+
+vi.mock("../../src/helpers/cardBuilder.js", () => ({
+  generateJudokaCardHTML: (...args) => generateJudokaCardHTMLMock(...args)
+}));
+
+vi.mock("../../src/helpers/utils.js", () => ({
+  createGokyoLookup: () => ({})
+}));
+
+vi.mock("../../src/helpers/dataUtils.js", () => ({
+  fetchDataWithErrorHandling: vi.fn()
+}));
+
+const judokaData = [
+  {
+    id: 1,
+    firstname: "A",
+    surname: "B",
+    country: "X",
+    countryCode: "x",
+    stats: { power: 1, speed: 1, technique: 1, kumikata: 1, newaza: 1 },
+    weightClass: "-60",
+    signatureMoveId: 1,
+    rarity: "common"
+  },
+  {
+    id: 2,
+    firstname: "C",
+    surname: "D",
+    country: "Y",
+    countryCode: "y",
+    stats: { power: 2, speed: 2, technique: 2, kumikata: 2, newaza: 2 },
+    weightClass: "+60",
+    signatureMoveId: 2,
+    rarity: "rare"
+  }
+];
+
+const gokyoData = [
+  { id: 0, name: "Jigoku-guruma" },
+  { id: 1, name: "Throw1" },
+  { id: 2, name: "Throw2" }
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("generateRandomCard", () => {
+  it("selects a random judoka and updates the DOM", async () => {
+    const container = document.createElement("div");
+    const generatedEl = document.createElement("span");
+    generatedEl.textContent = "card";
+
+    getRandomJudokaMock = vi.fn(() => judokaData[1]);
+    generateJudokaCardHTMLMock = vi.fn(async () => generatedEl);
+
+    const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
+
+    await generateRandomCard(judokaData, gokyoData, container, true);
+
+    expect(getRandomJudokaMock).toHaveBeenCalledWith(expect.any(Array));
+    expect(generateJudokaCardHTMLMock).toHaveBeenCalled();
+    expect(container.firstChild).toBe(generatedEl);
+  });
+
+  it("falls back to id 0 when selection fails", async () => {
+    const container = document.createElement("div");
+    const fallbackEl = document.createElement("div");
+
+    getRandomJudokaMock = vi.fn(() => {
+      throw new Error("fail");
+    });
+    generateJudokaCardHTMLMock = vi.fn(async () => fallbackEl);
+
+    const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
+
+    await generateRandomCard([], gokyoData, container, true);
+
+    expect(generateJudokaCardHTMLMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 0 }),
+      expect.anything()
+    );
+    expect(container.firstChild).toBe(fallbackEl);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `generateRandomCard` helper
- update randomJudoka page to use helper
- use helper in game logic
- add unit tests for random card generation

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6846f71d6f60832693374ba078a4f9ab