### PR TITLE
Update fonts to Open Sans and Russo One

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -66,14 +66,14 @@
 }
 
 body {
-  font-family: "League Spartan", sans-serif;
+  font-family: "Open Sans", sans-serif;
   font-size: 16px; /* Body text size */
   line-height: 1.4; /* Line height */
 }
 
 h1,
 h2 {
-  font-family: "League Spartan", sans-serif;
+  font-family: "Russo One", sans-serif;
 }
 
 h1 {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -24,7 +24,7 @@
 
 /* General body styles */
 body {
-  font-family: "League Spartan", sans-serif; /* Updated token */
+  font-family: "Open Sans", sans-serif; /* Updated token */
   color: var(--color-text); /* Updated token */
   background-color: var(--color-tertiary); /* Updated token */
   line-height: 1.4; /* Updated token */
@@ -146,7 +146,7 @@ svg {
 /* Button styles */
 button {
   font-size: 1rem;
-  font-family: "Noto Sans", sans-serif;
+  font-family: "Open Sans", sans-serif;
   border: none;
   background-color: var(--button-bg);
   color: var(--button-text-color);
@@ -424,7 +424,7 @@ button .ripple {
   margin: 0;
   padding: 3px min(1px, 0.6vh);
   border-top: 1px solid var(--card-border-color);
-  font-family: "Noto Sans", sans-serif;
+  font-family: "Open Sans", sans-serif;
   font-size: var(--font-small);
   font-weight: bold;
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -9,7 +9,7 @@
 }
 
 body {
-  font-family: "League Spartan", sans-serif; /* Updated token */
+  font-family: "Open Sans", sans-serif; /* Updated token */
   color: var(--color-text); /* Updated token */
   background-color: var(--color-tertiary); /* Updated token */
   line-height: 1.4; /* Updated token */

--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -16,7 +16,7 @@
 }
 
 .meditation-title {
-  font-family: "League Spartan", sans-serif; /* Updated token */
+  font-family: "Russo One", sans-serif;
   font-size: clamp(32px, 5vw, 40px); /* Updated token */
   color: var(--color-text-inverted);
   text-align: center;
@@ -85,7 +85,7 @@
 
 .quote-heading {
   color: var(--color-text-inverted);
-  font-family: "League Spartan", sans-serif;
+  font-family: "Russo One", sans-serif;
   font-size: clamp(18px, 3vw, 24px);
   text-align: center;
   align-self: center;

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -32,7 +32,7 @@
 
 /* Utility class for small annotations */
 .small-text {
-  font-family: "Noto Sans", sans-serif;
+  font-family: "Open Sans", sans-serif;
   font-size: var(--font-small);
   font-weight: 500;
 }


### PR DESCRIPTION
## Summary
- switch base body font to Open Sans
- use Russo One for heading styles
- update layout and component fonts
- replace `Noto Sans` usages with Open Sans
- set Open Sans font in utilities and quote styles

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686e9abff8708326a361131a74e3bb23