### PR TITLE
Add retry option for judoka carousel

### DIFF
--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -123,8 +123,15 @@
             retryButton.setAttribute("type", "button");
             retryButton.setAttribute("aria-label", "Retry loading judoka data");
             retryButton.addEventListener("click", async () => {
-              await loadData();
-              await renderCarousel(allJudoka);
+              retryButton.disabled = true; // Disable the button to prevent multiple clicks
+              try {
+                await loadData();
+                await renderCarousel(allJudoka);
+              } catch (error) {
+                console.error("Error during retry:", error);
+              } finally {
+                retryButton.disabled = false; // Re-enable the button after processing
+              }
             });
             carouselContainer.appendChild(retryButton);
           }

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -116,6 +116,16 @@
             errorMessage.textContent =
               "Network error occurred. Please check your connection and try again.";
             carouselContainer.appendChild(errorMessage);
+
+            const retryButton = document.createElement("button");
+            retryButton.className = "retry-button";
+            retryButton.textContent = "Retry";
+            retryButton.setAttribute("aria-label", "Retry loading judoka data");
+            retryButton.addEventListener("click", async () => {
+              await loadData();
+              await renderCarousel(allJudoka);
+            });
+            carouselContainer.appendChild(retryButton);
           }
 
           let countriesLoaded = false;

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -120,6 +120,7 @@
             const retryButton = document.createElement("button");
             retryButton.className = "retry-button";
             retryButton.textContent = "Retry";
+            retryButton.setAttribute("type", "button");
             retryButton.setAttribute("aria-label", "Retry loading judoka data");
             retryButton.addEventListener("click", async () => {
               await loadData();

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -805,6 +805,21 @@ button .ripple {
   display: block;
 }
 
+.retry-button {
+  margin: 1rem auto 0;
+  padding: 0.5rem 1rem;
+  background: var(--button-bg);
+  color: var(--button-text-color);
+  border: none;
+  border-radius: 4px;
+  display: block;
+}
+
+.retry-button:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 /* Reduce motion for the country panel */
 @media (prefers-reduced-motion: reduce) {
   .country-panel[hidden],


### PR DESCRIPTION
## Summary
- handle errors in the Browse Judoka carousel with a retry button
- style the retry button for focus and spacing

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686af795b2948326a0cbc49fe9c6cf6d