### PR TITLE
Fix contrast check CLI reference

### DIFF
--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -107,7 +107,7 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 - Line-height: 1.4× font size
 - Letter-spacing: 0.5% (League Spartan), normal (Noto Sans)
 - Avoid using all caps in body text for readability
-- Use the `wcag-contrast-checker` tool (`npm run check:contrast`) to validate new CSS styles
+- Use the `wcag-contrast` CLI (`npm run check:contrast`) to validate new CSS styles
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest",
     "test:screenshot": "playwright test",
     "lint": "npx prettier . --check && npx eslint .",
-    "check:contrast": "wcag-contrast-checker src/styles/*.css",
+    "check:contrast": "wcag-contrast src/styles/*.css",
     "prepare": "husky install",
     "validate:data": "node scripts/validateData.js"
   },


### PR DESCRIPTION
## Summary
- fix `check:contrast` npm script to use `wcag-contrast`
- update UI design standards to reference the correct CLI

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm run check:contrast` *(fails: wcag-contrast: not found)*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_685b2956b9908326a1812bfae8374684