### PR TITLE
Align game mode settings layout

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -68,8 +68,9 @@ function initializeControls(settings, gameModes) {
   if (modesContainer && Array.isArray(gameModes)) {
     const sortedModes = [...gameModes].sort((a, b) => a.order - b.order);
     sortedModes.forEach((mode) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "settings-item";
       const label = document.createElement("label");
-      label.className = "settings-item";
       const input = document.createElement("input");
       input.type = "checkbox";
       input.id = `mode-${mode.id}`;
@@ -79,7 +80,8 @@ function initializeControls(settings, gameModes) {
       span.textContent = mode.name;
       label.appendChild(input);
       label.appendChild(span);
-      modesContainer.appendChild(label);
+      wrapper.appendChild(label);
+      modesContainer.appendChild(wrapper);
 
       input.addEventListener("change", () => {
         const prev = !input.checked;

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -73,12 +73,12 @@
             </select>
           </div>
         </fieldset>
+        <section
+          id="game-mode-toggle-container"
+          class="game-mode-toggle-container settings-form"
+          aria-label="Game Mode Selector"
+        ></section>
       </form>
-      <section
-        id="game-mode-toggle-container"
-        class="game-mode-toggle-container"
-        aria-label="Game Mode Selector"
-      ></section>
     </main>
 
     <footer>


### PR DESCRIPTION
## Summary
- ensure game mode toggles share the same style as other settings
- wrap generated game mode options in `.settings-item` containers

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686d67e38ce48326bf30deeca0d05e42