### PR TITLE
Fix PRD card code bullet typo

### DIFF
--- a/design/productRequirementsDocuments/prdCardCodeGeneration.md
+++ b/design/productRequirementsDocuments/prdCardCodeGeneration.md
@@ -252,7 +252,7 @@ Code Generation and Sharing Flow
 
 - [ ] 2.0 Error Handling and Edge Cases
 
-  - [ ] 2.1 Fallback to a generic card code (judoka id=0] if encoding fails.
+  - [ ] 2.1 Fallback to a generic card code (judoka id=0) if encoding fails.
   - [ ] 2.2 Handle unusually large string input safely.
 
 - [ ] 3.0 Unit Tests


### PR DESCRIPTION
## Summary
- fix bracket typo in card code generation PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686b91b73b4c8326848c3bcd939257da