### PR TITLE
Fix View Judoka aria label

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
             <h2>Battle Mode: Team Battle</h2>
           </div>
         </a>
-        <a href="./src/pages/carouselJudoka.html" class="game-tile" aria-label="View all judoka">
+        <a href="./src/pages/carouselJudoka.html" class="game-tile" aria-label="View Judoka">
           <div class="svgTile">
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,8 +1,6 @@
 import { test, expect } from "@playwright/test";
 const FILTER_BY_COUNTRY_LOCATOR = /filter judoka by country/i;
 
-const FILTER_BY_COUNTRY_LOCATOR = "Filter judoka by country";
-
 test.describe("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/carouselJudoka.html");

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -7,12 +7,12 @@ test.describe("Homepage", () => {
 
   test("navigation links visible", async ({ page }) => {
     await expect(page.getByRole("navigation")).toBeVisible();
-    await expect(page.getByRole("link", { name: /view all judoka/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
   });
 
   test("view judoka link navigates", async ({ page }) => {
-    await page.getByRole("link", { name: /view all judoka/i }).click();
-    await expect(page).toHaveURL(/randomJudoka\.html/);
+    await page.getByRole("link", { name: /view judoka/i }).click();
+    await expect(page).toHaveURL(/carouselJudoka\.html/);
   });
 });


### PR DESCRIPTION
## Summary
- change aria-label for View Judoka tile
- remove duplicate constant in Browse Judoka test
- update View Judoka Playwright assertions

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: essential elements not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475bfd10f48326a5a8258e0b80f4ad