### PR TITLE
Remove duplicate CSS resets and consolidate keyframes

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -85,3 +85,12 @@ h2 {
   font-size: 32px;
   font-weight: bold;
 }
+
+@keyframes scroll {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(calc(-250px * 7));
+  }
+}

--- a/src/styles/bottom-navbar.css
+++ b/src/styles/bottom-navbar.css
@@ -1,11 +1,3 @@
-*,
-*::before,
-*::after {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
 .bottom-navbar {
   min-height: max(7vh, 12px);
   display: inline-flex;

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -1,11 +1,4 @@
 /* Responsive styles for the Judoka Card Carousel */
-*,
-*::before,
-*::after {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
 
 /* Default styles for desktop */
 .card-carousel {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,81 +1,8 @@
 @import "./bottom-navbar.css";
-/* Reset default browser styles for all elements */
-*,
-*::before,
-*::after {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
 
 .noscript-warning {
   color: red;
   font-weight: bold;
-}
-
-@keyframes scroll {
-  0% {
-    transform: translateX(0);
-  }
-  100% {
-    transform: translateX(calc(-250px * 7));
-  }
-}
-
-/* General body styles */
-body {
-  font-family: "Open Sans", sans-serif; /* Updated token */
-  color: var(--color-text); /* Updated token */
-  background-color: var(--color-tertiary); /* Updated token */
-  line-height: 1.4; /* Updated token */
-}
-
-.home-screen {
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  min-height: 100dvh;
-  max-width: 100%;
-  align-items: center;
-}
-
-.kodokan-screen {
-  display: grid;
-  grid-template-rows: auto 1fr auto auto;
-  min-height: 100dvh;
-  max-width: 100%;
-  align-items: center;
-}
-
-.kodokan-grid {
-  display: grid;
-  grid-template-columns: auto 1fr;
-}
-
-.helper-container {
-  grid-column: 1/1;
-}
-
-.header {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  background-color: var(--color-tertiary); /* Updated token */
-  box-shadow: var(--shadow-base); /* Updated token */
-  width: 100%;
-}
-
-.character-slot {
-  height: 20px;
-  opacity: 0.5;
-}
-
-.logo-container {
-  display: flex;
-  justify-content: center;
-}
-
-.logo {
-  height: 5dvh;
 }
 
 .card {
@@ -591,38 +518,6 @@ button .ripple {
 
 .top-navbar ul {
   list-style: none;
-}
-
-.country-flag-slider {
-  background: rgba(0, 32, 82, 0.5);
-  overflow: hidden;
-  position: relative;
-  width: 100%;
-
-  .country-flag-slide-track {
-    animation: scroll var(--slide-track-speed) linear infinite;
-    display: flex;
-    /* width: calc(250px * 14); */
-  }
-
-  .slide {
-    display: inline-flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 0.3em 3dvw;
-    text-align: center;
-    max-width: 45vw;
-    white-space: pre;
-  }
-
-  .flag-image {
-    max-height: 5dvh;
-    margin: 0.5rem;
-    border-radius: 4px;
-    min-width: var(--touch-target-size);
-    min-height: var(--touch-target-size);
-  }
 }
 
 .filter-bar {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,12 +1,5 @@
 @import "./bottom-navbar.css";
 /* General body styles */
-*,
-*::before,
-*::after {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
 
 body {
   font-family: "Open Sans", sans-serif; /* Updated token */

--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -1,11 +1,4 @@
 /* Layout tweaks for meditation screen */
-*,
-*::before,
-*::after {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
 
 .meditation-screen {
   display: flex;

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -1,12 +1,3 @@
-/* Reset default browser styles for all elements */
-*,
-*::before,
-*::after {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
 /* Updated to align with the design standards */
 .noscript-warning {
   color: var(--color-primary); /* Updated token */
@@ -44,24 +35,9 @@
   color: var(--color-text); /* Updated token */
 }
 
-@keyframes scroll {
-  0% {
-    transform: translateX(0);
-  }
-  100% {
-    transform: translateX(calc(-250px * 7));
-  }
-}
-
 /* Optional: Hide spinner by default with the hidden class */
 .hidden {
   display: none;
-}
-
-/* Utility: constrain long-form text to improve readability */
-.long-form {
-  max-width: 70ch;
-  margin-inline: auto;
 }
 
 /* Add Reduced Motion support */


### PR DESCRIPTION
## Summary
- keep universal reset only in base.css
- consolidate `@keyframes scroll` in base.css
- remove body and layout rules from components.css
- keep only one `.long-form` utility
- run Prettier, ESLint, Vitest, Playwright and Pa11y

## Testing
- `npx prettier . --write`
- `npx eslint . --fix`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686f9dfd4560832694f09271a1824123