### PR TITLE
Update loadSettings to throw on missing storage

### DIFF
--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -20,7 +20,7 @@ const SAVE_DELAY_MS = 100;
  * Load persisted settings from localStorage.
  *
  * @pseudocode
- * 1. If `localStorage` is unavailable, return `DEFAULT_SETTINGS`.
+ * 1. Throw an error if `localStorage` is unavailable.
  * 2. Retrieve the JSON string stored under `SETTINGS_KEY`.
  *    - When no value exists, return `DEFAULT_SETTINGS`.
  * 3. Parse the JSON and merge with `DEFAULT_SETTINGS`.
@@ -32,7 +32,7 @@ const SAVE_DELAY_MS = 100;
 export async function loadSettings() {
   try {
     if (typeof localStorage === "undefined") {
-      return { ...DEFAULT_SETTINGS };
+      throw new Error("localStorage unavailable");
     }
     const raw = localStorage.getItem(SETTINGS_KEY);
     if (!raw) {


### PR DESCRIPTION
## Summary
- document that loadSettings throws when localStorage is missing
- actually throw `new Error("localStorage unavailable")` when storage is not present

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/settings-utils.test.js` *(fails: updates a single setting and persists)*
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686c148babec8326a20f74c4127c5d79