### PR TITLE
Detect Node for Ajv import

### DIFF
--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -25,9 +25,12 @@
 // In-memory cache for data fetched from URLs
 const dataCache = new Map();
 
+function isNodeEnvironment() {
+  return typeof process !== "undefined" && process.versions && process.versions.node;
+}
+
 export async function getAjv() {
-  const isNode = typeof process !== "undefined" && process?.versions?.node;
-  if (isNode) {
+  if (isNodeEnvironment()) {
     const Ajv = (await import("ajv")).default;
     return new Ajv();
   }

--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -26,13 +26,17 @@
 const dataCache = new Map();
 
 export async function getAjv() {
-  if (typeof window !== "undefined") {
-    const module = await import("https://esm.sh/ajv@6");
-    return new module.default();
-  } else {
+  const isNode = typeof process !== "undefined" && process?.versions?.node;
+  if (isNode) {
     const Ajv = (await import("ajv")).default;
     return new Ajv();
   }
+  if (typeof window !== "undefined") {
+    const module = await import("https://esm.sh/ajv@6");
+    return new module.default();
+  }
+  const Ajv = (await import("ajv")).default;
+  return new Ajv();
 }
 
 // Ajv instance for JSON schema validation

--- a/tests/data/schema-validation.test.js
+++ b/tests/data/schema-validation.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { readFile } from "fs/promises";
-import { getAjv } from "./src/helpers/dataUtils.js";
+import { getAjv } from "../../src/helpers/dataUtils.js";
 import { fileURLToPath } from "url";
 import path from "path";
 


### PR DESCRIPTION
## Summary
- load Ajv from local package when running under Node
- ensure schema validation test imports helper using correct path

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 13 failed, 5 skipped, 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684a063b32948326a028e5ee6b29a16e