### PR TITLE
Refactor Playwright fixtures

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,21 +1,11 @@
 import { test, expect } from "@playwright/test";
+import { registerCommonRoutes } from "./fixtures/commonRoutes.js";
 
 const COUNTRY_TOGGLE_LOCATOR = /choose country/i;
 
 test.describe("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
-    await page.route("**/src/data/judoka.json", (route) =>
-      route.fulfill({ path: "tests/fixtures/judoka.json" })
-    );
-    await page.route("**/src/data/gokyo.json", (route) =>
-      route.fulfill({ path: "tests/fixtures/gokyo.json" })
-    );
-    await page.route("**/src/data/countryCodeMapping.json", (route) =>
-      route.fulfill({ path: "tests/fixtures/countryCodeMapping.json" })
-    );
-    await page.route("https://flagcdn.com/**", (route) =>
-      route.fulfill({ path: "src/assets/countryFlags/placeholder-flag.png" })
-    );
+    await registerCommonRoutes(page);
     await page.goto("/src/pages/browseJudoka.html");
   });
 

--- a/playwright/fixtures/commonRoutes.js
+++ b/playwright/fixtures/commonRoutes.js
@@ -1,0 +1,20 @@
+/**
+ * Register routes to serve fixture data for core JSON files and flag images.
+ *
+ * @param {import('@playwright/test').Page} page - The Playwright page.
+ * @returns {Promise<void>} Promise resolving when routes have been registered.
+ */
+export async function registerCommonRoutes(page) {
+  await page.route("**/src/data/judoka.json", (route) =>
+    route.fulfill({ path: "tests/fixtures/judoka.json" })
+  );
+  await page.route("**/src/data/gokyo.json", (route) =>
+    route.fulfill({ path: "tests/fixtures/gokyo.json" })
+  );
+  await page.route("**/src/data/countryCodeMapping.json", (route) =>
+    route.fulfill({ path: "tests/fixtures/countryCodeMapping.json" })
+  );
+  await page.route("https://flagcdn.com/**", (route) =>
+    route.fulfill({ path: "src/assets/countryFlags/placeholder-flag.png" })
+  );
+}

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -1,16 +1,9 @@
 import { test, expect } from "@playwright/test";
+import { registerCommonRoutes } from "./fixtures/commonRoutes.js";
 
 test.describe("View Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
-    await page.route("**/src/data/judoka.json", (route) =>
-      route.fulfill({ path: "tests/fixtures/judoka.json" })
-    );
-    await page.route("**/src/data/gokyo.json", (route) =>
-      route.fulfill({ path: "tests/fixtures/gokyo.json" })
-    );
-    await page.route("**/src/data/countryCodeMapping.json", (route) =>
-      route.fulfill({ path: "tests/fixtures/countryCodeMapping.json" })
-    );
+    await registerCommonRoutes(page);
     await page.goto("/src/pages/randomJudoka.html");
   });
 

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import fs from "fs";
+import { registerCommonRoutes } from "./fixtures/commonRoutes.js";
 
 // Allow skipping screenshots via the SKIP_SCREENSHOTS environment variable
 const runScreenshots = process.env.SKIP_SCREENSHOTS !== "true";
@@ -21,6 +22,7 @@ test.describe(runScreenshots ? "Screenshot suite" : "Screenshot suite (skipped)"
 
   for (const { url, name } of pages) {
     test(`screenshot ${url}`, async ({ page }) => {
+      await registerCommonRoutes(page);
       await page.route("**/src/data/gameModes.json", (route) => {
         route.fulfill({ path: "tests/fixtures/gameModes.json" });
       });
@@ -33,9 +35,6 @@ test.describe(runScreenshots ? "Screenshot suite" : "Screenshot suite (skipped)"
           route.continue();
         }
       });
-      await page.route("https://flagcdn.com/**", (route) =>
-        route.fulfill({ path: "src/assets/countryFlags/placeholder-flag.png" })
-      );
       await page.addInitScript(() => {
         Math.random = () => 0.42;
       });


### PR DESCRIPTION
## Summary
- centralize repeated Playwright routes in `fixtures/commonRoutes.js`
- use `registerCommonRoutes` in relevant specs
- keep screenshot tests clean of duplicate flag handling

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686c4c55112c8326ad0ee99d0a3717be