### PR TITLE
Add flag selection improvements

### DIFF
--- a/src/helpers/countryUtils.js
+++ b/src/helpers/countryUtils.js
@@ -172,17 +172,16 @@ export async function getFlagUrl(countryCode) {
  * 3. Sort the countries alphabetically:
  *    - Order the filtered countries using `localeCompare` on the `country` name.
  *
- * 4. Generate slides for each active country:
+ * 4. Generate a button slide for each active country:
  *    - For each country:
- *      a. Create a `div` element for the slide container.
- *      b. Add a flag image:
+ *      a. Create a `button` element with classes `flag-button` and `slide`.
+ *      b. Set the `value` to the country's name and add an `aria-label`.
+ *      c. Add a flag image:
  *         - Create an `img` element.
  *         - Fetch the flag URL using `getFlagUrl`.
- *         - Set the `src` attribute to the flag URL or fallback URL if an error occurs.
- *      c. Add the country name:
- *         - Create a `p` element.
- *         - Set its text content to the country's name.
- *      d. Append the slide container to the specified container.
+ *         - Set the `src` attribute to the flag URL or a fallback URL on error.
+ *      d. Add the country name inside a `p` element.
+ *      e. Append the button directly to the specified container.
  *
  * 5. Handle errors:
  *    - Log any errors encountered during the process.
@@ -197,10 +196,8 @@ export async function populateCountryList(container) {
       .filter((country) => country.active)
       .sort((a, b) => a.country.localeCompare(b.country));
 
-    const allSlide = document.createElement("div");
-    allSlide.className = "slide";
     const allButton = document.createElement("button");
-    allButton.className = "flag-button";
+    allButton.className = "flag-button slide";
     allButton.value = "all";
     allButton.setAttribute("aria-label", "All Countries");
     const allImg = document.createElement("img");
@@ -211,8 +208,7 @@ export async function populateCountryList(container) {
     allLabel.textContent = "All";
     allButton.appendChild(allImg);
     allButton.appendChild(allLabel);
-    allSlide.appendChild(allButton);
-    container.appendChild(allSlide);
+    container.appendChild(allButton);
 
     for (const country of activeCountries) {
       if (!country.country || !country.code) {
@@ -220,11 +216,8 @@ export async function populateCountryList(container) {
         continue;
       }
 
-      const slide = document.createElement("div");
-      slide.className = "slide";
-
       const button = document.createElement("button");
-      button.className = "flag-button";
+      button.className = "flag-button slide";
       button.value = country.country;
       button.setAttribute("aria-label", country.country);
 
@@ -244,9 +237,8 @@ export async function populateCountryList(container) {
       countryName.textContent = country.country;
       button.appendChild(flagImg);
       button.appendChild(countryName);
-      slide.appendChild(button);
 
-      container.appendChild(slide);
+      container.appendChild(button);
     }
   } catch (error) {
     console.error("Error fetching country data:", error);

--- a/src/pages/carouselJudoka.html
+++ b/src/pages/carouselJudoka.html
@@ -53,6 +53,7 @@
             <!-- Country names will be dynamically inserted here -->
           </div>
         </div>
+        <button id="clear-filter" class="clear-filter-button">Clear selection</button>
       </aside>
 
       <footer>
@@ -121,12 +122,42 @@
             if (e.key === "Escape") {
               toggleCountryPanel(toggleBtn, countryPanel, false);
             }
+
+            if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+              const buttons = Array.from(
+                countryListContainer.querySelectorAll("button.flag-button")
+              );
+              const current = document.activeElement;
+              const index = buttons.indexOf(current);
+              if (index !== -1) {
+                e.preventDefault();
+                const offset = e.key === "ArrowRight" ? 1 : -1;
+                const next = (index + offset + buttons.length) % buttons.length;
+                buttons[next].focus();
+              }
+            }
+          });
+
+          function highlightSelection(button) {
+            const buttons = countryListContainer.querySelectorAll("button.flag-button");
+            buttons.forEach((b) => b.classList.remove("selected"));
+            button.classList.add("selected");
+          }
+
+          const clearBtn = document.getElementById("clear-filter");
+
+          clearBtn.addEventListener("click", async () => {
+            const buttons = countryListContainer.querySelectorAll("button.flag-button");
+            buttons.forEach((b) => b.classList.remove("selected"));
+            await renderCarousel(allJudoka);
+            toggleCountryPanel(toggleBtn, countryPanel, false);
           });
 
           countryListContainer.addEventListener("click", async (e) => {
             const button = e.target.closest("button.flag-button");
             if (!button) return;
             const selected = button.value;
+            highlightSelection(button);
             const filtered =
               selected === "all" ? allJudoka : allJudoka.filter((j) => j.country === selected);
             await renderCarousel(filtered);

--- a/src/pages/carouselJudoka.html
+++ b/src/pages/carouselJudoka.html
@@ -124,20 +124,21 @@
             }
 
             if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
-              const buttons = Array.from(
-                countryListContainer.querySelectorAll("button.flag-button")
-              );
-              const current = document.activeElement;
-              const index = buttons.indexOf(current);
-              if (index !== -1) {
-                e.preventDefault();
-                const offset = e.key === "ArrowRight" ? 1 : -1;
-                const next = (index + offset + buttons.length) % buttons.length;
-                buttons[next].focus();
-              }
+              handleKeyboardNavigation(e, countryListContainer, "flag-button");
             }
           });
 
+          function handleKeyboardNavigation(event, container, buttonClass) {
+            const buttons = Array.from(container.querySelectorAll(`button.${buttonClass}`));
+            const current = document.activeElement;
+            const index = buttons.indexOf(current);
+            if (index !== -1) {
+              event.preventDefault();
+              const offset = event.key === "ArrowRight" ? 1 : -1;
+              const next = (index + offset + buttons.length) % buttons.length;
+              buttons[next].focus();
+            }
+          }
           function highlightSelection(button) {
             const buttons = countryListContainer.querySelectorAll("button.flag-button");
             buttons.forEach((b) => b.classList.remove("selected"));

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -780,3 +780,18 @@ button .ripple {
 .flag-button:focus {
   outline: 2px solid var(--color-primary);
 }
+
+.flag-button.selected {
+  border: 2px solid var(--color-primary);
+  border-radius: 4px;
+}
+
+.clear-filter-button {
+  margin: 1rem auto 0;
+  padding: 0.3rem 0.5rem;
+  background: var(--button-bg);
+  color: var(--button-text-color);
+  border: none;
+  border-radius: 4px;
+  display: block;
+}


### PR DESCRIPTION
## Summary
- make each flag slide a button
- highlight selected flag buttons
- allow keyboard navigation between flags
- add Clear selection button to country panel

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:contrast` *(fails: wcag-contrast not found)*
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_685c5806d6d48326874343550b9176f1