### PR TITLE
Add pseudo-japanese toggle test

### DIFF
--- a/design/productRequirementsDocuments/prdPseudoJapanese.md
+++ b/design/productRequirementsDocuments/prdPseudoJapanese.md
@@ -124,3 +124,4 @@ Prevents accidental taps and creates distinct flow—finish reading before proce
   - [ ] 5.2 Validate local conversion, static fallback activation, and toggle performance.
   - [ ] 5.3 Ensure <500ms conversion time and <200ms toggle response.
   - [ ] 5.4 Conduct UX testing on different screen sizes and platforms.
+  - [ ] 5.5 Add Playwright test `pseudo-japanese-toggle.spec.js` verifying the language toggle on the quote screen.

--- a/playwright/pseudo-japanese-toggle.spec.js
+++ b/playwright/pseudo-japanese-toggle.spec.js
@@ -1,6 +1,7 @@
+import * as path from "path";
 import { test, expect } from "@playwright/test";
 
-const FIXTURE_PATH = "tests/fixtures/aesopsFables.json";
+const FIXTURE_PATH = path.resolve(__dirname, "../tests/fixtures/aesopsFables.json");
 
 /**
  * Ensure the language toggle swaps between English and pseudo-Japanese text.

--- a/playwright/pseudo-japanese-toggle.spec.js
+++ b/playwright/pseudo-japanese-toggle.spec.js
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+const FIXTURE_PATH = "tests/fixtures/aesopsFables.json";
+
+/**
+ * Ensure the language toggle swaps between English and pseudo-Japanese text.
+ */
+test.describe("Pseudo-Japanese toggle", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/src/data/aesopsFables.json", (route) =>
+      route.fulfill({ path: FIXTURE_PATH })
+    );
+    await page.goto("/src/pages/quoteKG.html");
+    await page.waitForSelector("#quote .quote-content");
+  });
+
+  test("toggle updates quote text", async ({ page }) => {
+    const quote = page.locator("#quote");
+    const toggle = page.locator("#language-toggle");
+
+    const originalHTML = await quote.innerHTML();
+
+    await toggle.click();
+    await expect(quote).toHaveClass(/jp-font/);
+    const toggledHTML = await quote.innerHTML();
+    expect(toggledHTML).not.toBe(originalHTML);
+
+    await toggle.click();
+    await expect(quote).not.toHaveClass(/jp-font/);
+    const revertedHTML = await quote.innerHTML();
+    expect(revertedHTML).toBe(originalHTML);
+  });
+});

--- a/tests/fixtures/aesopsFables.json
+++ b/tests/fixtures/aesopsFables.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": 1,
+    "title": "The Wind and the Sun",
+    "story": "The Wind and the Sun once had a contest."
+  }
+]


### PR DESCRIPTION
## Summary
- add Playwright test for pseudo-Japanese toggle
- create fixture for deterministic quote
- update PRD tasks with new test reference

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `SKIP_SCREENSHOTS=true npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_684829e35c30832689f083e3f5af17e1