### PR TITLE
Handle pre-encoded HTML names

### DIFF
--- a/src/helpers/cardRender.js
+++ b/src/helpers/cardRender.js
@@ -1,7 +1,7 @@
 // Constants
 const PLACEHOLDER_ID = 0;
 
-import { escapeHTML } from "./utils.js";
+import { escapeHTML, decodeHTML } from "./utils.js";
 
 /**
  * Generates the portrait HTML for a judoka card.
@@ -150,7 +150,7 @@ export function generateCardSignatureMove(judoka, gokyoLookup, cardType = "commo
   const foundName = technique?.name;
 
   if (foundName) {
-    techniqueName = escapeHTML(foundName.trim());
+    techniqueName = escapeHTML(decodeHTML(foundName.trim()));
   } else {
     techniqueName = escapeHTML(techniqueName);
   }

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -27,6 +27,32 @@ export function escapeHTML(str) {
   return String(str).replace(/[&<>"']/g, (char) => escapeMap[char] || char);
 }
 
+// Decode common HTML entities back to characters
+const decodeMap = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#039;": "'"
+};
+
+/**
+ * Decodes basic HTML entities in a string.
+ *
+ * @pseudocode
+ * 1. If input is null or undefined, return empty string.
+ * 2. Convert input to string.
+ * 3. Replace `&amp;`, `&lt;`, `&gt;`, `&quot;`, and `&#039;` with their corresponding characters.
+ * 4. Return the decoded string.
+ *
+ * @param {string} str - The string containing HTML entities.
+ * @returns {string} The decoded string.
+ */
+export function decodeHTML(str) {
+  if (str === null || str === undefined) return "";
+  return String(str).replace(/&(amp|lt|gt|quot|#039);/g, (match) => decodeMap[match] || match);
+}
+
 /**
  * Gets a value or falls back to a default if the value is missing.
  *

--- a/tests/helpers/core-utils.test.js
+++ b/tests/helpers/core-utils.test.js
@@ -159,7 +159,7 @@ describe("generateCardSignatureMove", () => {
         { signatureMoveId: 1 },
         { 1: { id: 1, name: "&lt;b&gt;alert(1)&lt;/b&gt;" } }
       );
-      expect(html).toContain("&amp;lt;b&amp;gt;alert(1)&amp;lt;/b&amp;gt;");
+      expect(html).toContain("&lt;b&gt;alert(1)&lt;/b&gt;");
     });
 
     it("should trim whitespace from technique names", () => {


### PR DESCRIPTION
## Summary
- support decoding basic HTML entities in utils
- render signature move names safely when entities already encoded
- update tests for new behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 2 failed | 20 passed)*
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_686c36a7541c83269e0025954fa56012