### PR TITLE
Update settings page render test

### DIFF
--- a/tests/helpers/settings-page.test.js
+++ b/tests/helpers/settings-page.test.js
@@ -48,7 +48,7 @@ describe("settingsPage module", () => {
     expect(fetchJson).toHaveBeenCalled();
     vi.useRealTimers();
   });
-  it("renders checkboxes for each mode", async () => {
+  it("renders checkboxes for all modes", async () => {
     vi.useFakeTimers();
     const gameModes = [
       { id: "classic", name: "Classic", category: "mainMenu" },


### PR DESCRIPTION
## Summary
- rename the settings page test to show all modes render

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 5 failed, 2 interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686d14ea2d3883269617adbc533e4515