### PR TITLE
Fix swipe gesture carousel test

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -121,10 +121,7 @@ test.describe("Browse Judoka screen", () => {
     const container = page.locator(".card-carousel");
     await container.waitFor();
     await page.waitForSelector('[data-testid="carousel"] .judoka-card');
-    const handle = await container.elementHandle();
-    await page.evaluate((el) => {
-      el.style.width = "200px";
-    }, handle);
+    await setCarouselWidth(page, "200px");
 
     const box = await container.boundingBox();
     const startX = box.x + box.width * 0.8;


### PR DESCRIPTION
## Summary
- use `setCarouselWidth` helper in the carousel swipe gesture test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot.spec.js screenshot /src/pages/browseJudoka.html)*

------
https://chatgpt.com/codex/tasks/task_e_6873750ce7f88326b3ba6096a61a846d