### PR TITLE
Fix duplicate card in Classic Battle

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -57,7 +57,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 | Priority | Feature                 | Description                                                                                             |
 | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------- |
-| P1       | Random Card Draw        | Draw one random card per player each round.                                                             |
+| P1       | Random Card Draw        | Draw one random card per player each round; the computer card must differ from the player's.            |
 | P1       | Stat Selection Timer    | Player selects stat within 30 seconds; otherwise, random stat is chosen. Default timer is fixed at 30s. |
 | P1       | Scoring                 | Increase score by one for each round win.                                                               |
 | P1       | Match End Condition     | End match on 10 points or after 25 rounds.                                                              |
@@ -70,6 +70,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Behavior on tie rounds: round ends with a message explaining the tie and an option to start the next round.
 - Match start conditions: both players begin with a score of zero; player goes first by drawing their card.
 - Players have 30 seconds to select a stat; if no selection is made, the system randomly selects a stat from the drawn card.
+- The computer's card must always differ from the player's card for each round.
 - **Default:** 30-second timer is fixed (not adjustable by the player at launch), but can be reviewed for future difficulty settings.
 
 ---

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -76,8 +76,10 @@ function startTimer() {
  *
  * @pseudocode
  * 1. Load judoka and gokyo data if not already cached.
- * 2. Draw a random card for the player using `generateRandomCard`.
- * 3. Select a random judoka for the computer and display it with `displayJudokaCard`.
+ * 2. Draw a random card for the player using `generateRandomCard` and capture
+ *    the selected judoka.
+ * 3. Select a different random judoka for the computer and display it with
+ *    `displayJudokaCard`.
  * 4. Initialize the round timer.
  *
  * @returns {Promise<void>} Resolves when cards are displayed.
@@ -93,8 +95,16 @@ export async function startRound() {
   }
   const playerContainer = document.getElementById("player-card");
   const computerContainer = document.getElementById("computer-card");
-  await generateRandomCard(judokaData, null, playerContainer, false);
-  const compJudoka = getRandomJudoka(judokaData);
+  let playerJudoka = null;
+  await generateRandomCard(judokaData, null, playerContainer, false, (j) => {
+    playerJudoka = j;
+  });
+  let compJudoka = getRandomJudoka(judokaData);
+  if (playerJudoka && judokaData.length > 1) {
+    while (compJudoka.id === playerJudoka.id) {
+      compJudoka = getRandomJudoka(judokaData);
+    }
+  }
   await displayJudokaCard(compJudoka, gokyoLookup, computerContainer);
   showResult("");
   updateScoreDisplay();

--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -88,7 +88,8 @@ export async function createCardForJudoka(judoka, gokyoLookup, containerEl, pref
  * 2. Ensure gokyo data is available:
  *    - Use the provided `gokyoData` or fetch `gokyo.json`.
  *    - Create a lookup object with `createGokyoLookup`.
- * 3. Select a random judoka using `getRandomJudoka`.
+ * 3. Select a random judoka using `getRandomJudoka` and invoke `onSelect`
+ *    with the chosen judoka when provided.
  * 4. Generate and display the card with `createCardForJudoka`.
  * 5. On any error, log the issue and display a fallback card (judoka id `0`).
  *
@@ -96,13 +97,15 @@ export async function createCardForJudoka(judoka, gokyoLookup, containerEl, pref
  * @param {GokyoEntry[]} [gokyoData] - Preloaded gokyo data.
  * @param {HTMLElement} containerEl - Element to contain the card.
  * @param {boolean} [prefersReducedMotion=false] - Motion preference flag.
+ * @param {function} [onSelect] - Callback invoked with the chosen judoka.
  * @returns {Promise<void>} Resolves when the card is appended.
  */
 export async function generateRandomCard(
   activeCards,
   gokyoData,
   containerEl,
-  prefersReducedMotion = false
+  prefersReducedMotion = false,
+  onSelect
 ) {
   if (!containerEl) return;
 
@@ -126,6 +129,9 @@ export async function generateRandomCard(
     }
 
     const selectedJudoka = getRandomJudoka(validJudoka);
+    if (typeof onSelect === "function") {
+      onSelect(selectedJudoka);
+    }
     await createCardForJudoka(selectedJudoka, gokyoLookup, containerEl, prefersReducedMotion);
     // else: do not update DOM if card is null/undefined
   } catch (error) {
@@ -134,6 +140,9 @@ export async function generateRandomCard(
     const fallbackJudoka = buildFallbackJudoka();
 
     try {
+      if (typeof onSelect === "function") {
+        onSelect(fallbackJudoka);
+      }
       await createCardForJudoka(fallbackJudoka, gokyoLookup, containerEl, prefersReducedMotion);
     } catch (fallbackError) {
       console.error("Error displaying fallback card:", fallbackError);

--- a/tests/helpers/classic-battle.test.js
+++ b/tests/helpers/classic-battle.test.js
@@ -1,16 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+let generateRandomCardMock;
+
 vi.mock("../../src/helpers/randomCard.js", () => ({
-  generateRandomCard: vi.fn(async (data, g, container) => {
-    container.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>5</span></li><li class="stat"><strong>Speed</strong> <span>5</span></li><li class="stat"><strong>Technique</strong> <span>5</span></li><li class="stat"><strong>Kumi-kata</strong> <span>5</span></li><li class="stat"><strong>Ne-waza</strong> <span>5</span></li></ul>`;
-  })
+  generateRandomCard: (...args) => generateRandomCardMock(...args)
 }));
 
+let getRandomJudokaMock;
+let displayJudokaCardMock;
+
 vi.mock("../../src/helpers/cardUtils.js", () => ({
-  getRandomJudoka: () => ({}),
-  displayJudokaCard: vi.fn(async (j, g, container) => {
-    container.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>3</span></li><li class="stat"><strong>Speed</strong> <span>3</span></li><li class="stat"><strong>Technique</strong> <span>3</span></li><li class="stat"><strong>Kumi-kata</strong> <span>3</span></li><li class="stat"><strong>Ne-waza</strong> <span>3</span></li></ul>`;
-  })
+  getRandomJudoka: (...args) => getRandomJudokaMock(...args),
+  displayJudokaCard: (...args) => displayJudokaCardMock(...args)
 }));
 
 vi.mock("../../src/helpers/dataUtils.js", () => ({
@@ -31,6 +32,14 @@ describe("classicBattle", () => {
       <p id="round-result"></p>
       <span id="round-timer"></span>`;
     timerSpy = vi.useFakeTimers();
+    generateRandomCardMock = vi.fn(async (data, g, container, _pm, cb) => {
+      container.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>5</span></li><li class="stat"><strong>Speed</strong> <span>5</span></li><li class="stat"><strong>Technique</strong> <span>5</span></li><li class="stat"><strong>Kumi-kata</strong> <span>5</span></li><li class="stat"><strong>Ne-waza</strong> <span>5</span></li></ul>`;
+      if (cb) cb({ id: 1 });
+    });
+    getRandomJudokaMock = vi.fn(() => ({ id: 2 }));
+    displayJudokaCardMock = vi.fn(async (j, g, container) => {
+      container.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>3</span></li><li class="stat"><strong>Speed</strong> <span>3</span></li><li class="stat"><strong>Technique</strong> <span>3</span></li><li class="stat"><strong>Kumi-kata</strong> <span>3</span></li><li class="stat"><strong>Ne-waza</strong> <span>3</span></li></ul>`;
+    });
   });
 
   afterEach(() => {
@@ -91,5 +100,25 @@ describe("classicBattle", () => {
     handleStatSelection("power");
 
     expect(document.getElementById("score-display").textContent).toBe("You: 10 Computer: 0");
+  });
+
+  it("draws a different card for the computer", async () => {
+    generateRandomCardMock = vi.fn(async (d, g, c, _pm, cb) => {
+      c.innerHTML = "<ul></ul>";
+      cb({ id: 1 });
+    });
+    let callCount = 0;
+    getRandomJudokaMock = vi.fn(() => {
+      callCount += 1;
+      return callCount === 1 ? { id: 1 } : { id: 2 };
+    });
+    displayJudokaCardMock = vi.fn(async () => {});
+    const { startRound } = await import("../../src/helpers/classicBattle.js");
+    await startRound();
+    expect(displayJudokaCardMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 2 }),
+      expect.anything(),
+      expect.anything()
+    );
   });
 });

--- a/tests/helpers/random-card.test.js
+++ b/tests/helpers/random-card.test.js
@@ -73,6 +73,17 @@ describe("generateRandomCard", () => {
     expect(container.firstChild).toBe(generatedEl);
   });
 
+  it("invokes onSelect callback with chosen judoka", async () => {
+    const container = document.createElement("div");
+    const generatedEl = document.createElement("span");
+    getRandomJudokaMock = vi.fn(() => judokaData[0]);
+    generateJudokaCardHTMLMock = vi.fn(async () => generatedEl);
+    const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
+    const cb = vi.fn();
+    await generateRandomCard(judokaData, gokyoData, container, true, cb);
+    expect(cb).toHaveBeenCalledWith(judokaData[0]);
+  });
+
   it("falls back to id 0 when selection fails", async () => {
     const container = document.createElement("div");
     const fallbackEl = document.createElement("div");


### PR DESCRIPTION
## Summary
- update Classic Battle so the computer always draws a different card
- support callback in `generateRandomCard` to capture the selected judoka
- document distinct card rule in `prdClassicBattle.md`
- test new callback and unique selection logic

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686ea523f3f08326a828609786847680