### PR TITLE
Add card entry animation

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -121,6 +121,31 @@ button .ripple {
     opacity: 0;
   }
 }
+
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-card {
+  animation: card-enter var(--scale-duration, 0.4s) ease-out forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-card {
+    animation: none;
+  }
+}
+
+.reduce-motion .animate-card {
+  animation: none;
+}
 /* Card styles */
 .card-container {
   display: flex;


### PR DESCRIPTION
## Summary
- animate cards entering with a card-enter keyframe
- skip the animation when reduced motion is requested

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686fa4fea8048326babd6009b0420a98