### PR TITLE
Add display mode setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
         <nav class="bottom-navbar"></nav>
       </footer>
       <script type="module" src="./src/helpers/setupBottomNavbar.js"></script>
+      <script type="module" src="./src/helpers/setupDisplaySettings.js"></script>
 
       <noscript>
         <p class="noscript-warning">

--- a/src/helpers/displayMode.js
+++ b/src/helpers/displayMode.js
@@ -1,0 +1,18 @@
+/**
+ * Apply the chosen display mode by toggling body classes.
+ *
+ * @pseudocode
+ * 1. Remove both `dark-mode` and `gray-mode` classes from `document.body`.
+ * 2. If `mode` is "dark", add the `dark-mode` class.
+ * 3. Else if `mode` is "gray", add the `gray-mode` class.
+ *
+ * @param {"light"|"dark"|"gray"} mode - Desired display mode.
+ */
+export function applyDisplayMode(mode) {
+  document.body.classList.remove("dark-mode", "gray-mode");
+  if (mode === "dark") {
+    document.body.classList.add("dark-mode");
+  } else if (mode === "gray") {
+    document.body.classList.add("gray-mode");
+  }
+}

--- a/src/helpers/displayMode.js
+++ b/src/helpers/displayMode.js
@@ -9,6 +9,11 @@
  * @param {"light"|"dark"|"gray"} mode - Desired display mode.
  */
 export function applyDisplayMode(mode) {
+  const validModes = ["light", "dark", "gray"];
+  if (!validModes.includes(mode)) {
+    console.warn(`Invalid display mode: "${mode}". Valid modes are: ${validModes.join(", ")}.`);
+    return;
+  }
   document.body.classList.remove("dark-mode", "gray-mode");
   if (mode === "dark") {
     document.body.classList.add("dark-mode");

--- a/src/helpers/setupDisplaySettings.js
+++ b/src/helpers/setupDisplaySettings.js
@@ -1,0 +1,28 @@
+/**
+ * Load saved settings and apply the user's display mode when the DOM is ready.
+ *
+ * @pseudocode
+ * 1. Define `init`:
+ *    a. Call `loadSettings()` to retrieve stored settings.
+ *    b. Call `applyDisplayMode` with `settings.displayMode`.
+ *    c. Log any errors to the console.
+ * 2. If the document is already loaded, run `init` immediately.
+ * 3. Otherwise, run `init` once on the `DOMContentLoaded` event.
+ */
+import { loadSettings } from "./settingsUtils.js";
+import { applyDisplayMode } from "./displayMode.js";
+
+async function init() {
+  try {
+    const settings = await loadSettings();
+    applyDisplayMode(settings.displayMode);
+  } catch (error) {
+    console.error("Failed to apply display mode:", error);
+  }
+}
+
+if (document.readyState !== "loading") {
+  init();
+} else {
+  document.addEventListener("DOMContentLoaded", init);
+}

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -64,6 +64,7 @@
       <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
     </footer>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+    <script type="module" src="../helpers/setupDisplaySettings.js"></script>
 
     <noscript>
       <p class="noscript-warning">

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -68,6 +68,7 @@
         <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
       </footer>
       <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+      <script type="module" src="../helpers/setupDisplaySettings.js"></script>
 
       <noscript>
         <p class="noscript-warning">
@@ -120,16 +121,14 @@
             if (allJudoka.length === 0) {
               const noResultsMessage = document.createElement("div");
               noResultsMessage.className = "no-results-message";
-              noResultsMessage.textContent =
-                "No cards available.";
+              noResultsMessage.textContent = "No cards available.";
               carouselContainer.appendChild(noResultsMessage);
             }
           } catch (error) {
             console.error("Error building the carousel:", error);
             const errorMessage = document.createElement("div");
             errorMessage.className = "error-message";
-            errorMessage.textContent =
-              "Unable to load roster.";
+            errorMessage.textContent = "Unable to load roster.";
             carouselContainer.appendChild(errorMessage);
 
             const retryButton = createButton("Retry", {

--- a/src/pages/createJudoka.html
+++ b/src/pages/createJudoka.html
@@ -48,6 +48,7 @@
       <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
     </footer>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+    <script type="module" src="../helpers/setupDisplaySettings.js"></script>
 
     <noscript>
       <p class="noscript-warning">

--- a/src/pages/meditation.html
+++ b/src/pages/meditation.html
@@ -65,6 +65,7 @@
       <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
     </footer>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+    <script type="module" src="../helpers/setupDisplaySettings.js"></script>
 
     <noscript>
       <p class="noscript-warning">

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -46,6 +46,7 @@
         <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
       </footer>
       <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+      <script type="module" src="../helpers/setupDisplaySettings.js"></script>
       <script type="module">
         import { fetchJson } from "../helpers/dataUtils.js";
         import { generateRandomCard } from "../helpers/randomCard.js";

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -88,6 +88,7 @@
       <nav class="bottom-navbar" data-testid="bottom-nav" aria-label="Bottom Navigation"></nav>
     </footer>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+    <script type="module" src="../helpers/setupDisplaySettings.js"></script>
 
     <noscript>
       <p class="noscript-warning">

--- a/src/pages/updateJudoka.html
+++ b/src/pages/updateJudoka.html
@@ -48,6 +48,7 @@
       <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
     </footer>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+    <script type="module" src="../helpers/setupDisplaySettings.js"></script>
 
     <noscript>
       <p class="noscript-warning">

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -41,6 +41,22 @@
   --font-extra-large: 3rem;
 }
 
+/* Dark mode variable overrides */
+.dark-mode {
+  --color-surface: #1a1a1a;
+  --color-background: #000000;
+  --color-text: #ffffff;
+  --color-text-inverted: #000000;
+}
+
+/* Gray mode variable overrides */
+.gray-mode {
+  --color-surface: #e0e0e0;
+  --color-background: #d0d0d0;
+  --color-text: #000000;
+  --color-text-inverted: #ffffff;
+}
+
 *,
 *::before,
 *::after {

--- a/tests/helpers/display-mode.test.js
+++ b/tests/helpers/display-mode.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { applyDisplayMode } from "../../src/helpers/displayMode.js";
+
+describe("applyDisplayMode", () => {
+  beforeEach(() => {
+    document.body.className = "";
+  });
+
+  afterEach(() => {
+    document.body.className = "";
+  });
+
+  it("adds dark-mode class for dark mode", () => {
+    applyDisplayMode("dark");
+    expect(document.body.classList.contains("dark-mode")).toBe(true);
+    expect(document.body.classList.contains("gray-mode")).toBe(false);
+  });
+
+  it("adds gray-mode class for gray mode", () => {
+    applyDisplayMode("gray");
+    expect(document.body.classList.contains("gray-mode")).toBe(true);
+    expect(document.body.classList.contains("dark-mode")).toBe(false);
+  });
+
+  it("removes classes for light mode", () => {
+    document.body.classList.add("dark-mode", "gray-mode");
+    applyDisplayMode("light");
+    expect(document.body.classList.contains("dark-mode")).toBe(false);
+    expect(document.body.classList.contains("gray-mode")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- support dark and gray display modes via CSS variables
- expose `applyDisplayMode` helper
- add DOM-ready script to apply saved mode
- include new script on all pages
- test display mode helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Classic battle flow timer auto-selects when expired)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686e8492c6888326a0c728e3212dc42f