### PR TITLE
Mock judoka data in Playwright tests

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -4,6 +4,15 @@ const FILTER_BY_COUNTRY_LOCATOR = /Filter( judokas?)? by country/i;
 
 test.describe("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
+    await page.route("**/src/data/judoka.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/judoka.json" })
+    );
+    await page.route("**/src/data/gokyo.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/gokyo.json" })
+    );
+    await page.route("**/src/data/countryCodeMapping.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/countryCodeMapping.json" })
+    );
     await page.goto("/src/pages/carouselJudoka.html");
   });
 
@@ -38,13 +47,13 @@ test.describe("Browse Judoka screen", () => {
 
     const allCards = page.locator("#carousel-container .judoka-card");
     const initialCount = await allCards.count();
+    expect(initialCount).toBe(3);
 
     await dropdown.selectOption("Japan");
 
     const filteredCards = page.locator("#carousel-container .judoka-card");
     const filteredCount = await filteredCards.count();
-    expect(filteredCount).toBeLessThan(initialCount);
-    expect(filteredCount).toBeGreaterThan(0);
+    expect(filteredCount).toBe(1);
 
     for (let i = 0; i < filteredCount; i++) {
       const flag = filteredCards.nth(i).locator(".card-top-bar img");
@@ -54,5 +63,10 @@ test.describe("Browse Judoka screen", () => {
     await dropdown.selectOption("all");
 
     await expect(page.locator("#carousel-container .judoka-card")).toHaveCount(initialCount);
+  });
+
+  test("displays country flags", async ({ page }) => {
+    await page.waitForSelector("#country-list .slide");
+    await expect(page.locator("#country-list .slide")).toHaveCount(3);
   });
 });

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -1,7 +1,16 @@
 import { test, expect } from "@playwright/test";
 
-test.describe.skip("View Judoka screen", () => {
+test.describe("View Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
+    await page.route("**/src/data/judoka.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/judoka.json" })
+    );
+    await page.route("**/src/data/gokyo.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/gokyo.json" })
+    );
+    await page.route("**/src/data/countryCodeMapping.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/countryCodeMapping.json" })
+    );
     await page.goto("/src/pages/randomJudoka.html");
   });
 
@@ -41,6 +50,9 @@ test.describe.skip("View Judoka screen", () => {
   test("draw card populates container", async ({ page }) => {
     await page.click("#draw-card-btn");
     const card = page.locator("#card-container .judoka-card");
+    await expect(card).toHaveCount(1);
     await expect(card).toBeVisible();
+    const flag = card.locator(".card-top-bar img");
+    await expect(flag).toHaveAttribute("alt", /(Portugal|United States|Japan) flag/i);
   });
 });

--- a/tests/fixtures/countryCodeMapping.json
+++ b/tests/fixtures/countryCodeMapping.json
@@ -1,0 +1,23 @@
+[
+  {
+    "country": "Portugal",
+    "code": "pt",
+    "lastUpdated": "2025-04-23T10:00:00Z",
+    "updatedBy": "user",
+    "active": true
+  },
+  {
+    "country": "Japan",
+    "code": "jp",
+    "lastUpdated": "2025-04-23T10:00:00Z",
+    "updatedBy": "user",
+    "active": true
+  },
+  {
+    "country": "United States",
+    "code": "us",
+    "lastUpdated": "2025-04-23T10:00:00Z",
+    "updatedBy": "user",
+    "active": true
+  }
+]

--- a/tests/fixtures/gokyo.json
+++ b/tests/fixtures/gokyo.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": 0,
+    "name": "Jigoku-guruma",
+    "japanese": "内股",
+    "category": "Nage-waza",
+    "subCategory": "Koshi-waza",
+    "description": "A mysterious unknown move.",
+    "link": "https://en.wikipedia.org/wiki/judo"
+  },
+  {
+    "id": 1,
+    "name": "Uchi-mata",
+    "japanese": "内股",
+    "category": "Nage-waza",
+    "subCategory": "Koshi-waza",
+    "description": "A powerful inner thigh throw.",
+    "link": "https://en.wikipedia.org/wiki/Uchi_mata"
+  },
+  {
+    "id": 2,
+    "name": "O-soto-gari",
+    "japanese": "大外刈",
+    "category": "Nage-waza",
+    "subCategory": "Ashi-waza",
+    "description": "A major outer reap throw.",
+    "link": "https://en.wikipedia.org/wiki/O_soto_gari"
+  }
+]

--- a/tests/fixtures/judoka.json
+++ b/tests/fixtures/judoka.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": 111,
+    "firstname": "Joana",
+    "surname": "Ramos",
+    "country": "Portugal",
+    "countryCode": "pt",
+    "weightClass": "-52",
+    "stats": {
+      "power": 6,
+      "speed": 7,
+      "technique": 8,
+      "kumikata": 7,
+      "newaza": 6
+    },
+    "signatureMoveId": 1,
+    "lastUpdated": "2025-04-22T10:00:00Z",
+    "profileUrl": "https://en.wikipedia.org/wiki/Joana_Ramos",
+    "bio": "More info to come...",
+    "gender": "female",
+    "isHidden": false,
+    "rarity": "Common",
+    "cardCode": "WKZ3-H4NF-MXT2-LQ93-JT8C",
+    "matchesWon": 0,
+    "matchesLost": 0,
+    "matchesDrew": 0
+  },
+  {
+    "id": 114,
+    "firstname": "Nina",
+    "surname": "Cutro-Kelly",
+    "country": "USA",
+    "countryCode": "us",
+    "weightClass": "+78",
+    "stats": {
+      "power": 9,
+      "speed": 6,
+      "technique": 7,
+      "kumikata": 7,
+      "newaza": 8
+    },
+    "signatureMoveId": 2,
+    "lastUpdated": "2025-04-20T15:30:00Z",
+    "profileUrl": "https://en.wikipedia.org/wiki/Nina_Cutro-Kelly",
+    "bio": "More info to come...",
+    "gender": "female",
+    "isHidden": false,
+    "rarity": "Common",
+    "cardCode": "WKZ3-H4NF-MXT2-LQ93-JT8D",
+    "matchesWon": 0,
+    "matchesLost": 0,
+    "matchesDrew": 0
+  },
+  {
+    "id": 776,
+    "firstname": "Shōzō",
+    "surname": "Fujii",
+    "country": "Japan",
+    "countryCode": "jp",
+    "weightClass": "-81",
+    "stats": {
+      "power": 8,
+      "speed": 8,
+      "technique": 8,
+      "kumikata": 7,
+      "newaza": 8
+    },
+    "signatureMoveId": 3,
+    "lastUpdated": "2025-04-28T15:30:00Z",
+    "profileUrl": "https://en.wikipedia.org/wiki/Shōzō_Fujii",
+    "bio": "More info to come...",
+    "gender": "male",
+    "isHidden": false,
+    "rarity": "Epic",
+    "cardCode": "WKZ3-H4NF-MXT2-LQ93-JT9D",
+    "matchesWon": 0,
+    "matchesLost": 0,
+    "matchesDrew": 0
+  }
+]


### PR DESCRIPTION
## Summary
- intercept network requests for judoka pages
- use fixture data to supply predictable judoka, gokyo and country mapping
- assert expected card and flag counts

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Homepage navigation links visible, Homepage view judoka link navigates, Random Judoka essential elements visible, Random Judoka battle link navigates)*


------
https://chatgpt.com/codex/tasks/task_e_6847ec89bc8c8326bda1bf4a5adbbb3c