### PR TITLE
Implement lazy loading for country list

### DIFF
--- a/src/helpers/countryUtils.js
+++ b/src/helpers/countryUtils.js
@@ -225,7 +225,7 @@ export async function populateCountryList(container) {
     allButton.appendChild(allLabel);
     container.appendChild(allButton);
 
-    const scrollContainer = container.parentElement || container;
+    const scrollContainer = options.scrollContainer || container;
     const BATCH_SIZE = 50;
     let rendered = 0;
 

--- a/src/helpers/countryUtils.js
+++ b/src/helpers/countryUtils.js
@@ -270,7 +270,7 @@ export async function populateCountryList(container) {
       const handleScroll = async () => {
         if (
           scrollContainer.scrollTop + scrollContainer.clientHeight >=
-          scrollContainer.scrollHeight - 5
+          scrollContainer.scrollHeight - SCROLL_THRESHOLD_PX
         ) {
           await renderBatch();
           if (rendered >= activeCountries.length) {

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -118,7 +118,16 @@
             carouselContainer.appendChild(errorMessage);
           }
 
-          toggleBtn.addEventListener("click", () => toggleCountryPanel(toggleBtn, countryPanel));
+          let countriesLoaded = false;
+
+          toggleBtn.addEventListener("click", async () => {
+            const wasOpen = countryPanel.classList.contains("open");
+            toggleCountryPanel(toggleBtn, countryPanel);
+            if (!wasOpen && !countriesLoaded) {
+              await populateCountryList(countryListContainer);
+              countriesLoaded = true;
+            }
+          });
 
           layoutToggle.addEventListener("click", () => toggleCountryPanelMode(countryPanel));
 
@@ -180,8 +189,6 @@
             }
             toggleCountryPanel(toggleBtn, countryPanel, false);
           });
-
-          populateCountryList(countryListContainer);
         });
       </script>
 


### PR DESCRIPTION
## Summary
- optimize country panel by rendering flags in batches
- lazy load country list on demand
- test lazy loading logic

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68682c25a6448326b6ce7bc3fcccb758