### PR TITLE
Add max width for long-form text

### DIFF
--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -92,7 +92,7 @@ function displayFable(fable) {
     const formattedStory = formatFableStory(fable.story);
     quoteDiv.innerHTML = `
       <div class="quote-heading" id="quote-heading">${fable.title}</div>
-      <div class="quote-content" id="quote-content">${formattedStory}</div>
+      <div class="quote-content long-form" id="quote-content">${formattedStory}</div>
     `;
   } else {
     quoteDiv.innerHTML = "<p>Well done, congratulations!</p>";

--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -59,7 +59,7 @@
   font-size: calc(16px + 1vw); /* Scales dynamically with viewport width */
   color: var(--color-text);
   line-height: 1.5;
-  max-width: 80%;
+  max-width: 70ch;
   margin: 0 auto;
   text-align: center;
 }
@@ -81,6 +81,8 @@
   align-self: center;
   justify-self: center;
   padding: 0 3rem 1rem 1rem;
+  max-width: 70ch;
+  margin: 0 auto;
 }
 
 /* cta button styles */

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -26,6 +26,12 @@
   display: none;
 }
 
+/* Utility: constrain long-form text to improve readability */
+.long-form {
+  max-width: 70ch;
+  margin-inline: auto;
+}
+
 /* Add Reduced Motion support */
 @media (prefers-reduced-motion: reduce) {
   .card-container {


### PR DESCRIPTION
## Summary
- follow typography guideline for long-form text
- add `.long-form` utility class
- limit quote width in CSS and quote builder

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: scroll buttons, pseudo-japanese toggle, screenshot, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6849d7913e188326ab6b4d2156410525