### PR TITLE
Fix duplicate card selection check

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -78,8 +78,9 @@ function startTimer() {
  * 1. Load judoka and gokyo data if not already cached.
  * 2. Draw a random card for the player using `generateRandomCard` and capture
  *    the selected judoka.
- * 3. Select a different random judoka for the computer and display it with
- *    `displayJudokaCard`.
+ * 3. Select a random judoka for the computer.
+ *    - If it matches the player's judoka, retry up to a safe limit.
+ *    - Display the chosen judoka with `displayJudokaCard`.
  * 4. Initialize the round timer.
  *
  * @returns {Promise<void>} Resolves when cards are displayed.
@@ -100,9 +101,13 @@ export async function startRound() {
     playerJudoka = j;
   });
   let compJudoka = getRandomJudoka(judokaData);
-  if (playerJudoka && judokaData.length > 1) {
-    while (compJudoka.id === playerJudoka.id) {
+  if (playerJudoka) {
+    // avoid showing the same judoka, but guard against infinite loops
+    let attempts = 0;
+    const maxAttempts = Math.max(judokaData?.length || 0, 5);
+    while (compJudoka.id === playerJudoka.id && attempts < maxAttempts) {
       compJudoka = getRandomJudoka(judokaData);
+      attempts += 1;
     }
   }
   await displayJudokaCard(compJudoka, gokyoLookup, computerContainer);

--- a/tests/helpers/randomJudoka-page.test.js
+++ b/tests/helpers/randomJudoka-page.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
 
-const html = fs.readFileSync ("src/pages/randomJudoka.html", "utf8");
+const html = fs.readFileSync("src/pages/randomJudoka.html", "utf8");
 
 describe("randomJudoka.html", () => {
   it("passes reduced motion flag when generating cards", () => {


### PR DESCRIPTION
## Summary
- update pseudocode and logic when selecting opponent card
- run Prettier on randomJudoka-page.test.js

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails to download vitest)*
- `npx playwright test` *(fails to download playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686eb055e7188326833deb22dae91706