### PR TITLE
Fix portrait container dimensions

### DIFF
--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -164,6 +164,7 @@ The design must be attractive and **minimize cognitive load**—presenting stats
 - **Aspect Ratio:** Card must strictly maintain **2:3 ratio**, adjusting internal elements responsively.
 - **Vertical Proportions:** With a card width of 300px (height 450px), allocate roughly 10% (45px) for the name and flag bar, 45% (200px) for the portrait, 35% (158px) for stats, and 10% (45px) for the signature move section.
 - Portrait images should fill the portrait area using `object-fit: cover` so no whitespace appears.
+- **Portrait Container:** `.card-portrait` now uses `width: 100%` and `height: 45%` so it matches its flex-basis and keeps the aspect ratio consistent.
 - **Rarity Border Colors:**
   - Common → Blue (#337AFF)
   - Rare → Red (#FF3333)

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -312,7 +312,7 @@ button .ripple {
   justify-content: center;
   align-items: flex-start;
   width: 100%;
-  height: 45%;
+  flex: 0 0 45%;
   overflow: hidden;
   background: linear-gradient(
     to bottom,

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -311,7 +311,8 @@ button .ripple {
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  width: auto;
+  width: 100%;
+  height: 45%;
   overflow: hidden;
   background: linear-gradient(
     to bottom,


### PR DESCRIPTION
## Summary
- make `.card-portrait` stretch full width and define a matching height
- document the width/height in the judoka card PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diffs)*

------
https://chatgpt.com/codex/tasks/task_e_687393e516508326a74ea61430997880