### PR TITLE
Add browser cache to Playwright baseline workflow

### DIFF
--- a/.github/workflows/playwright-baseline.yml
+++ b/.github/workflows/playwright-baseline.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/playwright-baseline.yml
+++ b/.github/workflows/playwright-baseline.yml
@@ -23,10 +23,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-playwright-
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps


### PR DESCRIPTION
## Summary
- cache Playwright browser binaries in the nightly baseline job

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 10 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68480fc77f608326a26f76f96def084d