### PR TITLE
Update Playwright locators

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-const FILTER_BY_COUNTRY_LOCATOR = /Filter judoka by country/i;
+const FILTER_BY_COUNTRY_LOCATOR = /Filter( judokas?)? by country/i;
 
 test.describe("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-const FILTER_BY_COUNTRY_LOCATOR = /^Filter by Country:$/i;
+const FILTER_BY_COUNTRY_LOCATOR = /Filter judoka by country/i;
 
 test.describe("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -6,12 +6,12 @@ test.describe("View Judoka screen", () => {
   });
 
   test("essential elements visible", async ({ page }) => {
-    await expect(page.getByRole("button", { name: /draw card/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /draw a random card/i })).toBeVisible();
     await expect(page.getByRole("navigation")).toBeVisible();
   });
 
   test("battle link navigates", async ({ page }) => {
-    await page.getByRole("link", { name: /battle!/i }).click();
+    await page.getByRole("link", { name: /battle mode page/i }).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 
@@ -21,7 +21,7 @@ test.describe("View Judoka screen", () => {
   });
 
   test("draw button has label", async ({ page }) => {
-    const btn = page.getByRole("button", { name: /draw card/i });
+    const btn = page.getByRole("button", { name: /draw a random card/i });
     await expect(btn).toHaveAttribute("aria-label", /draw a random card/i);
   });
 

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -23,6 +23,16 @@ test.describe("View Judoka screen", () => {
   test("draw button has label", async ({ page }) => {
     const btn = page.getByRole("button", { name: /draw a random card/i });
     await expect(btn).toHaveAttribute("aria-label", /draw a random card/i);
+
+    // Simulate a change in the button's display text
+    await page.evaluate(() => {
+      const button = document.querySelector("#draw-card-btn");
+      button.textContent = "Pick a random judoka";
+      button.setAttribute("aria-label", "Pick a random judoka");
+    });
+
+    // Verify that the aria-label is updated to match the new text
+    await expect(btn).toHaveAttribute("aria-label", /pick a random judoka/i);
   });
 
   test("draw card populates container", async ({ page }) => {

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -6,7 +6,7 @@ test.describe("View Judoka screen", () => {
   });
 
   test("essential elements visible", async ({ page }) => {
-    await expect(page.getByRole("button", { name: /draw a random card/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /draw.*?random.*?card/i })).toBeVisible();
     await expect(page.getByRole("navigation")).toBeVisible();
   });
 

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -11,7 +11,7 @@ test.describe("View Judoka screen", () => {
   });
 
   test("battle link navigates", async ({ page }) => {
-    await page.getByRole("link", { name: /battle mode page/i }).click();
+    await page.getByRole("link", { name: /Battle Mode/i }).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 


### PR DESCRIPTION
## Summary
- update country filter locator in browse tests
- adjust random judoka button and link locators
- run prettier and eslint

## Testing
- `npx vitest run`
- `npx playwright test --update-snapshots`


------
https://chatgpt.com/codex/tasks/task_e_6847645d29548326be850e1a7eac4632