### PR TITLE
Fix missing URL in teamBattleFemale mode

### DIFF
--- a/src/data/gameModes.json
+++ b/src/data/gameModes.json
@@ -62,6 +62,7 @@
     "description": "A team-based mode where female players compete in groups.",
     "category": "teamBattle",
     "order": 60,
+    "url": "teamBattleFemale.html",
     "isHidden": true,
     "rules": {
       "base": "teamBattle",


### PR DESCRIPTION
## Summary
- add `teamBattleFemale.html` URL to `teamBattleFemale` game mode

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686423312d9083268f79a47b951aa009