### PR TITLE
Add min size to flag buttons

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -650,6 +650,8 @@ button .ripple {
     max-height: 5dvh;
     margin: 0.5rem;
     border-radius: 4px;
+    min-width: 48px;
+    min-height: 48px;
   }
 }
 
@@ -780,6 +782,8 @@ button .ripple {
   border: none;
   color: var(--color-text-inverted);
   cursor: pointer;
+  min-width: 48px;
+  min-height: 48px;
 }
 
 .flag-button:focus {


### PR DESCRIPTION
## Summary
- ensure flag images and buttons meet 48px touch target requirement

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68682c17d1908326a4e3b85fdce143b7