### PR TITLE
Add waits for UI selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,20 +174,25 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
+
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
+
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
+
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
+
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
+
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -41,6 +41,8 @@ test.describe("Browse Judoka screen", () => {
   test("scroll buttons have labels", async ({ page }) => {
     const left = page.locator(".scroll-button.left");
     const right = page.locator(".scroll-button.right");
+    await page.waitForSelector(".scroll-button.left");
+    await page.waitForSelector(".scroll-button.right");
     await expect(left).toHaveAttribute("aria-label", /scroll left/i);
     await expect(right).toHaveAttribute("aria-label", /scroll right/i);
   });

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -39,7 +39,6 @@ test.describe("View Judoka screen", () => {
   test("draw card populates container", async ({ page }) => {
     await page.getByTestId("draw-button").click();
     const card = page.getByTestId("card-container").locator(".judoka-card");
-    await page.waitForSelector('[data-testid="card-container"] .judoka-card');
     await expect(card).toHaveCount(1);
     await expect(card).toBeVisible();
     const flag = card.locator(".card-top-bar img");

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -39,6 +39,7 @@ test.describe("View Judoka screen", () => {
   test("draw card populates container", async ({ page }) => {
     await page.getByTestId("draw-button").click();
     const card = page.getByTestId("card-container").locator(".judoka-card");
+    await page.waitForSelector('[data-testid="card-container"] .judoka-card');
     await expect(card).toHaveCount(1);
     await expect(card).toBeVisible();
     const flag = card.locator(".card-top-bar img");

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -410,4 +410,4 @@ export async function buildCardCarousel(judokaList, gokyoData) {
   return wrapper;
 }
 
-export { addScrollMarkers, updateScrollButtonState };
+export { addScrollMarkers };


### PR DESCRIPTION
## Summary
- wait for scroll buttons before checking labels
- wait for random card to appear in E2E tests
- remove duplicate export in carousel builder
- format README via Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot.spec.js snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6873863906a48326b4e7b1522263d3bd