### PR TITLE
Fix meditation header/footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Import styles in this order: `base.css` first, then layout and component files, 
 
 Global rules should not be repeated across files.
 
+All pages include a fixed header and persistent bottom navigation bar. The body has top and bottom padding to ensure content scrolls under these elements.
+
 The `.animate-card` class in `components.css` reveals new cards with a short
 fade and upward slide. A `prefers-reduced-motion` media query removes the
 animation so the card appears instantly when motion reduction is requested.

--- a/design/productRequirementsDocuments/prdNavigationBar.md
+++ b/design/productRequirementsDocuments/prdNavigationBar.md
@@ -100,13 +100,13 @@ The bottom navigation bar appears consistently across all game screens, dynamica
 
 ## Functional Requirements
 
-| Priority | Feature                | Description                                                                                          |
-| -------- | ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| P1       | Standard Nav Bar       | Fixed horizontal navigation with scalable links and bottom-left corner logo.                         |
-| P2       | Portrait Text Menu     | Text-based vertical menu expansion on logo click for portrait and landscape (collapsed) orientation. |
-| P2       | Small Screens Support  | Adjust text menu for screens as small as 320px — scale font and spacing.                             |
-| P2       | Visual Feedback        | Positive click/tap feedback animation for all links and buttons.                                     |
-| P1       | Fallback Data Handling | Hardcoded default mode list if `gameModes.json` fails to load.                                       |
+| Priority | Feature                | Description                                                                                                       |
+| -------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| P1       | Standard Nav Bar       | Fixed horizontal navigation pinned to the bottom of the viewport with scalable links and bottom-left corner logo. |
+| P2       | Portrait Text Menu     | Text-based vertical menu expansion on logo click for portrait and landscape (collapsed) orientation.              |
+| P2       | Small Screens Support  | Adjust text menu for screens as small as 320px — scale font and spacing.                                          |
+| P2       | Visual Feedback        | Positive click/tap feedback animation for all links and buttons.                                                  |
+| P1       | Fallback Data Handling | Hardcoded default mode list if `gameModes.json` fails to load.                                                    |
 
 ---
 

--- a/src/styles/bottom-navbar.css
+++ b/src/styles/bottom-navbar.css
@@ -1,4 +1,8 @@
 .bottom-navbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 100;
   min-height: max(7vh, 12px);
   display: inline-flex;
   min-width: 100vw;
@@ -8,6 +12,7 @@
   justify-content: space-evenly;
   box-shadow: var(--shadow-base); /* Elevation */
   font-size: max(1.3rem, 1.8vw);
+  width: 100%;
 }
 
 .bottom-navbar ul {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -7,6 +7,8 @@ body {
   background-image: url("./assets/images/bgTileBlue.png");
   background-repeat: repeat;
   background-size: 50vw auto;
+  padding-top: 8vh;
+  padding-bottom: 7vh;
 }
 
 .home-screen {
@@ -37,12 +39,17 @@ body {
 } */
 
 .header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   background-color: var(--color-tertiary); /* Updated token */
   box-shadow: var(--shadow-base); /* Updated token */
   width: 100%;
+  min-height: 8vh;
 }
 
 .character-slot {


### PR DESCRIPTION
## Summary
- pin navigation bar and header to viewport
- pad body so content scrolls below fixed elements
- document fixed layout in README
- clarify navigation bar requirement in PRD

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68718308ce188326b5f9064ead44913f