### PR TITLE
Remove unused clearBottomNavbar argument

### DIFF
--- a/src/helpers/navigationBar.js
+++ b/src/helpers/navigationBar.js
@@ -17,7 +17,7 @@ import { loadSettings } from "./settingsUtils.js";
 export function toggleExpandedMapView(gameModes) {
   const navBar = document.querySelector(".bottom-navbar");
   if (!navBar) return; // Guard: do nothing if navbar is missing
-  clearBottomNavbar(navBar); // Clear existing content
+  clearBottomNavbar(); // Clear existing content
 
   const validModes = validateGameModes(gameModes);
 


### PR DESCRIPTION
## Summary
- remove unused `navBar` argument when clearing the bottom nav

## Testing
- `npx prettier . --check`
- `npx eslint src/helpers/navigationBar.js`
- `npx vitest run`
- `npx playwright test` *(fails: Battle Judoka page essential elements visible, and others)*

------
https://chatgpt.com/codex/tasks/task_e_686d2c34d5c88326b8abda8520e97c92