### PR TITLE
Fix update judoka navigation link locator

### DIFF
--- a/playwright/updateJudoka.spec.js
+++ b/playwright/updateJudoka.spec.js
@@ -29,7 +29,6 @@ test.describe("Update Judoka page", () => {
 
     await page.getByRole("link", { name: /update judoka/i }).click();
     await expect(page).toHaveURL(/updateJudoka\.html/);
-    await page.goBack({ waitUntil: "load" });
 
     const battleLink = page.getByRole("link", { name: /classic battle/i });
     await battleLink.waitFor();


### PR DESCRIPTION
## Summary
- adjust navigation test for Update Judoka page

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `SKIP_SCREENSHOTS=true npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686d654c10a88326bb28b6fe900feea2