### PR TITLE
Fix double-escaping in signature move rendering

### DIFF
--- a/src/helpers/cardRender.js
+++ b/src/helpers/cardRender.js
@@ -116,7 +116,7 @@ export function generateCardStats(card, cardType = "common") {
  *    - Use `signatureMoveId` to find the matching technique.
  *    - Fallback to the default technique (PLACEHOLDER_ID) if no match is found.
  *
- * 3. Escape the technique name to prevent XSS.
+ * 3. Decode any HTML entities and then escape the technique name to prevent XSS.
  *
  * 4. Construct the signature move HTML:
  *    - Create a `<div>` element with the class `signature-move-container` and the card type as an additional class.
@@ -150,7 +150,8 @@ export function generateCardSignatureMove(judoka, gokyoLookup, cardType = "commo
   const foundName = technique?.name;
 
   if (foundName) {
-    techniqueName = escapeHTML(foundName.trim()).replace(/&amp;amp;/g, "&amp;");
+    const decodedName = decodeHTML(foundName).trim();
+    techniqueName = escapeHTML(decodedName);
   } else {
     techniqueName = escapeHTML(techniqueName);
   }


### PR DESCRIPTION
## Summary
- decode HTML entities before escaping technique names
- update pseudocode to mention decoding step

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686c3b075a6883268fead39a9caec2c6