### PR TITLE
Add ToggleSwitch component

### DIFF
--- a/src/components/ToggleSwitch.js
+++ b/src/components/ToggleSwitch.js
@@ -1,0 +1,48 @@
+/**
+ * Create a toggle switch element with optional id, name and checked state.
+ *
+ * @pseudocode
+ * 1. Create a wrapper div with class `settings-item`.
+ * 2. Create a label with class `switch` and set `htmlFor` when an id is provided.
+ * 3. Inside the label, add an `input` of type checkbox using provided options
+ *    for `id`, `name`, `checked` and `aria-label`.
+ * 4. Add a `div` acting as the slider and a `span` containing the label text.
+ * 5. Append the input, slider and span to the label and return the wrapper
+ *    containing the complete toggle switch markup.
+ *
+ * @param {string} labelText - Visible text for the toggle label.
+ * @param {object} [options] - Additional configuration.
+ * @param {string} [options.id] - Id attribute for the input/label.
+ * @param {string} [options.name] - Name attribute for the input.
+ * @param {boolean} [options.checked=false] - Initial checked state.
+ * @param {string} [options.ariaLabel] - Custom ARIA label, defaults to labelText.
+ * @returns {HTMLDivElement} Wrapper element containing the toggle switch.
+ */
+export function createToggleSwitch(labelText, options = {}) {
+  const { id, name, checked = false, ariaLabel = labelText } = options;
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "settings-item";
+
+  const label = document.createElement("label");
+  label.className = "switch";
+  if (id) label.htmlFor = id;
+
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  if (id) input.id = id;
+  if (name) input.name = name;
+  input.checked = checked;
+  input.setAttribute("aria-label", ariaLabel);
+
+  const slider = document.createElement("div");
+  slider.className = "slider round";
+
+  const span = document.createElement("span");
+  span.textContent = labelText;
+
+  label.append(input, slider, span);
+  wrapper.appendChild(label);
+
+  return wrapper;
+}

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -1,6 +1,7 @@
 import { loadSettings, updateSetting } from "./settingsUtils.js";
 import { loadGameModes, updateGameModeHidden } from "./gameModeUtils.js";
 import { showSettingsError } from "./showSettingsError.js";
+import { createToggleSwitch } from "../components/ToggleSwitch.js";
 
 function applyInputState(element, value) {
   if (!element) return;
@@ -68,24 +69,15 @@ function initializeControls(settings, gameModes) {
   if (modesContainer && Array.isArray(gameModes)) {
     const sortedModes = [...gameModes].sort((a, b) => a.order - b.order);
     sortedModes.forEach((mode) => {
-      const wrapper = document.createElement("div");
-      wrapper.className = "settings-item";
-      const label = document.createElement("label");
-      label.className = "switch";
-      const input = document.createElement("input");
-      input.type = "checkbox";
-      input.id = `mode-${mode.id}`;
-      input.checked = currentSettings.gameModes[mode.id] !== false;
-      input.setAttribute("aria-label", mode.name);
-      const slider = document.createElement("div");
-      slider.className = "slider round";
-      const span = document.createElement("span");
-      span.textContent = `${mode.name} (${mode.category} - ${mode.order})`;
-      label.appendChild(input);
-      label.appendChild(slider);
-      label.appendChild(span);
-      wrapper.appendChild(label);
+      const wrapper = createToggleSwitch(`${mode.name} (${mode.category} - ${mode.order})`, {
+        id: `mode-${mode.id}`,
+        name: mode.id,
+        checked: currentSettings.gameModes[mode.id] !== false,
+        ariaLabel: mode.name
+      });
+
       modesContainer.appendChild(wrapper);
+      const input = wrapper.querySelector("input");
 
       input.addEventListener("change", () => {
         const prev = !input.checked;

--- a/tests/helpers/toggle-switch.test.js
+++ b/tests/helpers/toggle-switch.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { createToggleSwitch } from "../../src/components/ToggleSwitch.js";
+
+describe("createToggleSwitch", () => {
+  it("creates the correct DOM structure", () => {
+    const wrapper = createToggleSwitch("Sound", {
+      id: "sound-toggle",
+      name: "sound",
+      checked: true,
+      ariaLabel: "Sound toggle"
+    });
+    const label = wrapper.querySelector("label.switch");
+    const input = wrapper.querySelector("input[type='checkbox']");
+    const slider = wrapper.querySelector(".slider");
+    const span = wrapper.querySelector("span");
+
+    expect(wrapper.className).toBe("settings-item");
+    expect(label).toBeInstanceOf(HTMLLabelElement);
+    expect(label?.htmlFor).toBe("sound-toggle");
+    expect(input?.id).toBe("sound-toggle");
+    expect(input?.name).toBe("sound");
+    expect(input?.checked).toBe(true);
+    expect(input?.getAttribute("aria-label")).toBe("Sound toggle");
+    expect(slider?.classList.contains("round")).toBe(true);
+    expect(span?.textContent).toBe("Sound");
+  });
+
+  it("defaults to unchecked when not specified", () => {
+    const wrapper = createToggleSwitch("Option");
+    const input = wrapper.querySelector("input[type='checkbox']");
+    expect(input?.checked).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `createToggleSwitch` component
- test toggle switch structure and defaults
- use the new component in settings page for game mode toggles

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_686d961e7b308326b3057f09ca7a1607