### PR TITLE
Fix settings init after DOM load

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -107,4 +107,8 @@ async function initializeSettingsPage() {
   }
 }
 
-document.addEventListener("DOMContentLoaded", initializeSettingsPage);
+if (document.readyState !== "loading") {
+  initializeSettingsPage();
+} else {
+  document.addEventListener("DOMContentLoaded", initializeSettingsPage);
+}


### PR DESCRIPTION
## Summary
- ensure settings page initializes after DOMContentLoaded event check

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot discrepancies and navigation link timing)*

------
https://chatgpt.com/codex/tasks/task_e_686d5ed2c7b0832682fceb71f142da5a