### PR TITLE
Fix card top bar escape expectations

### DIFF
--- a/src/helpers/cardTopBar.js
+++ b/src/helpers/cardTopBar.js
@@ -1,5 +1,5 @@
 import { getCountryNameFromCode } from "./countryUtils.js";
-import { getValue, escapeHTML } from "./utils.js";
+import { getValue } from "./utils.js";
 import { debugLog } from "./debug.js";
 
 const PLACEHOLDER_FLAG_URL = "../assets/countryFlags/placeholder-flag.png";
@@ -25,21 +25,19 @@ export function createNoDataContainer() {
 }
 
 /**
- * Extracts and sanitizes judoka data (firstname, surname, and countryCode).
+ * Extracts judoka data (firstname, surname, and countryCode).
  *
  * @pseudocode
- * 1. Extract and sanitize `firstname`:
+ * 1. Extract `firstname`:
  *    - Use `getValue` to default to `"Unknown"` if missing.
- *    - Use `escapeHTML` to sanitize the value.
  *
- * 2. Extract and sanitize `surname`:
+ * 2. Extract `surname`:
  *    - Use `getValue` to default to an empty string (`""`) if missing.
- *    - Use `escapeHTML` to sanitize the value.
  *
  * 3. Extract `countryCode`:
  *    - Use `getValue` to default to `"unknown"` if missing.
  *
- * 4. Return an object containing the sanitized `firstname`, `surname`, and `countryCode`.
+ * 4. Return an object containing the extracted `firstname`, `surname`, and `countryCode`.
  */
 function extractJudokaData(judoka) {
   const firstname = getValue(judoka.firstname, "Unknown");
@@ -134,7 +132,7 @@ export function createFlagImage(finalFlagUrl, countryName) {
   flagImg.src = finalFlagUrl || PLACEHOLDER_FLAG_URL;
 
   const safeCountryName = countryName ? countryName : "Unknown";
-  // Use text to rely on the browser to escape characters when serializing
+  // Set alt attribute directly; the browser will handle any necessary escaping
   flagImg.setAttribute("alt", `${safeCountryName} flag`);
 
   flagImg.setAttribute("loading", "lazy");

--- a/tests/card/card-top-bar.test.js
+++ b/tests/card/card-top-bar.test.js
@@ -94,13 +94,13 @@ describe("generateCardTopBar", () => {
       flagUrl
     );
     expect(result.outerHTML).toContain("&lt;John&gt;");
-    expect(result.outerHTML).toContain("&quot;Doe&quot;");
+    expect(result.outerHTML).toContain('"Doe"');
   });
 
   it("escapes HTML in country name for alt attribute", async () => {
     vi.spyOn(countryUtils, "getCountryNameFromCode").mockResolvedValueOnce("<France>");
     const result = await generateCardTopBar(judoka, flagUrl);
-    expect(result.outerHTML).toContain('alt="&lt;France&gt; flag"');
+    expect(result.outerHTML).toContain('alt="<France> flag"');
   });
 
   it("includes alt attribute even if countryName is falsy", async () => {
@@ -143,7 +143,7 @@ describe("createNameContainer", () => {
   it("escapes HTML in firstname and surname", () => {
     const nameContainer = createNameContainer("<John>", '"Doe"');
     expect(nameContainer.outerHTML).toContain("&lt;John&gt;");
-    expect(nameContainer.outerHTML).toContain("&quot;Doe&quot;");
+    expect(nameContainer.outerHTML).toContain('"Doe"');
   });
 });
 
@@ -161,7 +161,7 @@ describe("createFlagImage", () => {
 
   it("escapes HTML in country name for alt attribute", () => {
     const flagImage = createFlagImage(flagUrl, "<France>");
-    expect(flagImage.outerHTML).toContain('alt="&lt;France&gt; flag"');
+    expect(flagImage.outerHTML).toContain('alt="<France> flag"');
   });
 
   it("uses 'Unknown flag' alt if countryName is falsy", () => {


### PR DESCRIPTION
## Summary
- update card-top-bar tests to expect DOM text rather than HTML entities
- adjust `cardTopBar` helper pseudocode and remove unused escapeHTML import

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686c1933caf083268de1ea3d341f6954