### PR TITLE
Add node environment comment to non-DOM tests

### DIFF
--- a/tests/data/schema-validation.test.js
+++ b/tests/data/schema-validation.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { readFile } from "fs/promises";
 import { getAjv } from "../../src/helpers/dataUtils.js";

--- a/tests/helpers/card-code.test.js
+++ b/tests/helpers/card-code.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { generateCardCode } from "../../src/helpers/cardCode.js";
 

--- a/tests/helpers/color-contrast.test.js
+++ b/tests/helpers/color-contrast.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";

--- a/tests/helpers/components-color-contrast.test.js
+++ b/tests/helpers/components-color-contrast.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";

--- a/tests/helpers/core-utils.test.js
+++ b/tests/helpers/core-utils.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { generateCardSignatureMove } from "../../src/helpers/cardRender.js";
 

--- a/tests/helpers/css-variable-parser.test.js
+++ b/tests/helpers/css-variable-parser.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { parseCssVariables } from "../../src/helpers/cssVariableParser.js";
 

--- a/tests/helpers/data-utils.test.js
+++ b/tests/helpers/data-utils.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 const originalFetch = global.fetch;

--- a/tests/helpers/error-utils.test.js
+++ b/tests/helpers/error-utils.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, test, expect } from "vitest";
 import { safeGenerate } from "../../src/helpers/errorUtils.js";
 

--- a/tests/helpers/helpers.test.js
+++ b/tests/helpers/helpers.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, test, expect } from "vitest";
 import { formatDate, escapeHTML } from "../../src/helpers/utils.js";
 

--- a/tests/helpers/pseudo-japanese.test.js
+++ b/tests/helpers/pseudo-japanese.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 // Minimal mapping for predictable testing


### PR DESCRIPTION
## Summary
- configure Vitest to use node environment for helper and data tests that don't need the DOM

## Testing
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686c4be0fccc8326b41b6c55b47be201