### PR TITLE
Add judoka validation helper

### DIFF
--- a/src/helpers/cardCode.js
+++ b/src/helpers/cardCode.js
@@ -1,6 +1,7 @@
 const XOR_KEY = 37;
 const ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // 32 readable characters
 const CARD_CODE_VERSION = "v1";
+import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
 
 /**
  * Encodes a string using XOR encryption.
@@ -105,21 +106,11 @@ function chunk(str, size = 4) {
  * @throws {Error} If required fields are missing from the judoka object.
  */
 export function generateCardCode(judoka) {
-  if (
-    !judoka ||
-    !judoka.firstname ||
-    !judoka.surname ||
-    !judoka.country ||
-    !judoka.weightClass ||
-    !judoka.signatureMoveId ||
-    !judoka.stats ||
-    typeof judoka.stats.power === "undefined" ||
-    typeof judoka.stats.speed === "undefined" ||
-    typeof judoka.stats.technique === "undefined" ||
-    typeof judoka.stats.kumikata === "undefined" ||
-    typeof judoka.stats.newaza === "undefined"
-  ) {
-    throw new Error("Missing required judoka fields for card code generation.");
+  const missing = getMissingJudokaFields(judoka);
+  if (!hasRequiredJudokaFields(judoka)) {
+    throw new Error(
+      `Missing required judoka fields for card code generation: ${missing.join(", ")}`
+    );
   }
 
   const stats = [

--- a/src/helpers/cardUtils.js
+++ b/src/helpers/cardUtils.js
@@ -1,5 +1,6 @@
 import { generateJudokaCardHTML } from "./cardBuilder.js";
 import { debugLog } from "./debug.js";
+import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
 
 /**
  * Selects a random judoka from the provided data array.
@@ -7,7 +8,7 @@ import { debugLog } from "./debug.js";
  * @pseudocode
  * 1. Validate the input data:
  *    - Ensure `data` is an array and contains valid entries.
- *    - Filter out invalid judoka objects (missing required fields).
+ *    - Filter out invalid judoka objects using `hasRequiredJudokaFields`.
  *    - Throw an error if no valid entries are found.
  *
  * 2. Generate a random index:
@@ -31,10 +32,7 @@ export function getRandomJudoka(data) {
   }
 
   // Filter out invalid entries
-  const validJudoka = data.filter(
-    (judoka) =>
-      judoka.firstname && judoka.surname && judoka.country && judoka.stats && judoka.signatureMoveId
-  );
+  const validJudoka = data.filter((judoka) => hasRequiredJudokaFields(judoka));
 
   if (validJudoka.length === 0) {
     throw new Error("No valid judoka data available to select.");
@@ -78,16 +76,10 @@ export function getRandomJudoka(data) {
 export async function displayJudokaCard(judoka, gokyo, gameArea) {
   debugLog("Judoka passed to displayJudokaCard:", judoka);
 
-  if (
-    !judoka ||
-    !judoka.firstname ||
-    !judoka.surname ||
-    !judoka.country ||
-    !judoka.stats ||
-    !judoka.signatureMoveId
-  ) {
+  if (!hasRequiredJudokaFields(judoka)) {
     console.error("Invalid judoka object:", judoka);
-    gameArea.innerHTML = "<p>⚠️ Invalid judoka data. Unable to display card.</p>";
+    const missing = getMissingJudokaFields(judoka).join(", ");
+    gameArea.innerHTML = `<p>⚠️ Invalid judoka data. Missing fields: ${missing}</p>`;
     return;
   }
 

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -2,6 +2,7 @@ import { createGokyoLookup } from "./utils.js";
 import { generateJudokaCard } from "./cardBuilder.js";
 import { fetchJson } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
+import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
 
 let fallbackJudoka;
 
@@ -325,7 +326,7 @@ function applyAccessibilityImprovements(wrapper) {
  * 4. Transform `gokyoData` into a lookup object for quick access.
  *
  * 5. Loop through the `judokaList` array:
- *    - Validate each judoka object (ensure required fields are present).
+ *    - Validate each judoka object using `hasRequiredJudokaFields`.
  *    - Generate a card using `generateJudokaCard`.
  *    - If validation fails or card generation returns `null`, load the fallback
  *      judoka (id `0`) and generate its card instead.
@@ -372,14 +373,10 @@ export async function buildCardCarousel(judokaList, gokyoData) {
   for (const judoka of judokaList) {
     let entry = judoka;
 
-    if (
-      !judoka.firstname ||
-      !judoka.surname ||
-      !judoka.country ||
-      !judoka.stats ||
-      judoka.signatureMoveId === undefined
-    ) {
+    if (!hasRequiredJudokaFields(judoka)) {
       console.error("Invalid judoka object:", judoka);
+      const missing = getMissingJudokaFields(judoka).join(", ");
+      console.error(`Missing fields: ${missing}`);
       entry = await getFallbackJudoka();
     }
 

--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -4,6 +4,8 @@ const dataCache = new Map();
 // Lazily instantiated Ajv singleton
 let ajvInstance;
 
+import { getMissingJudokaFields } from "./judokaValidation.js";
+
 /**
  * Determine if the code is running in a Node environment.
  *
@@ -95,9 +97,8 @@ export async function fetchJson(url, schema) {
  *    - If validation fails, throw an error with a descriptive message.
  *
  * 2. For `judoka` type data:
- *    - Define required fields: `firstname`, `surname`, `country`, `stats`, `signatureMoveId`.
- *    - Check for missing fields using `filter`.
- *    - If any required fields are missing, throw an error listing the missing fields.
+ *    - Use `getMissingJudokaFields` to determine which fields are absent.
+ *    - Throw an error listing the missing fields when any are found.
  *
  * @param {any} data - The data to validate.
  * @param {string} type - A descriptive name for the type of data being validated (e.g., "judoka", "country").
@@ -109,8 +110,7 @@ export function validateData(data, type) {
   }
 
   if (type === "judoka") {
-    const requiredFields = ["firstname", "surname", "country", "stats", "signatureMoveId"];
-    const missingFields = requiredFields.filter((field) => !data[field]);
+    const missingFields = getMissingJudokaFields(data);
     if (missingFields.length > 0) {
       throw new Error(`Invalid judoka data: Missing fields: ${missingFields.join(", ")}`);
     }

--- a/src/helpers/judokaValidation.js
+++ b/src/helpers/judokaValidation.js
@@ -1,0 +1,70 @@
+export const requiredJudokaFields = [
+  "firstname",
+  "surname",
+  "country",
+  "countryCode",
+  "stats",
+  "weightClass",
+  "signatureMoveId",
+  "rarity"
+];
+
+export const requiredStatsFields = ["power", "speed", "technique", "kumikata", "newaza"];
+
+/**
+ * Returns an array of missing fields from a judoka object.
+ *
+ * @pseudocode
+ * 1. Initialize an empty `missing` array.
+ * 2. Check each field in `requiredJudokaFields`:
+ *    - If `judoka[field]` is `undefined` or `null`, add `field` to `missing`.
+ * 3. Check required stats subfields:
+ *    - If `judoka.stats` is `null` or `undefined`,
+ *      - Add `stats` and every `stats.<subfield>` to `missing`.
+ *    - Otherwise, for each subfield in `requiredStatsFields`,
+ *      - Add `stats.<subfield>` when the value is `undefined` or `null`.
+ * 4. Return the `missing` array.
+ *
+ * @param {Object} judoka - Judoka object to inspect.
+ * @returns {string[]} Array of missing field names.
+ */
+export function getMissingJudokaFields(judoka) {
+  const missing = [];
+  if (!judoka || typeof judoka !== "object") {
+    return requiredJudokaFields.concat(requiredStatsFields.map((f) => `stats.${f}`));
+  }
+
+  for (const field of requiredJudokaFields) {
+    if (judoka[field] === undefined || judoka[field] === null) {
+      missing.push(field);
+    }
+  }
+
+  if (judoka.stats === undefined || judoka.stats === null) {
+    for (const sub of requiredStatsFields) {
+      missing.push(`stats.${sub}`);
+    }
+  } else {
+    for (const sub of requiredStatsFields) {
+      if (judoka.stats[sub] === undefined || judoka.stats[sub] === null) {
+        missing.push(`stats.${sub}`);
+      }
+    }
+  }
+
+  return missing;
+}
+
+/**
+ * Determines whether a judoka object contains all required fields.
+ *
+ * @pseudocode
+ * 1. Call `getMissingJudokaFields` with the provided `judoka`.
+ * 2. Return `true` if the resulting array is empty; otherwise return `false`.
+ *
+ * @param {Object} judoka - Judoka object to check.
+ * @returns {boolean} `true` when all required fields are present.
+ */
+export function hasRequiredJudokaFields(judoka) {
+  return getMissingJudokaFields(judoka).length === 0;
+}

--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -2,6 +2,7 @@ import { fetchJson } from "./dataUtils.js";
 import { createGokyoLookup } from "./utils.js";
 import { generateJudokaCardHTML } from "./cardBuilder.js";
 import { getRandomJudoka } from "./cardUtils.js";
+import { hasRequiredJudokaFields } from "./judokaValidation.js";
 import { DATA_DIR } from "./constants.js";
 
 /**
@@ -90,17 +91,7 @@ export async function generateRandomCard(
     const judokaData = activeCards || (await fetchJson(`${DATA_DIR}judoka.json`));
 
     const validJudoka = Array.isArray(judokaData)
-      ? judokaData.filter((j) => {
-          const hasRequired =
-            j.firstname &&
-            j.surname &&
-            j.countryCode &&
-            j.stats &&
-            j.weightClass &&
-            j.signatureMoveId !== undefined &&
-            j.rarity;
-          return !j.isHidden && hasRequired;
-        })
+      ? judokaData.filter((j) => !j.isHidden && hasRequiredJudokaFields(j))
       : [];
 
     if (validJudoka.length === 0) {

--- a/tests/helpers/card-code.test.js
+++ b/tests/helpers/card-code.test.js
@@ -6,7 +6,9 @@ const validJudoka = {
   firstname: "Test",
   surname: "User",
   country: "Nowhere",
+  countryCode: "NW",
   weightClass: "-90",
+  rarity: "common",
   signatureMoveId: 42,
   stats: {
     power: 1,

--- a/tests/helpers/data-utils.test.js
+++ b/tests/helpers/data-utils.test.js
@@ -125,7 +125,9 @@ describe("validateData", () => {
   it("throws when required judoka fields are missing", async () => {
     const { validateData } = await import("../../src/helpers/dataUtils.js");
     const badData = { firstname: "A", surname: "B", stats: {}, signatureMoveId: 1 };
-    expect(() => validateData(badData, "judoka")).toThrow("Missing fields: country");
+    expect(() => validateData(badData, "judoka")).toThrow(
+      "Missing fields: country, countryCode, weightClass, rarity, stats.power, stats.speed, stats.technique, stats.kumikata, stats.newaza"
+    );
   });
 
   it("accepts valid judoka data", async () => {
@@ -134,8 +136,17 @@ describe("validateData", () => {
       firstname: "A",
       surname: "B",
       country: "X",
-      stats: {},
-      signatureMoveId: 1
+      countryCode: "X",
+      stats: {
+        power: 1,
+        speed: 1,
+        technique: 1,
+        kumikata: 1,
+        newaza: 1
+      },
+      weightClass: "-60",
+      signatureMoveId: 0,
+      rarity: "common"
     };
     expect(() => validateData(goodData, "judoka")).not.toThrow();
   });
@@ -144,7 +155,7 @@ describe("validateData", () => {
     const { validateData } = await import("../../src/helpers/dataUtils.js");
     const badData = { firstname: "A" };
     expect(() => validateData(badData, "judoka")).toThrow(
-      "Missing fields: surname, country, stats, signatureMoveId"
+      "Missing fields: surname, country, countryCode, stats, weightClass, signatureMoveId, rarity, stats.power, stats.speed, stats.technique, stats.kumikata, stats.newaza"
     );
   });
 

--- a/tests/helpers/judoka-validation.test.js
+++ b/tests/helpers/judoka-validation.test.js
@@ -1,0 +1,37 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import {
+  getMissingJudokaFields,
+  hasRequiredJudokaFields,
+  requiredJudokaFields,
+  requiredStatsFields
+} from "../../src/helpers/judokaValidation.js";
+
+describe("judokaValidation", () => {
+  it("identifies no missing fields", () => {
+    const judoka = {
+      firstname: "A",
+      surname: "B",
+      country: "X",
+      countryCode: "X",
+      stats: { power: 1, speed: 1, technique: 1, kumikata: 1, newaza: 1 },
+      weightClass: "-60",
+      signatureMoveId: 0,
+      rarity: "common"
+    };
+    expect(getMissingJudokaFields(judoka)).toEqual([]);
+    expect(hasRequiredJudokaFields(judoka)).toBe(true);
+  });
+
+  it("reports missing fields", () => {
+    const judoka = { firstname: "A" };
+    const missing = getMissingJudokaFields(judoka);
+    expect(missing).toContain("surname");
+    expect(hasRequiredJudokaFields(judoka)).toBe(false);
+  });
+
+  it("exports field lists", () => {
+    expect(Array.isArray(requiredJudokaFields)).toBe(true);
+    expect(Array.isArray(requiredStatsFields)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- create `judokaValidation.js` with utilities for validating judoka data
- replace inline checks with `getMissingJudokaFields` and `hasRequiredJudokaFields`
- update modules and tests to use new helper and allow `signatureMoveId: 0`
- add tests for judoka validation helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Screenshot suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d6a0ac78c83268f96951e3eca2d12