### PR TITLE
Add husky pre-commit hook

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky > $*"
+  }
+  readonly husky_skip_init=1
+  [ -f ~/.huskyrc ] && . ~/.huskyrc
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint && npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,13 @@ If a UI change is intended, update baseline screenshots with:
 npx playwright test --update-snapshots
 ```
 
+## Git Hooks
+
+The project uses [Husky](https://typicode.github.io/husky) for local Git hooks.
+Run `npm install` followed by `npm run prepare` after cloning to enable the
+pre-commit hook. The hook automatically runs `npm run lint` and `npm test` to
+catch issues before commits are created.
+
 ## Pseudocode and Documentation Rules
 
 JU-DO-KON! relies heavily on detailed JSDoc comments with `@pseudocode`

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "scripts": {
     "test": "vitest",
-    "test:screenshot": "playwright test"
+    "test:screenshot": "playwright test",
+    "lint": "eslint .",
+    "prepare": "husky install"
   },
   "keywords": [],
   "author": "",
@@ -23,7 +25,8 @@
     "globals": "^16.0.0",
     "jsdom": "^26.1.0",
     "prettier": "^3.5.3",
-    "vitest": "^3.1.2"
+    "vitest": "^3.1.2",
+    "husky": "^9.0.0"
   },
   "dependencies": {
     "agent-base": "^7.1.3",


### PR DESCRIPTION
## Summary
- add husky with pre-commit hook to run lint and tests
- document how to enable git hooks

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 13 failed, 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684a08b4ec988326b33b8ae5419feda0