### PR TITLE
Fix duplicate locator constant

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,6 +1,4 @@
 import { test, expect } from "@playwright/test";
-const FILTER_BY_COUNTRY_LOCATOR = /filter judoka by country/i;
-
 const FILTER_BY_COUNTRY_LOCATOR = "Filter judoka by country";
 
 test.describe("Browse Judoka screen", () => {


### PR DESCRIPTION
## Summary
- clean up unused locator constant in the Browse Judoka Playwright spec

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npx playwright test` *(fails: 403 Forbidden fetching playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68475bc1a7388326b9fb8a4725a4ce3b