### PR TITLE
Add reduced motion rule for country panel

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -800,3 +800,10 @@ button .ripple {
   border-radius: 4px;
   display: block;
 }
+
+/* Reduce motion for the country panel */
+@media (prefers-reduced-motion: reduce) {
+  .country-panel {
+    transition: none !important;
+  }
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -803,7 +803,8 @@ button .ripple {
 
 /* Reduce motion for the country panel */
 @media (prefers-reduced-motion: reduce) {
-  .country-panel {
-    transition: none !important;
+  .country-panel[hidden],
+  .country-panel.grid {
+    transition: none;
   }
 }


### PR DESCRIPTION
## Summary
- disable transition on `.country-panel` when the user prefers reduced motion

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68682c2fd6f48326a8719dbba5e6b37d