### PR TITLE
Improve country filter accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ The repository specifies commenting standards in design/codeStandards. JSDoc com
 - Playable directly in the browser
 - Loading indicator for better user experience
 - Modularized JavaScript for better maintainability
-- Slide-in country picker for filtering judoka by flag
+- Slide-in country picker for filtering judoka by flag with accessible
+  `aria-label` descriptions
 
 ## About JU-DO-KON!
 

--- a/design/productRequirementsDocuments/prdCountryPickerFilter.md
+++ b/design/productRequirementsDocuments/prdCountryPickerFilter.md
@@ -197,7 +197,9 @@ Key Details:
 
 - [ ] 5.0 Ensure Accessibility and Compliance
 
-  - [ ] 5.1 Add alt-text for all flag icons based on country names.
+  - [ ] 5.1 Add alt-text for all flag icons based on country names and apply
+        `aria-label` text like "Filter by {country}" to each flag button for
+        screen readers.
   - [ ] 5.2 Ensure color contrast ratios meet WCAG 2.1 AA standards.
   - [ ] 5.3 Enforce minimum tap target size (44x44px) for touch devices (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness)).
   - [ ] 5.4 Ensure flags are displayed alphabetically.

--- a/src/helpers/countryUtils.js
+++ b/src/helpers/countryUtils.js
@@ -183,7 +183,8 @@ export async function getFlagUrl(countryCode) {
  *    - When scrolling near the bottom, generate the next batch of 50 until all
  *      countries are rendered.
  *    - Each button is created as follows:
- *      a. Create a `button.flag-button.slide` element and set its value/label.
+ *      a. Create a `button.flag-button.slide` element, set its value, and apply
+ *         an `aria-label` like "Filter by {country}" for screen readers.
  *      b. Add an `img` for the flag using `getFlagUrl` with a fallback on
  *         failure.
  *      c. Append the country name in a `p` element.
@@ -216,7 +217,8 @@ export async function populateCountryList(container) {
     const allButton = document.createElement("button");
     allButton.className = "flag-button slide";
     allButton.value = "all";
-    allButton.setAttribute("aria-label", "All Countries");
+    // Include an accessible description for assistive tech
+    allButton.setAttribute("aria-label", "Show all countries");
     const allImg = document.createElement("img");
     allImg.alt = "All countries";
     allImg.className = "flag-image";
@@ -242,7 +244,8 @@ export async function populateCountryList(container) {
         const button = document.createElement("button");
         button.className = "flag-button slide";
         button.value = country.country;
-        button.setAttribute("aria-label", country.country);
+        // Use an accessible label describing the filtering action
+        button.setAttribute("aria-label", `Filter by ${country.country}`);
 
         const flagImg = document.createElement("img");
         flagImg.alt = `${country.country} Flag`;

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -121,6 +121,8 @@
             if (allJudoka.length === 0) {
               const noResultsMessage = document.createElement("div");
               noResultsMessage.className = "no-results-message";
+              noResultsMessage.setAttribute("role", "status");
+              noResultsMessage.setAttribute("aria-live", "polite");
               noResultsMessage.textContent = "No cards available.";
               carouselContainer.appendChild(noResultsMessage);
             }
@@ -128,6 +130,8 @@
             console.error("Error building the carousel:", error);
             const errorMessage = document.createElement("div");
             errorMessage.className = "error-message";
+            errorMessage.setAttribute("role", "alert");
+            errorMessage.setAttribute("aria-live", "assertive");
             errorMessage.textContent = "Unable to load roster.";
             carouselContainer.appendChild(errorMessage);
 
@@ -218,6 +222,8 @@
             if (filtered.length === 0) {
               const noResultsMessage = document.createElement("div");
               noResultsMessage.className = "no-results-message";
+              noResultsMessage.setAttribute("role", "status");
+              noResultsMessage.setAttribute("aria-live", "polite");
               noResultsMessage.textContent = "No judoka available for this country";
               carouselContainer.appendChild(noResultsMessage);
             }

--- a/tests/helpers/populate-country-list.test.js
+++ b/tests/helpers/populate-country-list.test.js
@@ -39,6 +39,26 @@ describe("populateCountryList", () => {
     expect(names).toEqual(["All", "Brazil", "Japan"]);
   });
 
+  it("applies accessible aria-labels to flag buttons", async () => {
+    const judoka = [{ id: 1, firstname: "A", surname: "B", country: "Japan" }];
+
+    const mapping = [{ country: "Japan", code: "jp", active: true }];
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => judoka })
+      .mockResolvedValueOnce({ ok: true, json: async () => mapping });
+
+    const { populateCountryList } = await import("../../src/helpers/countryUtils.js");
+
+    const container = document.createElement("div");
+    await populateCountryList(container);
+
+    const buttons = container.querySelectorAll("button.flag-button");
+    expect(buttons[0].getAttribute("aria-label")).toBe("Show all countries");
+    expect(buttons[1].getAttribute("aria-label")).toBe("Filter by Japan");
+  });
+
   it("lazy loads additional countries on scroll", async () => {
     const judoka = Array.from({ length: 60 }, (_, i) => ({
       id: i,


### PR DESCRIPTION
## Summary
- label flag buttons with action text for screen readers
- announce Browse Judoka empty/error messages via ARIA attributes
- document ARIA-label requirement in PRD
- note accessible flag picker in README
- test new aria-labels

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686f9bb18ff48326b1d01abfd73be42a