### PR TITLE
Filter navbar game modes via settings

### DIFF
--- a/src/helpers/bottomNavigation.js
+++ b/src/helpers/bottomNavigation.js
@@ -1,5 +1,6 @@
 import { debugLog } from "./debug.js";
 import { DATA_DIR } from "./constants.js";
+import { loadSettings } from "./settingsUtils.js";
 
 /**
  * Toggles the expanded map view for landscape mode.
@@ -150,20 +151,23 @@ function addTouchFeedback() {
  *
  * 3. Select the `.bottom-navbar` element and exit if not found.
  *
- * 4. Filter the game modes:
- *    - Include only modes where `category` is "mainMenu" and `isHidden` is `false`.
+ * 4. Load user settings to determine disabled game modes.
  *
- * 5. Sort the filtered game modes by their `order` property in ascending order.
+ * 5. Filter the game modes:
+ *    - Include only modes where `category` is "mainMenu", `isHidden` is `false`,
+ *      and the mode is not disabled in settings.
  *
- * 6. Check if there are any active modes:
+ * 6. Sort the filtered game modes by their `order` property in ascending order.
+ *
+ * 7. Check if there are any active modes:
  *    - If no modes are available, display "No game modes available" in the navigation bar.
  *
- * 7. Map the sorted game modes to HTML list items (`<li>`):
+ * 8. Map the sorted game modes to HTML list items (`<li>`):
  *    - Each list item contains a link (`<a>`) to the corresponding game mode's URL.
  *
- * 8. Update the navigation bar (`.bottom-navbar ul`) with the generated HTML.
+ * 9. Update the navigation bar (`.bottom-navbar ul`) with the generated HTML.
  *
- * 9. Handle any errors during the process:
+ * 10. Handle any errors during the process:
  *    - Log the error to the console and display fallback items in the navigation bar.
  *
  * @returns {Promise<void>} A promise that resolves once the navbar is populated.
@@ -183,8 +187,15 @@ export async function populateNavbar() {
     if (!navBar) return; // Guard: do nothing if navbar is missing
     clearBottomNavbar();
 
+    const settings = await loadSettings();
+
     const activeModes = validateGameModes(
-      data.filter((mode) => mode.category === "mainMenu" && mode.isHidden === false)
+      data.filter(
+        (mode) =>
+          mode.category === "mainMenu" &&
+          mode.isHidden === false &&
+          settings.gameModes[mode.id] !== false
+      )
     ).sort((a, b) => a.order - b.order);
 
     debugLog("Validated game modes:", activeModes);

--- a/tests/helpers/bottom-navigation.test.js
+++ b/tests/helpers/bottom-navigation.test.js
@@ -133,9 +133,17 @@ describe("populateNavbar", () => {
     const navBar = setupDom();
     stubLogoQuery();
     const data = [
-      { name: "A", url: "a.html", category: "mainMenu", order: 2, isHidden: false },
-      { name: "B", url: "b.html", category: "mainMenu", order: 1, isHidden: false }
+      { id: "A", name: "A", url: "a.html", category: "mainMenu", order: 2, isHidden: false },
+      { id: "B", name: "B", url: "b.html", category: "mainMenu", order: 1, isHidden: false }
     ];
+    const loadSettings = vi.fn().mockResolvedValue({
+      sound: true,
+      fullNavMap: true,
+      motionEffects: true,
+      displayMode: "light",
+      gameModes: { B: false }
+    });
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => data });
 
     const { populateNavbar } = await import("../../src/helpers/bottomNavigation.js");
@@ -143,9 +151,9 @@ describe("populateNavbar", () => {
     await populateNavbar();
 
     const items = navBar.querySelectorAll("li");
-    expect(items).toHaveLength(2);
-    expect(items[0].textContent).toBe("B");
-    expect(items[1].textContent).toBe("A");
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toBe("A");
+    expect(loadSettings).toHaveBeenCalled();
   });
 
   it("falls back to default items when fetch fails", async () => {


### PR DESCRIPTION
## Summary
- load `loadSettings` in `bottomNavigation.js`
- exclude disabled modes when populating navigation bar
- update pseudocode to mention settings filtering
- mock `loadSettings` in bottom-navigation tests and verify disabled modes aren't shown

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686cfe200d74832687183b7fd16de321