### PR TITLE
Fix timer test

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -10,9 +10,8 @@ test.describe("Classic battle flow", () => {
     });
     await page.goto("/src/pages/battleJudoka.html");
     await page.waitForSelector("#round-timer");
-    await page.waitForTimeout(1500);
-    const resultText = await page.locator("#round-result").textContent();
-    expect(resultText).not.toBe("");
+    const result = page.locator("#round-result");
+    await expect(result).not.toHaveText("", { timeout: 1200 });
   });
 
   test("tie message appears on equal stats", async ({ page }) => {


### PR DESCRIPTION
## Summary
- update auto-select timer test in Playwright to use toHaveText expectation

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 7 screenshot tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ea04ccdb883269bf17b55e1c953f3