### PR TITLE
Fix flaky timer test

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -11,8 +11,8 @@ test.describe("Classic battle flow", () => {
     await page.goto("/src/pages/battleJudoka.html");
     await page.waitForSelector("#round-timer");
     await page.waitForTimeout(1500);
-    const text = await page.locator("#score-display").textContent();
-    expect(text).not.toBe("You: 0 Computer: 0");
+    const resultText = await page.locator("#round-result").textContent();
+    expect(resultText).not.toBe("");
   });
 
   test("tie message appears on equal stats", async ({ page }) => {


### PR DESCRIPTION
## Summary
- ensure the auto-select test verifies result text instead of relying on score

## Testing
- `npx prettier playwright/classicBattleFlow.spec.js --check`
- `npx eslint playwright/classicBattleFlow.spec.js` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686e862f47b48326b7a55a4f444a0fd7