### PR TITLE
Update screenshot page list format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ build/
 .github/ISSUE_TEMPLATE/*.md
 design/productRequirementsDocuments/*.md
 src/pages/quoteKG.html
+test-results/

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -1,5 +1,4 @@
 import { test, expect } from "@playwright/test";
-import path from "node:path";
 
 // Allow skipping screenshots via the SKIP_SCREENSHOTS environment variable
 const runScreenshots = process.env.SKIP_SCREENSHOTS !== "true";
@@ -8,19 +7,18 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
   test.skip(!runScreenshots);
   // List of pages to capture screenshots for
   const pages = [
-    "/",
-    "/src/pages/battleJudoka.html",
-    "/src/pages/carouselJudoka.html",
-    "/src/pages/createJudoka.html",
-    "/src/pages/randomJudoka.html",
-    "/src/pages/quoteKG.html",
-    "/src/pages/updateJudoka.html"
+    { url: "/", name: "homepage.png" },
+    { url: "/src/pages/battleJudoka.html", name: "battleJudoka.png" },
+    { url: "/src/pages/carouselJudoka.html", name: "carouselJudoka.png" },
+    { url: "/src/pages/createJudoka.html", name: "createJudoka.png" },
+    { url: "/src/pages/randomJudoka.html", name: "randomJudoka.png" },
+    { url: "/src/pages/quoteKG.html", name: "quoteKG.png" },
+    { url: "/src/pages/updateJudoka.html", name: "updateJudoka.png" }
   ];
 
-  for (const url of pages) {
+  for (const { url, name } of pages) {
     test(`screenshot ${url}`, async ({ page }) => {
       await page.goto(url, { waitUntil: "domcontentloaded" });
-      const name = url === "/" ? "homepage.png" : path.basename(url).replace(".html", ".png");
       await expect(page).toHaveScreenshot(name, { fullPage: true });
     });
   }


### PR DESCRIPTION
## Summary
- expand Playwright screenshot page list to include names
- skip formatting on autogenerated test output

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68481d6b940483269ff53bac7445a571