### PR TITLE
Fix portrait image scaling on judoka cards

### DIFF
--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -163,6 +163,7 @@ The design must be attractive and **minimize cognitive load**—presenting stats
 
 - **Aspect Ratio:** Card must strictly maintain **2:3 ratio**, adjusting internal elements responsively.
 - **Vertical Proportions:** With a card width of 300px (height 450px), allocate roughly 10% (45px) for the name and flag bar, 45% (200px) for the portrait, 35% (158px) for stats, and 10% (45px) for the signature move section.
+- Portrait images should fill the portrait area using `object-fit: cover` so no whitespace appears.
 - **Rarity Border Colors:**
   - Common → Blue (#337AFF)
   - Rare → Red (#FF3333)

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -318,7 +318,7 @@ button .ripple {
 }
 
 .card-portrait img {
-  width: auto;
+  width: 100%;
   height: 100%;
   object-fit: cover;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- ensure portraits fill card space in components CSS
- document using `object-fit: cover` for portraits

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(failed: carousel responds to arrow keys, carousel responds to swipe gestures, screenshot /src/pages/browseJudoka.html)*
- `npm run check:contrast` *(failed to start server)*

------
https://chatgpt.com/codex/tasks/task_e_68735846b9a8832694efdaf551aeda38