### PR TITLE
Document server requirement for contrast check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Run the following commands from the repository root before committing. If any co
 ```bash
 npx prettier . --check       # verify formatting
 npx eslint .                 # lint the codebase
-npm run check:contrast       # run Pa11y accessibility audit on http://localhost:5000
+npm run check:contrast       # run Pa11y accessibility audit on http://localhost:5000 (start a dev server first)
 npx vitest run                # run unit tests
 npx playwright test          # run Playwright UI tests
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ root. Fix any issues and rerun the checks until they all pass.
 ```bash
 npx prettier . --check       # verify formatting
 npx eslint .                 # lint the codebase
-npm run check:contrast       # run Pa11y accessibility audit on http://localhost:5000
+npm run check:contrast       # run Pa11y accessibility audit on http://localhost:5000 (requires the dev server to be running)
 npx vitest run               # run unit tests
 npx playwright test          # run Playwright UI tests
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
    npm start  # lightweight local dev server
    # Then visit: http://localhost:5000
    ```
-3. Verify formatting, linting, and color contrast before committing:
+3. Verify formatting, linting, and color contrast before committing. Make sure a local server (for example `npm start`) is running so Pa11y can access http://localhost:5000:
    ```bash
    npm run lint
    npm run check:contrast  # runs Pa11y against http://localhost:5000
@@ -192,4 +192,4 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 
 ## Contributing
 
-Please format your code with **Prettier**, lint it with **ESLint**, run **Vitest** and **Playwright**, and verify color contrast with `npm run check:contrast` (Pa11y) before submitting a pull request. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full checklist.
+Please format your code with **Prettier**, lint it with **ESLint**, run **Vitest** and **Playwright**, and verify color contrast with `npm run check:contrast` (Pa11y) while the development server is running before submitting a pull request. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full checklist.


### PR DESCRIPTION
## Summary
- update README and CONTRIBUTING docs to clarify Pa11y needs a running server
- mention this prerequisite in `AGENTS.md`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:contrast` *(fails: insufficient contrast ratio)*
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_685c766debe48326a3b1f69c7e81aa1e