### PR TITLE
Fix timers in settings page test

### DIFF
--- a/tests/helpers/settings-page.test.js
+++ b/tests/helpers/settings-page.test.js
@@ -21,11 +21,13 @@ describe("settingsPage module", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     vi.resetModules();
     document.body.innerHTML = "";
   });
 
   it("loads settings and game modes on DOMContentLoaded", async () => {
+    vi.useFakeTimers();
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const fetchData = vi.fn().mockResolvedValue([]);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);


### PR DESCRIPTION
## Summary
- mock timers in settings page unit test

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686c45bb1a888326ad369dccefe66322