### PR TITLE
Fix settings toggle initialization

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -69,7 +69,7 @@ function initializeControls(settings, gameModes) {
   if (modesContainer && Array.isArray(gameModes)) {
     const sortedModes = [...gameModes].sort((a, b) => a.order - b.order);
     sortedModes.forEach((mode) => {
-      const isChecked = Object.prototype.hasOwnProperty.call(currentSettings.gameModes, mode.id)
+      const isChecked = Object.hasOwn(currentSettings.gameModes, mode.id)
         ? currentSettings.gameModes[mode.id]
         : !mode.isHidden;
       const wrapper = createToggleSwitch(`${mode.name} (${mode.category} - ${mode.order})`, {

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -69,10 +69,13 @@ function initializeControls(settings, gameModes) {
   if (modesContainer && Array.isArray(gameModes)) {
     const sortedModes = [...gameModes].sort((a, b) => a.order - b.order);
     sortedModes.forEach((mode) => {
+      const isChecked = Object.prototype.hasOwnProperty.call(currentSettings.gameModes, mode.id)
+        ? currentSettings.gameModes[mode.id]
+        : !mode.isHidden;
       const wrapper = createToggleSwitch(`${mode.name} (${mode.category} - ${mode.order})`, {
         id: `mode-${mode.id}`,
         name: mode.id,
-        checked: currentSettings.gameModes[mode.id] !== false,
+        checked: isChecked,
         ariaLabel: mode.name
       });
 

--- a/tests/helpers/settings-page.test.js
+++ b/tests/helpers/settings-page.test.js
@@ -85,6 +85,32 @@ describe("settingsPage module", () => {
     expect(labels[2].textContent).toBe("Dojo (mainMenu - 30)");
   });
 
+  it("checkbox state reflects isHidden when no setting exists", async () => {
+    vi.useFakeTimers();
+    const gameModes = [
+      { id: "team", name: "Team", category: "mainMenu", order: 5, isHidden: true }
+    ];
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updateSetting = vi.fn().mockResolvedValue(baseSettings);
+    const loadGameModes = vi.fn().mockResolvedValue(gameModes);
+    const updateGameModeHidden = vi.fn();
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadGameModes,
+      updateGameModeHidden
+    }));
+
+    await import("../../src/helpers/settingsPage.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const input = document.getElementById("mode-team");
+    expect(input.checked).toBe(false);
+  });
+
   it("updates isHidden when a checkbox is toggled", async () => {
     vi.useFakeTimers();
     const gameModes = [{ id: "classic", name: "Classic", category: "mainMenu", isHidden: false }];


### PR DESCRIPTION
## Summary
- default toggle states to reflect stored gameMode `isHidden`
- test that toggles respect `isHidden` when no saved setting

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686d9a5c58a083268dfd46c7dc7774a6