### PR TITLE
Fix navigation links for portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ SKIP_SCREENSHOTS=true npm run test:screenshot
 
 The repository follows a simple layout. GitHub Pages requires `index.html` to live at the project root.
 
-- `index.html` – landing page served by GitHub Pages.
+- `index.html` – landing page served by GitHub Pages. Internal navigation links
+  use relative paths (e.g., `../../index.html`) so the site can be served from
+  any base URL.
 - `src/` – contains the game logic and assets:
   - `game.js`
   - `helpers/`

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -30,7 +30,7 @@
     <header class="header">
       <div class="character-slot left"></div>
       <div class="logo-container">
-        <a href="/judokon/index.html" data-testid="home-link">
+        <a href="../../index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -32,7 +32,7 @@
       <header class="header">
         <div class="character-slot left"></div>
         <div class="logo-container">
-          <a href="/judokon/index.html" data-testid="home-link">
+          <a href="../../index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>

--- a/src/pages/createJudoka.html
+++ b/src/pages/createJudoka.html
@@ -30,7 +30,7 @@
     <header class="header">
       <div class="character-slot left"></div>
       <div class="logo-container">
-        <a href="/judokon/index.html" data-testid="home-link">
+        <a href="../../index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>

--- a/src/pages/meditation.html
+++ b/src/pages/meditation.html
@@ -16,7 +16,7 @@
     <header class="header">
       <div class="character-slot left"></div>
       <div class="logo-container">
-        <a href="/judokon/index.html" data-testid="home-link">
+        <a href="../../index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -31,7 +31,7 @@
       <header class="header">
         <div class="character-slot left"></div>
         <div class="logo-container">
-          <a href="/judokon/index.html" data-testid="home-link">
+          <a href="../../index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -30,7 +30,7 @@
     <header class="header">
       <div class="character-slot left"></div>
       <div class="logo-container">
-        <a href="/judokon/index.html" data-testid="home-link">
+        <a href="../../index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>

--- a/src/pages/updateJudoka.html
+++ b/src/pages/updateJudoka.html
@@ -30,7 +30,7 @@
     <header class="header">
       <div class="character-slot left"></div>
       <div class="logo-container">
-        <a href="/judokon/index.html" data-testid="home-link">
+        <a href="../../index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>


### PR DESCRIPTION
## Summary
- link home buttons using relative URL so site can be deployed at any base path
- mention relative URLs in project structure docs

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden to fetch vitest)*
- `npx playwright test` *(fails: 403 Forbidden to fetch playwright)*

------
https://chatgpt.com/codex/tasks/task_e_686ffd45f39c832692765a442b33339d