### PR TITLE
Fix country filter test

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -54,9 +54,9 @@ test.describe("Browse Judoka screen", () => {
     await toggle.click();
     const panel = page.getByRole("region");
     await panel.waitFor();
-    await expect(page.locator("#carousel-container .judoka-card")).toHaveCountLessThan(
-      initialCount
-    );
+    await page.waitForTimeout(500);
+    const countAfterFilter = await page.locator("#carousel-container .judoka-card").count();
+    expect(countAfterFilter).toBeLessThan(initialCount);
     await page.getByRole("button", { name: "Japan" }).click({ force: true });
 
     const filteredCards = page.locator("#carousel-container .judoka-card");


### PR DESCRIPTION
## Summary
- update `country filter updates carousel` test to use explicit count check

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:contrast` *(fails: wcag-contrast not found)*
- `npx vitest run`
- `SKIP_SCREENSHOTS=true npx playwright test` *(fails: country filter test assertion fails)*

------
https://chatgpt.com/codex/tasks/task_e_685c4ef632d88326a7247edc834ad545