### PR TITLE
Fix Safari carousel scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,25 +170,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 
@@ -233,9 +228,9 @@ server is running to verify adequate color contrast.
 JU-DO-KON! is tested in the latest versions of Chrome, Firefox, Safari, and Edge.
 The card carousel uses modern CSS like `clamp()` for flexible sizing. Safari 15
 and older do not support `clamp()`, so cards fall back to a fixed `300px` width.
-Safari may also expand flex items if `min-width` isn't explicitly set. When
-styling `.card-carousel`, set `min-width: 100%` (or `0`) so horizontal scrolling
-works correctly. Mobile Safari supports smooth scrolling via
+Safari may expand flex items if `min-width` isn't explicitly set. Set
+`min-width: 0` on `.card-carousel` so horizontal scrolling works correctly.
+Mobile Safari supports smooth scrolling via
 `-webkit-overflow-scrolling: touch`.
 
 ## Future Plans

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -8,7 +8,8 @@
   gap: var(--space-lg); /* Generous whitespace */
   scroll-behavior: smooth; /* Smooth scrolling effect */
   width: 100%; /* Ensure carousel doesn't exceed container width */
-  min-width: 100%; /* Override flex item's default min-width */
+  /* Safari flexbox quirk: set min-width to 0 so container doesn't expand */
+  min-width: 0;
   max-width: 100%; /* Prevent overflow */
   padding: var(--space-md); /* Add padding for visual spacing */
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- set `min-width: 0` on carousel container to prevent Safari overflow
- update docs with Safari guidance

## Testing
- `npx prettier README.md src/styles/carousel.css --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68716cdb3e8083268331b5025dcfee55