### PR TITLE
Improve settings error popup animation

### DIFF
--- a/src/helpers/showSettingsError.js
+++ b/src/helpers/showSettingsError.js
@@ -16,5 +16,9 @@ export function showSettingsError() {
   popup.setAttribute("aria-live", "assertive");
   popup.textContent = "Failed to update settings.";
   document.body.appendChild(popup);
+  requestAnimationFrame(() => popup.classList.add("show"));
+  setTimeout(() => {
+    popup.classList.remove("show");
+  }, 1800);
   setTimeout(() => popup.remove(), 2000);
 }

--- a/tests/helpers/show-settings-error.test.js
+++ b/tests/helpers/show-settings-error.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { showSettingsError } from "../../src/helpers/showSettingsError.js";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("showSettingsError", () => {
+  it("shows and then removes the error popup", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", (cb) => cb());
+
+    showSettingsError();
+    let popup = document.querySelector(".settings-error-popup");
+    expect(popup).toBeTruthy();
+    expect(popup.classList.contains("show")).toBe(true);
+
+    vi.advanceTimersByTime(1800);
+    popup = document.querySelector(".settings-error-popup");
+    expect(popup).toBeTruthy();
+    expect(popup.classList.contains("show")).toBe(false);
+
+    vi.advanceTimersByTime(200);
+    expect(document.querySelector(".settings-error-popup")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- enhance `showSettingsError` to animate popup appearance and disappearance
- add unit test for the timed removal logic

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686cfe831414832685a43c09e428816f