### PR TITLE
Use shared SVG fallback constant

### DIFF
--- a/src/helpers/svgFallback.js
+++ b/src/helpers/svgFallback.js
@@ -10,7 +10,15 @@
  *
  * @param {string} fallbackSrc - Path to the fallback PNG image.
  */
-export function applySvgFallback(fallbackSrc = "./src/assets/images/judokonLogoSmall.png") {
+
+/**
+ * Default fallback PNG used when SVGs fail to load.
+ *
+ * @constant {string}
+ */
+export const DEFAULT_FALLBACK = "./src/assets/images/judokonLogoSmall.png";
+
+export function applySvgFallback(fallbackSrc = DEFAULT_FALLBACK) {
   const svgImages = document.querySelectorAll('img[src$=".svg"]');
 
   svgImages.forEach((img) => {

--- a/tests/helpers/svg-fallback.test.js
+++ b/tests/helpers/svg-fallback.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { applySvgFallback } from "../../src/helpers/svgFallback.js";
+import { applySvgFallback, DEFAULT_FALLBACK } from "../../src/helpers/svgFallback.js";
 
 afterEach(() => {
   document.body.innerHTML = "";
@@ -42,7 +42,8 @@ describe("applySvgFallback", () => {
     img.dispatchEvent(new Event("error"));
 
     // Should replace src with the default fallback image
-    expect(img.src).toContain(DEFAULT_FALLBACK);
+    // jsdom resolves relative paths to absolute URLs
+    expect(img.src).toContain(DEFAULT_FALLBACK.replace("./", "/"));
   });
 
   it("does not add svg-fallback class to non-SVG images", () => {


### PR DESCRIPTION
## Summary
- export `DEFAULT_FALLBACK` from `svgFallback.js`
- use that constant as the default path when applying a fallback
- import the constant in the SVG fallback tests
- adjust the test for jsdom's absolute URL resolution

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686c1a7b240c8326b5c4ce960a31c8ee