### PR TITLE
Adjust card carousel contrast styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,20 +164,25 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
+
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
+
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
+
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
+
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
+
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -275,8 +275,7 @@ function applyAccessibilityImprovements(wrapper) {
   // Ensure contrast ratios for text and background
   const cards = wrapper.querySelectorAll(".judoka-card");
   cards.forEach((card) => {
-    card.style.color = "#000"; // Ensure text is dark for contrast
-    card.style.backgroundColor = "#fff"; // Ensure background is light for contrast
+    card.style.color = "var(--color-text-inverted)";
   });
 }
 


### PR DESCRIPTION
## Summary
- update README formatting for Prettier 3
- rely on CSS variables for carousel card colors

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687145b212b88326aea76c29ea40e9d9