### PR TITLE
Fix settings page labels

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -77,7 +77,7 @@ function initializeControls(settings, gameModes) {
       input.id = `mode-${mode.id}`;
       input.checked = currentSettings.gameModes[mode.id] !== false;
       input.setAttribute("aria-label", mode.name);
-      const slider = document.createElement("span");
+      const slider = document.createElement("div");
       slider.className = "slider round";
       const span = document.createElement("span");
       span.textContent = `${mode.name} (${mode.category} - ${mode.order})`;

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -44,7 +44,7 @@
           <div class="settings-item">
             <label for="sound-toggle" class="switch">
               <input type="checkbox" id="sound-toggle" name="sound" aria-label="Sound" />
-              <span class="slider round"></span>
+              <div class="slider round"></div>
               <span>Sound</span>
             </label>
           </div>
@@ -56,14 +56,14 @@
                 name="navmap"
                 aria-label="Full Navigation Map"
               />
-              <span class="slider round"></span>
+              <div class="slider round"></div>
               <span>Full Navigation Map</span>
             </label>
           </div>
           <div class="settings-item">
             <label for="motion-toggle" class="switch">
               <input type="checkbox" id="motion-toggle" name="motion" aria-label="Motion Effects" />
-              <span class="slider round"></span>
+              <div class="slider round"></div>
               <span>Motion Effects</span>
             </label>
           </div>


### PR DESCRIPTION
## Summary
- update settings label markup to prevent extra span nodes
- adjust HTML slider element for compatibility

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686d93f163908326a31ef424eac10d88