### PR TITLE
Fix card tile text contrast

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -81,6 +81,7 @@ body {
 .card {
   padding: 1rem;
   background-color: var(--color-secondary);
+  color: var(--color-text-inverted);
   border-block-start: 0.5rem solid var(--color-primary);
   border-radius: var(--radius-md);
   text-align: center;


### PR DESCRIPTION
## Summary
- ensure text on home tiles uses `--color-text-inverted`

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_686e6422701c832696910719f22139fe