### PR TITLE
Fix settings utils export

### DIFF
--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -11,6 +11,7 @@ const DEFAULT_SETTINGS = {
   displayMode: "light",
   gameModes: {}
 };
+export { DEFAULT_SETTINGS };
 
 let saveTimer;
 const SAVE_DELAY_MS = 100;

--- a/tests/helpers/settings-utils.test.js
+++ b/tests/helpers/settings-utils.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "../../src/helpers/settingsUtils.js";
 
 /**
  * @fileoverview


### PR DESCRIPTION
## Summary
- export DEFAULT_SETTINGS in settingsUtils helper
- update settings-utils tests to import constant

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: localStorage unavailable and other errors)*
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_686bec1bce808326ab1980f0109567d9