### PR TITLE
Fix mocked Math.random cleanup

### DIFF
--- a/tests/helpers/pseudo-japanese.test.js
+++ b/tests/helpers/pseudo-japanese.test.js
@@ -5,9 +5,13 @@ const mapping = {
   letters: { a: ["ア"], b: ["バ"], c: ["カ"], d: ["ダ"], e: ["エ"] }
 };
 
+const originalFetch = global.fetch;
+
 describe("convertToPseudoJapanese", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
+    global.fetch = originalFetch;
     vi.resetModules();
   });
 


### PR DESCRIPTION
## Summary
- reset Math.random and fetch mocks in pseudo-japanese tests

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6846fc1afd908326876c0de15461a66c