### PR TITLE
Add card accessibility attributes

### DIFF
--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -236,6 +236,8 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
 
   const judokaCard = document.createElement("div");
   judokaCard.className = `judoka-card ${cardType}`;
+  judokaCard.setAttribute("role", "button");
+  judokaCard.setAttribute("aria-label", `${judoka.firstname} ${judoka.surname} card`);
 
   const genderClass = judoka.gender === "female" ? "female-card" : "male-card";
   judokaCard.classList.add(genderClass);

--- a/tests/card/judokaCardAccessibility.test.js
+++ b/tests/card/judokaCardAccessibility.test.js
@@ -1,0 +1,35 @@
+import { generateJudokaCardHTML, generateJudokaCard } from "../../src/helpers/cardBuilder.js";
+
+const judoka = {
+  id: 1,
+  firstname: "John",
+  surname: "Doe",
+  country: "USA",
+  countryCode: "us",
+  stats: { power: 5, speed: 5, technique: 5, kumikata: 5, newaza: 5 },
+  weightClass: "-100kg",
+  signatureMoveId: 1,
+  rarity: "common",
+  gender: "male"
+};
+
+const gokyoLookup = {
+  1: { id: 1, name: "Uchi-mata" }
+};
+
+describe("judoka card accessibility attributes", () => {
+  it("applies role and aria-label to judoka-card element", async () => {
+    const container = await generateJudokaCardHTML(judoka, gokyoLookup);
+    const card = container.querySelector(".judoka-card");
+    expect(card).toHaveAttribute("role", "button");
+    expect(card).toHaveAttribute("aria-label", `${judoka.firstname} ${judoka.surname} card`);
+  });
+
+  it("retains accessibility attributes when added to DOM", async () => {
+    const containerEl = document.createElement("div");
+    await generateJudokaCard(judoka, gokyoLookup, containerEl);
+    const card = containerEl.querySelector(".judoka-card");
+    expect(card).toHaveAttribute("role", "button");
+    expect(card).toHaveAttribute("aria-label", `${judoka.firstname} ${judoka.surname} card`);
+  });
+});


### PR DESCRIPTION
## Summary
- update `generateJudokaCardHTML` to set `role` and `aria-label` on each card
- keep these attributes when cards are generated via `generateJudokaCard`
- add new unit tests to check for these accessibility attributes

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68714356e37c8326847115c731d9bfa2