### PR TITLE
Add data validation npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
 ## Data Schemas and Validation
 
 JSON files in `src/data` are validated against matching schemas in `src/schemas`.
-Use the Ajv CLI to ensure files conform to their schema:
+Validate all data files at once with the npm script:
+
+```bash
+npm run validate:data
+```
+
+You can also validate a single pair manually:
 
 ```bash
 npx ajv validate -s src/schemas/judoka.schema.json -d src/data/judoka.json

--- a/design/dataSchemas/README.md
+++ b/design/dataSchemas/README.md
@@ -4,7 +4,7 @@ This project stores gameplay data in JSON files under `src/data`. Each file has 
 
 ## Running Validation
 
-Use the [Ajv](https://ajv.js.org/) CLI (installed globally or via `npx`) to validate data files:
+Use the [Ajv](https://ajv.js.org/) CLI (installed globally or via `npx`) to validate data files, or run `npm run validate:data` to check all pairs at once:
 
 ```bash
 npx ajv validate -s src/schemas/judoka.schema.json -d src/data/judoka.json

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest",
     "test:screenshot": "playwright test",
     "lint": "npx prettier . --check && npx eslint .",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "validate:data": "npx ajv validate -s src/schemas/judoka.schema.json -d src/data/judoka.json && npx ajv validate -s src/schemas/gameModes.schema.json -d src/data/gameModes.json && npx ajv validate -s src/schemas/weightCategories.schema.json -d src/data/weightCategories.json && npx ajv validate -s src/schemas/countryCodeMapping.schema.json -d src/data/countryCodeMapping.json && npx ajv validate -s src/schemas/gokyo.schema.json -d src/data/gokyo.json"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `validate:data` script that runs Ajv for all data/schema pairs
- mention new npm script in README
- mention script in data schema docs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot and navigation tests)*

------
https://chatgpt.com/codex/tasks/task_e_684ec2b0783083269da314a0deb4cab9