### PR TITLE
Fix __dirname usage in Playwright test

### DIFF
--- a/playwright/pseudo-japanese-toggle.spec.js
+++ b/playwright/pseudo-japanese-toggle.spec.js
@@ -1,6 +1,8 @@
 import * as path from "path";
+import { fileURLToPath } from "url";
 import { test, expect } from "@playwright/test";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE_PATH = path.resolve(__dirname, "../tests/fixtures/aesopsFables.json");
 
 /**


### PR DESCRIPTION
## Summary
- resolve __dirname in ES module for pseudo-japanese test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 5 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68491eda9b0083269ab8295a3f899058