### PR TITLE
Fix package scripts test path handling

### DIFF
--- a/tests/package-scripts.test.js
+++ b/tests/package-scripts.test.js
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "node:path";
 
-const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url)));
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkgPath = path.join(__dirname, "../package.json");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
 
 describe("npm scripts", () => {
   it("check:contrast uses pa11y", () => {


### PR DESCRIPTION
## Summary
- update test to derive `__dirname` with `fileURLToPath`
- read `package.json` via `path.join`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:contrast` *(fails: Failed to launch the browser process)*
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_685c63413b14832695c57fb4008871a1