### PR TITLE
Add modal component

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
 - `src/` – contains the game logic and assets:
   - `game.js`
   - `helpers/`
+  - `components/` – small DOM factories like `Button`, `ToggleSwitch`, and the new `Modal` dialog
   - `pages/`
     HTML pages. Each page imports a matching module from
     `src/helpers` (for example `randomJudokaPage.js`) that wires up its
@@ -163,25 +164,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -21,6 +21,12 @@ HTML pages under `src/pages` each load a dedicated module located in
 `settingsPage.js`) expose setup functions that attach event listeners and
 initialize page-specific behavior.
 
+## components/
+
+Factory functions that create reusable UI elements. `Button.js` and
+`ToggleSwitch.js` return styled controls. `Modal.js` builds an accessible
+dialog with focus trapping and open/close helpers.
+
 ## data and schemas
 
 Structured gameplay data lives in `src/data`. Matching JSON Schemas in `src/schemas` describe and validate these files. The `npm run validate:data` script uses Ajv to ensure data integrity.

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,0 +1,89 @@
+/**
+ * Create a reusable modal dialog with accessible behavior.
+ *
+ * @pseudocode
+ * 1. Build a backdrop element with `modal-backdrop` class and `hidden` attribute.
+ * 2. Inside it place a `div.modal` with `role="dialog"` and `aria-modal="true"`.
+ * 3. Append provided content nodes into the modal.
+ * 4. Expose `open()` and `close()` functions to toggle the backdrop,
+ *    manage focus and `aria-expanded` on the trigger.
+ * 5. Clicking the backdrop or pressing Escape closes the modal.
+ * 6. While open, trap focus inside the modal container.
+ *
+ * @param {HTMLElement|DocumentFragment} content - Dialog contents.
+ * @returns {{ element: HTMLElement, open(trigger?: HTMLElement): void, close(): void }}
+ *   Modal API with DOM element and controls.
+ */
+export function createModal(content) {
+  const backdrop = document.createElement("div");
+  backdrop.className = "modal-backdrop";
+  backdrop.setAttribute("hidden", "");
+
+  const dialog = document.createElement("div");
+  dialog.className = "modal";
+  dialog.setAttribute("role", "dialog");
+  dialog.setAttribute("aria-modal", "true");
+  dialog.tabIndex = -1;
+
+  dialog.append(content);
+  backdrop.append(dialog);
+
+  let returnFocus = null;
+  let removeTrap = () => {};
+
+  function trapFocus(el) {
+    const selectors = "a[href], button, textarea, input, select, [tabindex]:not([tabindex='-1'])";
+    const focusables = Array.from(el.querySelectorAll(selectors));
+    if (focusables.length === 0) return () => {};
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    function handle(e) {
+      if (e.key !== "Tab") return;
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    el.addEventListener("keydown", handle);
+    return () => el.removeEventListener("keydown", handle);
+  }
+
+  function handleEscape(e) {
+    if (e.key === "Escape") close();
+  }
+
+  function open(trigger) {
+    returnFocus = trigger ?? null;
+    backdrop.removeAttribute("hidden");
+    dialog.classList.add("open");
+    if (trigger) trigger.setAttribute("aria-expanded", "true");
+    removeTrap = trapFocus(dialog);
+    const focusTarget = dialog.querySelector(
+      "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])"
+    );
+    (focusTarget || dialog).focus();
+    document.addEventListener("keydown", handleEscape);
+  }
+
+  function close() {
+    dialog.classList.remove("open");
+    backdrop.setAttribute("hidden", "");
+    removeTrap();
+    document.removeEventListener("keydown", handleEscape);
+    if (returnFocus) {
+      returnFocus.setAttribute("aria-expanded", "false");
+      returnFocus.focus();
+    }
+  }
+
+  backdrop.addEventListener("click", (e) => {
+    if (e.target === backdrop) close();
+  });
+
+  return { element: backdrop, open, close };
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -840,3 +840,45 @@ button .ripple {
 .slider.round::before {
   border-radius: 50%;
 }
+
+/* Modal styles */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.modal-backdrop[hidden] {
+  display: none;
+}
+
+.modal {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-base);
+  padding: var(--space-lg);
+  max-width: 600px;
+  width: 90%;
+  animation: modal-enter 300ms ease-out;
+}
+
+@keyframes modal-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal {
+    animation: none;
+  }
+}

--- a/tests/helpers/modalComponent.test.js
+++ b/tests/helpers/modalComponent.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { createModal } from "../../src/components/Modal.js";
+
+function buildContent() {
+  const frag = document.createDocumentFragment();
+  const cancel = document.createElement("button");
+  cancel.textContent = "Cancel";
+  cancel.id = "cancel-btn";
+  const save = document.createElement("button");
+  save.textContent = "Save";
+  frag.append(cancel, save);
+  return frag;
+}
+
+describe("createModal", () => {
+  it("opens and closes the modal with focus management", () => {
+    const trigger = document.createElement("button");
+    trigger.id = "trigger";
+    document.body.appendChild(trigger);
+
+    const { element, open, close } = createModal(buildContent());
+    document.body.appendChild(element);
+
+    open(trigger);
+    expect(element.hasAttribute("hidden")).toBe(false);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(document.activeElement.id).toBe("cancel-btn");
+
+    close();
+    expect(element.hasAttribute("hidden")).toBe(true);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(trigger);
+  });
+});


### PR DESCRIPTION
## Summary
- implement a reusable `createModal` helper with open/close methods
- style modal overlay and dialog
- document new components folder
- mention modal component in architecture overview
- test modal behaviour

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68714340daac83268e167e7fba821ee2