### PR TITLE
Enhance display mode tests

### DIFF
--- a/src/helpers/displayMode.js
+++ b/src/helpers/displayMode.js
@@ -6,6 +6,8 @@
  *    - If the value is invalid, log a warning and exit early.
  *
  * 2. Set `document.body.dataset.theme` to the provided mode value.
+ * 3. Remove any existing `*-mode` classes from `document.body` and add the
+ *    class corresponding to the new mode (e.g. `dark-mode`).
  *
  * @param {"light"|"dark"|"gray"} mode - Desired display mode.
  */
@@ -16,4 +18,8 @@ export function applyDisplayMode(mode) {
     return;
   }
   document.body.dataset.theme = mode;
+  for (const m of validModes) {
+    document.body.classList.remove(`${m}-mode`);
+  }
+  document.body.classList.add(`${mode}-mode`);
 }

--- a/tests/helpers/display-mode.test.js
+++ b/tests/helpers/display-mode.test.js
@@ -2,36 +2,49 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { applyDisplayMode } from "../../src/helpers/displayMode.js";
 
 describe("applyDisplayMode", () => {
+  let style;
+
   beforeEach(() => {
     document.body.removeAttribute("data-theme");
+    document.body.className = "";
+    style = document.createElement("style");
+    style.textContent = `
+      body.light-mode { background-color: rgb(255, 255, 255); }
+      body.dark-mode { background-color: rgb(0, 0, 0); }
+      body.gray-mode { background-color: rgb(205, 205, 205); }
+    `;
+    document.head.appendChild(style);
   });
 
   afterEach(() => {
     document.body.removeAttribute("data-theme");
+    document.body.className = "";
+    style.remove();
   });
 
-  it("sets data-theme to dark for dark mode", () => {
-    applyDisplayMode("dark");
-    expect(document.body.dataset.theme).toBe("dark");
-  });
-
-  it("sets data-theme to gray for gray mode", () => {
-    applyDisplayMode("gray");
-    expect(document.body.dataset.theme).toBe("gray");
-  });
-
-  it("sets data-theme to light for light mode", () => {
-    document.body.dataset.theme = "dark";
-    applyDisplayMode("light");
-    expect(document.body.dataset.theme).toBe("light");
+  it.each(["dark", "gray", "light"])("sets data-theme and class for %s mode", (mode) => {
+    applyDisplayMode(mode);
+    expect(document.body.dataset.theme).toBe(mode);
+    expect(document.body.classList.contains(`${mode}-mode`)).toBe(true);
   });
 
   it("warns when an invalid mode is provided", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     document.body.dataset.theme = "dark";
+    document.body.classList.add("dark-mode");
     applyDisplayMode("neon");
     expect(warnSpy).toHaveBeenCalled();
     expect(document.body.dataset.theme).toBe("dark");
+    expect(document.body.classList.contains("dark-mode")).toBe(true);
     warnSpy.mockRestore();
+  });
+
+  it("switching modes updates computed styles", () => {
+    applyDisplayMode("light");
+    const lightBg = getComputedStyle(document.body).backgroundColor;
+    applyDisplayMode("dark");
+    const darkBg = getComputedStyle(document.body).backgroundColor;
+    expect(lightBg).not.toBe(darkBg);
+    expect(darkBg).toBe("rgb(0, 0, 0)");
   });
 });


### PR DESCRIPTION
## Summary
- update `applyDisplayMode` to toggle body classes
- expand unit tests for display mode to cover class application and computed styles

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_686feea1ce588326907508897874ea90