### PR TITLE
Add carousel constants

### DIFF
--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -1,7 +1,12 @@
 import { createGokyoLookup } from "./utils.js";
 import { generateJudokaCard } from "./cardBuilder.js";
 import { fetchJson } from "./dataUtils.js";
-import { DATA_DIR } from "./constants.js";
+import {
+  DATA_DIR,
+  CAROUSEL_SCROLL_DISTANCE,
+  CAROUSEL_SWIPE_THRESHOLD,
+  SPINNER_DELAY_MS
+} from "./constants.js";
 
 let fallbackJudoka;
 
@@ -191,7 +196,7 @@ function createLoadingSpinner(wrapper) {
 
   const timeoutId = setTimeout(() => {
     spinner.style.display = "block";
-  }, 2000);
+  }, SPINNER_DELAY_MS);
 
   return { spinner, timeoutId };
 }
@@ -234,11 +239,11 @@ function setupKeyboardNavigation(container) {
     const index = Array.from(cards).indexOf(active);
 
     if (event.key === "ArrowLeft") {
-      container.scrollBy({ left: -300, behavior: "smooth" });
+      container.scrollBy({ left: -CAROUSEL_SCROLL_DISTANCE, behavior: "smooth" });
       const prevIndex = index > 0 ? index - 1 : 0;
       cards[prevIndex]?.focus();
     } else if (event.key === "ArrowRight") {
-      container.scrollBy({ left: 300, behavior: "smooth" });
+      container.scrollBy({ left: CAROUSEL_SCROLL_DISTANCE, behavior: "smooth" });
       const nextIndex = index >= 0 ? Math.min(cards.length - 1, index + 1) : 0;
       cards[nextIndex]?.focus();
     }
@@ -268,10 +273,10 @@ function setupSwipeNavigation(container) {
     const touchEndX = event.changedTouches[0].clientX;
     const swipeDistance = touchEndX - touchStartX;
 
-    if (swipeDistance > 50) {
-      container.scrollBy({ left: -300, behavior: "smooth" });
-    } else if (swipeDistance < -50) {
-      container.scrollBy({ left: 300, behavior: "smooth" });
+    if (swipeDistance > CAROUSEL_SWIPE_THRESHOLD) {
+      container.scrollBy({ left: -CAROUSEL_SCROLL_DISTANCE, behavior: "smooth" });
+    } else if (swipeDistance < -CAROUSEL_SWIPE_THRESHOLD) {
+      container.scrollBy({ left: CAROUSEL_SCROLL_DISTANCE, behavior: "smooth" });
     }
   });
 }
@@ -400,8 +405,8 @@ export async function buildCardCarousel(judokaList, gokyoData) {
   clearTimeout(timeoutId);
   spinner.style.display = "none";
 
-  const leftButton = createScrollButton("left", container, 300);
-  const rightButton = createScrollButton("right", container, 300);
+  const leftButton = createScrollButton("left", container, CAROUSEL_SCROLL_DISTANCE);
+  const rightButton = createScrollButton("right", container, CAROUSEL_SCROLL_DISTANCE);
 
   wrapper.appendChild(leftButton);
   wrapper.appendChild(container);

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -9,3 +9,42 @@
  * @constant {string}
  */
 export const DATA_DIR = new URL("../data/", import.meta.url).href;
+
+/**
+ * Distance in pixels that the carousel scrolls when using keyboard
+ * navigation or scroll buttons.
+ *
+ * @constant {number}
+ */
+export const CAROUSEL_SCROLL_DISTANCE = 300;
+
+/**
+ * Minimum swipe distance in pixels required to trigger carousel
+ * scrolling on touch devices.
+ *
+ * @constant {number}
+ */
+export const CAROUSEL_SWIPE_THRESHOLD = 50;
+
+/**
+ * Delay in milliseconds before showing the loading spinner in the
+ * carousel.
+ *
+ * @constant {number}
+ */
+export const SPINNER_DELAY_MS = 2000;
+
+/**
+ * Duration in milliseconds before hiding the settings error popup.
+ *
+ * @constant {number}
+ */
+export const SETTINGS_FADE_MS = 1800;
+
+/**
+ * Duration in milliseconds before removing the settings error popup
+ * from the DOM.
+ *
+ * @constant {number}
+ */
+export const SETTINGS_REMOVE_MS = 2000;

--- a/src/helpers/showSettingsError.js
+++ b/src/helpers/showSettingsError.js
@@ -7,6 +7,8 @@
  * 3. Append the div to `document.body`.
  * 4. Remove the popup after 2 seconds.
  */
+import { SETTINGS_FADE_MS, SETTINGS_REMOVE_MS } from "./constants.js";
+
 export function showSettingsError() {
   const existing = document.querySelector(".settings-error-popup");
   existing?.remove();
@@ -19,6 +21,6 @@ export function showSettingsError() {
   requestAnimationFrame(() => popup.classList.add("show"));
   setTimeout(() => {
     popup.classList.remove("show");
-  }, 1800);
-  setTimeout(() => popup.remove(), 2000);
+  }, SETTINGS_FADE_MS);
+  setTimeout(() => popup.remove(), SETTINGS_REMOVE_MS);
 }

--- a/tests/helpers/show-settings-error.test.js
+++ b/tests/helpers/show-settings-error.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { showSettingsError } from "../../src/helpers/showSettingsError.js";
+import { SETTINGS_FADE_MS, SETTINGS_REMOVE_MS } from "../../src/helpers/constants.js";
 
 beforeEach(() => {
   document.body.innerHTML = "";
@@ -21,12 +22,12 @@ describe("showSettingsError", () => {
     expect(popup).toBeTruthy();
     expect(popup.classList.contains("show")).toBe(true);
 
-    vi.advanceTimersByTime(1800);
+    vi.advanceTimersByTime(SETTINGS_FADE_MS);
     popup = document.querySelector(".settings-error-popup");
     expect(popup).toBeTruthy();
     expect(popup.classList.contains("show")).toBe(false);
 
-    vi.advanceTimersByTime(200);
+    vi.advanceTimersByTime(SETTINGS_REMOVE_MS - SETTINGS_FADE_MS);
     expect(document.querySelector(".settings-error-popup")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- centralize various timing constants
- use constants in carousel builder and settings error helpers
- update tests for settings error constants

## Testing
- `npx vitest run`
- `npx playwright test` *(fails: screenshot differences)*

------
https://chatgpt.com/codex/tasks/task_e_686d6b63ba0c83268fd075e64dde1ddf