### PR TITLE
Fix arrow key carousel test

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -103,7 +103,7 @@ test.describe("Browse Judoka screen", () => {
 
   test("carousel responds to arrow keys", async ({ page }) => {
     const container = page.locator('[data-testid="carousel"]');
-    await container.waitFor();
+    await page.waitForSelector('[data-testid="carousel"] .judoka-card');
     await setCarouselWidth(page, "200px");
 
     await container.focus();


### PR DESCRIPTION
## Summary
- ensure judoka cards are loaded before resizing carousel for keyboard test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_686d046981a88326b1bd3aedab8610ec