### PR TITLE
Use spacing tokens and define missing CSS variables

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -25,6 +25,15 @@
   --space-lg: 24px;
   --space-xl: 32px;
 
+  /* Aliases for compatibility */
+  --space-small: var(--space-sm);
+  --space-medium: var(--space-md);
+  --space-large: var(--space-lg);
+
+  /* Touch target and breakpoints */
+  --touch-target-size: 48px;
+  --breakpoint-lg: 1024px;
+
   /* Updated border radius */
   --radius-sm: 4px; /* Inputs, badges */
   --radius-md: 8px; /* Buttons */

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -16,7 +16,7 @@
   scroll-behavior: smooth; /* Smooth scrolling effect */
   width: 100%; /* Ensure carousel doesn't exceed container width */
   max-width: 100%; /* Prevent overflow */
-  padding: 10px; /* Add padding for visual spacing */
+  padding: var(--space-md); /* Add padding for visual spacing */
 }
 
 .judoka-card {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -322,7 +322,7 @@ button .ripple {
   max-width: 250px;
   min-width: 100px;
   flex: 1 1 0;
-  margin-left: min(5px, 5dvw);
+  margin-left: min(var(--space-sm), 5dvw);
 }
 
 .card-name .firstname {
@@ -341,12 +341,12 @@ button .ripple {
   margin: 0;
   display: flex;
   align-items: center;
-  padding-left: 5px;
+  padding-left: var(--space-sm);
   justify-content: right;
   max-width: 60px;
   min-width: 35px;
   flex: 1 1 0;
-  margin-right: min(4px, 1.4vw);
+  margin-right: min(var(--space-xs), 1.4vw);
 }
 
 .card-flag img {
@@ -468,7 +468,7 @@ button .ripple {
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-tertiary);
   white-space: nowrap;
-  padding: min(10px, 2.3vw) 8px;
+  padding: min(var(--space-md), 2.3vw) var(--space-sm);
   font-size: min(14px, 4dvw);
   max-width: 150px;
   min-width: 90px;
@@ -487,7 +487,7 @@ button .ripple {
   border-radius: var(--radius-sm);
   border: 1px solid var(--card-signature-move-bg);
   white-space: nowrap;
-  padding: min(5px, 2.3vw) 8px;
+  padding: min(var(--space-sm), 2.3vw) var(--space-sm);
   font-size: min(12px, 4vw);
   max-width: 150px;
   flex: 1 1 0;
@@ -561,11 +561,11 @@ button .ripple {
 }
 
 .scroll-button.left {
-  left: 10px;
+  left: var(--space-sm);
 }
 
 .scroll-button.right {
-  right: 10px;
+  right: var(--space-sm);
 }
 
 .judoka-card:target {


### PR DESCRIPTION
## Summary
- define spacing and breakpoint variables in `base.css`
- replace hard-coded padding in carousel with token
- normalize spacing units in component styles

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 4 screenshot diffs)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_686f9caa93dc8326941fcf9b3b6b3025