### PR TITLE
Add architecture overview doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   - `styles/`
 - `tests/` – Vitest unit tests.
 - `design/` – documentation and code standards.
+- [Architecture Overview](design/architecture.md) – summary of key modules.
 
 ## Data Schemas and Validation
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -1,0 +1,19 @@
+# Project Architecture Overview
+
+This document summarizes the main source folders and their responsibilities.
+
+## game.js
+
+The entry point for the browser. It waits for `DOMContentLoaded` and wires up all game interactions. Helper functions are imported here to build the carousel, fetch data, and render random cards.
+
+## helpers/
+
+Reusable utilities organized by concern (card building, data fetching, random card generation, etc.). Each module is documented with JSDoc and `@pseudocode` blocks for clarity.
+
+## data and schemas
+
+Structured gameplay data lives in `src/data`. Matching JSON Schemas in `src/schemas` describe and validate these files. The `npm run validate:data` script uses Ajv to ensure data integrity.
+
+## tests
+
+Unit tests under `tests/` run in the Vitest `jsdom` environment. The `playwright/` directory contains end‑to‑end tests and screenshot comparisons to prevent UI regressions.


### PR DESCRIPTION
## Summary
- add `design/architecture.md` overview document
- link the new document from README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: unable to access fonts and screenshots)*

------
https://chatgpt.com/codex/tasks/task_e_684ee940b4108326834c63b733676888