### PR TITLE
Add Playwright specs for judoka pages

### DIFF
--- a/playwright/battleJudoka.spec.js
+++ b/playwright/battleJudoka.spec.js
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Battle Judoka page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/src/pages/battleJudoka.html");
+  });
+
+  test("page loads", async ({ page }) => {
+    await expect(page).toHaveTitle(/Ju-Do-Kon!/i);
+  });
+
+  test("essential elements visible", async ({ page }) => {
+    await expect(page.getByRole("navigation")).toBeVisible();
+    await expect(page.getByRole("img", { name: "JU-DO-KON! Logo" })).toBeVisible();
+    await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /update judoka/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /battle!/i })).toBeVisible();
+  });
+
+  test("navigation links work", async ({ page }) => {
+    await page.getByRole("link", { name: /view judoka/i }).click();
+    await expect(page).toHaveURL(/randomJudoka\.html/);
+    await page.goBack();
+    await page.getByRole("link", { name: /update judoka/i }).click();
+    await expect(page).toHaveURL(/updateJudoka\.html/);
+    await page.goBack();
+    await page.getByRole("link", { name: /battle!/i }).click();
+    await expect(page).toHaveURL(/battleJudoka\.html/);
+  });
+});

--- a/playwright/createJudoka.spec.js
+++ b/playwright/createJudoka.spec.js
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Create Judoka page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/src/pages/createJudoka.html");
+  });
+
+  test("page loads", async ({ page }) => {
+    await expect(page).toHaveTitle(/Ju-Do-Kon!/i);
+  });
+
+  test("essential elements visible", async ({ page }) => {
+    await expect(page.getByRole("navigation")).toBeVisible();
+    await expect(page.getByRole("img", { name: "JU-DO-KON! Logo" })).toBeVisible();
+    await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /update judoka/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /battle!/i })).toBeVisible();
+  });
+
+  test("navigation links work", async ({ page }) => {
+    await page.getByRole("link", { name: /view judoka/i }).click();
+    await expect(page).toHaveURL(/randomJudoka\.html/);
+    await page.goBack();
+    await page.getByRole("link", { name: /update judoka/i }).click();
+    await expect(page).toHaveURL(/updateJudoka\.html/);
+    await page.goBack();
+    await page.getByRole("link", { name: /battle!/i }).click();
+    await expect(page).toHaveURL(/battleJudoka\.html/);
+  });
+});

--- a/playwright/updateJudoka.spec.js
+++ b/playwright/updateJudoka.spec.js
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Update Judoka page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/src/pages/updateJudoka.html");
+  });
+
+  test("page loads", async ({ page }) => {
+    await expect(page).toHaveTitle(/Ju-Do-Kon!/i);
+  });
+
+  test("essential elements visible", async ({ page }) => {
+    await expect(page.getByRole("navigation")).toBeVisible();
+    await expect(page.getByRole("img", { name: "JU-DO-KON! Logo" })).toBeVisible();
+    await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /update judoka/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /battle!/i })).toBeVisible();
+  });
+
+  test("navigation links work", async ({ page }) => {
+    await page.getByRole("link", { name: /view judoka/i }).click();
+    await expect(page).toHaveURL(/randomJudoka\.html/);
+    await page.goBack();
+    await page.getByRole("link", { name: /update judoka/i }).click();
+    await expect(page).toHaveURL(/updateJudoka\.html/);
+    await page.goBack();
+    await page.getByRole("link", { name: /battle!/i }).click();
+    await expect(page).toHaveURL(/battleJudoka\.html/);
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright tests for Battle Judoka page
- add Playwright tests for Update Judoka page
- add Playwright tests for Create Judoka page

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6847ec9d2a688326aba47ac5652db5be