### PR TITLE
Fix weather units

### DIFF
--- a/.github/workflows/lintAutofix.yml
+++ b/.github/workflows/lintAutofix.yml
@@ -103,7 +103,8 @@ jobs:
         id: weather
         run: |
           CITY="Wokingham"
-          WEATHER=$(curl -s "wttr.in/$CITY?format=%t+%c" || echo "")
+          # '&m' forces temperature in Celsius
+          WEATHER=$(curl -s "wttr.in/$CITY?format=%t+%c&m" || echo "")
           if [ -n "$WEATHER" ]; then
             echo "weather=$WEATHER in $CITY" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary
- ensure workflow weather fetch uses Celsius units

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_684e90a8716483268017e525084d547a