### PR TITLE
Update country filter locator

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 
-const FILTER_BY_COUNTRY_LOCATOR = "Filter judoka by country";
+// locator for the country dropdown label in carouselJudoka.html
+const FILTER_BY_COUNTRY_LOCATOR = /Filter by Country:/i;
 
 test.describe("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary
- update locator text in browse-judoka Playwright tests

## Testing
- `npx prettier . --write` *(fails: `npx` not found)*
- `npx eslint .` *(fails: `npx` not found)*
- `npx prettier . --check` *(fails: `npx` not found)*
- `npx vitest run` *(fails: `npx` not found)*
- `npx playwright test` *(fails: `npx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475ae841548326817ca3e851cfd02f