### PR TITLE
Add settings page initialization module

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -57,21 +57,21 @@ function initializeControls(settings, gameModes) {
   }
 
   soundToggle?.addEventListener("change", () => {
-    const prev = soundToggle.checked ? false : true; // previous state
+    const prev = !soundToggle.checked; // previous state
     handleUpdate("sound", soundToggle.checked, () => {
       soundToggle.checked = prev;
     });
   });
 
   navToggle?.addEventListener("change", () => {
-    const prev = navToggle.checked ? false : true;
+    const prev = !navToggle.checked;
     handleUpdate("fullNavMap", navToggle.checked, () => {
       navToggle.checked = prev;
     });
   });
 
   motionToggle?.addEventListener("change", () => {
-    const prev = motionToggle.checked ? false : true;
+    const prev = !motionToggle.checked;
     handleUpdate("motionEffects", motionToggle.checked, () => {
       motionToggle.checked = prev;
     });

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -100,7 +100,7 @@ function initializeControls(settings, gameModes) {
       modesContainer.appendChild(label);
 
       input.addEventListener("change", () => {
-        const prev = input.checked ? false : true;
+        const prev = !input.checked;
         const updated = {
           ...currentSettings.gameModes,
           [mode.id]: input.checked

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -1,0 +1,127 @@
+import { loadSettings, updateSetting } from "./settingsUtils.js";
+import { fetchDataWithErrorHandling } from "./dataUtils.js";
+import { DATA_DIR } from "./constants.js";
+
+/**
+ * Display a temporary popup when a settings update fails.
+ *
+ * @pseudocode
+ * 1. Remove any existing popup element with the `.settings-error-popup` class.
+ * 2. Create a new div with that class containing an error message.
+ * 3. Append the div to `document.body`.
+ * 4. Remove the popup after 2 seconds.
+ */
+export function showSettingsError() {
+  const existing = document.querySelector(".settings-error-popup");
+  existing?.remove();
+  const popup = document.createElement("div");
+  popup.className = "settings-error-popup";
+  popup.textContent = "Failed to update settings.";
+  document.body.appendChild(popup);
+  setTimeout(() => popup.remove(), 2000);
+}
+
+function applyInputState(element, value) {
+  if (!element) return;
+  if (element.type === "checkbox") {
+    element.checked = Boolean(value);
+  } else {
+    element.value = value;
+  }
+}
+
+function initializeControls(settings, gameModes) {
+  let currentSettings = { ...settings };
+
+  const soundToggle = document.getElementById("sound-toggle");
+  const navToggle = document.getElementById("navmap-toggle");
+  const motionToggle = document.getElementById("motion-toggle");
+  const displaySelect = document.getElementById("display-mode-select");
+  const modesContainer = document.getElementById("game-mode-toggle-container");
+
+  applyInputState(soundToggle, currentSettings.sound);
+  applyInputState(navToggle, currentSettings.fullNavMap);
+  applyInputState(motionToggle, currentSettings.motionEffects);
+  applyInputState(displaySelect, currentSettings.displayMode);
+
+  function handleUpdate(key, value, revert) {
+    updateSetting(key, value)
+      .then((updated) => {
+        currentSettings = updated;
+      })
+      .catch((err) => {
+        console.error("Failed to update setting", err);
+        revert();
+        showSettingsError();
+      });
+  }
+
+  soundToggle?.addEventListener("change", () => {
+    const prev = soundToggle.checked ? false : true; // previous state
+    handleUpdate("sound", soundToggle.checked, () => {
+      soundToggle.checked = prev;
+    });
+  });
+
+  navToggle?.addEventListener("change", () => {
+    const prev = navToggle.checked ? false : true;
+    handleUpdate("fullNavMap", navToggle.checked, () => {
+      navToggle.checked = prev;
+    });
+  });
+
+  motionToggle?.addEventListener("change", () => {
+    const prev = motionToggle.checked ? false : true;
+    handleUpdate("motionEffects", motionToggle.checked, () => {
+      motionToggle.checked = prev;
+    });
+  });
+
+  displaySelect?.addEventListener("change", () => {
+    const previous = currentSettings.displayMode;
+    handleUpdate("displayMode", displaySelect.value, () => {
+      displaySelect.value = previous;
+    });
+  });
+
+  if (modesContainer && Array.isArray(gameModes)) {
+    const mainModes = gameModes.filter((m) => m.category === "mainMenu");
+    mainModes.forEach((mode) => {
+      const label = document.createElement("label");
+      label.className = "settings-item";
+      const input = document.createElement("input");
+      input.type = "checkbox";
+      input.id = `mode-${mode.id}`;
+      input.checked = currentSettings.gameModes[mode.id] !== false;
+      const span = document.createElement("span");
+      span.textContent = mode.name;
+      label.appendChild(input);
+      label.appendChild(span);
+      modesContainer.appendChild(label);
+
+      input.addEventListener("change", () => {
+        const prev = input.checked ? false : true;
+        const updated = {
+          ...currentSettings.gameModes,
+          [mode.id]: input.checked
+        };
+        handleUpdate("gameModes", updated, () => {
+          input.checked = prev;
+        });
+      });
+    });
+  }
+}
+
+async function initializeSettingsPage() {
+  try {
+    const settings = await loadSettings();
+    const gameModes = await fetchDataWithErrorHandling(`${DATA_DIR}gameModes.json`);
+    initializeControls(settings, gameModes);
+  } catch (error) {
+    console.error("Error loading settings page:", error);
+    showSettingsError();
+  }
+}
+
+document.addEventListener("DOMContentLoaded", initializeSettingsPage);

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -848,3 +848,15 @@ button .ripple {
     transition: none;
   }
 }
+
+.settings-error-popup {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-primary);
+  color: var(--button-text-color);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  z-index: 1000;
+}

--- a/tests/helpers/settings-page.test.js
+++ b/tests/helpers/settings-page.test.js
@@ -40,9 +40,7 @@ describe("settingsPage module", () => {
 
     await import("../../src/helpers/settingsPage.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
-    await new Promise((r) => setTimeout(r, 0));
-    await new Promise((r) => setTimeout(r, 0));
-    await new Promise((r) => setTimeout(r, 0));
+    vi.runAllTimers();
 
     expect(loadSettings).toHaveBeenCalled();
     expect(fetchData).toHaveBeenCalled();

--- a/tests/helpers/settings-page.test.js
+++ b/tests/helpers/settings-page.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const baseSettings = {
+  sound: true,
+  fullNavMap: true,
+  motionEffects: true,
+  displayMode: "light",
+  gameModes: {}
+};
+
+describe("settingsPage module", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input id="sound-toggle" type="checkbox">
+      <input id="navmap-toggle" type="checkbox">
+      <input id="motion-toggle" type="checkbox">
+      <select id="display-mode-select"></select>
+      <section id="game-mode-toggle-container"></section>
+    `;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    document.body.innerHTML = "";
+  });
+
+  it("loads settings and game modes on DOMContentLoaded", async () => {
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const fetchData = vi.fn().mockResolvedValue([]);
+    const updateSetting = vi.fn().mockResolvedValue(baseSettings);
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchDataWithErrorHandling: fetchData
+    }));
+    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+
+    await import("../../src/helpers/settingsPage.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(loadSettings).toHaveBeenCalled();
+    expect(fetchData).toHaveBeenCalled();
+  });
+});

--- a/tests/helpers/settings-utils.test.js
+++ b/tests/helpers/settings-utils.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { DEFAULT_SETTINGS } from "../../src/helpers/settingsUtils.js";
 
 /**


### PR DESCRIPTION
## Summary
- add `settingsPage.js` to initialize settings screen
- style `settings-error-popup` notification
- test that settings page loads data on `DOMContentLoaded`
- tidy unused variable in existing tests

## Testing
- `npx prettier src/helpers/settingsPage.js src/styles/components.css tests/helpers/settings-page.test.js tests/helpers/settings-utils.test.js --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686c3f4a9b248326afb0e5ec9283293f