### PR TITLE
Add card code helper tests

### DIFF
--- a/tests/helpers/card-code.test.js
+++ b/tests/helpers/card-code.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { generateCardCode } from "../../src/helpers/cardCode.js";
+
+const validJudoka = {
+  firstname: "Test",
+  surname: "User",
+  country: "Nowhere",
+  weightClass: "-90",
+  signatureMoveId: 42,
+  stats: {
+    power: 1,
+    speed: 2,
+    technique: 3,
+    kumikata: 4,
+    newaza: 5
+  }
+};
+
+describe("generateCardCode", () => {
+  it("generates a code string for valid judoka", () => {
+    const code = generateCardCode(validJudoka);
+    expect(typeof code).toBe("string");
+    expect(code).toMatch(/^[A-Z0-9]{1,4}(?:-[A-Z0-9]{1,4})*$/);
+  });
+
+  it("throws an error when required fields are missing", () => {
+    const incomplete = { ...validJudoka };
+    delete incomplete.firstname;
+    expect(() => generateCardCode(incomplete)).toThrowError(
+      "Missing required judoka fields for card code generation."
+    );
+  });
+
+  it("returns the same code for the same input", () => {
+    const first = generateCardCode(validJudoka);
+    const second = generateCardCode(validJudoka);
+    expect(first).toBe(second);
+  });
+});

--- a/tests/helpers/card-code.test.js
+++ b/tests/helpers/card-code.test.js
@@ -26,8 +26,8 @@ describe("generateCardCode", () => {
   it("throws an error when required fields are missing", () => {
     const incomplete = { ...validJudoka };
     delete incomplete.firstname;
-    expect(() => generateCardCode(incomplete)).toThrowError(
-      "Missing required judoka fields for card code generation."
+    expect(() => generateCardCode(incomplete)).toThrow(
+      /Missing/
     );
   });
 


### PR DESCRIPTION
## Summary
- add tests for generateCardCode helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot comparison errors)*

------
https://chatgpt.com/codex/tasks/task_e_684827252c148326a6da7e56ddf33c4b