### PR TITLE
Center draw button on Random Judoka page

### DIFF
--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -38,8 +38,10 @@
         <div class="character-slot right"></div>
       </header>
 
-      <div id="card-container" class="card-container"></div>
-      <button id="draw-card-btn" class="draw-card-btn">Draw Card!</button>
+      <div class="card-section">
+        <div id="card-container" class="card-container"></div>
+        <button id="draw-card-btn" class="draw-card-btn">Draw Card!</button>
+      </div>
 
       <footer>
         <nav class="bottom-navbar"></nav>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -739,6 +739,16 @@ button .ripple {
   font-weight: bold;
 }
 
+.card-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.card-section .draw-card-btn {
+  align-self: center;
+}
+
 .country-panel {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- wrap random judoka card container and button in `.card-section`
- add flex centering styles for `.card-section`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diff on randomJudoka page)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686bbbe9152c83268d6b0045a1c179d9