### PR TITLE
Remove filter from settings modes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ build/
 .github/ISSUE_TEMPLATE/*.md
 src/schemas/*.json
 test-results/
+design/productRequirementsDocuments/*.md

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -67,9 +67,7 @@ function initializeControls(settings, gameModes) {
   });
 
   if (modesContainer && Array.isArray(gameModes)) {
-    const sortedModes = gameModes
-      .filter((mode) => mode.category === "mainMenu")
-      .sort((a, b) => a.order - b.order);
+    const sortedModes = [...gameModes].sort((a, b) => a.order - b.order);
     sortedModes.forEach((mode) => {
       const label = document.createElement("label");
       label.className = "settings-item";

--- a/tests/helpers/settings-page.test.js
+++ b/tests/helpers/settings-page.test.js
@@ -48,7 +48,7 @@ describe("settingsPage module", () => {
     expect(fetchJson).toHaveBeenCalled();
     vi.useRealTimers();
   });
-  it("renders checkboxes for each main menu mode", async () => {
+  it("renders checkboxes for each mode", async () => {
     vi.useFakeTimers();
     const gameModes = [
       { id: "classic", name: "Classic", category: "mainMenu" },
@@ -73,9 +73,9 @@ describe("settingsPage module", () => {
 
     const container = document.getElementById("game-mode-toggle-container");
     const checkboxes = container.querySelectorAll("input[type='checkbox']");
-    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes).toHaveLength(3);
     expect(container.querySelector("#mode-classic")).toBeTruthy();
     expect(container.querySelector("#mode-dojo")).toBeTruthy();
-    expect(container.querySelector("#mode-blitz")).toBeNull();
+    expect(container.querySelector("#mode-blitz")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- show all game modes in settings page
- update unit test for new behavior
- ignore PRD markdown files in Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: navigation link visible)*

------
https://chatgpt.com/codex/tasks/task_e_686d106c536c8326a77a75e05fc988df