### PR TITLE
Update base styles with design tokens

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -4,12 +4,15 @@
   --scale-duration: 0.4s;
   --slide-track-speed: 40s;
   /* Colors */
-  --primary-bg: #1c4b95;
-  --secondary-bg: #0c3f7a;
-  --text-color: white;
-  /* Accent colors */
-  --accent-red: #a71916; /* primary action color */
-  --accent-red-dark: #880000; /* hover state for accent red */
+  --color-primary: #3c5ad6;
+  --color-surface: #ffffff;
+  --color-background: #f5f7fa;
+  --color-text: #1a1a1a;
+  --color-accent: #e04f5f;
+  --color-text-muted: #4a5055;
+  --color-placeholder: #a0a0a0;
+  /* Existing palette */
+  --color-accent-dark: #880000; /* hover state for accent red */
   --accent-beige: #e8d9c3; /* light highlight */
   --accent-blue-dark: #22223b; /* navigation background */
   --accent-grey: #ccc; /* neutral UI elements */
@@ -35,10 +38,18 @@
   --padding-extra-large: 2rem;
 
   /* Border radius */
-  --border-radius-small: 4px;
-  --border-radius-medium: 8px;
-  --border-radius-large: 12px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
 
   /* Box shadow */
   /* --box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2); */
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-surface: #1a1a1a;
+    --color-background: #000000;
+    --color-text: #ffffff;
+  }
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -25,8 +25,8 @@
 /* General body styles */
 body {
   font-family: "Open Sans", sans-serif;
-  /* background: linear-gradient(to bottom, var(--primary-bg), var(--secondary-bg)); */
-  color: var(--text-color); /* Default text color */
+  /* background: linear-gradient(to bottom, var(--color-primary), var(--color-surface)); */
+  color: var(--color-text); /* Default text color */
   min-height: 100dvh;
   min-width: 100vw;
   background-image: url("../assets/images/bgTileBlue.png");
@@ -64,7 +64,7 @@ body {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  background-color: var(--accent-red);
+  background-color: var(--color-accent);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   width: 100%;
 }
@@ -99,7 +99,7 @@ body {
 }
 
 .game-tile:hover {
-  background: var(--accent-red-dark);
+  background: var(--color-accent-dark);
   color: #fff;
   cursor: pointer;
   transform: scale(1.05);
@@ -194,7 +194,7 @@ a:focus-visible {
   aspect-ratio: 2 / 3;
   border: max(13px, 1vh) solid var(--card-border-color);
   border: max(13px, 1dvh) solid var(--card-border-color);
-  border-radius: var(--border-radius-large);
+  border-radius: var(--radius-lg);
   background-color: var(--card-bg-color);
   box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.3);
   overflow: hidden;
@@ -273,7 +273,7 @@ a:focus-visible {
 /* Top bar of the card (name and flag) */
 .card-top-bar {
   background-color: var(--card-bg-color);
-  color: var(--text-color);
+  color: var(--color-text);
   justify-content: space-around;
   display: inline-flex;
   align-items: center;
@@ -373,7 +373,7 @@ a:focus-visible {
 
 .card-stats {
   background-color: var(--card-bg-color);
-  color: var(--text-color);
+  color: var(--color-text);
   padding: var(--padding-small) var(--padding-large);
   margin: 0;
   display: flex;
@@ -474,7 +474,7 @@ a:focus-visible {
   color: var(--button-text-color);
   text-decoration: none;
   font-weight: bold;
-  border-radius: var(--border-radius-small);
+  border-radius: var(--radius-sm);
   transition: background-color 0.3s ease;
 }
 
@@ -695,10 +695,10 @@ a:focus-visible {
   width: min(300px, 80vw);
   min-height: 64px;
   padding: var(--padding-medium) var(--padding-large);
-  background-color: var(--primary-bg);
-  color: var(--text-color);
+  background-color: var(--color-primary);
+  color: var(--color-text);
   border: 2px solid #fff;
-  border-radius: var(--border-radius-medium);
+  border-radius: var(--radius-md);
   font-size: 1.25rem;
   font-weight: bold;
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2,7 +2,7 @@
 /* General body styles */
 body {
   font-family: "Open Sans", sans-serif;
-  color: var(--text-color);
+  color: var(--color-text);
   min-height: 100dvh;
   min-width: 100vw;
   background-image: url("./assets/images/bgTileBlue.png");
@@ -39,7 +39,7 @@ body {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  background-color: var(--accent-red);
+  background-color: var(--color-accent);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   width: 100%;
 }
@@ -73,8 +73,8 @@ body {
   }
 }
 .homeHelperContainer {
-  background: var(--secondary-bg);
-  border: 2px solid var(--secondary-bg);
+  background: var(--color-surface);
+  border: 2px solid var(--color-surface);
   border-radius: 4px 12px 12px 4px;
   text-align: center;
   /* position: absolute; */

--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -9,7 +9,7 @@
 
 .victory-title {
   font-size: 2rem;
-  color: var(--text-color);
+  color: var(--color-text);
   text-align: center;
   margin-top: 0.5rem;
 }
@@ -56,7 +56,7 @@
 
 .quote {
   font-size: calc(16px + 1vw); /* Scales dynamically with viewport width */
-  color: var(--text-color);
+  color: var(--color-text);
   line-height: 1.5;
   max-width: 80%;
   margin: 0 auto;
@@ -64,7 +64,7 @@
 }
 
 .quote-heading {
-  color: var(--text-color);
+  color: var(--color-text);
   font-size: 1.5rem;
   text-align: left;
   align-self: center;
@@ -73,7 +73,7 @@
 }
 
 .quote-content {
-  color: var(--text-color);
+  color: var(--color-text);
   font-size: 1rem;
   text-align: justify;
   align-self: center;
@@ -87,8 +87,8 @@
   min-height: 48px;
   padding: 0.75rem 2rem;
   font-size: 1.1rem;
-  color: var(--text-color);
-  background-color: var(--accent-red);
+  color: var(--color-text);
+  background-color: var(--color-accent);
   text-decoration: none;
   border-radius: 8px;
   margin-top: 1rem;
@@ -100,7 +100,7 @@
 .language-toggle:hover,
 .language-toggle:focus,
 .language-toggle:focus-visible {
-  background-color: var(--accent-red-dark);
+  background-color: var(--color-accent-dark);
 }
 
 /* Responsive: KG image above quote on narrow screens */
@@ -153,10 +153,10 @@
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  background-color: var(--accent-red);
-  color: var(--text-color);
+  background-color: var(--color-accent);
+  color: var(--color-text);
   border: none;
-  border-radius: var(--border-radius-medium);
+  border-radius: var(--radius-md);
   padding: 0.5rem 0.75rem;
   margin-top: 0.5rem;
   cursor: pointer;
@@ -168,14 +168,14 @@
 .language-toggle:hover,
 .language-toggle:focus,
 .language-toggle:focus-visible {
-  background-color: var(--accent-red-dark);
+  background-color: var(--color-accent-dark);
 }
 
 .flag-icon {
   display: inline-block;
   font-size: 1.25rem;
   line-height: 1;
-  border-radius: var(--border-radius-small);
+  border-radius: var(--radius-sm);
   border: 1px solid #fff;
   padding: 0 0.1rem;
 }


### PR DESCRIPTION
## Summary
- rename style variables to follow design tokens
- add prefers-color-scheme media query for dark mode
- update styles to use new variable names

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: scroll button labels, screenshot diffs)*

------
https://chatgpt.com/codex/tasks/task_e_6849c64af7288326843aa9c61ffc12af