### PR TITLE
Update background color tokens

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -52,7 +52,7 @@
 
 /* Dark mode variable overrides */
 .dark-mode {
-  --color-surface: #1a1a1a;
+  --color-surface: #121212;
   --color-background: #000000;
   --color-text: #ffffff;
   --color-text-inverted: #000000;
@@ -60,8 +60,8 @@
 
 /* Gray mode variable overrides */
 .gray-mode {
-  --color-surface: #e0e0e0;
-  --color-background: #d0d0d0;
+  --color-surface: #f0f0f0;
+  --color-background: #cdcdcd;
   --color-text: #000000;
   --color-text-inverted: #ffffff;
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -105,7 +105,7 @@ a:focus-visible {
 button .ripple {
   position: absolute;
   border-radius: 50%;
-  background: rgba(0, 0, 0, 0.2);
+  background-color: var(--color-surface);
   transform: scale(0);
   animation: ripple var(--transition-fast);
   pointer-events: none;
@@ -323,7 +323,7 @@ button .ripple {
   position: absolute;
   margin-top: var(--space-small); /* Updated token */
   right: var(--space-small); /* Updated token */
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: var(--color-surface);
   border-radius: var(--radius-sm); /* Updated token */
   color: var(--color-text-inverted);
   font-weight: bold;
@@ -455,7 +455,7 @@ button .ripple {
   justify-content: center;
   align-items: center;
   height: 75vh;
-  background-color: rgba(34, 34, 59, 0.8);
+  background-color: var(--color-surface);
   backdrop-filter: blur(10px);
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.5);
   overflow: hidden;
@@ -469,18 +469,18 @@ button .ripple {
 }
 
 .card-carousel::-webkit-scrollbar-thumb {
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--color-surface);
   border-radius: 4px;
 }
 
 .card-carousel::-webkit-scrollbar-track {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: var(--color-background);
 }
 
 .scroll-button {
   position: relative;
-  background-color: rgba(0, 0, 0, 0.1);
-  color: white;
+  background-color: var(--color-surface);
+  color: var(--color-text-inverted);
   border: 1px solid var(--color-tertiary);
   border-radius: 50%;
   min-width: 48px;
@@ -495,7 +495,7 @@ button .ripple {
 }
 
 .scroll-button:hover {
-  background-color: rgba(89, 0, 255, 0.9);
+  background-color: var(--color-surface);
   transform: scale(1.05);
   box-shadow: var(--shadow-base);
 }
@@ -808,7 +808,7 @@ button .ripple {
   display: inline-block;
   width: 60px;
   height: 34px;
-  background-color: #878787;
+  background-color: var(--color-surface);
   border-radius: var(--radius-pill);
   transition: var(--transition-fast);
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -102,7 +102,7 @@ body {
   backdrop-filter: blur(10px);
 }
 .country-flag-slider {
-  background: rgba(0, 32, 82, 0.5);
+  background-color: var(--color-surface);
   overflow: hidden;
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- use `var(--color-surface)` for card and carousel backgrounds
- adjust scrollbar, ripple and slider colors
- update layout slider background token
- tweak dark mode and gray mode overrides

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatches)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_686fbfcdbd948326a8404f14f5b40c08