### PR TITLE
Lazy Ajv instance

### DIFF
--- a/src/helpers/bottomNavigation.js
+++ b/src/helpers/bottomNavigation.js
@@ -161,7 +161,7 @@ function addTouchFeedback() {
  * @returns {void}
  */
 export function populateNavbar() {
-  fetch(`${DATA_DIR}gameModes.json`)
+  return fetch(`${DATA_DIR}gameModes.json`)
     .then((response) => {
       if (!response.ok) {
         throw new Error(`Failed to fetch game modes: ${response.status}`);

--- a/tests/helpers/data-utils.test.js
+++ b/tests/helpers/data-utils.test.js
@@ -154,12 +154,12 @@ describe("validateWithSchema", () => {
   it("throws when data does not match schema", async () => {
     const schema = { type: "object", properties: { a: { type: "string" } }, required: ["a"] };
     const { validateWithSchema } = await import("../../src/helpers/dataUtils.js");
-    expect(() => validateWithSchema({ a: 1 }, schema)).toThrow("Schema validation failed");
+    await expect(validateWithSchema({ a: 1 }, schema)).rejects.toThrow("Schema validation failed");
   });
 
   it("does not throw when data matches schema", async () => {
     const schema = { type: "object", properties: { a: { type: "string" } }, required: ["a"] };
     const { validateWithSchema } = await import("../../src/helpers/dataUtils.js");
-    expect(() => validateWithSchema({ a: "b" }, schema)).not.toThrow();
+    await expect(validateWithSchema({ a: "b" }, schema)).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- lazily create Ajv instance and cache it
- update schema validation helper to await Ajv
- adjust data-utils tests for async validator
- return the fetch promise from `populateNavbar`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Test was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684a0a76af4c83269e89c0ea054f714c