### PR TITLE
Note Safari scrollbar workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Mobile Safari supports smooth scrolling via
 Safari may expand grid columns when the container width is undefined.
 Setting `width: 100%` on both `.kodokan-grid` and `.kodokan-screen`
 keeps the carousel from stretching beyond the viewport.
+Safari counts scrollbars in the `vw` unit. A wrapper with `min-width: 100vw` can become wider than the page and trigger horizontal scrolling. We now set `width: 100%` on the body and navbars (optionally `overflow-x: hidden`) so the layout stays within the viewport.
 
 ## Future Plans
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Mobile Safari supports smooth scrolling via
 Safari may expand grid columns when the container width is undefined.
 Setting `width: 100%` on both `.kodokan-grid` and `.kodokan-screen`
 keeps the carousel from stretching beyond the viewport.
-Safari counts scrollbars in the `vw` unit. A wrapper with `min-width: 100vw` can become wider than the page and trigger horizontal scrolling. We now set `width: 100%` on the body and navbars (optionally `overflow-x: hidden`) so the layout stays within the viewport.
+Safari counts scrollbars in the `vw` unit, which can lead to unexpected layout behavior. For example, a wrapper with `min-width: 100vw` may become wider than the page and cause horizontal scrolling. To prevent this, set `width: 100%` on the body and navbars. Optionally, use `overflow-x: hidden` to ensure the layout stays within the viewport.
 
 ## Future Plans
 


### PR DESCRIPTION
## Summary
- document Safari scrollbar issue when using `min-width: 100vw`
- mention the fix using `width: 100%` and optional `overflow-x: hidden`

## Testing
- `npx prettier README.md --check`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot /src/pages/settings.html)*

------
https://chatgpt.com/codex/tasks/task_e_68718ac09a6c8326bb41be00b96d8b96