### PR TITLE
Fix homepage tile layout

### DIFF
--- a/design/productRequirementsDocuments/prdHomePageNavigation.md
+++ b/design/productRequirementsDocuments/prdHomePageNavigation.md
@@ -227,6 +227,7 @@ Each tile contains:
   - Tile container should use Flex/Grid with breakpoint control.
   - Single-column layout for mobile view (portrait resolution)
   - Tiles stretch to 100% width with top and bottom padding
+  - Tile grid height equals `100dvh` minus the top and bottom bar heights so tiles always fill the viewport
   - Tap targets clearly bounded with shadow or color background
   - Include visible focus outline for keyboard navigation
 

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -410,4 +410,4 @@ export async function buildCardCarousel(judokaList, gokyoData) {
   return wrapper;
 }
 
-export { addScrollMarkers, updateScrollButtonState };
+export { addScrollMarkers };

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -10,6 +10,11 @@
   box-shadow: var(--shadow-base);
   cursor: pointer;
   transition: transform var(--transition-fast);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
 }
 
 .card:hover {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -69,15 +69,17 @@ body {
 .game-mode-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
   gap: var(--space-lg); /* Updated token */
   padding: 0 var(--space-xl); /* Updated token */
   flex: 1 1 auto;
-  min-height: 85%;
+  height: calc(100dvh - var(--header-height) - var(--footer-height));
 }
 
 @media (max-width: 768px) {
   .game-mode-grid {
     grid-template-columns: 1fr;
+    grid-template-rows: repeat(4, 1fr);
   }
 }
 .homeHelperContainer {


### PR DESCRIPTION
## Summary
- make home screen tile grid fill viewport
- stretch `.card` items to fill grid cells
- fix duplicate export in `carouselBuilder.js`
- document viewport-height tile grid

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot comparison)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687386fad17c832694b2a0c96b866090