### PR TITLE
Center quote block content

### DIFF
--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -50,6 +50,11 @@
   background-color: var(--color-secondary);
   border: 2px solid var(--color-primary);
   border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--space-md);
 }
 
 .quote-loader {
@@ -82,7 +87,7 @@
   color: var(--color-text-inverted);
   font-family: "League Spartan", sans-serif;
   font-size: clamp(18px, 3vw, 24px);
-  text-align: left;
+  text-align: center;
   align-self: center;
   justify-self: center;
   padding: var(--space-medium);
@@ -92,7 +97,7 @@
 .quote-content {
   color: var(--color-text-inverted);
   font-size: clamp(18px, 2vw, 24px);
-  text-align: justify;
+  text-align: center;
   align-self: center;
   justify-self: center;
   padding: 5dvh 5dvw;


### PR DESCRIPTION
## Summary
- center the language toggle button, loader, and quote in the meditation page

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6865759e21b883269e0bd416b8f2f894