### PR TITLE
Fix husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/h"
 
 npm run lint && npm test


### PR DESCRIPTION
## Summary
- update pre-commit hook to use new Husky `h` helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: tile hover zoom, contrast ratio and screenshot expectations)*

------
https://chatgpt.com/codex/tasks/task_e_684a6de2b1508326bc1236f00c8b9ee5