### PR TITLE
Add PRD follow-up note for feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/ju-do-kon--feature-request.md
+++ b/.github/ISSUE_TEMPLATE/ju-do-kon--feature-request.md
@@ -98,3 +98,5 @@ Upon clicking Country Filter:
 # 👇 Ready to Start!
 
 _Happy feature-building for Ju-Do-Kon!_
+
+_Once approved, draft a PRD using the standard template (`design/productRequirementsDocuments/prdTemplate.md`)._

--- a/design/productRequirementsDocuments/prdGitHubEnhancementCriteria.md
+++ b/design/productRequirementsDocuments/prdGitHubEnhancementCriteria.md
@@ -1,7 +1,9 @@
 ---
 # 🎴 Ju-Do-Kon! Game Feature Request Criteria (Tailored)
 
-These criteria help ensure each feature or enhancement is clear, player-focused, and easily implementable by the dev team. **Every Ju-Do-Kon! feature request should meet these 5 criteria**:
+These criteria help ensure each feature or enhancement is clear, player-focused, and easily implementable by the dev team. **Every Ju-Do-Kon! feature request should meet these 5 criteria**.
+
+Once a request is approved, draft a PRD using `prdTemplate.md` in this directory.
 ---
 
 ## 1. ✅ **Clear Problem Statement**


### PR DESCRIPTION
## Summary
- mention PRD template in feature request criteria doc
- note in the feature request issue template that approved issues should lead to a PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: meditation screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6861bdfd28b48326b4d7c0fa9d7fc6ca