### PR TITLE
Add dependencies for random card draw

### DIFF
--- a/design/productRequirementsDocuments/prdTeamBattleFemale.md
+++ b/design/productRequirementsDocuments/prdTeamBattleFemale.md
@@ -33,6 +33,7 @@
 ## Dependencies
 
 - Uses the common Team Battle ruleset for scoring.
+- Matches call `generateRandomCard` as described in [prdDrawRandomCard.md](prdDrawRandomCard.md).
 
 ## Open Questions
 

--- a/design/productRequirementsDocuments/prdTeamBattleMale.md
+++ b/design/productRequirementsDocuments/prdTeamBattleMale.md
@@ -33,6 +33,7 @@
 ## Dependencies
 
 - Relies on the base Team Battle ruleset for scoring and rounds.
+- Matches call `generateRandomCard` as described in [prdDrawRandomCard.md](prdDrawRandomCard.md).
 
 ## Open Questions
 

--- a/design/productRequirementsDocuments/prdTeamBattleMixed.md
+++ b/design/productRequirementsDocuments/prdTeamBattleMixed.md
@@ -33,6 +33,7 @@
 ## Dependencies
 
 - Relies on the base Team Battle ruleset for scoring and rounds.
+- Matches call `generateRandomCard` as described in [prdDrawRandomCard.md](prdDrawRandomCard.md).
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary
- mention `generateRandomCard` usage in team battle PRDs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686574fc86988326b0e8624629fc3c75