### PR TITLE
Update carousel scroll buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,20 +173,25 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
+
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
+
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
+
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
+
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
+
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -19,7 +19,7 @@ import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidat
  *
  * 2. Create a button element:
  *    - Assign a class based on the `direction` (e.g., "scroll-button left" or "scroll-button right").
- *    - Set the inner HTML to display an arrow symbol ("<" for left, ">" for right).
+ *    - Set the inner HTML to display an inline SVG chevron pointing left or right.
  *    - Add an accessible label (`aria-label`) for screen readers (e.g., "Scroll Left").
  *
  * 3. Add a click event listener to the button:
@@ -50,7 +50,10 @@ export function createScrollButton(direction, container, scrollAmount) {
 
   button.className = `scroll-button ${direction}`;
 
-  button.innerHTML = direction === "left" ? "&lt;" : "&gt;";
+  button.innerHTML =
+    direction === "left"
+      ? '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M15 18l-6-6 6-6"/></svg>'
+      : '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>';
 
   button.setAttribute(
     "aria-label",

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -504,7 +504,7 @@ button .ripple {
   top: 50%;
   transform: translateY(-50%);
   background-color: var(--color-surface);
-  color: var(--color-text-inverted);
+  color: var(--color-text);
   border: 1px solid var(--color-tertiary);
   border-radius: 50%;
   min-width: 48px;
@@ -516,6 +516,11 @@ button .ripple {
   align-items: center;
   z-index: 10;
   transition: background-color scale box-shadow 0.9s ease-in-out;
+}
+
+.scroll-button svg {
+  width: 24px;
+  height: 24px;
 }
 
 .scroll-button:hover {

--- a/tests/card/cardBuilder.test.js
+++ b/tests/card/cardBuilder.test.js
@@ -23,14 +23,16 @@ describe("createScrollButton", () => {
   it("should create a scroll button with the correct class and inner HTML when direction is left", () => {
     const button = createScrollButton("left", container, 100);
     expect(button.className).toBe("scroll-button left");
-    expect(button.innerHTML).toBe("&lt;");
+    expect(button.innerHTML).toContain("<svg");
+    expect(button.innerHTML).toContain("</svg>");
     expect(button).toHaveAttribute("aria-label", "Scroll Left");
   });
 
   it("should create a scroll button with the correct class and inner HTML when direction is right", () => {
     const button = createScrollButton("right", container, 100);
     expect(button.className).toBe("scroll-button right");
-    expect(button.innerHTML).toBe("&gt;");
+    expect(button.innerHTML).toContain("<svg");
+    expect(button.innerHTML).toContain("</svg>");
     expect(button).toHaveAttribute("aria-label", "Scroll Right");
   });
 


### PR DESCRIPTION
## Summary
- inline SVGs for carousel scroll buttons
- tweak scroll-button styles to use text color and override SVG size
- expect SVG markup in scroll button tests
- format README with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68734bd8a5dc8326bf58a404182ee991