### PR TITLE
Add Settings page Playwright tests

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Settings page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/src/pages/settings.html");
+  });
+
+  test("page loads", async ({ page }) => {
+    await expect(page).toHaveTitle(/Ju-Do-Kon!/i);
+  });
+
+  test("essential elements visible", async ({ page }) => {
+    await expect(page.getByRole("navigation")).toBeVisible();
+    await expect(page.getByRole("img", { name: "JU-DO-KON! Logo" })).toBeVisible();
+    await expect(page.getByLabel(/sound/i)).toBeVisible();
+    await expect(page.getByLabel(/full navigation map/i)).toBeVisible();
+    await expect(page.getByLabel(/motion effects/i)).toBeVisible();
+    await expect(page.getByLabel(/display mode/i)).toBeVisible();
+  });
+});

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -69,7 +69,11 @@
           </div>
         </fieldset>
       </form>
-      <section id="game-mode-toggle-container" class="game-mode-toggle-container" aria-label="Game Mode Selector"></section>
+      <section
+        id="game-mode-toggle-container"
+        class="game-mode-toggle-container"
+        aria-label="Game Mode Selector"
+      ></section>
     </main>
 
     <footer>


### PR DESCRIPTION
## Summary
- prettify settings.html
- add Playwright spec for the settings page

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686c41315a1c83268452116906905147