### PR TITLE
Update docs for filter icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The repository specifies commenting standards in design/codeStandards. JSDoc com
 - Playable directly in the browser
 - Loading indicator for better user experience
 - Modularized JavaScript for better maintainability
-- Slide-in country picker for filtering judoka by flag with accessible
+- Slide-in country picker, opened via a filter icon, for filtering judoka by flag with accessible
   `aria-label` descriptions
 - Country picker panel appears below the fixed header for unobstructed viewing
 

--- a/design/productRequirementsDocuments/prdCountryPickerFilter.md
+++ b/design/productRequirementsDocuments/prdCountryPickerFilter.md
@@ -51,6 +51,7 @@ Key Details:
 - Users can only select one country at a time.
 - A "Clear" button is provided to clear the selection and revert to displaying all judoka.
 - Default display mode when opened is **slide-in panel**.
+- The toggle is represented by a filter list icon.
 
 ---
 
@@ -67,7 +68,7 @@ Key Details:
 
 | Priority | Feature                         | Description                                                                          |
 | -------- | ------------------------------- | ------------------------------------------------------------------------------------ |
-| **P1**   | Country selector toggle         | Allow users to toggle the country selector panel and filter judoka cards by country. |
+| **P1**   | Country selector toggle         | Allow users to toggle the country selector panel via a filter list icon and filter judoka cards by country. |
 | **P1**   | Filtering and responsive time   | Ensure filtering is completed within 1 second for 90% of sessions.                   |
 | **P2**   | Three display modes             | Provide hidden, slide-in (default), and full-screen grid views for the selector.     |
 | **P2**   | Clear button                    | Provide a clear, easy way to remove the current country filter.                      |


### PR DESCRIPTION
## Summary
- clarify how the country picker opens in README
- document filter list icon in the PRD for the Country Picker

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: carousel arrow/swipe tests and screenshot diff)*

------
https://chatgpt.com/codex/tasks/task_e_6873589195a4832684111afd8595415c