### PR TITLE
Ensure bottom navbar links have 48px touch targets

### DIFF
--- a/src/styles/bottom-navbar.css
+++ b/src/styles/bottom-navbar.css
@@ -24,6 +24,11 @@
   list-style-type: none;
 }
 
+.bottom-navbar ul li {
+  min-height: 48px;
+  padding: var(--space-sm);
+}
+
 .bottom-navbar a,
 .top-navbar a {
   color: var(--button-text-color); /* Adaptive text color */

--- a/tests/helpers/bottom-navbar-css.test.js
+++ b/tests/helpers/bottom-navbar-css.test.js
@@ -1,0 +1,28 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import postcss from "postcss";
+
+function getLiRule(css) {
+  const root = postcss.parse(css);
+  let target;
+  root.walkRules((rule) => {
+    if (rule.selector === ".bottom-navbar ul li") {
+      target = rule;
+    }
+  });
+  return target;
+}
+
+describe("bottom-navbar touch target", () => {
+  it("li elements are at least 48px tall", () => {
+    const css = readFileSync("src/styles/bottom-navbar.css", "utf8");
+    const rule = getLiRule(css);
+    expect(rule).toBeTruthy();
+    const minHeight = rule.nodes.find((d) => d.prop === "min-height")?.value;
+    const padding = rule.nodes.find((d) => d.prop === "padding")?.value;
+    expect(minHeight).toBeDefined();
+    expect(parseInt(minHeight)).toBeGreaterThanOrEqual(48);
+    expect(padding).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- style bottom navbar list items with `min-height` and padding
- test CSS rule to ensure touch target size on small viewports

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 10 failed)*
- `npm run check:contrast`
- `npm run test:screenshot` *(fails: 10 failed)*

------
https://chatgpt.com/codex/tasks/task_e_686d4cd24f7483268663fb05b9e381c0