### PR TITLE
Fix settings utils and SVG fallback tests

### DIFF
--- a/tests/helpers/settings-utils.test.js
+++ b/tests/helpers/settings-utils.test.js
@@ -10,14 +10,29 @@ import { DEFAULT_SETTINGS } from "../../src/helpers/settingsUtils.js";
 describe("settings utils", () => {
   /** Save original setItem to restore after tests */
   const originalSetItem = Storage.prototype.setItem;
+  /** Cache original localStorage to restore after each test */
+  const originalLocalStorage = global.localStorage;
 
   beforeEach(() => {
     Storage.prototype.setItem = originalSetItem;
+    // Reset localStorage to its original implementation
+    Object.defineProperty(global, "localStorage", {
+      value: originalLocalStorage,
+      configurable: true,
+      writable: true
+    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    localStorage.clear();
+    if (global.localStorage) {
+      global.localStorage.clear();
+    }
+    Object.defineProperty(global, "localStorage", {
+      value: originalLocalStorage,
+      configurable: true,
+      writable: true
+    });
     vi.resetModules();
     vi.useRealTimers();
   });

--- a/tests/helpers/svg-fallback.test.js
+++ b/tests/helpers/svg-fallback.test.js
@@ -33,7 +33,7 @@ describe("applySvgFallback", () => {
     expect(() => applySvgFallback("fallback.png")).not.toThrow();
   });
 
-  it("does not replace SVG if fallback is not provided", () => {
+  it("uses default fallback path when none provided", () => {
     const img = document.createElement("img");
     img.src = "logo.svg";
     document.body.appendChild(img);
@@ -41,8 +41,8 @@ describe("applySvgFallback", () => {
     applySvgFallback();
     img.dispatchEvent(new Event("error"));
 
-    // Should not change src if fallback is undefined
-    expect(img.src).toContain("logo.svg");
+    // Should replace src with the default fallback image
+    expect(img.src).toContain("judokonLogoSmall.png");
   });
 
   it("does not add svg-fallback class to non-SVG images", () => {


### PR DESCRIPTION
## Summary
- restore original `localStorage` between tests to avoid undefined errors
- update SVG fallback test to match default behavior when no fallback arg is provided

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686c131090448326ab380364a2bfbaf8