### PR TITLE
Fix browse judoka filter test expectations

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -56,7 +56,7 @@ test.describe("Browse Judoka screen", () => {
     await panel.waitFor();
     await page.waitForTimeout(500);
     const countAfterFilter = await page.locator("#carousel-container .judoka-card").count();
-    expect(countAfterFilter).toBeLessThan(initialCount);
+    expect(countAfterFilter).toBe(initialCount);
     await page.getByRole("button", { name: "Japan" }).click({ force: true });
 
     const filteredCards = page.locator("#carousel-container .judoka-card");


### PR DESCRIPTION
## Summary
- correct expectation for initial country filter state in Playwright tests

## Testing
- `npx prettier . --check` *(fails: command not found)*
- `npx eslint .` *(fails: command not found)*
- `npm run check:contrast` *(fails: command not found)*
- `npx vitest run` *(fails: command not found)*
- `npx playwright test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c533f2c588326915436b2ec5a7c68