### PR TITLE
Fix bottom-nav portrait menu test

### DIFF
--- a/tests/helpers/bottom-navigation.test.js
+++ b/tests/helpers/bottom-navigation.test.js
@@ -92,8 +92,6 @@ describe("togglePortraitTextMenu", () => {
   });
 
   it("creates list items for valid game modes", async () => {
-    const navBar = setupDom();
-    stubLogoQuery();
     const modes = [
       { name: "Mode1", url: "mode1.html", image: "img1.png" },
       { name: "Mode2", url: "mode2.html", image: "img2.png" },


### PR DESCRIPTION
## Summary
- fix duplicate setup of `.bottom-navbar` in `togglePortraitTextMenu` test

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686c1645c4748326a81c37fe6efd21b4