### PR TITLE
Support reduced motion preference

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -2,6 +2,7 @@ import { fetchJson, validateData } from "./helpers/dataUtils.js";
 import { buildCardCarousel, addScrollMarkers } from "./helpers/carouselBuilder.js";
 import { generateRandomCard } from "./helpers/randomCard.js";
 import { DATA_DIR } from "./helpers/constants.js";
+import { shouldReduceMotionSync } from "./helpers/motionUtils.js";
 
 /**
  * Initializes game interactions after the DOM is ready.
@@ -95,7 +96,7 @@ document.addEventListener("DOMContentLoaded", () => {
     showRandom.classList.add("hidden");
     gameArea.innerHTML = "";
 
-    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const prefersReducedMotion = shouldReduceMotionSync();
 
     await generateRandomCard(null, null, gameArea, prefersReducedMotion);
   });

--- a/src/helpers/buttonEffects.js
+++ b/src/helpers/buttonEffects.js
@@ -7,10 +7,13 @@
  * 3. Position the ripple at the click coordinates and animate it.
  * 4. Remove the ripple once the animation finishes.
  */
+import { shouldReduceMotionSync } from "./motionUtils.js";
+
 export function setupButtonEffects() {
   const buttons = document.querySelectorAll("button");
   buttons.forEach((button) => {
     button.addEventListener("mousedown", (event) => {
+      if (shouldReduceMotionSync()) return;
       if (button.querySelector("span.ripple")) return; // Prevent multiple ripples
       const ripple = document.createElement("span");
       ripple.className = "ripple";

--- a/src/helpers/motionUtils.js
+++ b/src/helpers/motionUtils.js
@@ -1,0 +1,47 @@
+/**
+ * Utilities for handling motion preference.
+ */
+
+/**
+ * Determine synchronously if motion effects should be reduced.
+ *
+ * @pseudocode
+ * 1. Attempt to read the "settings" item from `localStorage`.
+ *    - Parse the JSON and check the `motionEffects` property.
+ * 2. If `motionEffects` is `false`, return `true`.
+ * 3. Otherwise, return whether the user prefers reduced motion via
+ *    `matchMedia('(prefers-reduced-motion: reduce)')`.
+ *
+ * @returns {boolean} True if motion effects should be reduced.
+ */
+export function shouldReduceMotionSync() {
+  try {
+    const raw = localStorage.getItem("settings");
+    if (raw) {
+      const data = JSON.parse(raw);
+      if (data && data.motionEffects === false) {
+        return true;
+      }
+    }
+  } catch {
+    // Ignore JSON and localStorage errors
+  }
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/**
+ * Apply the motion preference by toggling a body class.
+ *
+ * @pseudocode
+ * 1. If `enabled` is `false`, add the `reduce-motion` class to `document.body`.
+ * 2. Otherwise, remove the `reduce-motion` class.
+ *
+ * @param {boolean} enabled - Whether motion effects are enabled.
+ */
+export function applyMotionPreference(enabled) {
+  if (!enabled) {
+    document.body.classList.add("reduce-motion");
+  } else {
+    document.body.classList.remove("reduce-motion");
+  }
+}

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -2,6 +2,7 @@ import { loadSettings, updateSetting } from "./settingsUtils.js";
 import { loadGameModes, updateGameModeHidden } from "./gameModeUtils.js";
 import { showSettingsError } from "./showSettingsError.js";
 import { createToggleSwitch } from "../components/ToggleSwitch.js";
+import { applyMotionPreference } from "./motionUtils.js";
 
 function applyInputState(element, value) {
   if (!element) return;
@@ -54,8 +55,10 @@ function initializeControls(settings, gameModes) {
 
   motionToggle?.addEventListener("change", () => {
     const prev = !motionToggle.checked;
+    applyMotionPreference(motionToggle.checked);
     handleUpdate("motionEffects", motionToggle.checked, () => {
       motionToggle.checked = prev;
+      applyMotionPreference(prev);
     });
   });
 

--- a/src/helpers/setupDisplaySettings.js
+++ b/src/helpers/setupDisplaySettings.js
@@ -11,11 +11,13 @@
  */
 import { loadSettings } from "./settingsUtils.js";
 import { applyDisplayMode } from "./displayMode.js";
+import { applyMotionPreference } from "./motionUtils.js";
 
 async function init() {
   try {
     const settings = await loadSettings();
     applyDisplayMode(settings.displayMode);
+    applyMotionPreference(settings.motionEffects);
   } catch (error) {
     console.error("Failed to apply display mode:", error);
   }

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -52,8 +52,9 @@
         import { generateRandomCard } from "../helpers/randomCard.js";
         import { DATA_DIR } from "../helpers/constants.js";
         import { createButton } from "../components/Button.js";
+        import { shouldReduceMotionSync } from "../helpers/motionUtils.js";
 
-        const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        const prefersReducedMotion = shouldReduceMotionSync();
 
         let cachedJudokaData = null;
         let cachedGokyoData = null;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -809,6 +809,11 @@ button .ripple {
   }
 }
 
+.reduce-motion .country-panel[hidden],
+.reduce-motion .country-panel.grid {
+  transition: none;
+}
+
 .settings-error-popup {
   position: fixed;
   top: 50%;

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -73,3 +73,10 @@
     transition: none !important;
   }
 }
+
+.reduce-motion .card-container {
+  animation: none !important;
+}
+.reduce-motion .draw-card-btn {
+  transition: none !important;
+}

--- a/tests/helpers/button-effects.test.js
+++ b/tests/helpers/button-effects.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { setupButtonEffects } from "../../src/helpers/buttonEffects.js";
 
 let button;
@@ -7,10 +7,20 @@ describe("setupButtonEffects", () => {
   beforeEach(() => {
     button = document.createElement("button");
     document.body.appendChild(button);
+    window.matchMedia = vi.fn().mockImplementation((q) => ({
+      matches: false,
+      media: q,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }));
   });
 
   afterEach(() => {
     document.body.innerHTML = "";
+    vi.restoreAllMocks();
   });
 
   it("creates and removes a ripple on mousedown", () => {

--- a/tests/helpers/motion-utils.test.js
+++ b/tests/helpers/motion-utils.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { shouldReduceMotionSync, applyMotionPreference } from "../../src/helpers/motionUtils.js";
+
+const matchMediaMock = (matches) =>
+  vi.fn().mockImplementation((query) => ({
+    matches,
+    media: query,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }));
+
+describe("motionUtils", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.className = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    document.body.className = "";
+  });
+
+  it("returns true when matchMedia prefers reduced motion", () => {
+    window.matchMedia = matchMediaMock(true);
+    expect(shouldReduceMotionSync()).toBe(true);
+  });
+
+  it("returns true when settings disable motion effects", () => {
+    window.matchMedia = matchMediaMock(false);
+    localStorage.setItem("settings", JSON.stringify({ motionEffects: false }));
+    expect(shouldReduceMotionSync()).toBe(true);
+  });
+
+  it("returns false when motion is enabled and no media preference", () => {
+    window.matchMedia = matchMediaMock(false);
+    localStorage.setItem("settings", JSON.stringify({ motionEffects: true }));
+    expect(shouldReduceMotionSync()).toBe(false);
+  });
+
+  it("toggles reduce-motion class on body", () => {
+    applyMotionPreference(false);
+    expect(document.body.classList.contains("reduce-motion")).toBe(true);
+    applyMotionPreference(true);
+    expect(document.body.classList.contains("reduce-motion")).toBe(false);
+  });
+});

--- a/tests/helpers/setup-bottom-navbar.test.js
+++ b/tests/helpers/setup-bottom-navbar.test.js
@@ -11,6 +11,16 @@ describe("setupBottomNavbar module", () => {
       json: () => Promise.resolve([])
     });
 
+    window.matchMedia = vi.fn().mockImplementation((q) => ({
+      matches: false,
+      media: q,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }));
+
     // Clear DOM
     document.body.innerHTML = "";
 


### PR DESCRIPTION
## Summary
- add motion utilities for checking localStorage and media query
- toggle `.reduce-motion` class via applyMotionPreference
- skip ripple and animations when motion preference is reduced
- apply reduced motion setting on page load and settings changes
- extend CSS to also use `.reduce-motion` class
- add unit tests for motion utilities and update existing tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Screenshot suite & classicBattleFlow)*

------
https://chatgpt.com/codex/tasks/task_e_686e9aac37e88326a6dd91f45cd3fce4