### PR TITLE
Update carousel styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 6. [Dependencies](#dependencies)
 7. [Project Structure](#project-structure)
 8. [Display Modes](#display-modes)
-9. [Future Plans](#future-plans)
-10. [Contributing](#contributing)
+9. [Browser Compatibility](#browser-compatibility)
+10. [Future Plans](#future-plans)
+11. [Contributing](#contributing)
 
 ## Quick Start
 
@@ -226,6 +227,13 @@ variables and call `applyDisplayMode("my-theme")` to activate it.
 
 If you modify theme colors, run `npm run check:contrast` while the development
 server is running to verify adequate color contrast.
+
+## Browser Compatibility
+
+JU-DO-KON! is tested in the latest versions of Chrome, Firefox, Safari, and Edge.
+The card carousel uses modern CSS like `clamp()` for flexible sizing. Safari 15
+and older do not support `clamp()`, so cards fall back to a fixed `300px` width.
+Mobile Safari supports smooth scrolling via `-webkit-overflow-scrolling: touch`.
 
 ## Future Plans
 

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -10,18 +10,22 @@
   width: 100%; /* Ensure carousel doesn't exceed container width */
   max-width: 100%; /* Prevent overflow */
   padding: var(--space-md); /* Add padding for visual spacing */
+  flex: 1 1 auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .judoka-card {
-  /*
-   * Use clamp() to keep cards legible on small screens while
-   * allowing more cards on wide layouts.
-   */
-  flex: 0 0 clamp(200px, calc(33.33% - var(--space-lg)), 300px);
+  flex: 0 0 300px;
   scroll-snap-align: center; /* Snap each card to the center */
   transition: transform var(--transition-fast); /* Smooth animations */
   border-radius: var(--radius-lg); /* Rounded corners */
   box-shadow: var(--shadow-base); /* Elevation */
+}
+
+@supports (flex-basis: clamp(1px, 1px, 1px)) {
+  .judoka-card {
+    flex-basis: clamp(200px, calc(33.33% - var(--space-lg)), 300px);
+  }
 }
 
 /* Hover effect for desktop */

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -487,7 +487,7 @@ button .ripple {
   min-height: 48px;
   aspect-ratio: 1/1;
   display: flex;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   justify-content: center;
   align-items: center;
   z-index: 10;


### PR DESCRIPTION
## Summary
- prevent flex growth for scroll button
- add Safari-friendly carousel styling
- note Safari support in README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687166a0f58c832699ff13462f92141e