### PR TITLE
Improve color contrast test coverage

### DIFF
--- a/tests/helpers/color-contrast.test.js
+++ b/tests/helpers/color-contrast.test.js
@@ -25,7 +25,12 @@ describe("base.css color contrast", () => {
     ["--button-active-bg", "--button-text-color"],
     ["--color-secondary", "--color-surface"],
     ["--color-primary", "--color-surface"],
-    ["--color-tertiary", "--color-secondary"]
+    ["--color-tertiary", "--color-secondary"],
+    ["--color-text", "--color-background"],
+    ["--color-primary", "--color-background"],
+    ["--color-secondary", "--color-background"],
+    ["--color-tertiary", "--color-text"],
+    ["--color-surface", "--color-text"]
   ];
 
   it.each(pairs)("%s vs %s should be >= 4.5", (a, b) => {


### PR DESCRIPTION
## Summary
- check more color pairs in color contrast tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:contrast` *(fails: unknown option `--chrome-launch-flags`)*
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_685c6a3f0fbc8326981adf14fd16878e