### PR TITLE
Add reduced motion test coverage

### DIFF
--- a/tests/helpers/button-effects.test.js
+++ b/tests/helpers/button-effects.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { setupButtonEffects } from "../../src/helpers/buttonEffects.js";
+import * as motionUtils from "../../src/helpers/motionUtils.js";
 
 let button;
 
@@ -68,5 +69,13 @@ describe("setupButtonEffects", () => {
     Object.defineProperty(event, "offsetY", { value: 2 });
     div.dispatchEvent(event);
     expect(div.querySelector("span.ripple")).toBeNull();
+  });
+
+  it("skips ripple when motion reduction is preferred", () => {
+    vi.spyOn(motionUtils, "shouldReduceMotionSync").mockReturnValue(true);
+    setupButtonEffects();
+    const event = new MouseEvent("mousedown");
+    button.dispatchEvent(event);
+    expect(button.querySelector("span.ripple")).toBeNull();
   });
 });

--- a/tests/helpers/display-mode.test.js
+++ b/tests/helpers/display-mode.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { applyDisplayMode } from "../../src/helpers/displayMode.js";
 
 describe("applyDisplayMode", () => {
@@ -27,5 +27,14 @@ describe("applyDisplayMode", () => {
     applyDisplayMode("light");
     expect(document.body.classList.contains("dark-mode")).toBe(false);
     expect(document.body.classList.contains("gray-mode")).toBe(false);
+  });
+
+  it("warns when an invalid mode is provided", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    document.body.classList.add("dark-mode");
+    applyDisplayMode("neon");
+    expect(warnSpy).toHaveBeenCalled();
+    expect(document.body.classList.contains("dark-mode")).toBe(true);
+    warnSpy.mockRestore();
   });
 });

--- a/tests/helpers/game-random.test.js
+++ b/tests/helpers/game-random.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+let showRandom;
+let gameArea;
+let carouselContainer;
+let showCarousel;
+let hideCard;
+
+function setupDom() {
+  showRandom = document.createElement("button");
+  showRandom.id = "showRandom";
+  gameArea = document.createElement("div");
+  gameArea.id = "gameArea";
+  carouselContainer = document.createElement("div");
+  carouselContainer.id = "carousel-container";
+  showCarousel = document.createElement("button");
+  showCarousel.id = "showCarousel";
+  hideCard = document.createElement("button");
+  hideCard.id = "hideCard";
+  document.body.append(showRandom, gameArea, carouselContainer, showCarousel, hideCard);
+}
+
+describe("game.js", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    document.body.innerHTML = "";
+  });
+
+  it("passes motion preference to generateRandomCard", async () => {
+    setupDom();
+    const generateRandomCard = vi.fn();
+    const shouldReduceMotionSync = vi.fn(() => true);
+    vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
+    vi.doMock("../../src/helpers/motionUtils.js", () => ({ shouldReduceMotionSync }));
+
+    await import("../../src/game.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    showRandom.dispatchEvent(new Event("click"));
+
+    expect(generateRandomCard).toHaveBeenCalledWith(null, null, gameArea, true);
+  });
+});

--- a/tests/helpers/motion-utils.test.js
+++ b/tests/helpers/motion-utils.test.js
@@ -41,6 +41,17 @@ describe("motionUtils", () => {
     expect(shouldReduceMotionSync()).toBe(false);
   });
 
+  it("handles invalid stored settings gracefully", () => {
+    window.matchMedia = matchMediaMock(true);
+    localStorage.setItem("settings", "not json");
+    expect(shouldReduceMotionSync()).toBe(true);
+  });
+
+  it("falls back to media query when no settings present", () => {
+    window.matchMedia = matchMediaMock(false);
+    expect(shouldReduceMotionSync()).toBe(false);
+  });
+
   it("toggles reduce-motion class on body", () => {
     applyMotionPreference(false);
     expect(document.body.classList.contains("reduce-motion")).toBe(true);

--- a/tests/helpers/randomJudoka-page.test.js
+++ b/tests/helpers/randomJudoka-page.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+
+const html = fs.readFileSync("src/pages/randomJudoka.html", "utf8");
+
+describe("randomJudoka.html", () => {
+  it("passes reduced motion flag when generating cards", () => {
+    expect(html).toMatch(/const prefersReducedMotion = shouldReduceMotionSync\(\)/);
+    expect(html).toMatch(/generateRandomCard\([^)]*prefersReducedMotion[^)]*\)/);
+  });
+});

--- a/tests/helpers/randomJudoka-page.test.js
+++ b/tests/helpers/randomJudoka-page.test.js
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import fs from "fs";
+import path from "path";
 
-const html = fs.readFileSync("src/pages/randomJudoka.html", "utf8");
+const html = fs.readFileSync(path.resolve(__dirname, "../src/pages/randomJudoka.html"), "utf8");
 
 describe("randomJudoka.html", () => {
   it("passes reduced motion flag when generating cards", () => {


### PR DESCRIPTION
## Summary
- test `displayMode` warnings
- test `motionUtils` with invalid or missing settings
- verify buttons skip ripple effect when motion is reduced
- check that `game.js` forwards motion preference
- ensure `randomJudoka.html` passes reduced motion flag

## Testing
- `npx vitest run`
- `npx prettier . --check`
- `npx eslint .`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686ea419f6ec8326b0cabaf90126245b