### PR TITLE
Add settings error helper

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -1,25 +1,7 @@
 import { loadSettings, updateSetting } from "./settingsUtils.js";
 import { fetchDataWithErrorHandling } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
-
-/**
- * Display a temporary popup when a settings update fails.
- *
- * @pseudocode
- * 1. Remove any existing popup element with the `.settings-error-popup` class.
- * 2. Create a new div with that class containing an error message.
- * 3. Append the div to `document.body`.
- * 4. Remove the popup after 2 seconds.
- */
-export function showSettingsError() {
-  const existing = document.querySelector(".settings-error-popup");
-  existing?.remove();
-  const popup = document.createElement("div");
-  popup.className = "settings-error-popup";
-  popup.textContent = "Failed to update settings.";
-  document.body.appendChild(popup);
-  setTimeout(() => popup.remove(), 2000);
-}
+import { showSettingsError } from "./showSettingsError.js";
 
 function applyInputState(element, value) {
   if (!element) return;

--- a/src/helpers/showSettingsError.js
+++ b/src/helpers/showSettingsError.js
@@ -1,0 +1,18 @@
+/**
+ * Display a temporary error popup for settings failures.
+ *
+ * @pseudocode
+ * 1. Remove any existing `.settings-error-popup` element.
+ * 2. Create a new div with that class containing an error message.
+ * 3. Append the div to `document.body`.
+ * 4. Remove the popup after 2 seconds.
+ */
+export function showSettingsError() {
+  const existing = document.querySelector(".settings-error-popup");
+  existing?.remove();
+  const popup = document.createElement("div");
+  popup.className = "settings-error-popup";
+  popup.textContent = "Failed to update settings.";
+  document.body.appendChild(popup);
+  setTimeout(() => popup.remove(), 2000);
+}

--- a/src/helpers/showSettingsError.js
+++ b/src/helpers/showSettingsError.js
@@ -12,6 +12,8 @@ export function showSettingsError() {
   existing?.remove();
   const popup = document.createElement("div");
   popup.className = "settings-error-popup";
+  popup.setAttribute("role", "alert");
+  popup.setAttribute("aria-live", "assertive");
   popup.textContent = "Failed to update settings.";
   document.body.appendChild(popup);
   setTimeout(() => popup.remove(), 2000);


### PR DESCRIPTION
## Summary
- add reusable helper to display settings error popups
- update settings page to import and use new helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686c49a471608326a725deb0292b22f1