### PR TITLE
Fix settings schema loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 
 ## Quick Start
 
-1. Make sure you have **Node 19+** and `npm` (or another package manager) installed.
+1. Make sure you have **Node 18+** and `npm` (or another package manager) installed.
 2. Clone the repository, install dependencies, and launch the development server:
    ```bash
    git clone https://github.com/cyanautomation/judokon.git

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -1,7 +1,13 @@
 import { validateWithSchema } from "./dataUtils.js";
-const settingsSchema = await import("../schemas/settings.schema.json", {
-  assert: { type: "json" }
-}).then((module) => module.default);
+let settingsSchema;
+try {
+  settingsSchema = await fetch(new URL("../schemas/settings.schema.json", import.meta.url)).then(
+    (r) => r.json()
+  );
+} catch {
+  settingsSchema = (await import("../schemas/settings.schema.json", { assert: { type: "json" } }))
+    .default;
+}
 
 const SETTINGS_KEY = "settings";
 const DEFAULT_SETTINGS = {

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -2,7 +2,12 @@ import { validateWithSchema } from "./dataUtils.js";
 let settingsSchema;
 try {
   settingsSchema = await fetch(new URL("../schemas/settings.schema.json", import.meta.url)).then(
-    (r) => r.json()
+    async (response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch settings schema: ${response.status} ${response.statusText}`);
+      }
+      return response.json();
+    }
   );
 } catch {
   settingsSchema = (await import("../schemas/settings.schema.json", { assert: { type: "json" } }))


### PR DESCRIPTION
## Summary
- load settings schema with fetch and fallback dynamic import
- update Node version requirement in README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Settings page > mode toggle visible, Update Judoka page > navigation links work)*

------
https://chatgpt.com/codex/tasks/task_e_686d4254d64c83269adf58e7814ca5ac