### PR TITLE
Adjust card width responsiveness

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -189,7 +189,7 @@ button:focus {
 
 .judoka-card {
   position: relative;
-  width: 300px;
+  width: clamp(200px, 40vw, 300px);
   aspect-ratio: 2 / 3;
   border: max(13px, 1vh) solid var(--card-border-color);
   border: max(13px, 1dvh) solid var(--card-border-color);
@@ -502,6 +502,16 @@ button:focus {
   max-height: 90vh;
   max-height: 90dvh;
   /*   background-color: royalblue; */
+}
+
+.card-carousel .judoka-card {
+  width: 300px;
+}
+
+@media (max-width: 768px) {
+  #card-container .judoka-card {
+    width: 70vw;
+  }
 }
 
 .card-carousel::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- make `.judoka-card` width responsive
- keep carousel card width fixed
- expand random Judoka card on small screens

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6846fb84c60c83268f72982bbd988fc1