### PR TITLE
Update settings layout

### DIFF
--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -147,6 +147,7 @@ As a user of the game _ju-do-kon!_, I want to be able to change settings such as
 
   - Tab order should proceed top-to-bottom: sound → nav map → motion → display mode → game mode toggles.
   - Users can navigate and activate each control without needing a mouse.
+  - **Section layout:** Both the general settings and game mode toggle list use the `.game-mode-toggle-container` grid for consistent spacing.
 
   | **Settings Menu Mockup 1**                                         | **Settings Menu Mockup 2**                                         | **Settings Menu Mockup 2**                                         |
   | ------------------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------ |

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -39,7 +39,7 @@
 
     <main class="container" role="main">
       <form id="settings-form" class="settings-form">
-        <fieldset>
+        <fieldset id="general-settings-container" class="game-mode-toggle-container settings-form">
           <legend class="visually-hidden">Game Settings</legend>
           <div class="settings-item">
             <label for="sound-toggle" class="switch">

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -783,6 +783,13 @@ button .ripple {
   pointer-events: auto;
 }
 
+/* Reset fieldset styles inside settings forms */
+.settings-form fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
 /* Settings form controls */
 .settings-form label {
   display: flex;


### PR DESCRIPTION
## Summary
- style core settings grid like game mode toggles
- reset fieldset styles so custom grid layout looks correct
- document shared grid usage in the Settings Menu PRD

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_687387b8faec832684ab76212b91078c