### PR TITLE
Update homepage Playwright tests

### DIFF
--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -5,11 +5,25 @@ test.describe("Homepage", () => {
     await page.goto("/index.html");
   });
 
+  test("page loads", async ({ page }) => {
+    await expect(page).toHaveTitle(/Ju-Do-Kon!/i);
+  });
+
+  test("logo has alt text", async ({ page }) => {
+    const logo = page.getByRole("img", { name: "JU-DO-KON! Logo" });
+    await expect(logo).toHaveAttribute("alt", "JU-DO-KON! Logo");
+  });
+
   test("navigation links visible", async ({ page }) => {
     await page.waitForSelector(".bottom-navbar a");
     await expect(page.getByRole("navigation")).toBeVisible();
     await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
+  });
+
+  test("footer navigation links present", async ({ page }) => {
+    const footerLinks = page.locator("footer .bottom-navbar a");
+    await expect(footerLinks).not.toHaveCount(0);
   });
 
   test("view judoka link navigates", async ({ page }) => {

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -10,7 +10,7 @@ test.describe("Homepage", () => {
   });
 
   test("logo has alt text", async ({ page }) => {
-    const logo = page.getByRole("img", { name: "JU-DO-KON! Logo" });
+    const logo = page.getByAltText("JU-DO-KON! Logo");
     await expect(logo).toHaveAttribute("alt", "JU-DO-KON! Logo");
   });
 


### PR DESCRIPTION
## Summary
- verify homepage logo alt text
- check title and footer navigation links

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/homepage.spec.js --reporter=list` *(fails: timeout waiting for navigation links)*

------
https://chatgpt.com/codex/tasks/task_e_684804b8a5208326b9dbbeda606e1ec1