### PR TITLE
Update Pa11y port to 5000

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Run the following commands from the repository root before committing. If any co
 ```bash
 npx prettier . --check       # verify formatting
 npx eslint .                 # lint the codebase
-npm run check:contrast       # run Pa11y accessibility audit on http://localhost:3000
+npm run check:contrast       # run Pa11y accessibility audit on http://localhost:5000
 npx vitest run                # run unit tests
 npx playwright test          # run Playwright UI tests
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ root. Fix any issues and rerun the checks until they all pass.
 ```bash
 npx prettier . --check       # verify formatting
 npx eslint .                 # lint the codebase
-npm run check:contrast       # run Pa11y accessibility audit on http://localhost:3000
+npm run check:contrast       # run Pa11y accessibility audit on http://localhost:5000
 npx vitest run               # run unit tests
 npx playwright test          # run Playwright UI tests
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 3. Verify formatting, linting, and color contrast before committing:
    ```bash
    npm run lint
-   npm run check:contrast  # runs Pa11y against http://localhost:3000
+   npm run check:contrast  # runs Pa11y against http://localhost:5000
    ```
 
 ### Debug Logging

--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -106,7 +106,7 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 - Line-height: 1.4× font size
 - Letter-spacing: 0.5% (League Spartan), normal (Noto Sans)
 - Avoid using all caps in body text for readability
-- Use the **Pa11y** CLI (`npm run check:contrast`) to validate contrast on the running site at http://localhost:3000
+- Use the **Pa11y** CLI (`npm run check:contrast`) to validate contrast on the running site at http://localhost:5000
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest",
     "test:screenshot": "playwright test",
     "lint": "npx prettier . --check && npx eslint .",
-    "check:contrast": "pa11y http://localhost:3000",
+    "check:contrast": "pa11y http://localhost:5000",
     "prepare": "husky install",
     "validate:data": "node scripts/validateData.js"
   },

--- a/tests/package-scripts.test.js
+++ b/tests/package-scripts.test.js
@@ -9,6 +9,6 @@ const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
 
 describe("npm scripts", () => {
   it("check:contrast uses pa11y", () => {
-    expect(pkg.scripts["check:contrast"]).toBe("pa11y http://localhost:3000");
+    expect(pkg.scripts["check:contrast"]).toBe("pa11y http://localhost:5000");
   });
 });


### PR DESCRIPTION
## Summary
- point `check:contrast` at http://localhost:5000
- update doc references to the new port
- adjust unit test expectations

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:contrast` *(fails: Running as root without --no-sandbox)*
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_685c66b59e60832684479dbd7bf80690