### PR TITLE
Implement shared judoka fallback

### DIFF
--- a/design/productRequirementsDocuments/prdDrawRandomCard.md
+++ b/design/productRequirementsDocuments/prdDrawRandomCard.md
@@ -55,6 +55,8 @@ Without this feature, players would be forced to pre-select cards, leading to pr
 - Optimize DOM updates for minimal reflows/repaints during animation.
 - Implement debounce to prevent double taps on “Draw Card” button.
 - Ensure fallback logic uses a single, consistent error card (judoka id=0).
+  The `getFallbackJudoka()` helper loads and caches this entry from
+  `judoka.json`.
 - Log random draw failures for post-launch debugging and analytics.
 
 ---
@@ -82,7 +84,7 @@ Motion** enabled, ensuring the card appears instantly without movement.
 ## Edge Cases / Failure States
 
 - **Same Card Reselection**: Duplicates are possible and expected — randomness allows repeats.
-- **Random Pick Failure**: If random draw fails (e.g., due to a code error), show a fallback card (judoka id=0, from judoka.json)
+- **Random Pick Failure**: If random draw fails (e.g., due to a code error), show a fallback card (judoka id=0, from `judoka.json`) via `getFallbackJudoka()`
 - **Empty Card Set**: Display a predefined error card (judoka id=0, from judoka.json) if no cards are available.
 - **Low Performance Devices**: Automatically downgrade to a static reveal if animations cannot sustain 60fps.
 - **Accessibility**:
@@ -124,6 +126,7 @@ Motion** enabled, ensuring the card appears instantly without movement.
 - A reveal animation (fade and slide via `.animate-card`) completes within 500ms at ≥60fps.
 - If the random function fails, a fallback card is shown (judoka id=0, from judoka.json).
 - If the active card set is empty, a fallback card is shown (judoka id=0, from judoka.json).
+  Both cases rely on the shared `getFallbackJudoka()` helper.
 - Animation is disabled if the user has enabled Reduced Motion settings.
 
 ---

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -1,44 +1,12 @@
 import { createGokyoLookup } from "./utils.js";
 import { generateJudokaCard } from "./cardBuilder.js";
-import { fetchJson } from "./dataUtils.js";
+import { getFallbackJudoka } from "./judokaUtils.js";
 import {
-  DATA_DIR,
   CAROUSEL_SCROLL_DISTANCE,
   CAROUSEL_SWIPE_THRESHOLD,
   SPINNER_DELAY_MS
 } from "./constants.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
-
-let fallbackJudoka;
-
-async function getFallbackJudoka() {
-  if (fallbackJudoka) {
-    return fallbackJudoka;
-  }
-  try {
-    const data = await fetchJson(`${DATA_DIR}judoka.json`);
-    if (Array.isArray(data)) {
-      fallbackJudoka = data.find((j) => j.id === 0) || null;
-    }
-    if (!fallbackJudoka) {
-      throw new Error("Fallback judoka with id 0 not found");
-    }
-  } catch (error) {
-    console.error("Failed to load fallback judoka:", error);
-    fallbackJudoka = {
-      id: 0,
-      firstname: "Unknown",
-      surname: "Judoka",
-      country: "Unknown",
-      countryCode: "N/A",
-      weightClass: "N/A",
-      stats: { power: 0, speed: 0, technique: 0, kumikata: 0, newaza: 0 },
-      signatureMoveId: 0,
-      rarity: "common"
-    };
-  }
-  return fallbackJudoka;
-}
 
 /**
  * Creates a scroll button with the specified direction and functionality.

--- a/src/helpers/judokaUtils.js
+++ b/src/helpers/judokaUtils.js
@@ -1,0 +1,55 @@
+import { fetchJson } from "./dataUtils.js";
+import { DATA_DIR } from "./constants.js";
+
+/**
+ * Retrieve the fallback judoka (id `0`) from `judoka.json`.
+ *
+ * @pseudocode
+ * 1. Return the cached value when available.
+ * 2. Fetch `judoka.json` and locate the entry with `id` `0`.
+ *    - Cache and return this entry when found.
+ * 3. On error, log the issue and return a hard-coded object
+ *    identical to the entry in `judoka.json`.
+ *
+ * @returns {Promise<Judoka>} A promise that resolves to the fallback judoka.
+ */
+let cachedFallback;
+export async function getFallbackJudoka() {
+  if (cachedFallback) {
+    return cachedFallback;
+  }
+  try {
+    const data = await fetchJson(`${DATA_DIR}judoka.json`);
+    if (Array.isArray(data)) {
+      const entry = data.find((j) => j.id === 0);
+      if (entry) {
+        cachedFallback = entry;
+        return entry;
+      }
+    }
+    throw new Error("Fallback judoka with id 0 not found");
+  } catch (error) {
+    console.error("Failed to load fallback judoka:", error);
+    cachedFallback = {
+      id: 0,
+      firstname: "Tatsuuma",
+      surname: "Ushiyama",
+      country: "Vanuatu",
+      countryCode: "vu",
+      weightClass: "+100",
+      stats: { power: 9, speed: 9, technique: 9, kumikata: 9, newaza: 9 },
+      signatureMoveId: 0,
+      lastUpdated: "2025-04-22T10:00:00Z",
+      profileUrl: "https://goldenkamuy.fandom.com/wiki/Tatsuuma_Ushiyama",
+      bio: "Tatsuuma Ushiyama (\u725b\u5c71 \u8fbb\u99ac, Ushiyama Tatsuuma), also known as Ushiyama the Undefeated (\u4e0d\u6557\u306e\u725b\u5c71, Fuhai no Ushiyama), is one of the Abashiri Convicts. He is a master judoka and one of the strongest and most dangerous fighters in Hokkaido.",
+      gender: "male",
+      isHidden: true,
+      rarity: "Legendary",
+      cardCode: "WKZ3-H4NF-MXT2-LQ93-JT8C",
+      matchesWon: 0,
+      matchesLost: 0,
+      matchesDrew: 0
+    };
+    return cachedFallback;
+  }
+}

--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -4,36 +4,7 @@ import { generateJudokaCardHTML } from "./cardBuilder.js";
 import { getRandomJudoka } from "./cardUtils.js";
 import { hasRequiredJudokaFields } from "./judokaValidation.js";
 import { DATA_DIR } from "./constants.js";
-
-/**
- * Builds a simple fallback judoka object used when data fails to load.
- *
- * @pseudocode
- * 1. Create an object with minimal judoka information.
- *    - Use neutral stats and placeholder text.
- * 2. Return this object for use in fallback card generation.
- *
- * @returns {Judoka} The fallback judoka data.
- */
-export function buildFallbackJudoka() {
-  return {
-    id: 0,
-    firstname: "Unknown",
-    surname: "Judoka",
-    country: "Unknown",
-    countryCode: "N/A",
-    stats: {
-      power: 0,
-      speed: 0,
-      technique: 0,
-      kumikata: 0,
-      newaza: 0
-    },
-    weightClass: "N/A",
-    signatureMoveId: 0,
-    rarity: "common"
-  };
-}
+import { getFallbackJudoka } from "./judokaUtils.js";
 
 /**
  * Replaces the contents of an element with the given card and animates it.
@@ -91,7 +62,8 @@ export async function createCardForJudoka(judoka, gokyoLookup, containerEl, pref
  * 3. Select a random judoka using `getRandomJudoka` and invoke `onSelect`
  *    with the chosen judoka when provided.
  * 4. Generate and display the card with `createCardForJudoka`.
- * 5. On any error, log the issue and display a fallback card (judoka id `0`).
+ * 5. On any error, log the issue and load the fallback judoka using
+ *    `getFallbackJudoka()` before displaying its card.
  *
  * @param {Judoka[]} [activeCards] - Preloaded judoka data.
  * @param {GokyoEntry[]} [gokyoData] - Preloaded gokyo data.
@@ -137,7 +109,7 @@ export async function generateRandomCard(
   } catch (error) {
     console.error("Error generating random card:", error);
 
-    const fallbackJudoka = buildFallbackJudoka();
+    const fallbackJudoka = await getFallbackJudoka();
 
     try {
       if (typeof onSelect === "function") {

--- a/tests/helpers/random-card.test.js
+++ b/tests/helpers/random-card.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 
 let getRandomJudokaMock;
 let generateJudokaCardHTMLMock;
+let getFallbackJudokaMock;
 
 vi.mock("../../src/helpers/cardUtils.js", () => ({
   getRandomJudoka: (...args) => getRandomJudokaMock(...args)
@@ -9,6 +10,10 @@ vi.mock("../../src/helpers/cardUtils.js", () => ({
 
 vi.mock("../../src/helpers/cardBuilder.js", () => ({
   generateJudokaCardHTML: (...args) => generateJudokaCardHTMLMock(...args)
+}));
+
+vi.mock("../../src/helpers/judokaUtils.js", () => ({
+  getFallbackJudoka: (...args) => getFallbackJudokaMock(...args)
 }));
 
 vi.mock("../../src/helpers/utils.js", () => ({
@@ -63,6 +68,7 @@ describe("generateRandomCard", () => {
 
     getRandomJudokaMock = vi.fn(() => judokaData[1]);
     generateJudokaCardHTMLMock = vi.fn(async () => generatedEl);
+    getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
 
     const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
 
@@ -78,6 +84,7 @@ describe("generateRandomCard", () => {
     const generatedEl = document.createElement("span");
     getRandomJudokaMock = vi.fn(() => judokaData[0]);
     generateJudokaCardHTMLMock = vi.fn(async () => generatedEl);
+    getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
     const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
     const cb = vi.fn();
     await generateRandomCard(judokaData, gokyoData, container, true, cb);
@@ -92,6 +99,7 @@ describe("generateRandomCard", () => {
       throw new Error("fail");
     });
     generateJudokaCardHTMLMock = vi.fn(async () => fallbackEl);
+    getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
 
     const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
 
@@ -112,6 +120,7 @@ describe("generateRandomCard", () => {
       throw new Error("fail");
     });
     generateJudokaCardHTMLMock = vi.fn(async () => fallbackEl);
+    getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
 
     const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
     const { fetchJson } = await import("../../src/helpers/dataUtils.js");
@@ -127,6 +136,7 @@ describe("generateRandomCard", () => {
   it("does not throw if container is null or undefined", async () => {
     getRandomJudokaMock = vi.fn(() => judokaData[0]);
     generateJudokaCardHTMLMock = vi.fn(async () => document.createElement("div"));
+    getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
     const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
     await expect(generateRandomCard(judokaData, gokyoData, null, true)).resolves.toBeUndefined();
     await expect(
@@ -140,6 +150,7 @@ describe("generateRandomCard", () => {
     generateJudokaCardHTMLMock = vi.fn(async () => {
       throw new Error("fail");
     });
+    getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
     const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
     await expect(
       generateRandomCard(judokaData, gokyoData, container, true)
@@ -151,6 +162,7 @@ describe("generateRandomCard", () => {
     const container = document.createElement("div");
     getRandomJudokaMock = vi.fn(() => judokaData[0]);
     generateJudokaCardHTMLMock = vi.fn(async () => null);
+    getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
     const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
     await generateRandomCard(judokaData, gokyoData, container, true);
     expect(container.childNodes.length).toBe(0);


### PR DESCRIPTION
## Summary
- provide `getFallbackJudoka` helper to load/cached fallback data
- use new helper in randomCard and carouselBuilder
- update unit tests for random card helper
- document helper in PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_686ffd89fcf083268b5cacd495d6cf4f