### PR TITLE
Add grid layout for settings game modes

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -140,3 +140,17 @@ body {
   margin: var(--space-sm); /* Updated token */
   border-radius: var(--radius-sm); /* Updated token */
 }
+
+/* Game mode toggles layout on settings page */
+.game-mode-toggle-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-lg);
+  padding: var(--space-lg);
+}
+
+@media (max-width: 768px) {
+  .game-mode-toggle-container {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive grid layout for game mode toggles on settings page

## Testing
- `npx prettier src/styles/layout.css --check`
- `npx eslint src/styles/layout.css` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_686d991f49e48326b265f79d4ccaf1f7