### PR TITLE
Add StatsPanel component

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,12 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
 - `src/` – contains the game logic and assets:
   - `game.js`
   - `helpers/`
-  - `components/` – small DOM factories like `Button`, `ToggleSwitch`, and the new `Modal` dialog
+  - `components/` – small DOM factories like `Button`, `ToggleSwitch`, the `Modal` dialog, and `StatsPanel`
+    ```javascript
+    import { createStatsPanel } from "./src/components/StatsPanel.js";
+    const panel = createStatsPanel({ power: 9, speed: 8, technique: 7 });
+    document.body.appendChild(panel);
+    ```
   - `pages/`
     HTML pages. Each page imports a matching module from
     `src/helpers` (for example `randomJudokaPage.js`) that wires up its

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -27,7 +27,8 @@ initialize page-specific behavior.
 
 Factory functions that create reusable UI elements. `Button.js` and
 `ToggleSwitch.js` return styled controls. `Modal.js` builds an accessible
-dialog with focus trapping and open/close helpers.
+dialog with focus trapping and open/close helpers. `StatsPanel.js` constructs
+the `.card-stats` section used within judoka cards.
 
 ## data and schemas
 

--- a/src/components/StatsPanel.js
+++ b/src/components/StatsPanel.js
@@ -1,0 +1,53 @@
+/**
+ * Create a stats panel element using the `.card-stats` structure.
+ *
+ * @pseudocode
+ * 1. Validate the `stats` object and throw an error when invalid.
+ * 2. Resolve panel classes from the provided `type` and `className` options.
+ * 3. Build a `<div>` with class `card-stats` containing a `<ul>` list.
+ *    - For each stat key (power, speed, technique, kumikata, newaza)
+ *      create an `<li>` with a label and value.
+ * 4. Return the completed panel element.
+ *
+ * @param {object} stats - Object with stat values.
+ * @param {object} [options] - Optional configuration.
+ * @param {string} [options.type="common"] - Card rarity or panel type.
+ * @param {string} [options.className] - Additional class name to apply.
+ * @returns {HTMLDivElement} The stats panel element.
+ */
+import { escapeHTML } from "../helpers/utils.js";
+
+export function createStatsPanel(stats, options = {}) {
+  if (!stats || typeof stats !== "object") {
+    throw new Error("Stats object is required");
+  }
+
+  const { type = "common", className } = options;
+  const { power = "?", speed = "?", technique = "?", kumikata = "?", newaza = "?" } = stats;
+
+  const panel = document.createElement("div");
+  panel.className = `card-stats ${type}`.trim();
+  if (className) panel.classList.add(className);
+
+  const list = document.createElement("ul");
+
+  function addItem(label, value) {
+    const li = document.createElement("li");
+    li.className = "stat";
+    const strong = document.createElement("strong");
+    strong.textContent = label;
+    const span = document.createElement("span");
+    span.innerHTML = escapeHTML(value);
+    li.append(strong, span);
+    list.appendChild(li);
+  }
+
+  addItem("Power", power);
+  addItem("Speed", speed);
+  addItem("Technique", technique);
+  addItem("Kumi-kata", kumikata);
+  addItem("Ne-waza", newaza);
+
+  panel.appendChild(list);
+  return panel;
+}

--- a/src/components/StatsPanel.js
+++ b/src/components/StatsPanel.js
@@ -42,12 +42,15 @@ export function createStatsPanel(stats, options = {}) {
     list.appendChild(li);
   }
 
-  addItem("Power", power);
-  addItem("Speed", speed);
-  addItem("Technique", technique);
-  addItem("Kumi-kata", kumikata);
-  addItem("Ne-waza", newaza);
+  const statsEntries = [
+    { label: "Power", key: power },
+    { label: "Speed", key: speed },
+    { label: "Technique", key: technique },
+    { label: "Kumi-kata", key: kumikata },
+    { label: "Ne-waza", key: newaza },
+  ];
 
+  statsEntries.forEach(({ label, key }) => addItem(label, key));
   panel.appendChild(list);
   return panel;
 }

--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -1,10 +1,7 @@
 import { getFlagUrl } from "./countryUtils.js";
 import { generateCardTopBar, createNoDataContainer } from "./cardTopBar.js";
-import {
-  generateCardPortrait,
-  generateCardStats,
-  generateCardSignatureMove
-} from "./cardRender.js";
+import { generateCardPortrait, generateCardSignatureMove } from "./cardRender.js";
+import { createStatsPanel } from "../components/StatsPanel.js";
 import { safeGenerate } from "./errorUtils.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
 
@@ -135,7 +132,7 @@ function validateJudoka(judoka) {
  *    - Add weight class information to the portrait section.
  *
  * 8. Append the stats section:
- *    - Generate stats HTML using `generateCardStats` and append it.
+ *    - Build the stats panel using `createStatsPanel` and append it.
  *    - If generation fails, append an empty stats container.
  *
  * 9. Append the signature move section:
@@ -177,11 +174,7 @@ function createPortraitSection(judoka) {
 
 function createStatsSection(judoka, cardType) {
   try {
-    const statsHTML = generateCardStats(judoka, cardType);
-    const statsElement = document.createElement("div");
-    statsElement.className = "card-stats";
-    statsElement.innerHTML = statsHTML;
-    return statsElement;
+    return createStatsPanel(judoka.stats, { type: cardType });
   } catch (error) {
     console.error("Failed to generate stats:", error);
     return createNoDataContainer();

--- a/tests/components/StatsPanel.test.js
+++ b/tests/components/StatsPanel.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { createStatsPanel } from "../../src/components/StatsPanel.js";
+
+describe("createStatsPanel", () => {
+  it("creates DOM structure with stat values", () => {
+    const panel = createStatsPanel({
+      power: 5,
+      speed: 6,
+      technique: 7,
+      kumikata: 8,
+      newaza: 9
+    });
+    const items = panel.querySelectorAll("li.stat");
+    expect(panel.classList.contains("card-stats")).toBe(true);
+    expect(items).toHaveLength(5);
+    expect(items[0].textContent).toContain("5");
+    expect(items[4].textContent).toContain("9");
+  });
+
+  it("applies custom type and class", () => {
+    const panel = createStatsPanel(
+      { power: 1, speed: 2 },
+      { type: "legendary", className: "extra" }
+    );
+    expect(panel.classList.contains("legendary")).toBe(true);
+    expect(panel.classList.contains("extra")).toBe(true);
+  });
+
+  it("throws when stats is missing", () => {
+    expect(() => createStatsPanel(null)).toThrowError("Stats object is required");
+  });
+});


### PR DESCRIPTION
## Summary
- create StatsPanel component
- update card builder to use the new panel
- document StatsPanel usage and note in architecture docs
- add unit tests for StatsPanel

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot comparisons)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6871501a0fec83268f98b963d634229d