### PR TITLE
Enable screenshot suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Run optional Playwright-based screenshot tests with:
 npm run test:screenshot
 ```
 
+Set `SKIP_SCREENSHOTS=true` to skip the screenshot suite if you only want to run
+the other Playwright tests:
+
+```bash
+SKIP_SCREENSHOTS=true npm run test:screenshot
+```
+
 ## Project Structure
 
 The repository follows a simple layout. GitHub Pages requires `index.html` to live at the project root.

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 // Allow skipping screenshots via the SKIP_SCREENSHOTS environment variable
-const runScreenshots = !process.env.SKIP_SCREENSHOTS;
+const runScreenshots = process.env.SKIP_SCREENSHOTS !== 'true';
 
 test.describe(runScreenshots ? "Screenshot suite" : "Screenshot suite (skipped)", () => {
   test.skip(!runScreenshots);

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -1,6 +1,10 @@
 import { test, expect } from "@playwright/test";
 
-test.describe.skip("Screenshot suite", () => {
+// Allow skipping screenshots via the SKIP_SCREENSHOTS environment variable
+const runScreenshots = !process.env.SKIP_SCREENSHOTS;
+
+test.describe(runScreenshots ? "Screenshot suite" : "Screenshot suite (skipped)", () => {
+  test.skip(!runScreenshots);
   // List of pages to capture screenshots for
   const pages = [
     "/",


### PR DESCRIPTION
## Summary
- run screenshot tests by default unless `SKIP_SCREENSHOTS` env var is set
- document how to skip screenshot tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: A snapshot doesn't exist for screenshot tests)*

------
https://chatgpt.com/codex/tasks/task_e_6847ec719354832694ddbb0af8372191