### PR TITLE
Fix timer wait in settings utils test

### DIFF
--- a/tests/helpers/settings-utils.test.js
+++ b/tests/helpers/settings-utils.test.js
@@ -102,9 +102,9 @@ describe("settings utils", () => {
     vi.useFakeTimers();
     const { updateSetting, loadSettings } = await import("../../src/helpers/settingsUtils.js");
     const promise = updateSetting("sound", false);
+    await Promise.resolve();
     await vi.advanceTimersByTimeAsync(110);
     await promise;
-    await Promise.resolve();
     const stored = await loadSettings();
     expect(stored.sound).toBe(false);
   });

--- a/tests/helpers/settings-utils.test.js
+++ b/tests/helpers/settings-utils.test.js
@@ -102,7 +102,7 @@ describe("settings utils", () => {
     vi.useFakeTimers();
     const { updateSetting, loadSettings } = await import("../../src/helpers/settingsUtils.js");
     const promise = updateSetting("sound", false);
-    await Promise.resolve();
+    await vi.nextTick();
     await vi.advanceTimersByTimeAsync(110);
     await promise;
     const stored = await loadSettings();


### PR DESCRIPTION
## Summary
- allow timer to schedule before advancing fake timers in `settings-utils.test.js`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Test timed out in 5000ms and other tests due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_686c1a8308a48326be553d06be1fc988