### PR TITLE
Fix quote builder DOM checks

### DIFF
--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -91,7 +91,9 @@ function formatFableStory(story) {
 function displayFable(fable) {
   const quoteDiv = document.getElementById("quote");
   const loaderDiv = document.getElementById("quote-loader");
-  if (!quoteDiv || !loaderDiv) return;
+  if (!quoteDiv || !loaderDiv) {
+    return;
+  }
 
   if (fable) {
     const formattedStory = formatFableStory(fable.story);

--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -70,17 +70,20 @@ function formatFableStory(story) {
  * 1. Reference the cached quote and loader elements:
  *    - `quoteDiv` and `loaderDiv` are module-level references to `#quote` and `#quote-loader`.
  *
- * 2. Check if a fable is provided:
+ * 2. Ensure the DOM elements exist:
+ *    - If either element is missing, exit early.
+ *
+ * 3. Check if a fable is provided:
  *    - If a fable is provided:
  *      a. Format the fable's story using `formatFableStory`.
  *      b. Update the quote div's inner HTML with the fable's title and formatted story.
  *    - If no fable is provided:
  *      a. Display a default congratulatory message in the quote div.
  *
- * 3. Update the quote div:
+ * 4. Update the quote div:
  *    - Use template literals to dynamically insert the fable's title and story into the HTML structure.
 
- * 4. Toggle visibility:
+ * 5. Toggle visibility:
  *    - Hide the loader element and remove the `hidden` class from the quote element.
  *
  * @param {Object|null} fable - The fable object containing the title and story, or `null` if no fable is available.
@@ -88,6 +91,8 @@ function formatFableStory(story) {
 function displayFable(fable) {
   const quoteDiv = document.getElementById("quote");
   const loaderDiv = document.getElementById("quote-loader");
+  if (!quoteDiv || !loaderDiv) return;
+
   if (fable) {
     const formattedStory = formatFableStory(fable.story);
     quoteDiv.innerHTML = `


### PR DESCRIPTION
## Summary
- avoid DOM errors in quoteBuilder when #quote or #quote-loader are missing
- document early exit logic in pseudocode

## Testing
- `npx prettier . --check` *(fails: Cannot reach npm registry)*
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686c0e5f1d18832693f8f65b653bbea5