### PR TITLE
Update settings unknown key test

### DIFF
--- a/tests/helpers/settings-utils.test.js
+++ b/tests/helpers/settings-utils.test.js
@@ -134,13 +134,7 @@ describe("settings utils", () => {
     );
     await vi.advanceTimersByTimeAsync(110);
     const stored = await loadSettings();
-    expect(stored).toEqual({
-      sound: true,
-      fullNavMap: true,
-      motionEffects: true,
-      displayMode: "light",
-      gameModes: {}
-    });
+    expect(stored).toEqual(DEFAULT_SETTINGS);
     expect(stored.nonexistentKey).toBeUndefined();
   });
 

--- a/tests/helpers/settings-utils.test.js
+++ b/tests/helpers/settings-utils.test.js
@@ -126,14 +126,22 @@ describe("settings utils", () => {
   /**
    * Should return default value when updating a non-existent key.
    */
-  it("returns default when updating unknown key", async () => {
+  it("rejects when updating unknown key", async () => {
     vi.useFakeTimers();
     const { updateSetting, loadSettings } = await import("../../src/helpers/settingsUtils.js");
-    const promise = updateSetting("nonexistentKey", "value");
+    await expect(updateSetting("nonexistentKey", "value")).rejects.toThrow(
+      "Schema validation failed"
+    );
     await vi.advanceTimersByTimeAsync(110);
-    await promise;
     const stored = await loadSettings();
-    expect(stored.nonexistentKey).toBe("value");
+    expect(stored).toEqual({
+      sound: true,
+      fullNavMap: true,
+      motionEffects: true,
+      displayMode: "light",
+      gameModes: {}
+    });
+    expect(stored.nonexistentKey).toBeUndefined();
   });
 
   /**


### PR DESCRIPTION
## Summary
- update test for unknown settings key to expect schema validation error and preserve defaults

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_686be1d92ff08326afbeea4e73631cd0