### PR TITLE
Add localStorage game mode management

### DIFF
--- a/src/helpers/gameModeUtils.js
+++ b/src/helpers/gameModeUtils.js
@@ -1,0 +1,93 @@
+import { fetchJson, validateWithSchema } from "./dataUtils.js";
+import { DATA_DIR } from "./constants.js";
+
+let schema;
+try {
+  schema = await fetch(new URL("../schemas/gameModes.schema.json", import.meta.url)).then(
+    async (r) => {
+      if (!r.ok) {
+        throw new Error(`Failed to fetch game modes schema: ${r.status}`);
+      }
+      return r.json();
+    }
+  );
+} catch {
+  schema = (await import("../schemas/gameModes.schema.json", { assert: { type: "json" } })).default;
+}
+
+const GAMEMODES_KEY = "gameModes";
+
+/**
+ * Load game modes from localStorage or fallback to the default JSON file.
+ *
+ * @pseudocode
+ * 1. Attempt to read `GAMEMODES_KEY` from `localStorage`.
+ *    - Parse and validate the JSON when present.
+ * 2. If no stored data exists, fetch `gameModes.json` from `DATA_DIR`.
+ *    - Persist the fetched array to `localStorage`.
+ * 3. Return the validated array of game mode objects.
+ *
+ * @returns {Promise<Array>} Resolved array of game mode objects.
+ */
+export async function loadGameModes() {
+  if (typeof localStorage === "undefined") {
+    throw new Error("localStorage unavailable");
+  }
+  const raw = localStorage.getItem(GAMEMODES_KEY);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      await validateWithSchema(parsed, schema);
+      return parsed;
+    } catch (err) {
+      console.warn("Failed to parse stored game modes", err);
+      localStorage.removeItem(GAMEMODES_KEY);
+    }
+  }
+  const data = await fetchJson(`${DATA_DIR}gameModes.json`, schema);
+  localStorage.setItem(GAMEMODES_KEY, JSON.stringify(data));
+  return data;
+}
+
+/**
+ * Persist an array of game modes to localStorage.
+ *
+ * @pseudocode
+ * 1. Validate the provided `modes` with the schema.
+ * 2. Serialize the array and store it under `GAMEMODES_KEY`.
+ *
+ * @param {Array} modes - Array of game mode objects.
+ * @returns {Promise<void>} Promise that resolves when saving completes.
+ */
+export async function saveGameModes(modes) {
+  await validateWithSchema(modes, schema);
+  if (typeof localStorage === "undefined") {
+    throw new Error("localStorage unavailable");
+  }
+  localStorage.setItem(GAMEMODES_KEY, JSON.stringify(modes));
+}
+
+/**
+ * Update the `isHidden` value for a specific game mode.
+ *
+ * @pseudocode
+ * 1. Load the current game modes using `loadGameModes()`.
+ * 2. Find the mode matching `id` and update its `isHidden` property.
+ *    - Throw an error if the mode is not found.
+ * 3. Validate and persist the updated array with `saveGameModes()`.
+ * 4. Return the updated array.
+ *
+ * @param {string} id - Identifier of the game mode to update.
+ * @param {boolean} isHidden - New hidden state for the mode.
+ * @returns {Promise<Array>} Updated array of game modes.
+ */
+export async function updateGameModeHidden(id, isHidden) {
+  const modes = await loadGameModes();
+  const index = modes.findIndex((m) => m.id === id);
+  if (index === -1) {
+    throw new Error(`Game mode not found: ${id}`);
+  }
+  modes[index] = { ...modes[index], isHidden };
+  await saveGameModes(modes);
+  return modes;
+}

--- a/src/helpers/navigationBar.js
+++ b/src/helpers/navigationBar.js
@@ -1,6 +1,6 @@
 import { debugLog } from "./debug.js";
-import { DATA_DIR } from "./constants.js";
 import { loadSettings } from "./settingsUtils.js";
+import { loadGameModes } from "./gameModeUtils.js";
 
 /**
  * Base path for navigation links derived from the current module location.
@@ -183,44 +183,7 @@ function addTouchFeedback() {
 
 export async function populateNavbar() {
   try {
-    let data;
-    let cached;
-
-    if (typeof localStorage !== "undefined") {
-      const stored = localStorage.getItem("gameModes");
-      if (stored) {
-        try {
-          cached = JSON.parse(stored);
-        } catch (e) {
-          console.warn("Failed to parse cached game modes", e);
-        }
-      }
-    }
-
-    if (navigator.onLine || !cached) {
-      try {
-        const response = await fetch(`${DATA_DIR}gameModes.json`);
-        if (!response.ok) {
-          throw new Error(`Failed to fetch game modes: ${response.status}`);
-        }
-        data = await response.json();
-        debugLog("Fetched game modes:", data);
-
-        if (typeof localStorage !== "undefined") {
-          localStorage.setItem("gameModes", JSON.stringify(data));
-        }
-      } catch (fetchErr) {
-        if (cached) {
-          console.warn("Using cached game modes due to fetch error", fetchErr);
-          data = cached;
-        } else {
-          throw fetchErr;
-        }
-      }
-    } else {
-      data = cached;
-      debugLog("Loaded cached game modes:", data);
-    }
+    const data = await loadGameModes();
 
     const navBar = document.querySelector(".bottom-navbar");
     if (!navBar) return; // Guard: do nothing if navbar is missing

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -92,6 +92,8 @@ function initializeControls(settings, gameModes) {
         });
         updateGameModeHidden(mode.id, !input.checked).catch((err) => {
           console.error("Failed to update game mode", err);
+          input.checked = prev; // Revert to previous state
+          showSettingsError(); // Notify the user of the error
         });
       });
     });

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -1,6 +1,5 @@
 import { loadSettings, updateSetting } from "./settingsUtils.js";
-import { fetchJson } from "./dataUtils.js";
-import { DATA_DIR } from "./constants.js";
+import { loadGameModes, updateGameModeHidden } from "./gameModeUtils.js";
 import { showSettingsError } from "./showSettingsError.js";
 
 function applyInputState(element, value) {
@@ -91,6 +90,9 @@ function initializeControls(settings, gameModes) {
         handleUpdate("gameModes", updated, () => {
           input.checked = prev;
         });
+        updateGameModeHidden(mode.id, !input.checked).catch((err) => {
+          console.error("Failed to update game mode", err);
+        });
       });
     });
   }
@@ -99,7 +101,7 @@ function initializeControls(settings, gameModes) {
 async function initializeSettingsPage() {
   try {
     const settings = await loadSettings();
-    const gameModes = await fetchJson(`${DATA_DIR}gameModes.json`);
+    const gameModes = await loadGameModes();
     initializeControls(settings, gameModes);
   } catch (error) {
     console.error("Error loading settings page:", error);

--- a/tests/helpers/bottom-navigation.test.js
+++ b/tests/helpers/bottom-navigation.test.js
@@ -150,9 +150,9 @@ describe("populateNavbar", () => {
       displayMode: "light",
       gameModes: { B: false }
     });
+    const loadGameModes = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
-    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => data });
-    Object.defineProperty(global.navigator, "onLine", { value: true, configurable: true });
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({ loadGameModes }));
 
     const { populateNavbar } = await import("../../src/helpers/navigationBar.js");
 
@@ -162,15 +162,15 @@ describe("populateNavbar", () => {
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toBe("A");
     expect(loadSettings).toHaveBeenCalled();
-    expect(JSON.parse(localStorage.getItem("gameModes"))).toEqual(data);
+    expect(loadGameModes).toHaveBeenCalled();
   });
 
   it("falls back to default items when fetch fails", async () => {
     const navBar = setupDom();
     stubLogoQuery();
     localStorage.removeItem("gameModes");
-    global.fetch = vi.fn().mockRejectedValue(new Error("fail"));
-    Object.defineProperty(global.navigator, "onLine", { value: true, configurable: true });
+    const loadGameModes = vi.fn().mockRejectedValue(new Error("fail"));
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({ loadGameModes }));
 
     const { populateNavbar } = await import("../../src/helpers/navigationBar.js");
 
@@ -197,9 +197,9 @@ describe("populateNavbar", () => {
       displayMode: "light",
       gameModes: {}
     });
+    const loadGameModes = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
-    global.fetch = vi.fn();
-    Object.defineProperty(global.navigator, "onLine", { value: false, configurable: true });
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({ loadGameModes }));
 
     const { populateNavbar } = await import("../../src/helpers/navigationBar.js");
 
@@ -208,6 +208,6 @@ describe("populateNavbar", () => {
     const items = navBar.querySelectorAll("li");
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toBe("X");
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(loadGameModes).toHaveBeenCalled();
   });
 });

--- a/tests/helpers/settings-page.test.js
+++ b/tests/helpers/settings-page.test.js
@@ -29,23 +29,24 @@ describe("settingsPage module", () => {
   it("loads settings and game modes on DOMContentLoaded", async () => {
     vi.useFakeTimers();
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
-    const fetchJson = vi.fn().mockResolvedValue([]);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
+    const loadGameModes = vi.fn().mockResolvedValue([]);
+    const updateGameModeHidden = vi.fn();
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
     }));
-    vi.doMock("../../src/helpers/dataUtils.js", () => ({
-      fetchJson
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadGameModes,
+      updateGameModeHidden
     }));
-    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
 
     await import("../../src/helpers/settingsPage.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
     await vi.runAllTimersAsync();
 
     expect(loadSettings).toHaveBeenCalled();
-    expect(fetchJson).toHaveBeenCalled();
+    expect(loadGameModes).toHaveBeenCalled();
     vi.useRealTimers();
   });
   it("renders checkboxes for all modes", async () => {
@@ -56,16 +57,17 @@ describe("settingsPage module", () => {
       { id: "dojo", name: "Dojo", category: "mainMenu" }
     ];
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
-    const fetchJson = vi.fn().mockResolvedValue(gameModes);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
+    const loadGameModes = vi.fn().mockResolvedValue(gameModes);
+    const updateGameModeHidden = vi.fn();
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
     }));
-    vi.doMock("../../src/helpers/dataUtils.js", () => ({
-      fetchJson
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadGameModes,
+      updateGameModeHidden
     }));
-    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
 
     await import("../../src/helpers/settingsPage.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
@@ -77,5 +79,32 @@ describe("settingsPage module", () => {
     expect(container.querySelector("#mode-classic")).toBeTruthy();
     expect(container.querySelector("#mode-dojo")).toBeTruthy();
     expect(container.querySelector("#mode-blitz")).toBeTruthy();
+  });
+
+  it("updates isHidden when a checkbox is toggled", async () => {
+    vi.useFakeTimers();
+    const gameModes = [{ id: "classic", name: "Classic", category: "mainMenu", isHidden: false }];
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updateSetting = vi.fn().mockResolvedValue(baseSettings);
+    const loadGameModes = vi.fn().mockResolvedValue(gameModes);
+    const updateGameModeHidden = vi.fn().mockResolvedValue([{ ...gameModes[0], isHidden: true }]);
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadGameModes,
+      updateGameModeHidden
+    }));
+
+    await import("../../src/helpers/settingsPage.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const input = document.getElementById("mode-classic");
+    input.checked = false;
+    input.dispatchEvent(new Event("change"));
+
+    expect(updateGameModeHidden).toHaveBeenCalledWith("classic", true);
   });
 });


### PR DESCRIPTION
## Summary
- store and update game modes in localStorage with new helper
- load game modes on settings page through helper and persist `isHidden`
- read stored modes when populating the navbar
- update unit tests for new helper logic

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diffs and timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_686d5f074fe88326ae1e94a4dff65cd0