### PR TITLE
Set color token for country panel

### DIFF
--- a/design/productRequirementsDocuments/prdBrowseJudoka.md
+++ b/design/productRequirementsDocuments/prdBrowseJudoka.md
@@ -263,4 +263,5 @@ No player settings or toggles are applicable for this feature.
   - [ ] 6.2 Manage focus state and ensure visible outlines
 
 ---
+
 [Back to Game Modes Overview](prdGameModes.md)

--- a/design/productRequirementsDocuments/prdGameModes.md
+++ b/design/productRequirementsDocuments/prdGameModes.md
@@ -293,7 +293,6 @@ Create a new judoka with custom stats and appearance.
 
 - Should there be limits on the number of custom judoka?
 
-
 ---
 
 ### Update A Judoka (Admin Mode)
@@ -363,7 +362,6 @@ Display a random judoka profile. [Read full PRD](prdRandomJudoka.md)
 
 - Should favourites influence the random selection?
 
-
 ---
 
 ### Meditation
@@ -400,4 +398,3 @@ A calm screen offering inspirational quotes and ambient visuals. [Read full PRD]
 #### Open Questions
 
 - Should quotes rotate daily or on every visit?
-

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -733,7 +733,7 @@ button .ripple {
   width: 75vw;
   max-width: 320px;
   height: 100%;
-  background: rgba(0, 32, 82, 0.9);
+  background: var(--color-secondary);
   overflow-y: auto;
   padding: var(--space-md);
   transform: translateX(100%);


### PR DESCRIPTION
## Summary
- switch `.country-panel` background to use `var(--color-secondary)`
- run Prettier formatting on docs to satisfy lint checks

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_686828c50c6483268ae7e4183730d932