### PR TITLE
Update design tokens and PRD

### DIFF
--- a/design/productRequirementsDocuments/prdNavigationMap.md
+++ b/design/productRequirementsDocuments/prdNavigationMap.md
@@ -154,3 +154,30 @@ Currently, the menu is purely functional but lacks the thematic cohesion that dr
   - [ ] 5.3 Test animation performance on devices to ensure ≥60fps.
   - [ ] 5.4 Verify all text labels meet WCAG 2.1 AA contrast standards (≥4.5:1).
 - [ ] **5.0 Add "Simple Menu Mode" toggle to settings (P3)**
+
+---
+
+## Non-Goals
+
+- No dynamic pathfinding or open-world navigation beyond the village map.
+- Does not introduce multiplayer map interactions.
+- Excludes voice-over or cutscene content.
+
+## Dependencies & Integrations
+
+- Relies on existing footer navigation and settings modules.
+- Uses current asset loader for map imagery.
+- Stores preferences in local storage.
+
+## Open Questions
+
+- Should future game modes appear on the map automatically?
+- Are audio cues required for map interactions?
+- Do we support landscape-only layouts?
+
+## Metadata
+
+- **Author:** Ju-Do-Kon! Team
+- **Last Edited:** 2024-05-01
+- **Target Version:** v1.2
+- **Related Features:** Navigation Bar, Settings Menu

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -232,7 +232,7 @@ function setupSwipeNavigation(container) {
 // Ensure WCAG compliance for touch target sizes and contrast ratios
 
 // Adjust button sizes for touch targets
-const MIN_TOUCH_TARGET_SIZE = 44;
+const MIN_TOUCH_TARGET_SIZE = 48;
 
 function ensureTouchTargetSize(element) {
   const style = window.getComputedStyle(element);

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -79,13 +79,13 @@ body {
 }
 
 .game-tile {
-  background: #fff;
-  border: 2px solid #ccc;
-  border-radius: 12px;
+  background: var(--color-surface);
+  border: 2px solid var(--color-tertiary);
+  border-radius: var(--radius-lg);
   padding: 1.5rem;
   text-align: center;
   font-size: 1rem;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-base);
   cursor: pointer;
   transition: transform 0.15s ease-in-out;
 }
@@ -128,14 +128,14 @@ body {
   max-height: 36vh;
   width: auto;
   aspect-ratio: 1 / 1;
-  border-radius: 1rem;
+  border-radius: var(--radius-lg);
   flex: 1 1 auto;
   object-fit: contain;
   align-items: center;
 }
 
 .locationTileSmall {
-  border-radius: 1rem;
+  border-radius: var(--radius-lg);
   display: flex;
   flex: 1 1 auto;
   max-width: 10vh;
@@ -145,7 +145,7 @@ body {
   max-width: 10vh;
   height: auto;
   aspect-ratio: 1 / 1;
-  border-radius: 1rem;
+  border-radius: var(--radius-lg);
   flex: 1 1 auto;
 }
 .svgTile {
@@ -475,7 +475,7 @@ button .ripple {
   width: 100%;
   color: var(--color-secondary);
   justify-content: center;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--color-tertiary);
   white-space: nowrap;
   padding: min(10px, 2.3vw) 8px;
@@ -494,7 +494,7 @@ button .ripple {
   height: 100%;
   color: #fed843;
   justify-content: center;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--card-signature-move-bg);
   white-space: nowrap;
   padding: min(5px, 2.3vw) 8px;
@@ -551,9 +551,10 @@ button .ripple {
   position: relative;
   background-color: rgba(0, 0, 0, 0.1);
   color: white;
-  border: 1px solid #838383;
+  border: 1px solid var(--color-tertiary);
   border-radius: 50%;
-  min-width: 2em;
+  min-width: 48px;
+  min-height: 48px;
   aspect-ratio: 1/1;
   display: flex;
   flex: 1 1 auto;
@@ -693,7 +694,7 @@ button .ripple {
 
 .loading-spinner {
   display: none;
-  border: 4px solid #f3f3f3;
+  border: 4px solid var(--color-surface);
   border: solid 1px var(--color-secondary);
   border-radius: 50%;
   width: 40px;


### PR DESCRIPTION
## Summary
- style game tiles using design tokens
- ensure scroll buttons meet minimum tap target size
- bump accessibility constant to 48px
- extend Navigation Map PRD with non-goals, dependencies, open questions and metadata

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Meditation screen visible, screenshot diffs)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_6861be44dc3483268274c68a325c03c1