### PR TITLE
Fix Safari carousel min-width

### DIFF
--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -8,6 +8,7 @@
   gap: var(--space-lg); /* Generous whitespace */
   scroll-behavior: smooth; /* Smooth scrolling effect */
   width: 100%; /* Ensure carousel doesn't exceed container width */
+  min-width: 100%; /* Override flex item's default min-width */
   max-width: 100%; /* Prevent overflow */
   padding: var(--space-md); /* Add padding for visual spacing */
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- set `min-width` on `.card-carousel` to avoid Safari flexbox bug

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch for browseJudoka page)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68716a6e333c832698d0d4245de1c538