### PR TITLE
Use reusable card component for home page tiles

### DIFF
--- a/design/productRequirementsDocuments/prdBrowseJudoka.md
+++ b/design/productRequirementsDocuments/prdBrowseJudoka.md
@@ -51,15 +51,15 @@ This problem is especially pressing now as the roster grows, and players want a 
 
 ## Functional Requirements
 
-| Priority | Feature                         | Description                                                      |
-| -------- | ------------------------------- | ---------------------------------------------------------------- |
-| P1       | Scrollable Card Interface       | Allow players to scroll through the full judoka roster.          |
-| P1       | Stats Data Binding              | Pull stats from `judoka.json` for accurate card display.         |
-| P1       | Responsive Layout               | Adapt card layout across devices (mobile & desktop).             |
-| P2       | Placeholder for Invalid Entries | Show default card if an entry is missing or invalid.             |
+| Priority | Feature                         | Description                                                                                                                                       |
+| -------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1       | Scrollable Card Interface       | Allow players to scroll through the full judoka roster.                                                                                           |
+| P1       | Stats Data Binding              | Pull stats from `judoka.json` for accurate card display.                                                                                          |
+| P1       | Responsive Layout               | Adapt card layout across devices (mobile & desktop).                                                                                              |
+| P2       | Placeholder for Invalid Entries | Show default card if an entry is missing or invalid.                                                                                              |
 | P2       | Carousel Display of Cards       | Present cards in a swipe/scroll carousel for efficient browsing. (See [PRD: Judoka Card Carousel](prdCardCarousel.md) for carousel requirements.) |
-| P2       | Hover/Keyboard Navigation       | Support interactions for accessibility.                          |
-| P3       | Scroll Markers                  | Indicate the user’s current position in the carousel.            |
+| P2       | Hover/Keyboard Navigation       | Support interactions for accessibility.                                                                                                           |
+| P3       | Scroll Markers                  | Indicate the user’s current position in the carousel.                                                                                             |
 
 ---
 

--- a/design/productRequirementsDocuments/prdCardCarousel.md
+++ b/design/productRequirementsDocuments/prdCardCarousel.md
@@ -25,6 +25,7 @@ Failure to provide an efficient browsing experience may impact core gameplay —
 ## Goals
 
 **Technical Performance Goals**
+
 - Carousel loads within 1 second for up to 150 cards.
 - Support smooth browsing of up to 50 cards without noticeable lag.
 - Users can browse through at least 10 cards within 30 seconds smoothly without lag.
@@ -32,6 +33,7 @@ Failure to provide an efficient browsing experience may impact core gameplay —
 - Keyboard navigation support for accessibility.
 
 **User Experience Goals**
+
 - Users can easily browse and find desired cards to assemble optimized teams.
 - Browsing the carousel feels smooth, intuitive, and visually engaging on both mobile and desktop devices.
 

--- a/design/productRequirementsDocuments/prdGameModes.md
+++ b/design/productRequirementsDocuments/prdGameModes.md
@@ -22,12 +22,14 @@ Improving session variety directly supports retention and encourages more person
 ### Goals
 
 **KPI Targets**
+
 - Increase returning player average session length by **20%**.
 - At least **80%** of users who begin a Team Battle complete the match.
 - **70%** of new players use Judoka Creation within their first week.
 - **60%** of all players trigger Meditation mode at least once weekly.
 
 **Player Experience Goals** _(qualitative)_
+
 - Players experience diverse ways to interact with their judoka.
 - Players find modes matching their mood: competitive, creative, or relaxing.
 

--- a/design/productRequirementsDocuments/prdPseudoJapanese.md
+++ b/design/productRequirementsDocuments/prdPseudoJapanese.md
@@ -182,4 +182,5 @@ Prevents accidental taps and creates distinct flow—finish reading before proce
   - [ ] 5.5 Add Playwright test `pseudo-japanese-toggle.spec.js` verifying the language toggle on the meditation screen.
 
 ---
+
         [Back to Game Modes Overview](prdGameModes.md)

--- a/design/productRequirementsDocuments/prdTeamBattleFemale.md
+++ b/design/productRequirementsDocuments/prdTeamBattleFemale.md
@@ -40,7 +40,6 @@ _Mode is identical to its [male counterpart](prdTeamBattleMale.md) except for th
 - Uses the common Team Battle ruleset for scoring.
 - Matches call `generateRandomCard` as described in [prdDrawRandomCard.md](prdDrawRandomCard.md).
 
-
 ---
 
 ## Related Features
@@ -49,4 +48,5 @@ _Mode is identical to its [male counterpart](prdTeamBattleMale.md) except for th
 - Entry point: [PRD: Team Battle Selection](prdTeamBattleSelection.md) screen.
 
 ---
+
 [Back to Game Modes Overview](prdGameModes.md)

--- a/design/productRequirementsDocuments/prdTeamBattleSelection.md
+++ b/design/productRequirementsDocuments/prdTeamBattleSelection.md
@@ -7,6 +7,7 @@ Simple menu that lets players quickly choose Male, Female, or Mixed modes for te
 **Game Mode ID:** teamBattleSelection (URL: teamBattleSelection.html)
 
 > This selection screen is the gateway to the three Team Battle modes:
+>
 > - [PRD: Team Battle Male](prdTeamBattleMale.md)
 > - [PRD: Team Battle Female](prdTeamBattleFemale.md)
 > - [PRD: Team Battle Mixed](prdTeamBattleMixed.md)

--- a/index.html
+++ b/index.html
@@ -37,11 +37,7 @@
       </header>
 
       <main class="game-mode-grid">
-        <a
-          href="./src/pages/battleJudoka.html"
-          class="game-tile red"
-          aria-label="Start classic battle mode"
-        >
+        <a href="./src/pages/battleJudoka.html" class="card" aria-label="Start classic battle mode">
           <div class="tile-content">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -57,7 +53,7 @@
             <h2>Classic Battle</h2>
           </div>
         </a>
-        <a href="./src/pages/browseJudoka.html" class="game-tile teal" aria-label="View Judoka">
+        <a href="./src/pages/browseJudoka.html" class="card" aria-label="View Judoka">
           <div class="tile-content">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -73,11 +69,7 @@
             <h2>Random Judoka</h2>
           </div>
         </a>
-        <a
-          href="./src/pages/randomJudoka.html"
-          class="game-tile gold"
-          aria-label="Update judoka information"
-        >
+        <a href="./src/pages/randomJudoka.html" class="card" aria-label="Update judoka information">
           <div class="tile-content">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -93,7 +85,7 @@
             <h2>Meditation</h2>
           </div>
         </a>
-        <a href="./src/pages/browseJudoka.html" class="game-tile blue" aria-label="Browse Judoka">
+        <a href="./src/pages/browseJudoka.html" class="card" aria-label="Browse Judoka">
           <div class="tile-content">
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -37,7 +37,7 @@ test.describe("Homepage", () => {
   });
 
   test("tile hover zoom and cursor", async ({ page }) => {
-    const tile = page.locator(".game-tile").first();
+    const tile = page.locator(".card").first();
     await tile.hover();
 
     await expect
@@ -56,7 +56,7 @@ test.describe("Homepage", () => {
   });
 
   test("keyboard navigation activates tiles", async ({ page }) => {
-    const tiles = page.locator(".game-tile");
+    const tiles = page.locator(".card");
 
     await page.keyboard.press("Tab");
     await expect(tiles.first()).toBeFocused();
@@ -84,7 +84,7 @@ test.describe("Homepage", () => {
   });
 
   test("tiles meet contrast ratio", async ({ page }) => {
-    const tile = page.locator(".game-tile").first();
+    const tile = page.locator(".card").first();
     const styles = await tile.evaluate((el) => {
       const cs = getComputedStyle(el);
       return { bg: cs.backgroundColor, color: cs.color };

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -78,45 +78,23 @@ body {
   height: 5dvh;
 }
 
-.game-tile {
-  background: var(--color-surface);
-  border: 2px solid var(--color-tertiary);
-  border-radius: var(--radius-lg);
-  padding: 1.5rem;
+.card {
+  padding: 1rem;
+  background-color: var(--color-secondary);
+  border-block-start: 0.5rem solid var(--color-primary);
+  border-radius: var(--radius-md);
   text-align: center;
-  font-size: 1rem;
   box-shadow: var(--shadow-base);
   cursor: pointer;
-  transition: transform 0.15s ease-in-out;
+  transition: transform var(--transition-fast);
 }
 
-.game-tile:hover {
+.card:hover {
   transform: scale(1.05);
 }
 
-.game-tile.red {
-  background: var(--color-secondary);
-  color: white;
-}
-
-.game-tile.teal {
-  background: var(--color-secondary);
-  color: white;
-}
-
-.game-tile.blue {
-  background: var(--color-secondary);
-  color: white;
-}
-
-.game-tile.purple {
-  background: var(--color-secondary);
-  color: white;
-}
-
-.game-tile.gold {
-  background: var(--color-secondary);
-  color: white;
+.game-tile {
+  composes: card;
 }
 
 .tile-content h2 {


### PR DESCRIPTION
## Summary
- add `.card` styles and alias `.game-tile` to it
- convert home page tile markup to use `.card`
- update Playwright tests for `.card` selector

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 3 failed snapshots)*
- `npm run check:contrast` *(fails: 4 contrast errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e5eee90548326881d4552b35a158e