### PR TITLE
Update settings utils timer handling

### DIFF
--- a/tests/helpers/settings-utils.test.js
+++ b/tests/helpers/settings-utils.test.js
@@ -102,7 +102,7 @@ describe("settings utils", () => {
     vi.useFakeTimers();
     const { updateSetting, loadSettings } = await import("../../src/helpers/settingsUtils.js");
     const promise = updateSetting("sound", false);
-    await vi.advanceTimersByTimeAsync(110);
+    await vi.runAllTimersAsync();
     await promise;
     await Promise.resolve();
     const stored = await loadSettings();


### PR DESCRIPTION
## Summary
- adjust timer resolution in settings utils test to use `vi.runAllTimersAsync()`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686c187fc63483268351815bd12c3a73