### PR TITLE
Fix Safari carousel overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,8 @@ with the carousel. Apply `min-width: 0` to `.carousel-container` and position
 `.scroll-button` absolutely to keep the carousel inside the viewport.
 Another Safari quirk allows the placeholder `#carousel-container` element to
 expand based on its children, producing a page wider than the viewport. Assign
-`width: 100%` and `overflow: hidden` to `#carousel-container` to constrain the
-carousel on this browser.
+`width: 100%`, `min-width: 0`, and `overflow: hidden` to `#carousel-container`
+to constrain the carousel on this browser.
 Mobile Safari supports smooth scrolling via
 `-webkit-overflow-scrolling: touch`.
 Safari may expand grid columns when the container width is undefined.

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -471,6 +471,7 @@ button .ripple {
 */
 #carousel-container {
   width: 100%;
+  min-width: 0;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- prevent Safari from widening the browse screen carousel
- document extra `min-width` workaround for Safari

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_687181da0fbc8326865858b6aff9f48c