### PR TITLE
Fix portrait placeholder path

### DIFF
--- a/src/helpers/cardRender.js
+++ b/src/helpers/cardRender.js
@@ -37,7 +37,7 @@ export function generateCardPortrait(card) {
   const { id, firstname, surname } = card;
   return `
     <div class="card-portrait">
-      <img src="../assets/judokaPortraits/judokaPortrait-${id}.png" alt="${firstname} ${surname}'s portrait" loading="lazy" onerror="this.src='../assets/judokaPortraits/judokaPortrait-0.png'">
+      <img src="../assets/judokaPortraits/judokaPortrait-${id}.png" alt="${firstname} ${surname}'s portrait" loading="lazy" onerror="this.onerror=null; this.src='../assets/judokaPortraits/judokaPortrait-0.png'">
     </div>
   `;
 }


### PR DESCRIPTION
## Summary
- fix fallback image path when portrait fails to load
- clarify pseudocode about placeholder portrait

## Testing
- `npx prettier . --check` *(fails: Code style issues found)*
- `npx eslint .`
- `npm run check:contrast` *(fails: 1 Errors)*
- `npx vitest run`
- `npx playwright test` *(fails: 7 failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ed930c974832687c2a294c6e55da8