### PR TITLE
Update battle mode link path

### DIFF
--- a/src/data/gameModes.json
+++ b/src/data/gameModes.json
@@ -6,7 +6,7 @@
     "description": "A standard one-on-one battle mode where players compete to win.",
     "category": "mainMenu",
     "order": 20,
-    "url": "shiai.html",
+    "url": "battleJudoka.html",
     "isHidden": false,
     "rules": {
       "rounds": 25,

--- a/src/helpers/bottomNavigation.js
+++ b/src/helpers/bottomNavigation.js
@@ -25,7 +25,7 @@ export function toggleExpandedMapView(gameModes) {
     .map(
       (mode) =>
         `<div class="map-tile" style="background-image: url('${mode.image}')">
-          <a href="src/pages/${mode.url}" aria-label="${mode.name}">${mode.name}</a>
+          <a href="/src/pages/${mode.url}" aria-label="${mode.name}">${mode.name}</a>
         </div>`
     )
     .join("");
@@ -76,7 +76,7 @@ export function togglePortraitTextMenu(gameModes) {
   textMenu.innerHTML = validModes
     .map(
       (mode) =>
-        `<li><a href="src/pages/${mode.url}" aria-label="${mode.name}">${mode.name}</a></li>`
+        `<li><a href="/src/pages/${mode.url}" aria-label="${mode.name}">${mode.name}</a></li>`
     )
     .join("");
 
@@ -187,7 +187,7 @@ export async function populateNavbar() {
 
     const ul = document.createElement("ul");
     ul.innerHTML = activeModes
-      .map((mode) => `<li><a href="src/pages/${mode.url}">${mode.name}</a></li>`)
+      .map((mode) => `<li><a href="/src/pages/${mode.url}">${mode.name}</a></li>`)
       .join("");
     navBar.appendChild(ul);
 

--- a/tests/helpers/bottom-navigation.test.js
+++ b/tests/helpers/bottom-navigation.test.js
@@ -55,7 +55,7 @@ describe("toggleExpandedMapView", () => {
     expect(view).toBeTruthy();
     const tiles = view.querySelectorAll(".map-tile");
     expect(tiles).toHaveLength(2);
-    expect(tiles[0].querySelector("a")).toHaveAttribute("href", "src/pages/mode1.html");
+    expect(tiles[0].querySelector("a")).toHaveAttribute("href", "/src/pages/mode1.html");
     expect(tiles[0].querySelector("a")).toHaveAttribute("aria-label", "Mode1");
     expect(tiles[0].textContent).toContain("Mode1");
   });
@@ -79,7 +79,7 @@ describe("togglePortraitTextMenu", () => {
     expect(menu).toBeTruthy();
     const items = menu.querySelectorAll("li");
     expect(items).toHaveLength(2);
-    expect(items[1].querySelector("a")).toHaveAttribute("href", "src/pages/mode2.html");
+    expect(items[1].querySelector("a")).toHaveAttribute("href", "/src/pages/mode2.html");
     expect(items[1].querySelector("a")).toHaveAttribute("aria-label", "Mode2");
     expect(items[1].textContent).toContain("Mode2");
   });


### PR DESCRIPTION
## Summary
- fix Classic Battle URL in `gameModes.json`
- use absolute paths in navigation link helpers
- adjust bottom navigation tests for new paths

## Testing
- `npx prettier . --write`
- `npx eslint . --fix`
- `npx vitest run`
- `SKIP_SCREENSHOTS=true npx playwright test` *(fails: view judoka link navigates, tiles meet contrast ratio)*

------
https://chatgpt.com/codex/tasks/task_e_684eca48ff4483269b1421c605badc20