### PR TITLE
Fix Playwright locator in random judoka test

### DIFF
--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -24,7 +24,7 @@ test.describe.skip("View Judoka screen", () => {
 
   test("draw button has label", async ({ page }) => {
     await page.waitForSelector("#draw-card-btn");
-    const btn = page.getByRole("button", { name: /draw card/i });
+    const btn = page.locator("#draw-card-btn");
     await expect(btn).toHaveAttribute("aria-label", /draw a random card/i);
 
     // Simulate a change in the button's display text


### PR DESCRIPTION
## Summary
- use stable selector in random-judoka.spec

## Testing
- `npx prettier playwright/random-judoka.spec.js --check`
- `npx eslint playwright/random-judoka.spec.js` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden to fetch vitest)*
- `npx playwright test` *(fails: 403 Forbidden to fetch playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6847e9875e588326a5a7be59cf63166c