### PR TITLE
Sync display and motion preferences

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -2,6 +2,7 @@ import { loadSettings, updateSetting } from "./settingsUtils.js";
 import { loadGameModes, updateGameModeHidden } from "./gameModeUtils.js";
 import { showSettingsError } from "./showSettingsError.js";
 import { createToggleSwitch } from "../components/ToggleSwitch.js";
+import { applyDisplayMode } from "./displayMode.js";
 import { applyMotionPreference } from "./motionUtils.js";
 
 function applyInputState(element, value) {
@@ -64,8 +65,11 @@ function initializeControls(settings, gameModes) {
 
   displaySelect?.addEventListener("change", () => {
     const previous = currentSettings.displayMode;
-    handleUpdate("displayMode", displaySelect.value, () => {
+    const mode = displaySelect.value;
+    applyDisplayMode(mode);
+    handleUpdate("displayMode", mode, () => {
       displaySelect.value = previous;
+      applyDisplayMode(previous);
     });
   });
 
@@ -108,6 +112,8 @@ async function initializeSettingsPage() {
   try {
     const settings = await loadSettings();
     const gameModes = await loadGameModes();
+    applyDisplayMode(settings.displayMode);
+    applyMotionPreference(settings.motionEffects);
     initializeControls(settings, gameModes);
   } catch (error) {
     console.error("Error loading settings page:", error);

--- a/tests/helpers/settings-page.test.js
+++ b/tests/helpers/settings-page.test.js
@@ -32,6 +32,8 @@ describe("settingsPage module", () => {
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
     const loadGameModes = vi.fn().mockResolvedValue([]);
     const updateGameModeHidden = vi.fn();
+    const applyDisplayMode = vi.fn();
+    const applyMotionPreference = vi.fn();
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
@@ -40,6 +42,12 @@ describe("settingsPage module", () => {
       loadGameModes,
       updateGameModeHidden
     }));
+    vi.doMock("../../src/helpers/displayMode.js", () => ({
+      applyDisplayMode
+    }));
+    vi.doMock("../../src/helpers/motionUtils.js", () => ({
+      applyMotionPreference
+    }));
 
     await import("../../src/helpers/settingsPage.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
@@ -47,6 +55,8 @@ describe("settingsPage module", () => {
 
     expect(loadSettings).toHaveBeenCalled();
     expect(loadGameModes).toHaveBeenCalled();
+    expect(applyDisplayMode).toHaveBeenCalledWith(baseSettings.displayMode);
+    expect(applyMotionPreference).toHaveBeenCalledWith(baseSettings.motionEffects);
     vi.useRealTimers();
   });
   it("renders checkboxes for all modes", async () => {


### PR DESCRIPTION
## Summary
- apply display and motion helpers when initializing settings page
- update handlers to preview changes before saving
- validate helper invocation in unit tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686ea4055d1c83268793c12175d83061