### PR TITLE
Add start and lint scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,17 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 ## Quick Start
 
 1. Make sure you have **Node 19+** and `npm` (or another package manager) installed.
-2. Clone the repository, install dependencies, and launch a lightweight local dev server:
+2. Clone the repository, install dependencies, and launch the development server:
    ```bash
    git clone https://github.com/cyanautomation/judokon.git
    cd judokon
    npm install
-   npx serve  # lightweight local dev server
+   npm start  # lightweight local dev server
    # Then visit: http://localhost:5000
+   ```
+3. Verify formatting and linting before committing:
+   ```bash
+   npm run lint
    ```
 
 ### Debug Logging

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "test": "tests"
   },
   "scripts": {
+    "start": "node scripts/playwrightServer.js",
     "test": "vitest",
     "test:screenshot": "playwright test",
-    "lint": "eslint .",
+    "lint": "npx prettier . --check && npx eslint .",
     "prepare": "husky install"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add a start script for the local dev server
- add a lint script using Prettier and ESLint
- document the new scripts in the Quick Start guide

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: tile contrast ratio and screenshot differences)*

------
https://chatgpt.com/codex/tasks/task_e_684a0ed93654832683102d68826b9428