### PR TITLE
Remove aria labels and update tests

### DIFF
--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -18,7 +18,7 @@ test.describe("Homepage", () => {
     await page.waitForSelector(".bottom-navbar a");
     await expect(page.getByRole("navigation")).toBeVisible();
     await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /^Classic Battle$/i })).toBeVisible();
   });
 
   test("footer navigation links present", async ({ page }) => {

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -15,13 +15,13 @@ test.describe("View Judoka screen", () => {
   });
 
   test("essential elements visible", async ({ page }) => {
-    await page.getByRole("button", { name: /draw a random card/i }).waitFor();
-    await expect(page.getByRole("button", { name: /draw a random card/i })).toBeVisible();
+    await page.getByRole("button", { name: /draw card/i }).waitFor();
+    await expect(page.getByRole("button", { name: /draw card/i })).toBeVisible();
     await expect(page.getByRole("navigation")).toBeVisible();
   });
 
   test("battle link navigates", async ({ page }) => {
-    const battleLink = page.getByRole("link", { name: /battle mode page/i });
+    const battleLink = page.getByRole("link", { name: /battle!/i });
     await battleLink.waitFor();
     await battleLink.click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
@@ -32,20 +32,17 @@ test.describe("View Judoka screen", () => {
     await expect(logo).toHaveAttribute("alt", "JU-DO-KON! Logo");
   });
 
-  test("draw button has label", async ({ page }) => {
-    await page.getByRole("button", { name: /draw a random card/i }).waitFor();
-    const btn = page.locator("#draw-card-btn");
-    await expect(btn).toHaveAttribute("aria-label", /draw a random card/i);
+  test("draw button accessible name updates", async ({ page }) => {
+    const btn = page.getByRole("button", { name: /draw card/i });
+    await btn.waitFor();
+    await expect(btn).toHaveText(/draw card/i);
 
-    // Simulate a change in the button's display text
     await page.evaluate(() => {
       const button = document.querySelector("#draw-card-btn");
       button.textContent = "Pick a random judoka";
-      button.setAttribute("aria-label", "Pick a random judoka");
     });
 
-    // Verify that the aria-label is updated to match the new text
-    await expect(btn).toHaveAttribute("aria-label", /pick a random judoka/i);
+    await expect(page.getByRole("button", { name: /pick a random judoka/i })).toBeVisible();
   });
 
   test("draw card populates container", async ({ page }) => {

--- a/playwright/updateJudoka.spec.js
+++ b/playwright/updateJudoka.spec.js
@@ -24,7 +24,10 @@ test.describe("Update Judoka page", () => {
     await page.getByRole("link", { name: /update judoka/i }).click();
     await expect(page).toHaveURL(/updateJudoka\.html/);
     await page.goBack();
-    await page.getByRole("link", { name: /battle!/i }).click();
+    await page
+      .getByRole("link", { name: /^Battle!$/i })
+      .first()
+      .click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 });

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -38,21 +38,19 @@
       </header>
 
       <div id="card-container" class="card-container"></div>
-      <button id="draw-card-btn" class="draw-card-btn" aria-label="Draw a random card">
-        Draw Card!
-      </button>
+      <button id="draw-card-btn" class="draw-card-btn">Draw Card!</button>
 
       <footer>
         <nav class="bottom-navbar">
           <ul>
             <li>
-              <a href="randomJudoka.html" aria-label="View Judoka page">View Judoka</a>
+              <a href="randomJudoka.html">View Judoka</a>
             </li>
             <li>
-              <a href="updateJudoka.html" aria-label="Update Judoka page">Update Judoka</a>
+              <a href="updateJudoka.html">Update Judoka</a>
             </li>
             <li>
-              <a href="battleJudoka.html" aria-label="Battle mode page">Battle!</a>
+              <a href="battleJudoka.html">Battle!</a>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
## Summary
- remove ARIA labels from randomJudoka and footer links
- update Playwright specs to match accessible names
- adjust homepage navigation test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `SKIP_SCREENSHOTS=true npx playwright test` *(fails: Update Judoka page navigation links)*

------
https://chatgpt.com/codex/tasks/task_e_68480893d7a08326a85a7f483537718c