### PR TITLE
Use fetchJson in settings page

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -1,5 +1,5 @@
 import { loadSettings, updateSetting } from "./settingsUtils.js";
-import { fetchDataWithErrorHandling } from "./dataUtils.js";
+import { fetchJson } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
 import { showSettingsError } from "./showSettingsError.js";
 
@@ -98,7 +98,7 @@ function initializeControls(settings, gameModes) {
 async function initializeSettingsPage() {
   try {
     const settings = await loadSettings();
-    const gameModes = await fetchDataWithErrorHandling(`${DATA_DIR}gameModes.json`);
+    const gameModes = await fetchJson(`${DATA_DIR}gameModes.json`);
     initializeControls(settings, gameModes);
   } catch (error) {
     console.error("Error loading settings page:", error);

--- a/tests/helpers/settings-page.test.js
+++ b/tests/helpers/settings-page.test.js
@@ -29,14 +29,14 @@ describe("settingsPage module", () => {
   it("loads settings and game modes on DOMContentLoaded", async () => {
     vi.useFakeTimers();
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
-    const fetchData = vi.fn().mockResolvedValue([]);
+    const fetchJson = vi.fn().mockResolvedValue([]);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
-      fetchDataWithErrorHandling: fetchData
+      fetchJson
     }));
     vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
 
@@ -45,6 +45,6 @@ describe("settingsPage module", () => {
     await vi.runAllTimersAsync();
 
     expect(loadSettings).toHaveBeenCalled();
-    expect(fetchData).toHaveBeenCalled();
+    expect(fetchJson).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- use `fetchJson` in `settingsPage`
- update unit tests for new mock

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_686cff2f7bdc8326ac523d0252b48714