### PR TITLE
Add data-testid attributes and update tests

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-const COUNTRY_TOGGLE_LOCATOR = /choose country/i;
+const COUNTRY_TOGGLE_LOCATOR = "country-toggle";
 
 test.describe("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
@@ -20,7 +20,7 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("essential elements visible", async ({ page }) => {
-    await expect(page.getByRole("button", { name: COUNTRY_TOGGLE_LOCATOR })).toBeVisible();
+    await expect(page.getByTestId(COUNTRY_TOGGLE_LOCATOR)).toBeVisible();
     await expect(page.getByRole("navigation")).toBeVisible();
     await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
   });
@@ -43,11 +43,11 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("country filter updates carousel", async ({ page }) => {
-    const toggle = page.getByRole("button", { name: COUNTRY_TOGGLE_LOCATOR });
+    const toggle = page.getByTestId(COUNTRY_TOGGLE_LOCATOR);
 
-    await page.waitForSelector("#carousel-container .judoka-card");
+    await page.waitForSelector("[data-testid=carousel-container] .judoka-card");
 
-    const allCards = page.locator("#carousel-container .judoka-card");
+    const allCards = page.locator("[data-testid=carousel-container] .judoka-card");
     const initialCount = await allCards.count();
     expect(initialCount).toBe(3);
 
@@ -55,11 +55,13 @@ test.describe("Browse Judoka screen", () => {
     const panel = page.getByRole("region");
     await panel.waitFor();
     await page.waitForTimeout(500);
-    const countAfterFilter = await page.locator("#carousel-container .judoka-card").count();
+    const countAfterFilter = await page
+      .locator("[data-testid=carousel-container] .judoka-card")
+      .count();
     expect(countAfterFilter).toBe(initialCount);
     await page.getByRole("button", { name: "Japan" }).click({ force: true });
 
-    const filteredCards = page.locator("#carousel-container .judoka-card");
+    const filteredCards = page.locator("[data-testid=carousel-container] .judoka-card");
     const filteredCount = await filteredCards.count();
     expect(filteredCount).toBe(1);
 
@@ -73,11 +75,13 @@ test.describe("Browse Judoka screen", () => {
     await page.waitForTimeout(350);
     await page.getByRole("button", { name: "All" }).click({ force: true });
 
-    await expect(page.locator("#carousel-container .judoka-card")).toHaveCount(initialCount);
+    await expect(page.locator("[data-testid=carousel-container] .judoka-card")).toHaveCount(
+      initialCount
+    );
   });
 
   test("displays country flags", async ({ page }) => {
-    const toggle = page.getByRole("button", { name: COUNTRY_TOGGLE_LOCATOR });
+    const toggle = page.getByTestId(COUNTRY_TOGGLE_LOCATOR);
     await toggle.click();
     await page.waitForSelector("#country-list .slide");
     const slides = page.locator("#country-list .slide");
@@ -86,7 +90,7 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test.skip("judoka card enlarges on hover", async ({ page }) => {
-    const card = page.locator("#carousel-container .judoka-card").first();
+    const card = page.locator("[data-testid=carousel-container] .judoka-card").first();
     await card.waitFor();
 
     const before = await card.boundingBox();
@@ -99,7 +103,7 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test.skip("carousel responds to arrow keys", async ({ page }) => {
-    const container = page.locator("#carousel-container");
+    const container = page.locator("[data-testid=carousel-container]");
     await container.waitFor();
 
     await container.focus();

--- a/playwright/meditation-screen.spec.js
+++ b/playwright/meditation-screen.spec.js
@@ -9,11 +9,11 @@ test.describe("Meditation screen", () => {
     await expect(page.getByRole("heading", { name: /pause\. breathe\. reflect\./i })).toBeVisible();
     await expect(page.getByAltText(/KG is ready to meditate/i)).toBeVisible();
     await expect(page.locator("#quote")).toBeVisible();
-    await expect(page.getByRole("link", { name: /continue your journey/i })).toBeVisible();
+    await expect(page.getByTestId("continue-link")).toBeVisible();
   });
 
   test("continue button navigates home", async ({ page }) => {
-    await page.getByRole("link", { name: /continue your journey/i }).click();
+    await page.getByTestId("continue-link").click();
     await expect(page).toHaveURL(/index\.html/);
   });
 

--- a/playwright/pseudo-japanese-toggle.spec.js
+++ b/playwright/pseudo-japanese-toggle.spec.js
@@ -19,7 +19,7 @@ test.describe("Pseudo-Japanese toggle", () => {
 
   test("toggle updates quote text", async ({ page }) => {
     const quote = page.locator("#quote");
-    const toggle = page.locator("#language-toggle");
+    const toggle = page.getByTestId("language-toggle");
 
     const originalHTML = await quote.innerHTML();
 

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -47,7 +47,7 @@ test.describe("View Judoka screen", () => {
 
   test("draw card populates container", async ({ page }) => {
     await page.getByTestId("draw-button").click();
-    const card = page.locator("[data-testid=card-container] .judoka-card");
+    const card = page.getByTestId('card-container').locator('.judoka-card');
     await expect(card).toHaveCount(1);
     await expect(card).toBeVisible();
     const flag = card.locator(".card-top-bar img");

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -15,8 +15,8 @@ test.describe("View Judoka screen", () => {
   });
 
   test("essential elements visible", async ({ page }) => {
-    await page.getByRole("button", { name: /draw card/i }).waitFor();
-    await expect(page.getByRole("button", { name: /draw card/i })).toBeVisible();
+    await page.getByTestId("draw-button").waitFor();
+    await expect(page.getByTestId("draw-button")).toBeVisible();
     await expect(page.getByRole("navigation")).toBeVisible();
   });
 
@@ -33,12 +33,12 @@ test.describe("View Judoka screen", () => {
   });
 
   test("draw button accessible name updates", async ({ page }) => {
-    const btn = page.getByRole("button", { name: /draw card/i });
+    const btn = page.getByTestId("draw-button");
     await btn.waitFor();
     await expect(btn).toHaveText(/draw card/i);
 
     await page.evaluate(() => {
-      const button = document.querySelector("#draw-card-btn");
+      const button = document.querySelector('[data-testid="draw-button"]');
       button.textContent = "Pick a random judoka";
     });
 
@@ -46,8 +46,8 @@ test.describe("View Judoka screen", () => {
   });
 
   test("draw card populates container", async ({ page }) => {
-    await page.click("#draw-card-btn");
-    const card = page.locator("#card-container .judoka-card");
+    await page.getByTestId("draw-button").click();
+    const card = page.locator("[data-testid=card-container] .judoka-card");
     await expect(card).toHaveCount(1);
     await expect(card).toBeVisible();
     const flag = card.locator(".card-top-bar img");

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -30,7 +30,7 @@
     <header class="header">
       <div class="character-slot left"></div>
       <div class="logo-container">
-        <a href="/judokon/index.html">
+        <a href="/judokon/index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>
@@ -40,12 +40,12 @@
     <main class="container" role="main">
       <!-- Section for the carousel -->
       <section id="carousel-section">
-        <div id="carousel-container" class="hidden"></div>
+        <div id="carousel-container" data-testid="carousel-container" class="hidden"></div>
       </section>
     </main>
 
     <footer>
-      <nav class="bottom-navbar"></nav>
+      <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
     </footer>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
 

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -32,7 +32,7 @@
       <header class="header">
         <div class="character-slot left"></div>
         <div class="logo-container">
-          <a href="/judokon/index.html">
+          <a href="/judokon/index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
@@ -41,11 +41,16 @@
 
       <main class="kodokan-grid" role="main">
         <div class="filter-bar">
-          <button id="country-toggle" aria-controls="country-panel" aria-expanded="false">
+          <button
+            id="country-toggle"
+            data-testid="country-toggle"
+            aria-controls="country-panel"
+            aria-expanded="false"
+          >
             Choose Country
           </button>
         </div>
-        <div id="carousel-container"></div>
+        <div id="carousel-container" data-testid="carousel-container"></div>
       </main>
 
       <aside id="country-panel" class="country-panel grid" role="region" hidden>
@@ -54,11 +59,13 @@
             <!-- Country names will be dynamically inserted here -->
           </div>
         </div>
-        <button id="clear-filter" class="clear-filter-button">Clear selection</button>
+        <button id="clear-filter" data-testid="clear-filter" class="clear-filter-button">
+          Clear selection
+        </button>
       </aside>
 
       <footer>
-        <nav class="bottom-navbar"></nav>
+        <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
       </footer>
       <script type="module" src="../helpers/setupBottomNavbar.js"></script>
 

--- a/src/pages/createJudoka.html
+++ b/src/pages/createJudoka.html
@@ -30,7 +30,7 @@
     <header class="header">
       <div class="character-slot left"></div>
       <div class="logo-container">
-        <a href="/judokon/index.html">
+        <a href="/judokon/index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>
@@ -40,12 +40,12 @@
     <main class="container" role="main">
       <!-- Section for the carousel -->
       <section id="carousel-section">
-        <div id="carousel-container" class="hidden"></div>
+        <div id="carousel-container" data-testid="carousel-container" class="hidden"></div>
       </section>
     </main>
 
     <footer>
-      <nav class="bottom-navbar"></nav>
+      <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
     </footer>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
 

--- a/src/pages/meditation.html
+++ b/src/pages/meditation.html
@@ -16,7 +16,7 @@
     <header class="header">
       <div class="character-slot left"></div>
       <div class="logo-container">
-        <a href="/judokon/index.html">
+        <a href="/judokon/index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>
@@ -32,7 +32,7 @@
         </div>
 
         <div class="quote-block">
-          <button id="language-toggle" class="language-toggle hidden">
+          <button id="language-toggle" data-testid="language-toggle" class="language-toggle hidden">
             <span class="jp-flag flag-icon"></span> 日本語風 / English
             <span class="uk-flag flag-icon"></span>
           </button>
@@ -54,6 +54,7 @@
       <a
         href="../../index.html"
         class="cta-button"
+        data-testid="continue-link"
         aria-label="Continue Your Journey to the main menu after your victory"
       >
         Continue Your Journey
@@ -61,7 +62,7 @@
     </main>
 
     <footer>
-      <nav class="bottom-navbar"></nav>
+      <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
     </footer>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
 

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -31,7 +31,7 @@
       <header class="header">
         <div class="character-slot left"></div>
         <div class="logo-container">
-          <a href="/judokon/index.html">
+          <a href="/judokon/index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
@@ -39,12 +39,14 @@
       </header>
 
       <div class="card-section">
-        <div id="card-container" class="card-container"></div>
-        <button id="draw-card-btn" class="draw-card-btn">Draw Card!</button>
+        <div id="card-container" data-testid="card-container" class="card-container"></div>
+        <button id="draw-card-btn" data-testid="draw-button" class="draw-card-btn">
+          Draw Card!
+        </button>
       </div>
 
       <footer>
-        <nav class="bottom-navbar"></nav>
+        <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
       </footer>
       <script type="module" src="../helpers/setupBottomNavbar.js"></script>
       <script type="module">

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -30,7 +30,7 @@
     <header class="header">
       <div class="character-slot left"></div>
       <div class="logo-container">
-        <a href="/judokon/index.html">
+        <a href="/judokon/index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>
@@ -77,7 +77,7 @@
     </main>
 
     <footer>
-      <nav class="bottom-navbar" aria-label="Bottom Navigation"></nav>
+      <nav class="bottom-navbar" data-testid="bottom-nav" aria-label="Bottom Navigation"></nav>
     </footer>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
 

--- a/src/pages/updateJudoka.html
+++ b/src/pages/updateJudoka.html
@@ -30,7 +30,7 @@
     <header class="header">
       <div class="character-slot left"></div>
       <div class="logo-container">
-        <a href="/judokon/index.html">
+        <a href="/judokon/index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>
@@ -40,12 +40,12 @@
     <main class="container" role="main">
       <!-- Section for the carousel -->
       <section id="carousel-section">
-        <div id="carousel-container" class="hidden"></div>
+        <div id="carousel-container" data-testid="carousel-container" class="hidden"></div>
       </section>
     </main>
 
     <footer>
-      <nav class="bottom-navbar"></nav>
+      <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
     </footer>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
 


### PR DESCRIPTION
## Summary
- add `data-testid` attributes to key buttons and sections in pages
- update Playwright tests to use `getByTestId` selectors

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast` *(fails: Error: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_686c4c639f5c8326bd91e32e6fcb8e09