### PR TITLE
Update helper path in root guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository contains the source for **JU-DO-KON!**, a browser-based card gam
 
 - `index.html` – landing page.
 - `game.js` – main browser logic.
-- `helpers/` – modular utilities used throughout the game. Functions include extensive JSDoc with `@pseudocode` blocks.
+- `src/helpers/` – modular utilities used throughout the game. Functions include extensive JSDoc with `@pseudocode` blocks.
 - `data/` – JSON files for judoka, gokyo techniques, and game configuration.
 - `tests/` – Vitest unit tests using the `jsdom` environment.
 - `playwright/` – Playwright tests for UI and end-to-end validation, including **screenshot tests**.

--- a/README.md
+++ b/README.md
@@ -174,20 +174,25 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
+
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
+
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
+
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
+
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
+
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -410,4 +410,4 @@ export async function buildCardCarousel(judokaList, gokyoData) {
   return wrapper;
 }
 
-export { addScrollMarkers, updateScrollButtonState };
+export { addScrollMarkers };


### PR DESCRIPTION
## Summary
- document helpers live under `src/helpers/`
- ensure `carouselBuilder` exports don't clash
- format docs with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot /src/pages/browseJudoka.html)*

------
https://chatgpt.com/codex/tasks/task_e_6873860c23448326a7a0e7fc4d2d5800