### PR TITLE
Add settings page screenshot

### DIFF
--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -15,7 +15,8 @@ test.describe(runScreenshots ? "Screenshot suite" : "Screenshot suite (skipped)"
     { url: "/src/pages/createJudoka.html", name: "createJudoka.png" },
     { url: "/src/pages/randomJudoka.html", name: "randomJudoka.png" },
     { url: "/src/pages/meditation.html", name: "meditation.png" },
-    { url: "/src/pages/updateJudoka.html", name: "updateJudoka.png" }
+    { url: "/src/pages/updateJudoka.html", name: "updateJudoka.png" },
+    { url: "/src/pages/settings.html", name: "settings.png" }
   ];
 
   for (const { url, name } of pages) {

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -69,7 +69,11 @@
           </div>
         </fieldset>
       </form>
-      <section id="game-mode-toggle-container" class="game-mode-toggle-container" aria-label="Game Mode Selector"></section>
+      <section
+        id="game-mode-toggle-container"
+        class="game-mode-toggle-container"
+        aria-label="Game Mode Selector"
+      ></section>
     </main>
 
     <footer>


### PR DESCRIPTION
## Summary
- include settings page in the screenshot suite
- format settings HTML for Prettier compliance

The screenshot test for `/src/pages/settings.html` fails locally because there is no baseline image yet. CI will generate it automatically.

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: no baseline for settings page)*

------
https://chatgpt.com/codex/tasks/task_e_686c413dd588832694737e7d1c928990