### PR TITLE
Remove accent beige contrast test

### DIFF
--- a/tests/helpers/components-color-contrast.test.js
+++ b/tests/helpers/components-color-contrast.test.js
@@ -40,9 +40,6 @@ function getComponentColors(vars) {
       colors[key] = resolveColor(match[1].trim(), vars);
     }
   }
-  if (vars["--accent-beige"]) {
-    colors.accentBeige = vars["--accent-beige"];
-  }
   return colors;
 }
 
@@ -60,11 +57,4 @@ describe("components.css color contrast", () => {
     const ratio = hex(bg, vars["--color-text-inverted"]);
     expect(ratio).toBeGreaterThanOrEqual(4.5);
   });
-
-  if (colors.accentBeige) {
-    it("--accent-beige vs --color-text should be >= 4.5", () => {
-      const ratio = hex(colors.accentBeige, vars["--color-text"]);
-      expect(ratio).toBeGreaterThanOrEqual(4.5);
-    });
-  }
 });


### PR DESCRIPTION
## Summary
- delete accent beige reference in components contrast helpers
- drop the accent beige color contrast test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:contrast` *(fails: net::ERR_CONNECTION_REFUSED)*
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_685c73e3a3fc8326bbf8867b044a6c66