### PR TITLE
Add aria-label check for country filter toggle

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -18,6 +18,10 @@ test.describe("Browse Judoka screen", () => {
 
   test("essential elements visible", async ({ page }) => {
     await expect(page.getByTestId(COUNTRY_TOGGLE_LOCATOR)).toBeVisible();
+    await expect(page.getByTestId("country-toggle")).toHaveAttribute(
+      "aria-label",
+      /country filter/i
+    );
     await expect(page.getByRole("navigation")).toBeVisible();
     await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
   });


### PR DESCRIPTION
## Summary
- update Browse Judoka e2e test
- ensure `country-toggle` has an accessible aria-label

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: carousel responds to arrow keys, carousel responds to swipe gestures, screenshot /src/pages/browseJudoka.html)*

------
https://chatgpt.com/codex/tasks/task_e_6873589696ac832693c412e58babf1cc