### PR TITLE
Add locator constant for browse test

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+const FILTER_BY_COUNTRY_LOCATOR = /filter judoka by country/i;
 
 test.describe("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary
- add `FILTER_BY_COUNTRY_LOCATOR` constant to `browse-judoka.spec.js`

## Testing
- `npx prettier . --write` *(fails: command not found)*
- `npx eslint . --fix` *(fails: command not found)*
- `npx prettier . --check` *(fails: command not found)*
- `npx eslint .` *(fails: command not found)*
- `npx vitest run` *(fails: command not found)*
- `npx playwright test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684758a39b648326bd4966716e20c45b