### PR TITLE
Add SVG fallback handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,9 +111,11 @@
       </script>
       <script type="module">
         import { populateNavbar } from "./src/helpers/bottomNavigation.js";
+        import { applySvgFallback } from "./src/helpers/svgFallback.js";
 
         document.addEventListener("DOMContentLoaded", () => {
           populateNavbar();
+          applySvgFallback();
         });
       </script>
     </div>

--- a/src/helpers/svgFallback.js
+++ b/src/helpers/svgFallback.js
@@ -1,0 +1,26 @@
+/**
+ * Applies a fallback image when SVGs fail to load.
+ *
+ * @pseudocode
+ * 1. Query all `<img>` elements with a `.svg` extension in the `src`.
+ * 2. Loop through each image:
+ *    a. Add an `error` event listener.
+ *    b. Replace `src` with `fallbackSrc` when an error occurs.
+ *    c. Add the `svg-fallback` CSS class.
+ *
+ * @param {string} fallbackSrc - Path to the fallback PNG image.
+ */
+export function applySvgFallback(fallbackSrc = "./src/assets/images/judokonLogoSmall.png") {
+  const svgImages = document.querySelectorAll('img[src$=".svg"]');
+
+  svgImages.forEach((img) => {
+    img.addEventListener(
+      "error",
+      () => {
+        img.src = fallbackSrc;
+        img.classList.add("svg-fallback");
+      },
+      { once: true }
+    );
+  });
+}

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -64,5 +64,12 @@
         "Your browser does not support modern JavaScript. Please update your browser to play JU-DO-KON!"
       );
     </script>
+    <script type="module">
+      import { applySvgFallback } from "../helpers/svgFallback.js";
+
+      document.addEventListener("DOMContentLoaded", () => {
+        applySvgFallback("../assets/images/judokonLogoSmall.png");
+      });
+    </script>
   </body>
 </html>

--- a/src/pages/carouselJudoka.html
+++ b/src/pages/carouselJudoka.html
@@ -143,6 +143,13 @@
           "Your browser does not support modern JavaScript. Please update your browser to play JU-DO-KON!"
         );
       </script>
+      <script type="module">
+        import { applySvgFallback } from "../helpers/svgFallback.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+          applySvgFallback("../assets/images/judokonLogoSmall.png");
+        });
+      </script>
     </div>
   </body>
 </html>

--- a/src/pages/createJudoka.html
+++ b/src/pages/createJudoka.html
@@ -64,5 +64,12 @@
         "Your browser does not support modern JavaScript. Please update your browser to play JU-DO-KON!"
       );
     </script>
+    <script type="module">
+      import { applySvgFallback } from "../helpers/svgFallback.js";
+
+      document.addEventListener("DOMContentLoaded", () => {
+        applySvgFallback("../assets/images/judokonLogoSmall.png");
+      });
+    </script>
   </body>
 </html>

--- a/src/pages/quoteKG.html
+++ b/src/pages/quoteKG.html
@@ -109,5 +109,12 @@
         setupLanguageToggle(quoteEl);
       });
     </script>
+    <script type="module">
+      import { applySvgFallback } from "../helpers/svgFallback.js";
+
+      document.addEventListener("DOMContentLoaded", () => {
+        applySvgFallback("../assets/images/judokonLogoSmall.png");
+      });
+    </script>
   </body>
 </html>

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -90,6 +90,13 @@
 
         document.getElementById("draw-card-btn").addEventListener("click", displayCard);
       </script>
+      <script type="module">
+        import { applySvgFallback } from "../helpers/svgFallback.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+          applySvgFallback("../assets/images/judokonLogoSmall.png");
+        });
+      </script>
       <noscript>
         <p class="noscript-warning">
           JU-DO-KON! requires JavaScript to run. Please enable JavaScript to play.

--- a/src/pages/updateJudoka.html
+++ b/src/pages/updateJudoka.html
@@ -64,5 +64,12 @@
         "Your browser does not support modern JavaScript. Please update your browser to play JU-DO-KON!"
       );
     </script>
+    <script type="module">
+      import { applySvgFallback } from "../helpers/svgFallback.js";
+
+      document.addEventListener("DOMContentLoaded", () => {
+        applySvgFallback("../assets/images/judokonLogoSmall.png");
+      });
+    </script>
   </body>
 </html>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -157,6 +157,11 @@ svg {
   aspect-ratio: 1 / 1;
   fill: #ffffff;
 }
+.svg-fallback {
+  width: 10vh;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+}
 /* Button styles */
 button {
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- add generic `applySvgFallback` helper
- style `.svg-fallback` images
- apply fallback logic across all HTML pages

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6846fecb0c588326a0f86d76cfb80266