### PR TITLE
Fix carousel arrow key test

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -5,6 +5,8 @@ async function setCarouselWidth(page, width) {
     const el = document.querySelector('[data-testid="carousel"]');
     if (el) {
       el.style.width = w;
+      // Disable flex growth so the test can control overflow
+      el.style.flex = "0 0 auto";
     }
   }, width);
 }


### PR DESCRIPTION
## Summary
- prevent the carousel element from stretching when resized in tests

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68736b42370083269004ea36a862f5a2