### PR TITLE
Add aria labels in settings page

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -75,6 +75,7 @@ function initializeControls(settings, gameModes) {
       input.type = "checkbox";
       input.id = `mode-${mode.id}`;
       input.checked = currentSettings.gameModes[mode.id] !== false;
+      input.setAttribute("aria-label", mode.name);
       const span = document.createElement("span");
       span.textContent = mode.name;
       label.appendChild(input);

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -43,19 +43,24 @@
           <legend class="visually-hidden">Game Settings</legend>
           <div class="settings-item">
             <label for="sound-toggle">
-              <input type="checkbox" id="sound-toggle" name="sound" />
+              <input type="checkbox" id="sound-toggle" name="sound" aria-label="Sound" />
               <span>Sound</span>
             </label>
           </div>
           <div class="settings-item">
             <label for="navmap-toggle">
-              <input type="checkbox" id="navmap-toggle" name="navmap" />
+              <input
+                type="checkbox"
+                id="navmap-toggle"
+                name="navmap"
+                aria-label="Full Navigation Map"
+              />
               <span>Full Navigation Map</span>
             </label>
           </div>
           <div class="settings-item">
             <label for="motion-toggle">
-              <input type="checkbox" id="motion-toggle" name="motion" />
+              <input type="checkbox" id="motion-toggle" name="motion" aria-label="Motion Effects" />
               <span>Motion Effects</span>
             </label>
           </div>


### PR DESCRIPTION
## Summary
- add aria-label attributes to settings toggles
- assign aria-labels to dynamically created game mode toggles

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: navigation links visible)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686d03ac4abc8326bd726fce5e7ddc5e