### PR TITLE
Update contrast docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Run the following commands from the repository root before committing. If any co
 ```bash
 npx prettier . --check       # verify formatting
 npx eslint .                 # lint the codebase
-npm run check:contrast       # ensure CSS meets WCAG AA contrast
+npm run check:contrast       # run Pa11y accessibility audit on http://localhost:3000
 npx vitest run                # run unit tests
 npx playwright test          # run Playwright UI tests
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ root. Fix any issues and rerun the checks until they all pass.
 ```bash
 npx prettier . --check       # verify formatting
 npx eslint .                 # lint the codebase
-npm run check:contrast       # ensure CSS meets WCAG AA contrast
+npm run check:contrast       # run Pa11y accessibility audit on http://localhost:3000
 npx vitest run               # run unit tests
 npx playwright test          # run Playwright UI tests
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 3. Verify formatting, linting, and color contrast before committing:
    ```bash
    npm run lint
-   npm run check:contrast
+   npm run check:contrast  # runs Pa11y against http://localhost:3000
    ```
 
 ### Debug Logging
@@ -192,4 +192,4 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 
 ## Contributing
 
-Please format your code with **Prettier**, lint it with **ESLint**, run **Vitest** and **Playwright**, and verify color contrast with `npm run check:contrast` before submitting a pull request. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full checklist.
+Please format your code with **Prettier**, lint it with **ESLint**, run **Vitest** and **Playwright**, and verify color contrast with `npm run check:contrast` (Pa11y) before submitting a pull request. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full checklist.

--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -106,7 +106,7 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 - Line-height: 1.4× font size
 - Letter-spacing: 0.5% (League Spartan), normal (Noto Sans)
 - Avoid using all caps in body text for readability
-- Use the `wcag-contrast` CLI (`npm run check:contrast`) to validate new CSS styles
+- Use the **Pa11y** CLI (`npm run check:contrast`) to validate contrast on the running site at http://localhost:3000
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check:contrast": "pa11y http://localhost:3000",
     "prepare": "husky install",
     "validate:data": "node scripts/validateData.js"
-  },  
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/tests/package-scripts.test.js
+++ b/tests/package-scripts.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url)));
+
+describe("npm scripts", () => {
+  it("check:contrast uses pa11y", () => {
+    expect(pkg.scripts["check:contrast"]).toBe("pa11y http://localhost:3000");
+  });
+});


### PR DESCRIPTION
## Summary
- document that `npm run check:contrast` now runs pa11y
- note pa11y in README, CONTRIBUTING, and code standards
- format `package.json` with Prettier
- add test that asserts the pa11y script exists

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm run check:contrast` *(fails: pa11y: not found)*
- `npx vitest run` *(fails: 403 Forbidden to download vitest)*
- `npx playwright test` *(fails: 403 Forbidden to download playwright)*

------
https://chatgpt.com/codex/tasks/task_e_685c5f8efdcc83269851595370f89eb8