### PR TITLE
Fix navbar link paths

### DIFF
--- a/src/helpers/navigationBar.js
+++ b/src/helpers/navigationBar.js
@@ -3,6 +3,11 @@ import { DATA_DIR } from "./constants.js";
 import { loadSettings } from "./settingsUtils.js";
 
 /**
+ * Base path for navigation links derived from the current module location.
+ */
+export const BASE_PATH = new URL("../pages/", import.meta.url);
+
+/**
  * Toggles the expanded map view for landscape mode.
  *
  * @pseudocode
@@ -29,7 +34,7 @@ export function toggleExpandedMapView(gameModes) {
       (mode) =>
         `<div class="map-tile">
           <img src="${mode.image}" alt="${mode.name}" loading="lazy">
-          <a href="/judokon/src/pages/${mode.url}" aria-label="${mode.name}">${mode.name}</a>
+          <a href="${BASE_PATH}${mode.url}" aria-label="${mode.name}">${mode.name}</a>
         </div>`
     )
     .join("");
@@ -83,7 +88,7 @@ export function togglePortraitTextMenu(gameModes) {
   textMenu.innerHTML = validModes
     .map(
       (mode) =>
-        `<li><a href="/judokon/src/pages/${mode.url}" aria-label="${mode.name}">${mode.name}</a></li>`
+        `<li><a href="${BASE_PATH}${mode.url}" aria-label="${mode.name}">${mode.name}</a></li>`
     )
     .join("");
 
@@ -207,7 +212,7 @@ export async function populateNavbar() {
 
     const ul = document.createElement("ul");
     ul.innerHTML = activeModes
-      .map((mode) => `<li><a href="/judokon/src/pages/${mode.url}">${mode.name}</a></li>`)
+      .map((mode) => `<li><a href="${BASE_PATH}${mode.url}">${mode.name}</a></li>`)
       .join("");
     navBar.appendChild(ul);
 
@@ -222,13 +227,17 @@ export async function populateNavbar() {
     const fallbackItems = [
       {
         name: "Random Judoka",
-        url: "/judokon/src/pages/randomJudoka.html",
+        url: `${BASE_PATH}randomJudoka.html`,
         image: "./src/assets/images/randomJudoka.png"
       },
-      { name: "Home", url: "/index.html", image: "./src/assets/images/home.png" },
+      {
+        name: "Home",
+        url: new URL("../../index.html", BASE_PATH),
+        image: "./src/assets/images/home.png"
+      },
       {
         name: "Classic Battle",
-        url: "/judokon/src/pages/battleJudoka.html",
+        url: `${BASE_PATH}battleJudoka.html`,
         image: "./src/assets/images/classicBattle.png"
       }
     ];

--- a/tests/helpers/bottom-navigation.test.js
+++ b/tests/helpers/bottom-navigation.test.js
@@ -47,7 +47,7 @@ describe("toggleExpandedMapView", () => {
       { url: "broken.html", image: "img3.png" }
     ];
 
-    const { toggleExpandedMapView } = await import("../../src/helpers/navigationBar.js");
+    const { toggleExpandedMapView, BASE_PATH } = await import("../../src/helpers/navigationBar.js");
 
     toggleExpandedMapView(modes);
 
@@ -55,7 +55,7 @@ describe("toggleExpandedMapView", () => {
     expect(view).toBeTruthy();
     const tiles = view.querySelectorAll(".map-tile");
     expect(tiles).toHaveLength(2);
-    expect(tiles[0].querySelector("a")).toHaveAttribute("href", "/judokon/src/pages/mode1.html");
+    expect(tiles[0].querySelector("a")).toHaveAttribute("href", `${BASE_PATH}mode1.html`);
     expect(tiles[0].querySelector("a")).toHaveAttribute("aria-label", "Mode1");
     expect(tiles[0].textContent).toContain("Mode1");
   });
@@ -98,7 +98,9 @@ describe("togglePortraitTextMenu", () => {
       { name: null, url: "broken.html" }
     ];
 
-    const { togglePortraitTextMenu } = await import("../../src/helpers/navigationBar.js");
+    const { togglePortraitTextMenu, BASE_PATH } = await import(
+      "../../src/helpers/navigationBar.js"
+    );
 
     togglePortraitTextMenu(modes);
 
@@ -106,7 +108,7 @@ describe("togglePortraitTextMenu", () => {
     expect(menu).toBeTruthy();
     const items = menu.querySelectorAll("li");
     expect(items).toHaveLength(2);
-    expect(items[1].querySelector("a")).toHaveAttribute("href", "/judokon/src/pages/mode2.html");
+    expect(items[1].querySelector("a")).toHaveAttribute("href", `${BASE_PATH}mode2.html`);
     expect(items[1].querySelector("a")).toHaveAttribute("aria-label", "Mode2");
     expect(items[1].textContent).toContain("Mode2");
   });


### PR DESCRIPTION
## Summary
- compute a base path for pages in navigationBar helper
- build navbar links using `BASE_PATH`
- update fallback link URLs
- adjust unit tests for new page path calculation

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 12 failed, 1 interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686d2c327e948326b7a0e4b1440ec5f5