### PR TITLE
Fix homepage selectors

### DIFF
--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -7,12 +7,12 @@ test.describe("Homepage", () => {
 
   test("navigation links visible", async ({ page }) => {
     await expect(page.getByRole("navigation")).toBeVisible();
-    await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /battle!/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /view all judoka/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
   });
 
   test("view judoka link navigates", async ({ page }) => {
-    await page.getByRole("link", { name: /view judoka/i }).click();
+    await page.getByRole("link", { name: /view all judoka/i }).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
   });
 });


### PR DESCRIPTION
## Summary
- update homepage test with current labels

## Testing
- `npx prettier . --write playwright/homepage.spec.js`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: ReferenceError FILTER_BY_COUNTRY_LOCATOR is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684758b797b4832687253eb437b5d925