### PR TITLE
Fix addScrollMarkers null checks

### DIFF
--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -97,15 +97,17 @@ export function createScrollButton(direction, container, scrollAmount) {
  * Adds scroll markers to indicate the user's position in the carousel.
  *
  * @pseudocode
- * 1. Create a `<div>` element with the class `scroll-markers`.
- * 2. Add markers for each card in the carousel.
+ * 1. Validate inputs and exit early if `container` or `wrapper` is missing.
+ * 2. Create a `<div>` element with the class `scroll-markers`.
+ * 3. Add markers for each card in the carousel.
  *    - Highlight the marker corresponding to the currently visible card.
- * 3. Update the highlighted marker on scroll events.
+ * 4. Update the highlighted marker on scroll events.
  *
- * @param {HTMLElement} container - The carousel container element.
- * @param {HTMLElement} wrapper - The carousel wrapper element.
+ * @param {HTMLElement} [container] - The carousel container element.
+ * @param {HTMLElement} [wrapper] - The carousel wrapper element.
  */
 function addScrollMarkers(container, wrapper) {
+  if (!container || !wrapper) return;
   const markers = document.createElement("div");
   markers.className = "scroll-markers";
 


### PR DESCRIPTION
## Summary
- handle missing container or wrapper in `addScrollMarkers`
- update pseudocode and JSDoc

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686c161b16ec83269ef36e3f5ea0630a