### PR TITLE
Ensure scroll markers render after carousel mounts

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1,5 +1,5 @@
 import { fetchJson, validateData } from "./helpers/dataUtils.js";
-import { buildCardCarousel } from "./helpers/carouselBuilder.js";
+import { buildCardCarousel, addScrollMarkers } from "./helpers/carouselBuilder.js";
 import { generateRandomCard } from "./helpers/randomCard.js";
 import { DATA_DIR } from "./helpers/constants.js";
 
@@ -53,6 +53,13 @@ document.addEventListener("DOMContentLoaded", () => {
         const carousel = await buildCardCarousel(judokaData, gokyoData);
         carouselContainer.appendChild(carousel);
         carouselContainer.classList.remove("hidden");
+
+        requestAnimationFrame(() => {
+          const containerEl = carousel.querySelector(".card-carousel");
+          if (containerEl) {
+            addScrollMarkers(containerEl, carousel);
+          }
+        });
 
         isCarouselBuilt = true;
         console.log("Carousel displayed on demand.");

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -411,7 +411,6 @@ export async function buildCardCarousel(judokaList, gokyoData) {
 
   setupKeyboardNavigation(container);
   setupSwipeNavigation(container);
-  addScrollMarkers(container, wrapper);
   applyAccessibilityImprovements(wrapper);
 
   return wrapper;

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -76,7 +76,7 @@
       </noscript>
 
       <script type="module">
-        import { buildCardCarousel } from "../helpers/carouselBuilder.js";
+        import { buildCardCarousel, addScrollMarkers } from "../helpers/carouselBuilder.js";
         import { populateCountryList } from "../helpers/countryUtils.js";
         import { toggleCountryPanel, toggleCountryPanelMode } from "../helpers/countryPanel.js";
         import { fetchJson } from "../helpers/dataUtils.js";
@@ -105,6 +105,13 @@
             carouselContainer.innerHTML = "";
             const carousel = await buildCardCarousel(list, gokyoData);
             carouselContainer.appendChild(carousel);
+
+            requestAnimationFrame(() => {
+              const containerEl = carousel.querySelector(".card-carousel");
+              if (containerEl) {
+                addScrollMarkers(containerEl, carousel);
+              }
+            });
           }
 
           try {


### PR DESCRIPTION
## Summary
- mount carousel markers after the carousel is inserted into the DOM
- remove early addScrollMarkers call

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden to registry.npmjs.org)*
- `npx playwright test` *(fails: 403 Forbidden to registry.npmjs.org)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_686e77325c3c8326b300a6260319a652