### PR TITLE
Adjust Playwright tests for hidden Update Judoka mode

### DIFF
--- a/playwright/battleJudoka.spec.js
+++ b/playwright/battleJudoka.spec.js
@@ -13,16 +13,14 @@ test.describe("Battle Judoka page", () => {
     await expect(page.getByRole("navigation")).toBeVisible();
     await expect(page.getByRole("img", { name: "JU-DO-KON! Logo" })).toBeVisible();
     await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /update judoka/i })).toBeVisible();
+    // 'Update Judoka' link is hidden in the current game modes configuration
+    // so only visible links are asserted
     await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
   });
 
   test("navigation links work", async ({ page }) => {
     await page.getByRole("link", { name: /view judoka/i }).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
-    await page.goBack({ waitUntil: "load" });
-    await page.getByRole("link", { name: /update judoka/i }).click();
-    await expect(page).toHaveURL(/updateJudoka\.html/);
     await page.goBack({ waitUntil: "load" });
     await page.getByRole("link", { name: /classic battle/i }).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);

--- a/playwright/createJudoka.spec.js
+++ b/playwright/createJudoka.spec.js
@@ -13,16 +13,13 @@ test.describe("Create Judoka page", () => {
     await expect(page.getByRole("navigation")).toBeVisible();
     await expect(page.getByRole("img", { name: "JU-DO-KON! Logo" })).toBeVisible();
     await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /update judoka/i })).toBeVisible();
+    // 'Update Judoka' is currently hidden via game modes configuration
     await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
   });
 
   test("navigation links work", async ({ page }) => {
     await page.getByRole("link", { name: /view judoka/i }).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
-    await page.goBack({ waitUntil: "load" });
-    await page.getByRole("link", { name: /update judoka/i }).click();
-    await expect(page).toHaveURL(/updateJudoka\.html/);
     await page.goBack({ waitUntil: "load" });
     await page.getByRole("link", { name: /classic battle/i }).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);


### PR DESCRIPTION
## Summary
- remove Update Judoka link checks from battle and create pages
- align navigation tests with current gameModes.json configuration

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686f9a200970832691b446c93a808258