### PR TITLE
Filter main menu game modes

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -67,7 +67,9 @@ function initializeControls(settings, gameModes) {
   });
 
   if (modesContainer && Array.isArray(gameModes)) {
-    const sortedModes = [...gameModes].sort((a, b) => a.order - b.order);
+    const sortedModes = gameModes
+      .filter((mode) => mode.category === "mainMenu")
+      .sort((a, b) => a.order - b.order);
     sortedModes.forEach((mode) => {
       const label = document.createElement("label");
       label.className = "settings-item";


### PR DESCRIPTION
## Summary
- filter out non-mainMenu modes on settings page

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: timed out waiting for elements and screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686d0cc5e2d08326a7125f902aa6c929