### PR TITLE
Add tests for data utils

### DIFF
--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -42,7 +42,9 @@ test.describe("Homepage", () => {
     await tile.hover();
 
     // Wait for the tile size to increase after hover
-    await expect.poll(async () => (await tile.boundingBox()).width, { timeout: 5000 }).toBeGreaterThan(before.width);
+    await expect
+      .poll(async () => (await tile.boundingBox()).width, { timeout: 5000 })
+      .toBeGreaterThan(before.width);
 
     const after = await tile.boundingBox();
     const ratio = after.width / before.width;

--- a/tests/helpers/data-utils.test.js
+++ b/tests/helpers/data-utils.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  global.fetch = originalFetch;
+  vi.resetModules();
+});
+
+describe("loadJSON", () => {
+  it("throws an error when the response is not ok", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    const { loadJSON } = await import("../../src/helpers/dataUtils.js");
+    await expect(loadJSON("/bad.json")).rejects.toThrow("Failed to load /bad.json (HTTP 404)");
+  });
+
+  it("throws an error when JSON parsing fails", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: vi.fn().mockRejectedValue(new SyntaxError("bad")) });
+    const { loadJSON } = await import("../../src/helpers/dataUtils.js");
+    await expect(loadJSON("/bad.json")).rejects.toBeInstanceOf(SyntaxError);
+  });
+});
+
+describe("fetchDataWithErrorHandling", () => {
+  it("throws an error when the response is not ok", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    const { fetchDataWithErrorHandling } = await import("../../src/helpers/dataUtils.js");
+    await expect(fetchDataWithErrorHandling("/error.json")).rejects.toThrow(
+      "Failed to fetch data from /error.json (HTTP 500)"
+    );
+  });
+
+  it("throws an error when JSON parsing fails", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: vi.fn().mockRejectedValue(new SyntaxError("fail")) });
+    const { fetchDataWithErrorHandling } = await import("../../src/helpers/dataUtils.js");
+    await expect(fetchDataWithErrorHandling("/error.json")).rejects.toBeInstanceOf(SyntaxError);
+  });
+});
+
+describe("validateData", () => {
+  it("throws for non-object data", async () => {
+    const { validateData } = await import("../../src/helpers/dataUtils.js");
+    expect(() => validateData(null, "judoka")).toThrow("Invalid or missing judoka data.");
+  });
+
+  it("throws when required judoka fields are missing", async () => {
+    const { validateData } = await import("../../src/helpers/dataUtils.js");
+    const badData = { firstname: "A", surname: "B", stats: {}, signatureMoveId: 1 };
+    expect(() => validateData(badData, "judoka")).toThrow("Missing fields: country");
+  });
+
+  it("accepts valid judoka data", async () => {
+    const { validateData } = await import("../../src/helpers/dataUtils.js");
+    const goodData = {
+      firstname: "A",
+      surname: "B",
+      country: "X",
+      stats: {},
+      signatureMoveId: 1
+    };
+    expect(() => validateData(goodData, "judoka")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add extensive tests for `loadJSON`, `fetchDataWithErrorHandling`, and `validateData`
- format `homepage.spec.js` with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot comparison errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849837453ec8326b7059ce22ec71cc9