### PR TITLE
Show message when country filter empty

### DIFF
--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -166,6 +166,12 @@
             const filtered =
               selected === "all" ? allJudoka : allJudoka.filter((j) => j.country === selected);
             await renderCarousel(filtered);
+            if (filtered.length === 0) {
+              const noResultsMessage = document.createElement("div");
+              noResultsMessage.className = "no-results-message";
+              noResultsMessage.textContent = "No judoka available for this country";
+              carouselContainer.appendChild(noResultsMessage);
+            }
             toggleCountryPanel(toggleBtn, countryPanel, false);
           });
 


### PR DESCRIPTION
## Summary
- warn users when no judoka exist for a country after filtering

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68682a9eb9dc8326ae896c1d4e14c008