### PR TITLE
Fix Safari carousel width

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,25 +170,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 
@@ -238,6 +233,10 @@ Safari may expand flex items if `min-width` isn't explicitly set. Set
 Safari 18 has a regression where flex items grow when scroll buttons are inline
 with the carousel. Apply `min-width: 0` to `.carousel-container` and position
 `.scroll-button` absolutely to keep the carousel inside the viewport.
+Another Safari quirk allows the placeholder `#carousel-container` element to
+expand based on its children, producing a page wider than the viewport. Assign
+`width: 100%` and `overflow: hidden` to `#carousel-container` to constrain the
+carousel on this browser.
 Mobile Safari supports smooth scrolling via
 `-webkit-overflow-scrolling: touch`.
 Safari may expand grid columns when the container width is undefined.

--- a/design/productRequirementsDocuments/prdBrowseJudoka.md
+++ b/design/productRequirementsDocuments/prdBrowseJudoka.md
@@ -177,36 +177,30 @@ Search will be included in a future update to keep the initial scope focused.
 ## Tasks
 
 - [ ] 1.0 Initialize Browse Judoka
-
   - [x] 1.1 Load `judoka.json` roster data.
   - [x] 1.2 Display the Country Flag Picker filter panel.
   - [x] 1.3 Invoke `buildCardCarousel` with loaded data.
 
 - [ ] 2.0 Responsive Layout and Accessibility
-
   - [ ] 2.1 Design card layouts for mobile (1-2 cards) and desktop (3-5 cards)
   - [ ] 2.2 Ensure touch targets ≥44px and WCAG 4.5:1 contrast compliance (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness))
   - [ ] 2.3 Add card enlargement on hover and keyboard focus highlighting
 
 - [ ] 3.0 Error Handling and Edge Case Management
-
   - [x] 3.1 Display “No cards available” if list empty
   - [ ] 3.2 Show error message with retry if `judoka.json` fails to load
   - [ ] 3.3 Use default card for invalid/missing entries or failed images
   - [ ] 3.4 Handle network interruptions with retry prompt
 
 - [ ] 4.0 Performance Optimization
-
   - [ ] 4.1 Ensure full list loads within 1 second for 100 cards
   - [ ] 4.2 Maintain ≥30fps during rapid scrolling
 
 - [ ] 5.0 Interaction Enhancements
-
   - [ ] 5.1 Add ripple or scaling animation on tap/click
   - [ ] 5.2 Implement scroll markers indicating carousel position
 
 - [ ] 6.0 Keyboard and Accessibility Support
-
   - [x] 6.1 Enable arrow key navigation left/right through cards
   - [ ] 6.2 Manage focus state and ensure visible outlines
 

--- a/design/productRequirementsDocuments/prdCardCodeGeneration.md
+++ b/design/productRequirementsDocuments/prdCardCodeGeneration.md
@@ -82,24 +82,19 @@ Simplifies storage and retrieval of Judoka data without exposing sensitive infor
 ### 3.2 Process (P1)
 
 1. **Concatenate Stats**
-
    - Combine power, speed, technique, kumikata, and newaza into a single string.
 
 2. **Build Raw Code String**
-
    - Format: `v1-FIRSTNAME-SURNAME-COUNTRY-WEIGHTCLASS-SIGNATUREMOVEID-STATS`
    - Example: `v1-TADAHIRO-NOMURA-JP-60-1234-98765`
 
 3. **Apply XOR Encoding**
-
    - XOR each character’s ASCII code with `(index + 37) % 256`.
 
 4. **Map to Readable Charset**
-
    - Map to: `ABCDEFGHJKLMNPQRSTUVWXYZ23456789` (avoiding I, O, 1, 0).
 
 5. **Chunking**
-
    - Group characters into 4-character chunks, separated by hyphens (`-`).
 
 6. **Output**
@@ -241,7 +236,6 @@ Code Generation and Sharing Flow
 ## Tasks
 
 - [ ] 1.0 Card Code Generation Function
-
   - [ ] 1.1 Validate input Judoka object for all required fields.
   - [x] 1.2 Concatenate Judoka stats and key attributes into raw string.
   - [x] 1.3 Apply XOR encoding with index-based key.
@@ -251,19 +245,16 @@ Code Generation and Sharing Flow
   - [ ] 1.7 Save the generated code into `judoka.json`.
 
 - [ ] 2.0 Error Handling and Edge Cases
-
   - [ ] 2.1 Fallback to a generic card code (judoka id=0) if encoding fails.
   - [ ] 2.2 Handle unusually large string input safely.
 
 - [ ] 3.0 Unit Tests
-
   - [ ] 3.1 Test valid Judoka object produces correct code format.
   - [ ] 3.2 Test invalid input triggers correct error fallback.
   - [ ] 3.3 Test same input always results in the same output code.
   - [ ] 3.4 Simulate edge cases like large inputs and validate fallback behavior.
 
 - [ ] 4.0 UI Surface Interaction
-
   - [ ] 4.1 Ensure the generated code is visible on relevant card display screens.
   - [ ] 4.2 Support copy-to-clipboard functionality.
   - [ ] 4.3 Add input validation for code entry screens.

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -149,26 +149,22 @@ _Resolved in [Future Considerations](#7-future-considerations):_ AI difficulty w
 ## 14. Tasks
 
 - [ ] 1.0 Implement Classic Battle Match Flow
-
   - [ ] 1.1 Create round loop: random card draw, stat selection, comparison
   - [ ] 1.2 Implement 30-second stat selection timer with auto-selection fallback
   - [ ] 1.3 Handle scoring updates on win, loss, and tie
   - [ ] 1.4 End match after 10 points or 25 rounds
 
 - [ ] 2.0 Add Early Quit Functionality
-
   - [ ] 2.1 Add "Quit Match" button to match UI
   - [ ] 2.2 Create confirmation prompt flow
   - [ ] 2.3 Record match as player loss upon quit confirmation
 
 - [ ] 3.0 Handle Edge Cases
-
   - [ ] 3.1 Implement player disconnect logic: abandon match and redirect to main menu
   - [ ] 3.2 Handle Judoka dataset load failure with error prompt and reload option
   - [ ] 3.3 Add fallback stat selection for AI if difficulty logic fails
 
 - [ ] 4.0 Polish UX and Accessibility
-
   - [ ] 4.1 Integrate consistent color coding (blue for player, red for AI)
   - [ ] 4.2 Apply WCAG-compliant contrast ratios
   - [ ] 4.3 Ensure touch targets ≥44px and support keyboard navigation (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness))

--- a/design/productRequirementsDocuments/prdCountryPickerFilter.md
+++ b/design/productRequirementsDocuments/prdCountryPickerFilter.md
@@ -171,7 +171,6 @@ Key Details:
 ## Tasks
 
 - [ ] 1.0 Implement Country Flag Picker UI
-
   - [ ] 1.1 Create hidden, slide-in panel (default), and full-screen grid layouts.
   - [ ] 1.2 Load country flags with alt-text and labels.
   - [ ] 1.3 Ensure responsive design for different screen sizes (mobile, tablet, desktop).
@@ -179,24 +178,20 @@ Key Details:
   - [ ] 1.5 Implement "Clear Selection" button.
 
 - [ ] 2.0 Set Up Filtering Logic
-
   - [x] 2.1 Load `judoka.json` and extract a list of available countries.
   - [ ] 2.2 Implement filtering of the card carousel based on the selected country.
   - [ ] 2.3 Display an empty state message if no judoka exist for the selected country.
 
 - [ ] 3.0 Optimize Performance
-
   - [ ] 3.1 Implement virtual scrolling or paging for >50 countries.
   - [ ] 3.2 Ensure the filtering action completes within 1 second for 90% of sessions.
   - [ ] 3.3 Ensure the country selector appears within 1 second when toggled.
 
 - [ ] 4.0 Handle Edge Cases
-
   - [ ] 4.1 Display a fallback icon if a flag asset fails to load.
   - [ ] 4.2 Implement progressive flag loading on slow networks.
 
 - [ ] 5.0 Ensure Accessibility and Compliance
-
   - [ ] 5.1 Add alt-text for all flag icons based on country names and apply
         `aria-label` text like "Filter by {country}" to each flag button for
         screen readers.

--- a/design/productRequirementsDocuments/prdHomePageNavigation.md
+++ b/design/productRequirementsDocuments/prdHomePageNavigation.md
@@ -208,7 +208,6 @@ Each tile contains:
 ### Battle Mode Section
 
 - **Contents**:
-
   - Header: “Battle Mode” with clear divider or label.
   - Tile 1: “Classic Battle” — icon left, label centered vertically.
   - Tile 2: “Team Battle” — same size and visual weight as Classic.
@@ -221,7 +220,6 @@ Each tile contains:
 ### Responsive Tile Stack Module
 
 - **Contents**:
-
   - Implement column-stacking at <768px with equal vertical spacing.
   - Ensure each tile remains fully visible without scroll.
   - Tile container should use Flex/Grid with breakpoint control.
@@ -235,7 +233,6 @@ Each tile contains:
 ### Judoka Management Module
 
 - **Contents**:
-
   - One large tile labeled “Manage Judoka”
   - On click, expands or opens modal with:
     - Create Judoka
@@ -294,13 +291,11 @@ Each tile contains:
   - [ ] Ensure full-tile clickability via JS/CSS.
   - [ ] Implement hover and click feedback (cursor pointer, 150ms slight zoom).
 - [ ] **Implement Responsive Grid Layout**
-
   - [ ] Create 2x2 grid layout for desktop viewports.
   - [ ] Implement 1-column stacking for mobile (<768px).
   - [ ] Test layout on tablet and mobile orientations.
 
 - [ ] **Add Accessibility Features**
-
   - [ ] Add `aria-labels` to each tile.
   - [ ] Ensure text contrast ratio ≥4.5:1.
   - [ ] Make icons `aria-hidden` if decorative.
@@ -312,7 +307,6 @@ Each tile contains:
   - [ ] Add fallback icon logic for load failure.
   - [ ] Verify all icons load under poor network conditions.
 - [ ] **Implement Keyboard Navigation and Focus Management**
-
   - [ ] Add `tabindex` attributes for tiles.
   - [ ] Handle keyboard activation events.
   - [ ] Ensure visual focus indicators are clear and accessible.

--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -186,7 +186,6 @@ The design must be attractive and **minimize cognitive load**—presenting stats
 ## Tasks
 
 - [ ] 4.0 Handle Edge Cases
-
   - [ ] 4.1 Show silhouette placeholder for missing portraits.
   - [ ] 4.2 Cap extreme stats and log errors.
   - [ ] 4.3 Display error messages for corrupted data.

--- a/design/productRequirementsDocuments/prdMeditationScreen.md
+++ b/design/productRequirementsDocuments/prdMeditationScreen.md
@@ -189,24 +189,20 @@ Provides agency without pressure. Allows the player to re-enter gameplay at thei
 ## Tasks
 
 - [x] **1.0 Implement Meditation Feedback Module**
-
   - [x] 1.1 Load and display KG character image.
   - [x] 1.2 Add calm headline (“Pause. Breathe. Reflect.”).
 
 - [ ] **2.0 Implement Quote Display Module**
-
   - [x] 2.1 Randomly select a quote from `aesopsFables.json`.
   - [ ] 2.2 Display the quote with dynamic, responsive text scaling.
   - [x] 2.3 Implement skeleton loader while fetching quote using the existing loading spinner styled with `var(--button-bg)`.
   - [x] 2.4 Fallback to default calm message if quote data fails.
 
 - [x] **3.0 Implement Action Button Module**
-
   - [x] 3.1 Add large, thumb-friendly CTA button ("Continue Your Journey").
   - [x] 3.2 Style CTA button with `var(--button-bg)` and `var(--button-hover-bg)`; ensure minimum 44px height and proper spacing (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness)).
 
 - [x] **4.0 Accessibility**
-
   - [x] 4.1 Add ARIA tags for screen readers.
 
 - [ ] **5.0 Performance & Load Time Optimization**

--- a/design/productRequirementsDocuments/prdNavigationMap.md
+++ b/design/productRequirementsDocuments/prdNavigationMap.md
@@ -133,17 +133,14 @@ Currently, the menu is purely functional but lacks the thematic cohesion that dr
 ## Tasks
 
 - [ ] **1.0 Design Village Map Navigation (P1)**
-
   - [ ] 1.1 Design tile positions on the village map grid with 44px+ targets (Dojo, Budokan, Kodokan).
 
 - [ ] **2.0 Implement Footer Map Expansion (P1)**
-
   - [ ] 2.1 Code smooth slide-up animation (<500ms, `ease-out` easing).
   - [ ] 2.2 Implement tap-outside-to-close and map icon toggle behavior.
   - [ ] 2.3 Handle device orientation changes mid-animation.
 
 - [ ] **3.0 Integrate Fallback Menu (P2)**
-
   - [ ] 3.1 Detect if village map assets fail to load
   - [ ] 3.2 Implement a high-contrast, text-only fallback menu.
   - [ ] 3.3 Ensure fallback loads within 1 second.

--- a/design/productRequirementsDocuments/prdPseudoJapanese.md
+++ b/design/productRequirementsDocuments/prdPseudoJapanese.md
@@ -151,25 +151,21 @@ Prevents accidental taps and creates distinct flow—finish reading before proce
 ## Tasks
 
 - [ ] 1.0 Implement Local Conversion System
-
   - [ ] 1.1 Create JSON mapping file for English-to-pseudo-Japanese conversion.
   - [ ] 1.2 Develop conversion logic to map input text via JSON.
   - [ ] 1.3 Implement input cleaning: strip unsupported characters.
   - [ ] 1.4 Substitute random pseudo-Japanese characters for unmapped input.
 
 - [ ] 2.0 Implement Toggle Button
-
   - [ ] 2.1 Design "日本語風 / English" toggle button with split flags.
   - [ ] 2.2 Implement text toggle with 200ms fade animation.
   - [ ] 2.3 Ensure toggle integrates cleanly with the meditation screen UI.
 
 - [ ] 3.0 Implement Static Fallback Mechanism
-
   - [ ] 3.1 Set predefined static pseudo-Japanese text as a final fallback.
   - [ ] 3.2 Trigger fallback if local mapping fails unexpectedly.
 
 - [ ] 4.0 Validation Testing (Non-Production)
-
   - [ ] 4.1 Set up API validation call to https://romaji2kana.com/api.
   - [ ] 4.2 Compare local conversion output with API results.
   - [ ] 4.3 Log discrepancies for manual review.

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -144,7 +144,6 @@ As a user of the game _ju-do-kon!_, I want to be able to change settings such as
   - Screen reader support: Each toggle/selector must have appropriate ARIA labels describing function and current state.
   - Color contrast: Minimum 4.5:1 contrast ratio in all display modes per WCAG 2.1.
 - **Interaction flow:**
-
   - Tab order should proceed top-to-bottom: sound → nav map → motion → display mode → game mode toggles.
   - Users can navigate and activate each control without needing a mouse.
 
@@ -205,24 +204,20 @@ As a user of the game _ju-do-kon!_, I want to be able to change settings such as
 ## Tasks
 
 - [ ] 1.0 Finalize UX & Accessibility
-
   - [ ] 1.1 Implement tab order and keyboard focus indicators.
   - [ ] 1.2 Add ARIA labels for all interactive elements.
   - [ ] 1.3 Confirm WCAG 2.1 compliance for color contrast.
 
 - [ ] 2.0 Implement Responsive Layout
-
   - [ ] 2.1 Design and code mobile-first stacking of controls.
   - [ ] 2.2 Ensure smooth reflow for orientation changes (**<300 ms**).
 
 - [ ] 3.0 Data Persistence & Error Handling
-
   - [ ] 3.1 Implement immediate data updates on setting change.
   - [ ] 3.2 Display CSS popup on read/write errors.
   - [ ] 3.3 Revert toggles/selectors on failed updates.
 
 - [ ] 4.0 List Game Modes
-
   - [ ] 4.1 Load all game modes from `gameModes.json`.
   - [ ] 4.2 Display error message if loading fails.
 

--- a/design/productRequirementsDocuments/prdUpdateJudoka.md
+++ b/design/productRequirementsDocuments/prdUpdateJudoka.md
@@ -222,31 +222,26 @@ Header and action layout are inconsistent, cluttered, and violate basic navigati
 ## Tasks
 
 - [ ] 1.0 Implement Judoka Edit Interface
-
   - [ ] 1.1 Load judoka data into editable fields with loading spinner
   - [ ] 1.2 Design form UI for stats (Strength, Speed, Technique, Endurance) and appearance (Gi color, Belt, Hairstyle)
   - [ ] 1.3 Add real-time validation with inline error messages and fade-in animation
 
 - [ ] 2.0 Save and Persistence
-
   - [ ] 2.1 Save edits to shared storage reliably within 1 second
   - [ ] 2.2 Show confirmation message with slide-up and fade-out animation on successful save
   - [ ] 2.3 Load saved edits correctly on reload
 
 - [ ] 3.0 Error Handling
-
   - [ ] 3.1 Display retry prompt modal when judoka data fails to load
   - [ ] 3.2 Show errors and retry option modal on save failures
   - [ ] 3.3 Handle simultaneous edits with clear conflict resolution messaging and data refresh
 
 - [ ] 4.0 Accessibility and UX Enhancements
-
   - [ ] 4.1 Support keyboard navigation and screen readers with ARIA labels
   - [ ] 4.2 Provide clear visual feedback on validation and save status including animations
   - [ ] 4.3 Implement disabled state and dismissible overlay message for edit locking
 
 - [ ] 5.0 Edit Locking Policy (pending decision)
-
   - [ ] 5.1 Lock editing when judoka enters ranked play
   - [ ] 5.2 Notify player with explanatory dismissible overlay
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -463,6 +463,17 @@ button .ripple {
   min-width: 0;
 }
 
+/*
+  Ensure the outer placeholder element doesn't grow wider than
+  the viewport when the carousel wrapper is inserted. Safari 18
+  may expand auto-width containers based on their children,
+  causing horizontal scroll.
+*/
+#carousel-container {
+  width: 100%;
+  overflow: hidden;
+}
+
 /* Carousel styles moved to carousel.css for better responsive design */
 
 .card-carousel::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- add style for `#carousel-container` to prevent Safari width overflow
- document Safari quirk in README
- reformat product requirement docs with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: package download forbidden)*
- `npx playwright test` *(fails: package download forbidden)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68717de2a1308326bf0ec09f8b41bce7