### PR TITLE
Add waitFor util for DOM checks

### DIFF
--- a/tests/helpers/quote-builder.test.js
+++ b/tests/helpers/quote-builder.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { waitFor } from "../waitFor.js";
 
 const originalFetch = global.fetch;
 
@@ -27,7 +28,7 @@ describe("displayRandomQuote", () => {
 
     await import("../../src/helpers/quoteBuilder.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
-    await new Promise((r) => setTimeout(r, 0));
+    await waitFor(() => !quoteDiv.classList.contains("hidden"));
 
     expect(quoteDiv.classList.contains("hidden")).toBe(false);
     expect(loader.classList.contains("hidden")).toBe(true);
@@ -46,7 +47,7 @@ describe("displayRandomQuote", () => {
 
     await import("../../src/helpers/quoteBuilder.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
-    await new Promise((r) => setTimeout(r, 0));
+    await waitFor(() => quoteDiv.textContent.length > 0);
 
     expect(quoteDiv.textContent).toContain("Take a breath. Even a still pond reflects the sky.");
   });

--- a/tests/waitFor.js
+++ b/tests/waitFor.js
@@ -1,0 +1,8 @@
+export async function waitFor(predicate, { timeout = 500, interval = 10 } = {}) {
+  const endTime = Date.now() + timeout;
+  while (Date.now() < endTime) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  throw new Error("waitFor timeout");
+}


### PR DESCRIPTION
## Summary
- create a small waitFor utility for tests
- replace timeout in quote-builder tests with waitFor

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npx playwright test` *(fails: 403 Forbidden fetching playwright)*

------
https://chatgpt.com/codex/tasks/task_e_685b1445a63c8326b6b7f232f7b8f608