### PR TITLE
Remove duplicate color contrast assertion

### DIFF
--- a/tests/helpers/components-color-contrast.test.js
+++ b/tests/helpers/components-color-contrast.test.js
@@ -58,9 +58,4 @@ describe("components.css color contrast", () => {
     const ratio = hex(bg, vars["--color-text-inverted"]);
     expect(ratio).toBeGreaterThanOrEqual(4.5);
   });
-
-  it("returns 1 for identical colors", () => {
-    expect(hex("#fff", "#fff")).toBe(1);
-    expect(hex("#000", "#000")).toBe(1);
-  });
 });


### PR DESCRIPTION
## Summary
- de-duplicate the identical color contrast test in `components-color-contrast.test.js`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 32 failed, 8 errors)*
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_686bdb04d4408326b3277d48fa6737e7