### PR TITLE
Add Playwright common setup fixture

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,5 +1,4 @@
-import { test, expect } from "@playwright/test";
-import { registerCommonRoutes } from "./fixtures/commonRoutes.js";
+import { test, expect } from "./fixtures/commonSetup.js";
 
 async function setCarouselWidth(page, width) {
   await page.evaluate((w) => {
@@ -14,7 +13,6 @@ const COUNTRY_TOGGLE_LOCATOR = "country-toggle";
 
 test.describe("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
-    await registerCommonRoutes(page);
     await page.goto("/src/pages/browseJudoka.html");
   });
 

--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -1,9 +1,7 @@
-import { test, expect } from "@playwright/test";
-import { registerCommonRoutes } from "./fixtures/commonRoutes.js";
+import { test, expect } from "./fixtures/commonSetup.js";
 
 test.describe("Classic battle flow", () => {
   test("timer auto-selects when expired", async ({ page }) => {
-    await registerCommonRoutes(page);
     await page.addInitScript(() => {
       const orig = window.setInterval;
       window.setInterval = (fn, ms, ...args) => orig(fn, Math.min(ms, 10), ...args);
@@ -15,7 +13,6 @@ test.describe("Classic battle flow", () => {
   });
 
   test("tie message appears on equal stats", async ({ page }) => {
-    await registerCommonRoutes(page);
     await page.addInitScript(() => {
       const orig = window.setInterval;
       window.setInterval = (fn, ms, ...args) => orig(fn, Math.max(ms, 3600000), ...args);
@@ -33,7 +30,6 @@ test.describe("Classic battle flow", () => {
   });
 
   test("quit match confirmation", async ({ page }) => {
-    await registerCommonRoutes(page);
     await page.goto("/src/pages/battleJudoka.html");
     page.on("dialog", (dialog) => dialog.accept());
     await page.locator("#quit-btn").click();

--- a/playwright/fixtures/commonSetup.js
+++ b/playwright/fixtures/commonSetup.js
@@ -1,0 +1,21 @@
+/**
+ * Playwright test setup that automatically registers common routes.
+ *
+ * @pseudocode
+ * 1. Import base test and expect from Playwright.
+ * 2. Import registerCommonRoutes helper.
+ * 3. Extend the base test's page fixture to register routes before each test.
+ * 4. Export the extended test and expect.
+ */
+import { test as base, expect } from "@playwright/test";
+import { registerCommonRoutes } from "./commonRoutes.js";
+
+export const test = base.extend({
+  /** @type {import('@playwright/test').Page} */
+  page: async ({ page }, use) => {
+    await registerCommonRoutes(page);
+    await use(page);
+  }
+});
+
+export { expect };

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -1,9 +1,7 @@
-import { test, expect } from "@playwright/test";
-import { registerCommonRoutes } from "./fixtures/commonRoutes.js";
+import { test, expect } from "./fixtures/commonSetup.js";
 
 test.describe("View Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
-    await registerCommonRoutes(page);
     await page.goto("/src/pages/randomJudoka.html");
   });
 

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -1,6 +1,5 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/commonSetup.js";
 import fs from "fs";
-import { registerCommonRoutes } from "./fixtures/commonRoutes.js";
 
 // Allow skipping screenshots via the SKIP_SCREENSHOTS environment variable
 const runScreenshots = process.env.SKIP_SCREENSHOTS !== "true";
@@ -21,7 +20,6 @@ test.describe(runScreenshots ? "Screenshot suite" : "Screenshot suite (skipped)"
 
   for (const { url, name } of pages) {
     test(`screenshot ${url}`, async ({ page }) => {
-      await registerCommonRoutes(page);
       await page.route("**/src/data/gameModes.json", (route) => {
         route.fulfill({ path: "tests/fixtures/gameModes.json" });
       });

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -1,9 +1,7 @@
-import { test, expect } from "@playwright/test";
-import { registerCommonRoutes } from "./fixtures/commonRoutes.js";
+import { test, expect } from "./fixtures/commonSetup.js";
 
 test.describe("Settings page", () => {
   test.beforeEach(async ({ page }) => {
-    await registerCommonRoutes(page);
     await page.route("**/src/data/gameModes.json", (route) =>
       route.fulfill({ path: "tests/fixtures/gameModes.json" })
     );


### PR DESCRIPTION
## Summary
- add `commonSetup.js` fixture to auto-register Playwright routes
- use new fixture across specs

## Testing
- `npx prettier . --check | head -n 15`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6871868fa6388326b6b9172c90e772a9