### PR TITLE
Improve navigation link waits

### DIFF
--- a/playwright/battleJudoka.spec.js
+++ b/playwright/battleJudoka.spec.js
@@ -20,10 +20,10 @@ test.describe("Battle Judoka page", () => {
   test("navigation links work", async ({ page }) => {
     await page.getByRole("link", { name: /view judoka/i }).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
-    await page.goBack();
+    await page.goBack({ waitUntil: "load" });
     await page.getByRole("link", { name: /update judoka/i }).click();
     await expect(page).toHaveURL(/updateJudoka\.html/);
-    await page.goBack();
+    await page.goBack({ waitUntil: "load" });
     await page.getByRole("link", { name: /classic battle/i }).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });

--- a/playwright/createJudoka.spec.js
+++ b/playwright/createJudoka.spec.js
@@ -20,10 +20,10 @@ test.describe("Create Judoka page", () => {
   test("navigation links work", async ({ page }) => {
     await page.getByRole("link", { name: /view judoka/i }).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
-    await page.goBack();
+    await page.goBack({ waitUntil: "load" });
     await page.getByRole("link", { name: /update judoka/i }).click();
     await expect(page).toHaveURL(/updateJudoka\.html/);
-    await page.goBack();
+    await page.goBack({ waitUntil: "load" });
     await page.getByRole("link", { name: /classic battle/i }).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });

--- a/playwright/updateJudoka.spec.js
+++ b/playwright/updateJudoka.spec.js
@@ -2,6 +2,9 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Update Judoka page", () => {
   test.beforeEach(async ({ page }) => {
+    await page.route("**/src/data/gameModes.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/gameModes.json" })
+    );
     await page.goto("/src/pages/updateJudoka.html");
   });
 
@@ -25,6 +28,7 @@ test.describe("Update Judoka page", () => {
     await expect(page).toHaveURL(/updateJudoka\.html/);
     await page.goBack({ waitUntil: "load" });
     const battleLink = page.locator('a[href$="battleJudoka.html"]');
+    await battleLink.waitFor({ state: "attached" });
     await expect(battleLink).toHaveCount(1);
   });
 });


### PR DESCRIPTION
## Summary
- add waiting for navigation link in update judoka test
- ensure other navigation tests wait for page load

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `SKIP_SCREENSHOTS=true npx playwright test` *(fails: Update Judoka page >> navigation links work)*

------
https://chatgpt.com/codex/tasks/task_e_686d57ecca0483268aef4c31f892dbea