### PR TITLE
Remove redundant color contrast test

### DIFF
--- a/tests/helpers/color-contrast.test.js
+++ b/tests/helpers/color-contrast.test.js
@@ -41,9 +41,4 @@ describe("base.css color contrast", () => {
       `Contrast ratio between ${a} (${vars[a]}) and ${b} (${vars[b]}) is ${ratio}, which is less than the required 4.5.`
     );
   });
-
-  it("returns 1 for identical colors", () => {
-    expect(hex("#ffffff", "#ffffff")).toBe(1);
-    expect(hex("#000", "#000")).toBe(1);
-  });
 });


### PR DESCRIPTION
## Summary
- delete the identical colors test from `color-contrast.test.js`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 29 failed tests)*
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_686be59145f8832687da00d7094ce8df