### PR TITLE
Fix Safari carousel overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,25 +170,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 
@@ -238,8 +233,8 @@ Safari may expand flex items if `min-width` isn't explicitly set. Set
 Mobile Safari supports smooth scrolling via
 `-webkit-overflow-scrolling: touch`.
 Safari may expand grid columns when the container width is undefined.
-Setting `width: 100%` on `.kodokan-grid` keeps the carousel from stretching
-beyond the viewport.
+Setting `width: 100%` on both `.kodokan-grid` and `.kodokan-screen`
+keeps the carousel from stretching beyond the viewport.
 
 ## Future Plans
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -21,6 +21,7 @@ body {
   display: grid;
   grid-template-rows: auto 1fr auto auto;
   min-height: 100dvh;
+  width: 100%;
   max-width: 100%;
   align-items: center;
 }


### PR DESCRIPTION
## Summary
- ensure Safari grid layout stays within viewport
- note fix in browser compatibility docs

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6871753af6c08326b086b8082469a3cc