### PR TITLE
Add JSDoc comments for debug helper

### DIFF
--- a/src/helpers/debug.js
+++ b/src/helpers/debug.js
@@ -1,7 +1,17 @@
+/**
+ * Indicates whether debug messages should be printed.
+ * Set `DEBUG_LOGGING=true` in the environment or on `window` to enable.
+ * @type {boolean}
+ */
 export const DEBUG_LOGGING =
   (typeof process !== "undefined" && process.env.DEBUG_LOGGING === "true") ||
   (typeof window !== "undefined" && window.DEBUG_LOGGING === true);
 
+/**
+ * Log provided arguments when debugging is enabled.
+ * @param {...unknown} args - Data passed to `console.log`.
+ * @returns {void}
+ */
 export function debugLog(...args) {
   if (DEBUG_LOGGING) {
     console.log(...args);


### PR DESCRIPTION
## Summary
- document DEBUG_LOGGING flag
- document `debugLog` function

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diffs)*

------
https://chatgpt.com/codex/tasks/task_e_6848277c4fe0832680243a58499a0b8d