### PR TITLE
Remove unused helper container

### DIFF
--- a/src/pages/carouselJudoka.html
+++ b/src/pages/carouselJudoka.html
@@ -38,7 +38,6 @@
       </header>
 
       <main class="kodokan-grid" role="main">
-        <div class="helper-container">TEST</div>
         <div class="filter-bar">
           <label for="country-filter">Filter by Country:</label>
           <select id="country-filter" aria-label="Filter judoka by country">


### PR DESCRIPTION
## Summary
- delete placeholder `<div class="helper-container">` from carousel page

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Timed out waiting for expect(locator).toBeVisible)*

------
https://chatgpt.com/codex/tasks/task_e_68475af99fac8326ad1686b009e7caca