### PR TITLE
Add slide-in country panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The repository specifies commenting standards in design/codeStandards. JSDoc com
 - Playable directly in the browser
 - Loading indicator for better user experience
 - Modularized JavaScript for better maintainability
+- Slide-in country picker for filtering judoka by flag
 
 ## About JU-DO-KON!
 

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -54,7 +54,7 @@ test.describe("Browse Judoka screen", () => {
     await toggle.click();
     const panel = page.getByRole("region");
     await panel.waitFor();
-    await page.waitForTimeout(350);
+    await expect(page.locator("#carousel-container .judoka-card")).toHaveCountLessThan(initialCount);
     await page.getByRole("button", { name: "Japan" }).click({ force: true });
 
     const filteredCards = page.locator("#carousel-container .judoka-card");

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-const FILTER_BY_COUNTRY_LOCATOR = /Filter( judokas?)? by country/i;
+const COUNTRY_TOGGLE_LOCATOR = /choose country/i;
 
 test.describe("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
@@ -13,11 +13,14 @@ test.describe("Browse Judoka screen", () => {
     await page.route("**/src/data/countryCodeMapping.json", (route) =>
       route.fulfill({ path: "tests/fixtures/countryCodeMapping.json" })
     );
+    await page.route("https://flagcdn.com/**", (route) =>
+      route.fulfill({ path: "src/assets/countryFlags/placeholder-flag.png" })
+    );
     await page.goto("/src/pages/carouselJudoka.html");
   });
 
   test("essential elements visible", async ({ page }) => {
-    await expect(page.getByRole("combobox", { name: FILTER_BY_COUNTRY_LOCATOR })).toBeVisible();
+    await expect(page.getByRole("button", { name: COUNTRY_TOGGLE_LOCATOR })).toBeVisible();
     await expect(page.getByRole("navigation")).toBeVisible();
     await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
   });
@@ -40,16 +43,19 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("country filter updates carousel", async ({ page }) => {
-    const dropdown = page.getByRole("combobox", { name: FILTER_BY_COUNTRY_LOCATOR });
+    const toggle = page.getByRole("button", { name: COUNTRY_TOGGLE_LOCATOR });
 
-    // wait for cards to load
     await page.waitForSelector("#carousel-container .judoka-card");
 
     const allCards = page.locator("#carousel-container .judoka-card");
     const initialCount = await allCards.count();
     expect(initialCount).toBe(3);
 
-    await dropdown.selectOption("Japan");
+    await toggle.click();
+    const panel = page.getByRole("region");
+    await panel.waitFor();
+    await page.waitForTimeout(350);
+    await page.getByRole("button", { name: "Japan" }).click({ force: true });
 
     const filteredCards = page.locator("#carousel-container .judoka-card");
     const filteredCount = await filteredCards.count();
@@ -60,14 +66,21 @@ test.describe("Browse Judoka screen", () => {
       await expect(flag).toHaveAttribute("alt", /Japan flag/i);
     }
 
-    await dropdown.selectOption("all");
+    await toggle.click();
+    await panel.waitFor();
+    await page.waitForTimeout(350);
+    await page.getByRole("button", { name: "All" }).click({ force: true });
 
     await expect(page.locator("#carousel-container .judoka-card")).toHaveCount(initialCount);
   });
 
   test("displays country flags", async ({ page }) => {
+    const toggle = page.getByRole("button", { name: COUNTRY_TOGGLE_LOCATOR });
+    await toggle.click();
     await page.waitForSelector("#country-list .slide");
-    await expect(page.locator("#country-list .slide")).toHaveCount(3);
+    const slides = page.locator("#country-list .slide");
+    await expect(slides).toHaveCount(4);
+    await expect(slides.first().locator("img")).toHaveAttribute("alt", /all countries/i);
   });
 
   test.skip("judoka card enlarges on hover", async ({ page }) => {

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -29,6 +29,9 @@ test.describe(runScreenshots ? "Screenshot suite" : "Screenshot suite (skipped)"
           route.continue();
         }
       });
+      await page.route("https://flagcdn.com/**", (route) =>
+        route.fulfill({ path: "src/assets/countryFlags/placeholder-flag.png" })
+      );
       await page.addInitScript(() => {
         Math.random = () => 0.42;
       });

--- a/src/helpers/countryPanel.js
+++ b/src/helpers/countryPanel.js
@@ -1,0 +1,39 @@
+/**
+ * Toggle the visibility of the country flag panel.
+ *
+ * @pseudocode
+ * 1. Determine if the panel is currently open using the `open` class.
+ * 2. Decide the next state based on the optional `show` parameter or the
+ *    current state.
+ * 3. If opening:
+ *    a. Remove the `hidden` attribute from the panel.
+ *    b. Add the `open` class for the slide-in animation.
+ *    c. Set `aria-expanded` on the toggle button to `true`.
+ *    d. Focus the first flag button inside the panel if it exists.
+ * 4. If closing:
+ *    a. Add the `hidden` attribute to hide the panel.
+ *    b. Remove the `open` class.
+ *    c. Set `aria-expanded` on the toggle button to `false`.
+ *    d. Return focus to the toggle button.
+ *
+ * @param {HTMLButtonElement} toggleButton - The controlling button.
+ * @param {HTMLElement} panel - The panel element.
+ * @param {boolean} [show] - Force open (`true`) or closed (`false`).
+ */
+export function toggleCountryPanel(toggleButton, panel, show) {
+  const isOpen = panel.classList.contains("open");
+  const shouldOpen = typeof show === "boolean" ? show : !isOpen;
+
+  if (shouldOpen) {
+    panel.removeAttribute("hidden");
+    panel.classList.add("open");
+    toggleButton.setAttribute("aria-expanded", "true");
+    const firstButton = panel.querySelector("button.flag-button");
+    firstButton?.focus();
+  } else {
+    panel.classList.remove("open");
+    panel.setAttribute("hidden", "");
+    toggleButton.setAttribute("aria-expanded", "false");
+    toggleButton.focus();
+  }
+}

--- a/src/helpers/countryUtils.js
+++ b/src/helpers/countryUtils.js
@@ -197,6 +197,23 @@ export async function populateCountryList(container) {
       .filter((country) => country.active)
       .sort((a, b) => a.country.localeCompare(b.country));
 
+    const allSlide = document.createElement("div");
+    allSlide.className = "slide";
+    const allButton = document.createElement("button");
+    allButton.className = "flag-button";
+    allButton.value = "all";
+    allButton.setAttribute("aria-label", "All Countries");
+    const allImg = document.createElement("img");
+    allImg.alt = "All countries";
+    allImg.className = "flag-image";
+    allImg.src = "https://flagcdn.com/w320/vu.png";
+    const allLabel = document.createElement("p");
+    allLabel.textContent = "All";
+    allButton.appendChild(allImg);
+    allButton.appendChild(allLabel);
+    allSlide.appendChild(allButton);
+    container.appendChild(allSlide);
+
     for (const country of activeCountries) {
       if (!country.country || !country.code) {
         console.warn("Skipping invalid country entry:", country);
@@ -205,6 +222,11 @@ export async function populateCountryList(container) {
 
       const slide = document.createElement("div");
       slide.className = "slide";
+
+      const button = document.createElement("button");
+      button.className = "flag-button";
+      button.value = country.country;
+      button.setAttribute("aria-label", country.country);
 
       const flagImg = document.createElement("img");
       flagImg.alt = `${country.country} Flag`;
@@ -218,11 +240,11 @@ export async function populateCountryList(container) {
         flagImg.src = "https://flagcdn.com/w320/vu.png"; // Fallback to Vanuatu flag
       }
 
-      slide.appendChild(flagImg);
-
       const countryName = document.createElement("p");
       countryName.textContent = country.country;
-      slide.appendChild(countryName);
+      button.appendChild(flagImg);
+      button.appendChild(countryName);
+      slide.appendChild(button);
 
       container.appendChild(slide);
     }

--- a/src/pages/carouselJudoka.html
+++ b/src/pages/carouselJudoka.html
@@ -40,19 +40,20 @@
 
       <main class="kodokan-grid" role="main">
         <div class="filter-bar">
-          <label for="country-filter">Filter by Country:</label>
-          <select id="country-filter" aria-label="Filter judoka by country">
-            <option value="all">All Countries</option>
-          </select>
+          <button id="country-toggle" aria-controls="country-panel" aria-expanded="false">
+            Choose Country
+          </button>
         </div>
         <div id="carousel-container"></div>
       </main>
 
-      <div class="country-flag-slider">
-        <div class="country-flag-slide-track" id="country-list">
-          <!-- Country names will be dynamically inserted here -->
+      <aside id="country-panel" class="country-panel" role="region" hidden>
+        <div class="country-flag-slider">
+          <div class="country-flag-slide-track" id="country-list">
+            <!-- Country names will be dynamically inserted here -->
+          </div>
         </div>
-      </div>
+      </aside>
 
       <footer>
         <nav class="bottom-navbar"></nav>
@@ -69,13 +70,15 @@
       <script type="module">
         import { buildCardCarousel } from "../helpers/carouselBuilder.js";
         import { populateCountryList } from "../helpers/countryUtils.js";
+        import { toggleCountryPanel } from "../helpers/countryPanel.js";
         import { fetchDataWithErrorHandling } from "../helpers/dataUtils.js";
         import { DATA_DIR } from "../helpers/constants.js";
 
         document.addEventListener("DOMContentLoaded", async () => {
           const carouselContainer = document.getElementById("carousel-container");
           const countryListContainer = document.getElementById("country-list");
-          const filterSelect = document.getElementById("country-filter");
+          const toggleBtn = document.getElementById("country-toggle");
+          const countryPanel = document.getElementById("country-panel");
 
           let allJudoka = [];
           let gokyoData = [];
@@ -87,16 +90,6 @@
             ]);
           }
 
-          function populateFilterOptions() {
-            const countries = [...new Set(allJudoka.map((j) => j.country).filter(Boolean))].sort();
-            for (const c of countries) {
-              const option = document.createElement("option");
-              option.value = c;
-              option.textContent = c;
-              filterSelect.appendChild(option);
-            }
-          }
-
           async function renderCarousel(list) {
             carouselContainer.innerHTML = "";
             const carousel = await buildCardCarousel(list, gokyoData);
@@ -105,7 +98,6 @@
 
           try {
             await loadData();
-            populateFilterOptions();
             await renderCarousel(allJudoka);
             if (allJudoka.length === 0) {
               const noResultsMessage = document.createElement("div");
@@ -123,11 +115,22 @@
             carouselContainer.appendChild(errorMessage);
           }
 
-          filterSelect.addEventListener("change", async () => {
-            const selected = filterSelect.value;
+          toggleBtn.addEventListener("click", () => toggleCountryPanel(toggleBtn, countryPanel));
+
+          countryPanel.addEventListener("keydown", (e) => {
+            if (e.key === "Escape") {
+              toggleCountryPanel(toggleBtn, countryPanel, false);
+            }
+          });
+
+          countryListContainer.addEventListener("click", async (e) => {
+            const button = e.target.closest("button.flag-button");
+            if (!button) return;
+            const selected = button.value;
             const filtered =
               selected === "all" ? allJudoka : allJudoka.filter((j) => j.country === selected);
             await renderCarousel(filtered);
+            toggleCountryPanel(toggleBtn, countryPanel, false);
           });
 
           populateCountryList(countryListContainer);

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -682,9 +682,12 @@ button .ripple {
   justify-content: center;
 }
 
-.filter-bar select {
+.filter-bar button {
   padding: 0.3rem 0.5rem;
   border-radius: 4px;
+  background: var(--button-bg);
+  color: var(--button-text-color);
+  border: none;
 }
 
 .scroll-markers {
@@ -742,4 +745,38 @@ button .ripple {
   border-radius: var(--radius-md); /* Updated token */
   font-size: 1.25rem;
   font-weight: bold;
+}
+
+.country-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 75vw;
+  max-width: 320px;
+  height: 100%;
+  background: rgba(0, 32, 82, 0.9);
+  overflow-y: auto;
+  padding: var(--space-md);
+  transform: translateX(100%);
+  transition: transform 300ms ease-in-out;
+  z-index: 50;
+}
+
+.country-panel.open {
+  transform: translateX(0);
+}
+
+.country-panel[hidden] {
+  display: none;
+}
+
+.flag-button {
+  background: transparent;
+  border: none;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.flag-button:focus {
+  outline: 2px solid var(--color-primary);
 }

--- a/tests/helpers/populate-country-list.test.js
+++ b/tests/helpers/populate-country-list.test.js
@@ -27,6 +27,6 @@ describe("populateCountryList", () => {
 
     const slides = container.querySelectorAll(".slide");
     const names = [...slides].map((s) => s.querySelector("p").textContent);
-    expect(names).toEqual(["Brazil", "Canada", "Japan"]);
+    expect(names).toEqual(["All", "Brazil", "Canada", "Japan"]);
   });
 });


### PR DESCRIPTION
## Summary
- convert country filter dropdown into a slide-in panel
- create `toggleCountryPanel` helper to open/close the region
- update country flag list to use buttons and include an "All" option
- style the slide-in panel and buttons
- adjust Playwright tests for new interaction
- document the feature in the README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:contrast` *(fails: wcag-contrast not found)*
- `npx vitest run`
- `SKIP_SCREENSHOTS=true npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_685c49953c188326b1efa7b815d5fa83