### PR TITLE
Update docs for page modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   - `game.js`
   - `helpers/`
   - `pages/`
+    HTML pages. Each page imports a matching module from
+    `src/helpers` (for example `randomJudokaPage.js`) that wires up its
+    interactive behavior.
   - `data/`
   - `schemas/`  
     JSON Schema definitions used to validate the data files.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -14,6 +14,13 @@ The entry point for the browser. It waits for `DOMContentLoaded` and wires up al
 Reusable utilities organized by concern (card building, data fetching, random card generation, etc.). Each module is documented with JSDoc and `@pseudocode` blocks for clarity.
 Key helpers include `generateRandomCard()` for choosing a card and `renderJudokaCard()` for injecting it into the DOM with an optional reveal animation.
 
+## page modules
+
+HTML pages under `src/pages` each load a dedicated module located in
+`src/helpers`. These modules (for example `randomJudokaPage.js` or
+`settingsPage.js`) expose setup functions that attach event listeners and
+initialize page-specific behavior.
+
 ## data and schemas
 
 Structured gameplay data lives in `src/data`. Matching JSON Schemas in `src/schemas` describe and validate these files. The `npm run validate:data` script uses Ajv to ensure data integrity.


### PR DESCRIPTION
## Summary
- clarify that each HTML page has a matching JavaScript module
- mention these page modules in architecture overview

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_687042f2e984832683cbe61de84bd3d6