### PR TITLE
Sort countries alphabetically

### DIFF
--- a/src/helpers/countryUtils.js
+++ b/src/helpers/countryUtils.js
@@ -169,7 +169,10 @@ export async function getFlagUrl(countryCode) {
  * 2. Filter active countries:
  *    - Include only countries where the `active` property is `true`.
  *
- * 3. Generate slides for each active country:
+ * 3. Sort the countries alphabetically:
+ *    - Order the filtered countries using `localeCompare` on the `country` name.
+ *
+ * 4. Generate slides for each active country:
  *    - For each country:
  *      a. Create a `div` element for the slide container.
  *      b. Add a flag image:
@@ -181,7 +184,7 @@ export async function getFlagUrl(countryCode) {
  *         - Set its text content to the country's name.
  *      d. Append the slide container to the specified container.
  *
- * 4. Handle errors:
+ * 5. Handle errors:
  *    - Log any errors encountered during the process.
  *
  * @param {HTMLElement} container - The DOM element where the country list will be appended.
@@ -190,7 +193,11 @@ export async function populateCountryList(container) {
   try {
     const countryData = await loadCountryCodeMapping();
 
-    for (const country of countryData.filter((country) => country.active)) {
+    const activeCountries = countryData
+      .filter((country) => country.active)
+      .sort((a, b) => a.country.localeCompare(b.country));
+
+    for (const country of activeCountries) {
       if (!country.country || !country.code) {
         console.warn("Skipping invalid country entry:", country);
         continue;

--- a/tests/helpers/populate-country-list.test.js
+++ b/tests/helpers/populate-country-list.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  global.fetch = originalFetch;
+  localStorage.clear();
+  document.body.innerHTML = "";
+  vi.resetModules();
+});
+
+describe("populateCountryList", () => {
+  it("renders active countries alphabetically", async () => {
+    const data = [
+      { country: "Japan", code: "jp", active: true },
+      { country: "Brazil", code: "br", active: true },
+      { country: "Canada", code: "ca", active: true }
+    ];
+
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => data });
+
+    const { populateCountryList } = await import("../../src/helpers/countryUtils.js");
+
+    const container = document.createElement("div");
+    await populateCountryList(container);
+
+    const slides = container.querySelectorAll(".slide");
+    const names = [...slides].map((s) => s.querySelector("p").textContent);
+    expect(names).toEqual(["Brazil", "Canada", "Japan"]);
+  });
+});


### PR DESCRIPTION
## Summary
- alphabetize countries in populateCountryList
- verify ordering with a unit test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:contrast` *(fails: wcag-contrast not found)*
- `npx vitest run`
- `npx playwright test` *(fails: screenshot differences)*

------
https://chatgpt.com/codex/tasks/task_e_685c47d69af483269a4b3deea6c8eb54