### PR TITLE
Fix navigation wait in updateJudoka test

### DIFF
--- a/.github/workflows/playwright-baseline.yml
+++ b/.github/workflows/playwright-baseline.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/playwright/updateJudoka.spec.js
+++ b/playwright/updateJudoka.spec.js
@@ -20,10 +20,10 @@ test.describe("Update Judoka page", () => {
   test("navigation links work", async ({ page }) => {
     await page.getByRole("link", { name: /view judoka/i }).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
-    await page.goBack();
+    await page.goBack({ waitUntil: "load" });
     await page.getByRole("link", { name: /update judoka/i }).click();
     await expect(page).toHaveURL(/updateJudoka\.html/);
-    await page.goBack();
+    await page.goBack({ waitUntil: "load" });
     await page.getByRole("link", { name: "Battle!" }).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });


### PR DESCRIPTION
## Summary
- ensure `updateJudoka` Playwright test waits for page navigation
- keep workflow YAML formatted

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Update Judoka page › navigation links work)*

------
https://chatgpt.com/codex/tasks/task_e_6848133a5bb083269433209fdeb74174