### PR TITLE
Improve settings form styling

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -18,6 +18,8 @@ export function showSettingsError() {
   existing?.remove();
   const popup = document.createElement("div");
   popup.className = "settings-error-popup";
+  popup.setAttribute("role", "alert");
+  popup.setAttribute("aria-live", "assertive");
   popup.textContent = "Failed to update settings.";
   document.body.appendChild(popup);
   requestAnimationFrame(() => {

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -9,7 +9,9 @@ import { DATA_DIR } from "./constants.js";
  * 1. Remove any existing popup element with the `.settings-error-popup` class.
  * 2. Create a new div with that class containing an error message.
  * 3. Append the div to `document.body`.
- * 4. Remove the popup after 2 seconds.
+ * 4. Add a `.show` class so CSS can fade it in.
+ * 5. Remove the `.show` class after 1.8 seconds to fade it out.
+ * 6. Remove the popup after 2 seconds.
  */
 export function showSettingsError() {
   const existing = document.querySelector(".settings-error-popup");
@@ -18,6 +20,10 @@ export function showSettingsError() {
   popup.className = "settings-error-popup";
   popup.textContent = "Failed to update settings.";
   document.body.appendChild(popup);
+  requestAnimationFrame(() => {
+    popup.classList.add("show");
+  });
+  setTimeout(() => popup.classList.remove("show"), 1800);
   setTimeout(() => popup.remove(), 2000);
 }
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -851,12 +851,61 @@ button .ripple {
 
 .settings-error-popup {
   position: fixed;
-  bottom: 1rem;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   background: var(--color-primary);
-  color: var(--button-text-color);
+  color: var(--color-text-inverted);
   padding: 0.5rem 1rem;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-base);
   z-index: 1000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast);
+}
+
+.settings-error-popup.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Settings form controls */
+.settings-form label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-height: 48px;
+}
+
+.settings-form input[type="checkbox"],
+.settings-form input[type="radio"] {
+  accent-color: var(--button-bg);
+  cursor: pointer;
+  min-width: 48px;
+  min-height: 48px;
+  border-radius: var(--radius-sm);
+  transition:
+    transform var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.settings-form select {
+  min-height: 48px;
+  padding: 0.5rem;
+  background-color: var(--button-bg);
+  color: var(--button-text-color);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.settings-form select:focus,
+.settings-form input[type="checkbox"]:focus-visible,
+.settings-form input[type="radio"]:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- style form controls to use button color tokens
- fade in/out `.settings-error-popup`
- keep minimum touch target and focus styling

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch for settings page)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686c499406348326962ec658df92b4af