### PR TITLE
Make weight class badge transparent

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -323,9 +323,9 @@ button .ripple {
   position: absolute;
   margin-top: var(--space-small); /* Updated token */
   right: var(--space-small); /* Updated token */
-  background-color: var(--color-surface);
+  background-color: transparent;
   border-radius: var(--radius-sm); /* Updated token */
-  color: var(--color-text-inverted);
+  color: #fff;
   font-weight: bold;
   padding: var(--space-small) var(--space-medium); /* Updated tokens */
   font-size: var(--font-small); /* Updated token */


### PR DESCRIPTION
## Summary
- adjust card badge styling to allow transparent background

## Testing
- `npx prettier . --write`
- `npx eslint . --fix`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6871583af0d48326851104176aa0f496