### PR TITLE
Fix swipe carousel test

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -118,6 +118,7 @@ test.describe("Browse Judoka screen", () => {
   test("carousel responds to swipe gestures", async ({ page }) => {
     const container = page.locator(".card-carousel");
     await container.waitFor();
+    await page.waitForSelector('[data-testid="carousel"] .judoka-card');
     const handle = await container.elementHandle();
     await page.evaluate((el) => {
       el.style.width = "200px";


### PR DESCRIPTION
## Summary
- wait for judoka cards to load before running swipe interaction test

## Testing
- `npx prettier playwright/browse-judoka.spec.js --check`
- `npx eslint playwright/browse-judoka.spec.js` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden to registry)*
- `npx playwright test` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68736bdec3d88326b317d2844a9a37b5