### PR TITLE
Add color contrast tests

### DIFF
--- a/tests/helpers/color-contrast.test.js
+++ b/tests/helpers/color-contrast.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { hex } from "wcag-contrast";
+
+function getCssVars() {
+  const css = readFileSync(resolve("src/styles/base.css"), "utf8");
+  const rootBlock = css.match(/:root\s*{([\s\S]*?)}/);
+  const vars = {};
+  if (rootBlock) {
+    const regex = /--([\w-]+)\s*:\s*([^;]+);/g;
+    let m;
+    while ((m = regex.exec(rootBlock[1])) !== null) {
+      vars[`--${m[1]}`] = m[2].trim();
+    }
+  }
+  return vars;
+}
+
+describe("base.css color contrast", () => {
+  const vars = getCssVars();
+  const pairs = [
+    ["--button-bg", "--button-text-color"],
+    ["--button-hover-bg", "--button-text-color"],
+    ["--button-active-bg", "--button-text-color"],
+    ["--color-secondary", "--color-surface"],
+    ["--color-primary", "--color-surface"],
+    ["--color-tertiary", "--color-secondary"]
+  ];
+
+  it.each(pairs)("%s vs %s should be >= 4.5", (a, b) => {
+    const ratio = hex(vars[a], vars[b]);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/tests/helpers/color-contrast.test.js
+++ b/tests/helpers/color-contrast.test.js
@@ -30,6 +30,6 @@ describe("base.css color contrast", () => {
 
   it.each(pairs)("%s vs %s should be >= 4.5", (a, b) => {
     const ratio = hex(vars[a], vars[b]);
-    expect(ratio).toBeGreaterThanOrEqual(4.5);
+    expect(ratio).toBeGreaterThanOrEqual(4.5, `Contrast ratio between ${a} (${vars[a]}) and ${b} (${vars[b]}) is ${ratio}, which is less than the required 4.5.`);
   });
 });


### PR DESCRIPTION
## Summary
- ensure base.css color tokens meet WCAG ratios
- verify button and palette variable pairs stay above 4.5:1

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:contrast` *(fails: wcag-contrast-checker not found)*
- `npx vitest run`
- `npx playwright test` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b27d50af08326b10cb05e1a663f37