### PR TITLE
Fix carousel scroll button limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The repository specifies commenting standards in design/codeStandards. JSDoc com
 - Slide-in country picker, opened via a filter icon, for filtering judoka by flag with accessible
   `aria-label` descriptions
 - Country picker panel appears below the fixed header for unobstructed viewing
+- Scroll buttons disable when the carousel reaches either end
 
 ## About JU-DO-KON!
 
@@ -173,25 +174,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -150,6 +150,25 @@ function validateGokyoData(gokyoData) {
 }
 
 /**
+ * Update scroll button disabled states based on container position.
+ *
+ * @pseudocode
+ * 1. Calculate the maximum scroll value using `scrollWidth` and
+ *    `clientWidth` of `container`.
+ * 2. Disable `leftBtn` when `scrollLeft` is at or before the first card.
+ * 3. Disable `rightBtn` when `scrollLeft` reaches the end of the carousel.
+ *
+ * @param {HTMLElement} container - The scrolling container element.
+ * @param {HTMLButtonElement} leftBtn - Button that scrolls left.
+ * @param {HTMLButtonElement} rightBtn - Button that scrolls right.
+ */
+export function updateScrollButtonState(container, leftBtn, rightBtn) {
+  const maxLeft = container.scrollWidth - container.clientWidth;
+  leftBtn.disabled = container.scrollLeft <= 0;
+  rightBtn.disabled = container.scrollLeft >= maxLeft;
+}
+
+/**
  * Creates a loading spinner and sets a timeout to display it.
  *
  * @pseudocode
@@ -379,6 +398,11 @@ export async function buildCardCarousel(judokaList, gokyoData) {
   wrapper.appendChild(container);
   wrapper.appendChild(rightButton);
 
+  const updateButtons = () => updateScrollButtonState(container, leftButton, rightButton);
+  updateButtons();
+  container.addEventListener("scroll", updateButtons);
+  window.addEventListener("resize", updateButtons);
+
   setupKeyboardNavigation(container);
   setupSwipeNavigation(container);
   applyAccessibilityImprovements(wrapper);
@@ -386,4 +410,4 @@ export async function buildCardCarousel(judokaList, gokyoData) {
   return wrapper;
 }
 
-export { addScrollMarkers };
+export { addScrollMarkers, updateScrollButtonState };

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -530,6 +530,11 @@ button .ripple {
   box-shadow: var(--shadow-base);
 }
 
+.scroll-button:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 .scroll-button.left {
   left: var(--space-sm);
 }

--- a/tests/helpers/scrollButtonState.test.js
+++ b/tests/helpers/scrollButtonState.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { updateScrollButtonState } from "../../src/helpers/carouselBuilder.js";
+
+describe("updateScrollButtonState", () => {
+  it("disables left button at start", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "scrollWidth", { value: 300 });
+    Object.defineProperty(container, "clientWidth", { value: 100 });
+    container.scrollLeft = 0;
+    const left = document.createElement("button");
+    const right = document.createElement("button");
+    updateScrollButtonState(container, left, right);
+    expect(left.disabled).toBe(true);
+    expect(right.disabled).toBe(false);
+  });
+
+  it("disables right button at end", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "scrollWidth", { value: 300 });
+    Object.defineProperty(container, "clientWidth", { value: 100 });
+    container.scrollLeft = 200;
+    const left = document.createElement("button");
+    const right = document.createElement("button");
+    updateScrollButtonState(container, left, right);
+    expect(left.disabled).toBe(false);
+    expect(right.disabled).toBe(true);
+  });
+
+  it("enables both buttons in middle", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "scrollWidth", { value: 300 });
+    Object.defineProperty(container, "clientWidth", { value: 100 });
+    container.scrollLeft = 50;
+    const left = document.createElement("button");
+    const right = document.createElement("button");
+    updateScrollButtonState(container, left, right);
+    expect(left.disabled).toBe(false);
+    expect(right.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- disable carousel scroll buttons when at the ends
- style disabled scroll buttons
- document the behavior in README
- test scroll button state logic

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_687374e10f388326b115918458095a4e