### PR TITLE
Update theme selector

### DIFF
--- a/src/helpers/displayMode.js
+++ b/src/helpers/displayMode.js
@@ -1,10 +1,11 @@
 /**
- * Apply the chosen display mode by toggling body classes.
+ * Apply the chosen display mode by setting a theme data attribute on the body.
  *
  * @pseudocode
- * 1. Remove both `dark-mode` and `gray-mode` classes from `document.body`.
- * 2. If `mode` is "dark", add the `dark-mode` class.
- * 3. Else if `mode` is "gray", add the `gray-mode` class.
+ * 1. Verify that `mode` is one of "light", "dark", or "gray".
+ *    - If the value is invalid, log a warning and exit early.
+ *
+ * 2. Set `document.body.dataset.theme` to the provided mode value.
  *
  * @param {"light"|"dark"|"gray"} mode - Desired display mode.
  */
@@ -14,10 +15,5 @@ export function applyDisplayMode(mode) {
     console.warn(`Invalid display mode: "${mode}". Valid modes are: ${validModes.join(", ")}.`);
     return;
   }
-  document.body.classList.remove("dark-mode", "gray-mode");
-  if (mode === "dark") {
-    document.body.classList.add("dark-mode");
-  } else if (mode === "gray") {
-    document.body.classList.add("gray-mode");
-  }
+  document.body.dataset.theme = mode;
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -51,7 +51,7 @@
 }
 
 /* Dark mode variable overrides */
-.dark-mode {
+[data-theme="dark"] {
   --color-surface: #121212;
   --color-background: #000000;
   --color-text: #ffffff;
@@ -59,7 +59,7 @@
 }
 
 /* Gray mode variable overrides */
-.gray-mode {
+[data-theme="gray"] {
   --color-surface: #f0f0f0;
   --color-background: #cdcdcd;
   --color-text: #000000;

--- a/tests/helpers/display-mode.test.js
+++ b/tests/helpers/display-mode.test.js
@@ -3,38 +3,35 @@ import { applyDisplayMode } from "../../src/helpers/displayMode.js";
 
 describe("applyDisplayMode", () => {
   beforeEach(() => {
-    document.body.className = "";
+    document.body.removeAttribute("data-theme");
   });
 
   afterEach(() => {
-    document.body.className = "";
+    document.body.removeAttribute("data-theme");
   });
 
-  it("adds dark-mode class for dark mode", () => {
+  it("sets data-theme to dark for dark mode", () => {
     applyDisplayMode("dark");
-    expect(document.body.classList.contains("dark-mode")).toBe(true);
-    expect(document.body.classList.contains("gray-mode")).toBe(false);
+    expect(document.body.dataset.theme).toBe("dark");
   });
 
-  it("adds gray-mode class for gray mode", () => {
+  it("sets data-theme to gray for gray mode", () => {
     applyDisplayMode("gray");
-    expect(document.body.classList.contains("gray-mode")).toBe(true);
-    expect(document.body.classList.contains("dark-mode")).toBe(false);
+    expect(document.body.dataset.theme).toBe("gray");
   });
 
-  it("removes classes for light mode", () => {
-    document.body.classList.add("dark-mode", "gray-mode");
+  it("sets data-theme to light for light mode", () => {
+    document.body.dataset.theme = "dark";
     applyDisplayMode("light");
-    expect(document.body.classList.contains("dark-mode")).toBe(false);
-    expect(document.body.classList.contains("gray-mode")).toBe(false);
+    expect(document.body.dataset.theme).toBe("light");
   });
 
   it("warns when an invalid mode is provided", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    document.body.classList.add("dark-mode");
+    document.body.dataset.theme = "dark";
     applyDisplayMode("neon");
     expect(warnSpy).toHaveBeenCalled();
-    expect(document.body.classList.contains("dark-mode")).toBe(true);
+    expect(document.body.dataset.theme).toBe("dark");
     warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- apply display mode using `data-theme` attribute
- update CSS variables to use `[data-theme]` selectors
- refactor tests for new theme handling

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_686fc6f1943c83269474ba9512067432