### PR TITLE
Update button styles for card draw and quote CTA

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -736,8 +736,7 @@ button .ripple {
   width: min(300px, 80vw);
   min-height: 64px;
   padding: var(--space-md) var(--space-lg); /* Updated tokens */
-  background-color: var(--color-primary); /* Updated token */
-  color: var(--color-text); /* Updated token */
+  /* colors come from the base button styles */
   border: 2px solid var(--color-surface); /* Updated token */
   border-radius: var(--radius-md); /* Updated token */
   font-size: 1.25rem;

--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -99,8 +99,8 @@
   min-height: 48px;
   padding: var(--space-md) var(--space-lg); /* Updated tokens */
   font-size: var(--font-medium); /* Updated token */
-  color: var(--color-text); /* Updated token */
-  background-color: var(--color-primary); /* Updated token */
+  color: var(--button-text-color);
+  background-color: var(--button-bg);
   text-decoration: none;
   border-radius: var(--radius-md); /* Updated token */
   margin-top: var(--space-md); /* Updated token */
@@ -109,7 +109,7 @@
 .cta-button:hover,
 .cta-button:focus,
 .cta-button:focus-visible {
-  background-color: var(--color-secondary); /* Updated token */
+  background-color: var(--button-hover-bg);
 }
 
 /* Responsive: KG image above quote on narrow screens */
@@ -158,6 +158,7 @@
   }
 }
 
+/* This toggle keeps its accent colors intentionally */
 .language-toggle {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- use base button colours for `.draw-card-btn`
- update `.cta-button` to use standard button variables
- note accent exception on `.language-toggle`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 7 screenshot tests)*

------
https://chatgpt.com/codex/tasks/task_e_6852f79dcbe083268ee346c18148ee31