### PR TITLE
Add Button component

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,6 +1,15 @@
 import { test, expect } from "@playwright/test";
 import { registerCommonRoutes } from "./fixtures/commonRoutes.js";
 
+async function setCarouselWidth(page, width) {
+  await page.evaluate((w) => {
+    const el = document.querySelector('[data-testid="carousel"]');
+    if (el) {
+      el.style.width = w;
+    }
+  }, width);
+}
+
 const COUNTRY_TOGGLE_LOCATOR = "country-toggle";
 
 test.describe("Browse Judoka screen", () => {

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -46,4 +46,29 @@ test.describe("View Judoka screen", () => {
     const flag = card.locator(".card-top-bar img");
     await expect(flag).toHaveAttribute("alt", /(Portugal|USA|Japan) flag/i);
   });
+
+  test("draw button uses design tokens", async ({ page }) => {
+    const btn = page.getByTestId("draw-button");
+    await btn.waitFor();
+    const styles = await btn.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return { bg: cs.backgroundColor, color: cs.color };
+    });
+    const vars = await page.evaluate(() => {
+      const root = getComputedStyle(document.documentElement);
+      return {
+        bg: root.getPropertyValue("--button-bg").trim(),
+        color: root.getPropertyValue("--button-text-color").trim()
+      };
+    });
+    const hexToRgb = (hex) => {
+      const h = hex.replace("#", "");
+      const r = parseInt(h.slice(0, 2), 16);
+      const g = parseInt(h.slice(2, 4), 16);
+      const b = parseInt(h.slice(4, 6), 16);
+      return `rgb(${r}, ${g}, ${b})`;
+    };
+    expect(styles.bg).toBe(hexToRgb(vars.bg));
+    expect(styles.color).toBe(hexToRgb(vars.color));
+  });
 });

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,0 +1,27 @@
+/**
+ * Create a styled button element using design tokens.
+ *
+ * @pseudocode
+ * 1. Create a `button` element.
+ * 2. Apply provided text and attributes such as `id`, `className` and `type`.
+ * 3. Set inline styles referencing `--button-bg` and `--button-text-color`.
+ * 4. Return the configured button element.
+ *
+ * @param {string} text - The button label.
+ * @param {object} [options] - Optional settings.
+ * @param {string} [options.id] - Id attribute for the button.
+ * @param {string} [options.className] - Additional class names.
+ * @param {string} [options.type="button"] - Button type attribute.
+ * @returns {HTMLButtonElement} The styled button element.
+ */
+export function createButton(text, options = {}) {
+  const { id, className, type = "button" } = options;
+  const button = document.createElement("button");
+  button.type = type;
+  button.textContent = text;
+  button.style.backgroundColor = "var(--button-bg)";
+  button.style.color = "var(--button-text-color)";
+  if (id) button.id = id;
+  if (className) button.className = className;
+  return button;
+}

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -362,6 +362,7 @@ export async function buildCardCarousel(judokaList, gokyoData) {
 
   const container = document.createElement("div");
   container.className = "card-carousel";
+  container.dataset.testid = "carousel";
 
   const wrapper = document.createElement("div");
   wrapper.className = "carousel-container";

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -81,6 +81,7 @@
         import { toggleCountryPanel, toggleCountryPanelMode } from "../helpers/countryPanel.js";
         import { fetchJson } from "../helpers/dataUtils.js";
         import { DATA_DIR } from "../helpers/constants.js";
+        import { createButton } from "../components/Button.js";
 
         document.addEventListener("DOMContentLoaded", async () => {
           const carouselContainer = document.getElementById("carousel-container");
@@ -124,10 +125,10 @@
               "Network error occurred. Please check your connection and try again.";
             carouselContainer.appendChild(errorMessage);
 
-            const retryButton = document.createElement("button");
-            retryButton.className = "retry-button";
-            retryButton.textContent = "Retry";
-            retryButton.setAttribute("type", "button");
+            const retryButton = createButton("Retry", {
+              className: "retry-button",
+              type: "button"
+            });
             retryButton.setAttribute("aria-label", "Retry loading judoka data");
             retryButton.addEventListener("click", async () => {
               retryButton.disabled = true; // Disable the button to prevent multiple clicks

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -40,9 +40,6 @@
 
       <div class="card-section">
         <div id="card-container" data-testid="card-container" class="card-container"></div>
-        <button id="draw-card-btn" data-testid="draw-button" class="draw-card-btn">
-          Draw Card!
-        </button>
       </div>
 
       <footer>
@@ -53,6 +50,7 @@
         import { fetchJson } from "../helpers/dataUtils.js";
         import { generateRandomCard } from "../helpers/randomCard.js";
         import { DATA_DIR } from "../helpers/constants.js";
+        import { createButton } from "../components/Button.js";
 
         const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
@@ -80,7 +78,15 @@
 
         preloadData().then(displayCard);
 
-        document.getElementById("draw-card-btn").addEventListener("click", displayCard);
+        const cardSection = document.querySelector(".card-section");
+        const drawButton = createButton("Draw Card!", {
+          id: "draw-card-btn",
+          className: "draw-card-btn",
+          type: "button"
+        });
+        drawButton.dataset.testid = "draw-button";
+        cardSection.appendChild(drawButton);
+        drawButton.addEventListener("click", displayCard);
       </script>
       <script type="module" src="../helpers/setupSvgFallback.js"></script>
       <noscript>

--- a/tests/helpers/button-component.test.js
+++ b/tests/helpers/button-component.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { createButton } from "../../src/components/Button.js";
+
+describe("createButton", () => {
+  it("creates a styled button with given options", () => {
+    const btn = createButton("Click", {
+      id: "btn",
+      className: "custom",
+      type: "submit"
+    });
+    expect(btn).toBeInstanceOf(HTMLButtonElement);
+    expect(btn.id).toBe("btn");
+    expect(btn.className).toBe("custom");
+    expect(btn.type).toBe("submit");
+    expect(btn.textContent).toBe("Click");
+    expect(btn.style.backgroundColor).toBe("var(--button-bg)");
+    expect(btn.style.color).toBe("var(--button-text-color)");
+  });
+
+  it("defaults type to button", () => {
+    const btn = createButton("Label");
+    expect(btn.type).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary
- create reusable button factory with design tokens
- use Button component on Browse Judoka and Random Judoka pages
- expose carousel container as `[data-testid="carousel"]`
- test Button factory with unit and Playwright tests
- ensure carousel keyboard test helper works

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686cd9ee78e48326800593b3236a27d5