### PR TITLE
Remove unused game tile style

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -16,10 +16,6 @@
   transform: scale(1.05);
 }
 
-.game-tile {
-  composes: card;
-}
-
 .tile-content h2 {
   padding-left: var(--space-large, 1rem);
   font-size: var(--font-large);


### PR DESCRIPTION
## Summary
- remove `.game-tile` rule from components.css

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 4 screenshot tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686fa4da37808326bb4f70909b9d8450