### PR TITLE
Improve carousel focus navigation

### DIFF
--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -345,10 +345,7 @@ export async function buildCardCarousel(judokaList, gokyoData) {
       continue;
     }
     handleBrokenImages(card);
-    const focusable = card.querySelector(".judoka-card");
-    if (focusable) {
-      focusable.tabIndex = 0;
-    }
+    card.tabIndex = 0;
   }
 
   clearTimeout(timeoutId);

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -182,18 +182,26 @@ function handleBrokenImages(card) {
  * @pseudocode
  * 1. Make the container focusable by setting `tabIndex` to 0.
  * 2. Add a `keydown` event listener to the container.
- *    - Scroll left when the "ArrowLeft" key is pressed.
- *    - Scroll right when the "ArrowRight" key is pressed.
+ *    - Scroll left when the "ArrowLeft" key is pressed and focus the previous card.
+ *    - Scroll right when the "ArrowRight" key is pressed and focus the next card.
  *
  * @param {HTMLElement} container - The carousel container element.
  */
 function setupKeyboardNavigation(container) {
   container.tabIndex = 0; // Make the carousel focusable
   container.addEventListener("keydown", (event) => {
+    const cards = container.querySelectorAll(".judoka-card");
+    const active = document.activeElement;
+    const index = Array.from(cards).indexOf(active);
+
     if (event.key === "ArrowLeft") {
       container.scrollBy({ left: -300, behavior: "smooth" });
+      const prevIndex = index > 0 ? index - 1 : 0;
+      cards[prevIndex]?.focus();
     } else if (event.key === "ArrowRight") {
       container.scrollBy({ left: 300, behavior: "smooth" });
+      const nextIndex = index >= 0 ? Math.min(cards.length - 1, index + 1) : 0;
+      cards[nextIndex]?.focus();
     }
   });
 }
@@ -282,6 +290,7 @@ function applyAccessibilityImprovements(wrapper) {
  *    - Generate a card using `generateJudokaCard`.
  *    - Handle broken card images by setting a fallback image.
  *    - Append the generated card to the carousel container.
+ *    - Make the card focusable by setting `tabIndex`.
  *
  * 6. Remove the loading spinner once all cards are processed.
  *
@@ -292,6 +301,7 @@ function applyAccessibilityImprovements(wrapper) {
  *
  * 8. Add keyboard navigation:
  *    - Enable scrolling with the left and right arrow keys.
+ *    - Move focus to the next or previous card after scrolling.
  *
  * 9. Add swipe functionality for touch devices:
  *    - Detect swipe gestures to scroll the carousel left or right.
@@ -335,6 +345,10 @@ export async function buildCardCarousel(judokaList, gokyoData) {
       continue;
     }
     handleBrokenImages(card);
+    const focusable = card.querySelector(".judoka-card");
+    if (focusable) {
+      focusable.tabIndex = 0;
+    }
   }
 
   clearTimeout(timeoutId);

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -189,8 +189,8 @@ function handleBrokenImages(card) {
  */
 function setupKeyboardNavigation(container) {
   container.tabIndex = 0; // Make the carousel focusable
+  const cards = container.querySelectorAll(".judoka-card"); // Cache the NodeList
   container.addEventListener("keydown", (event) => {
-    const cards = container.querySelectorAll(".judoka-card");
     const active = document.activeElement;
     const index = Array.from(cards).indexOf(active);
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -278,6 +278,12 @@ button .ripple {
   transform: scale(1.1); /* Updated token */
 }
 
+/* Keyboard focus outline */
+.judoka-card:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 4px;
+}
+
 /* Common card variables */
 .judoka-card.common {
   --card-bg-color: #001749;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -279,11 +279,15 @@ button .ripple {
 }
 
 /* Keyboard focus outline */
-.judoka-card:focus {
+.judoka-card:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 4px;
 }
 
+/* Fallback for older browsers */
+.judoka-card:focus:not(:focus-visible) {
+  outline: none;
+}
 /* Common card variables */
 .judoka-card.common {
   --card-bg-color: #001749;


### PR DESCRIPTION
## Summary
- highlight judoka cards on keyboard focus
- make judoka cards focusable in `buildCardCarousel`
- move focus with arrow keys in `setupKeyboardNavigation`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686afbf453f08326bae444add844551b