### PR TITLE
Fix duplicate Symbol test

### DIFF
--- a/tests/helpers/data-utils.test.js
+++ b/tests/helpers/data-utils.test.js
@@ -115,7 +115,7 @@ describe("fetchDataWithErrorHandling", () => {
       .fn()
       .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue(data1) })
       .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue(data2) });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal("fetch", fetchMock);
 
     const { fetchDataWithErrorHandling } = await import("../../src/helpers/dataUtils.js");
     const url1 = "/one.json";

--- a/tests/helpers/helpers.test.js
+++ b/tests/helpers/helpers.test.js
@@ -106,11 +106,6 @@ describe("formatDate", () => {
     const obj = { valueOf: () => "not-a-date" };
     expect(formatDate(obj)).toBe("Invalid Date");
   });
-
-  test("does not throw for Symbol input", () => {
-    expect(() => formatDate(Symbol("date"))).not.toThrow();
-    expect(formatDate(Symbol("date"))).toBe("Invalid Date");
-  });
 });
 
 describe("escapeHTML", () => {


### PR DESCRIPTION
## Summary
- remove redundant `Symbol` check in helper tests
- update Prettier formatting

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 13 failed, 10 passed)*
- `npx playwright test --reporter=list`

------
https://chatgpt.com/codex/tasks/task_e_686bd85e69d483269b3655e512a0a584