### PR TITLE
Add helper test suites

### DIFF
--- a/tests/helpers/button-effects.test.js
+++ b/tests/helpers/button-effects.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { setupButtonEffects } from "../../src/helpers/buttonEffects.js";
+
+let button;
+
+describe("setupButtonEffects", () => {
+  beforeEach(() => {
+    button = document.createElement("button");
+    document.body.appendChild(button);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("creates and removes a ripple on mousedown", () => {
+    setupButtonEffects();
+    const event = new MouseEvent("mousedown");
+    Object.defineProperty(event, "offsetX", { value: 5 });
+    Object.defineProperty(event, "offsetY", { value: 10 });
+    button.dispatchEvent(event);
+
+    const ripple = button.querySelector("span.ripple");
+    expect(ripple).toBeTruthy();
+    expect(ripple.style.left).toBe("5px");
+    expect(ripple.style.top).toBe("10px");
+
+    ripple.dispatchEvent(new Event("animationend"));
+    expect(button.querySelector("span.ripple")).toBeNull();
+  });
+});

--- a/tests/helpers/quote-builder.test.js
+++ b/tests/helpers/quote-builder.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  global.fetch = originalFetch;
+  document.body.innerHTML = "";
+  vi.resetModules();
+});
+
+describe("displayRandomQuote", () => {
+  it("renders a fetched fable", async () => {
+    const quoteDiv = document.createElement("div");
+    quoteDiv.id = "quote";
+    quoteDiv.className = "hidden";
+    const loader = document.createElement("div");
+    loader.id = "quote-loader";
+    const toggle = document.createElement("button");
+    toggle.id = "language-toggle";
+    toggle.className = "hidden";
+    document.body.append(quoteDiv, loader, toggle);
+
+    const data = [{ id: 1, title: "A", story: "B" }];
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => data });
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    await import("../../src/helpers/quoteBuilder.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(quoteDiv.classList.contains("hidden")).toBe(false);
+    expect(loader.classList.contains("hidden")).toBe(true);
+    expect(quoteDiv.innerHTML).toContain("A");
+    expect(toggle.classList.contains("hidden")).toBe(false);
+  });
+
+  it("shows fallback text when fetching fails", async () => {
+    const quoteDiv = document.createElement("div");
+    quoteDiv.id = "quote";
+    const loader = document.createElement("div");
+    loader.id = "quote-loader";
+    document.body.append(quoteDiv, loader);
+
+    global.fetch = vi.fn().mockRejectedValue(new Error("fail"));
+
+    await import("../../src/helpers/quoteBuilder.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(quoteDiv.textContent).toContain("Well done, congratulations!");
+  });
+});

--- a/tests/helpers/svg-fallback.test.js
+++ b/tests/helpers/svg-fallback.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { applySvgFallback } from "../../src/helpers/svgFallback.js";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("applySvgFallback", () => {
+  it("replaces broken SVG source with fallback", () => {
+    const img = document.createElement("img");
+    img.src = "logo.svg";
+    document.body.appendChild(img);
+
+    applySvgFallback("fallback.png");
+    img.dispatchEvent(new Event("error"));
+
+    expect(img.src).toContain("fallback.png");
+    expect(img.classList.contains("svg-fallback")).toBe(true);
+  });
+
+  it("ignores non-SVG images", () => {
+    const img = document.createElement("img");
+    img.src = "logo.png";
+    document.body.appendChild(img);
+
+    applySvgFallback("fallback.png");
+    img.dispatchEvent(new Event("error"));
+
+    expect(img.src).toContain("logo.png");
+  });
+});


### PR DESCRIPTION
## Summary
- test `setupButtonEffects` for ripple creation/removal
- test `applySvgFallback` for replacing broken SVG images
- test `displayRandomQuote` for showing quotes or a fallback

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 9 failed, 5 skipped, 32 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684ee922fd188326bac16378bb65ef1d