### PR TITLE
Consolidate JSON fetching helper

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1,4 +1,4 @@
-import { fetchDataWithErrorHandling, validateData } from "./helpers/dataUtils.js";
+import { fetchJson, validateData } from "./helpers/dataUtils.js";
 import { buildCardCarousel } from "./helpers/carouselBuilder.js";
 import { generateRandomCard } from "./helpers/randomCard.js";
 import { DATA_DIR } from "./helpers/constants.js";
@@ -44,8 +44,8 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       try {
-        const judokaData = await fetchDataWithErrorHandling(`${DATA_DIR}judoka.json`);
-        const gokyoData = await fetchDataWithErrorHandling(`${DATA_DIR}gokyo.json`);
+        const judokaData = await fetchJson(`${DATA_DIR}judoka.json`);
+        const gokyoData = await fetchJson(`${DATA_DIR}gokyo.json`);
 
         validateData(judokaData, "judoka");
         validateData(gokyoData, "gokyo");

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -1,6 +1,6 @@
 import { createGokyoLookup } from "./utils.js";
 import { generateJudokaCard } from "./cardBuilder.js";
-import { fetchDataWithErrorHandling } from "./dataUtils.js";
+import { fetchJson } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
 
 let fallbackJudoka;
@@ -10,7 +10,7 @@ async function getFallbackJudoka() {
     return fallbackJudoka;
   }
   try {
-    const data = await fetchDataWithErrorHandling(`${DATA_DIR}judoka.json`);
+    const data = await fetchJson(`${DATA_DIR}judoka.json`);
     if (Array.isArray(data)) {
       fallbackJudoka = data.find((j) => j.id === 0) || null;
     }

--- a/src/helpers/pseudoJapanese.js
+++ b/src/helpers/pseudoJapanese.js
@@ -1,14 +1,12 @@
 import { DATA_DIR } from "./constants.js";
-import { fetchDataWithErrorHandling } from "./dataUtils.js";
+import { fetchJson } from "./dataUtils.js";
 
 const STATIC_FALLBACK = "\u65e5\u672c\u8a9e\u98a8\u30c6\u30ad\u30b9\u30c8"; // 日本語風テキスト
 let converterPromise;
 
 async function loadConverter() {
   if (!converterPromise) {
-    converterPromise = fetchDataWithErrorHandling(`${DATA_DIR}japaneseConverter.json`).catch(
-      () => null
-    );
+    converterPromise = fetchJson(`${DATA_DIR}japaneseConverter.json`).catch(() => null);
   }
   return converterPromise;
 }

--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -1,4 +1,4 @@
-import { fetchDataWithErrorHandling } from "./dataUtils.js";
+import { fetchJson } from "./dataUtils.js";
 import { createGokyoLookup } from "./utils.js";
 import { generateJudokaCardHTML } from "./cardBuilder.js";
 import { getRandomJudoka } from "./cardUtils.js";
@@ -36,7 +36,7 @@ export async function generateRandomCard(
   if (!containerEl) return;
 
   try {
-    const judokaData = activeCards || (await fetchDataWithErrorHandling(`${DATA_DIR}judoka.json`));
+    const judokaData = activeCards || (await fetchJson(`${DATA_DIR}judoka.json`));
 
     const validJudoka = Array.isArray(judokaData)
       ? judokaData.filter((j) => {
@@ -56,7 +56,7 @@ export async function generateRandomCard(
       throw new Error("No valid judoka entries found");
     }
 
-    const gokyo = gokyoData || (await fetchDataWithErrorHandling(`${DATA_DIR}gokyo.json`));
+    const gokyo = gokyoData || (await fetchJson(`${DATA_DIR}gokyo.json`));
     const gokyoLookup = createGokyoLookup(gokyo);
 
     const selectedJudoka = getRandomJudoka(validJudoka);
@@ -95,7 +95,7 @@ export async function generateRandomCard(
     };
 
     try {
-      const gokyo = gokyoData || (await fetchDataWithErrorHandling(`${DATA_DIR}gokyo.json`));
+      const gokyo = gokyoData || (await fetchJson(`${DATA_DIR}gokyo.json`));
       const gokyoLookup = createGokyoLookup(gokyo);
       const fallbackCard = await generateJudokaCardHTML(fallbackJudoka, gokyoLookup);
 

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -72,7 +72,7 @@
         import { buildCardCarousel } from "../helpers/carouselBuilder.js";
         import { populateCountryList } from "../helpers/countryUtils.js";
         import { toggleCountryPanel, toggleCountryPanelMode } from "../helpers/countryPanel.js";
-        import { fetchDataWithErrorHandling } from "../helpers/dataUtils.js";
+        import { fetchJson } from "../helpers/dataUtils.js";
         import { DATA_DIR } from "../helpers/constants.js";
 
         document.addEventListener("DOMContentLoaded", async () => {
@@ -88,8 +88,8 @@
 
           async function loadData() {
             [allJudoka, gokyoData] = await Promise.all([
-              fetchDataWithErrorHandling(`${DATA_DIR}judoka.json`),
-              fetchDataWithErrorHandling(`${DATA_DIR}gokyo.json`)
+              fetchJson(`${DATA_DIR}judoka.json`),
+              fetchJson(`${DATA_DIR}gokyo.json`)
             ]);
           }
 

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -48,7 +48,7 @@
       </footer>
       <script type="module" src="../helpers/setupBottomNavbar.js"></script>
       <script type="module">
-        import { fetchDataWithErrorHandling } from "../helpers/dataUtils.js";
+        import { fetchJson } from "../helpers/dataUtils.js";
         import { generateRandomCard } from "../helpers/randomCard.js";
         import { DATA_DIR } from "../helpers/constants.js";
 
@@ -59,8 +59,8 @@
 
         async function preloadData() {
           try {
-            cachedJudokaData = await fetchDataWithErrorHandling(`${DATA_DIR}judoka.json`);
-            cachedGokyoData = await fetchDataWithErrorHandling(`${DATA_DIR}gokyo.json`);
+            cachedJudokaData = await fetchJson(`${DATA_DIR}judoka.json`);
+            cachedGokyoData = await fetchJson(`${DATA_DIR}gokyo.json`);
           } catch (error) {
             console.error("Error preloading data:", error);
           }

--- a/tests/helpers/random-card.test.js
+++ b/tests/helpers/random-card.test.js
@@ -16,7 +16,7 @@ vi.mock("../../src/helpers/utils.js", () => ({
 }));
 
 vi.mock("../../src/helpers/dataUtils.js", () => ({
-  fetchDataWithErrorHandling: vi.fn()
+  fetchJson: vi.fn()
 }));
 
 const judokaData = [


### PR DESCRIPTION
## Summary
- replace `loadJSON` and `fetchDataWithErrorHandling` with new `fetchJson`
- update helpers and pages to use new unified API
- adjust unit tests for consolidated helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686c41aa023c8326ac755f6756865e27