### PR TITLE
Fix settings page test timing

### DIFF
--- a/tests/helpers/settings-page.test.js
+++ b/tests/helpers/settings-page.test.js
@@ -42,7 +42,7 @@ describe("settingsPage module", () => {
 
     await import("../../src/helpers/settingsPage.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
-    vi.runAllTimers();
+    await vi.runAllTimersAsync();
 
     expect(loadSettings).toHaveBeenCalled();
     expect(fetchData).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- flush fake timers asynchronously in the settings page unit test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686c482595e08326870785fc03b632a6