### PR TITLE
Add text inverted color token

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -10,6 +10,7 @@
   --color-surface: #ffffff; /* Light mode surfaces */
   --color-background: #ffffff; /* Light mode background */
   --color-text: #000000; /* Light mode text */
+  --color-text-inverted: #ffffff;
 
   --button-bg: #0c3f7a;
   --button-hover-bg: #0b5bb0;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -317,7 +317,7 @@ button .ripple {
 /* Top bar of the card (name and flag) */
 .card-top-bar {
   background-color: var(--card-bg-color);
-  color: var(--color-text); /* Updated token */
+  color: var(--color-text-inverted);
   justify-content: space-around;
   display: inline-flex;
   align-items: center;
@@ -398,7 +398,7 @@ button .ripple {
   right: var(--space-small); /* Updated token */
   background-color: rgba(0, 0, 0, 0.4);
   border-radius: var(--radius-sm); /* Updated token */
-  color: var(--color-text); /* Updated token */
+  color: var(--color-text-inverted);
   font-weight: bold;
   padding: var(--space-small) var(--space-medium); /* Updated tokens */
   font-size: var(--font-small); /* Updated token */
@@ -413,7 +413,7 @@ button .ripple {
 
 .card-stats {
   background-color: var(--card-bg-color);
-  color: var(--color-text);
+  color: var(--color-text-inverted);
   padding: var(--space-small) var(--space-large);
   margin: 0;
   display: flex;
@@ -612,7 +612,7 @@ button .ripple {
   min-width: 100vw;
   justify-content: space-evenly;
   background-color: var(--color-secondary);
-  color: var(--color-text);
+  color: var(--color-text-inverted);
   text-align: center;
   padding: 1vh 0;
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.2);
@@ -773,7 +773,7 @@ button .ripple {
 .flag-button {
   background: transparent;
   border: none;
-  color: var(--color-text);
+  color: var(--color-text-inverted);
   cursor: pointer;
 }
 

--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -18,7 +18,7 @@
 .meditation-title {
   font-family: "League Spartan", sans-serif; /* Updated token */
   font-size: clamp(32px, 5vw, 40px); /* Updated token */
-  color: var(--color-text); /* Updated token */
+  color: var(--color-text-inverted);
   text-align: center;
   margin-top: var(--space-sm); /* Updated token */
   background-color: var(--color-primary);
@@ -67,7 +67,7 @@
 
 .quote {
   font-size: clamp(18px, 2vw, 24px);
-  color: var(--color-text); /* Updated token */
+  color: var(--color-text-inverted);
   line-height: 1.4; /* Updated token */
   max-width: 70ch;
   margin: 0 auto;
@@ -75,7 +75,7 @@
 }
 
 .quote-heading {
-  color: var(--color-text); /* Updated token */
+  color: var(--color-text-inverted);
   font-family: "League Spartan", sans-serif;
   font-size: clamp(18px, 2vw, 24px);
   text-align: left;
@@ -85,7 +85,7 @@
 }
 
 .quote-content {
-  color: var(--color-text); /* Updated token */
+  color: var(--color-text-inverted);
   font-size: clamp(18px, 2vw, 24px);
   text-align: justify;
   align-self: center;
@@ -172,7 +172,7 @@
   align-items: center;
   gap: var(--space-small); /* Updated token */
   background-color: var(--color-secondary); /* Updated token */
-  color: var(--color-text); /* Updated token */
+  color: var(--color-text-inverted);
   border: none;
   border-radius: var(--radius-md); /* Updated token */
   padding: var(--space-small) var(--space-medium); /* Updated tokens */


### PR DESCRIPTION
## Summary
- add `--color-text-inverted` CSS variable
- use inverted text color for dark component styles
- tweak quote screen styles for better contrast

## Testing
- `npx prettier . --write`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_685c6eb4c1d48326ac223225a9172dc4