### PR TITLE
Add icon prefix to Random Judoka draw button

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,25 +174,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -14,7 +14,7 @@ The entry point for the browser. It waits for `DOMContentLoaded` and wires up al
 Reusable utilities organized by concern (card building, data fetching, random card generation, etc.). Each module is documented with JSDoc and `@pseudocode` blocks for clarity.
 Key helpers include `generateRandomCard()` for choosing a card and `renderJudokaCard()` for injecting it into the DOM with an optional reveal animation.
 
-`src/components/` holds reusable UI pieces. `Button.js` exposes a `createButton` helper that applies design tokens. Typical pages import this module along with the `setupButtonEffects` helper to keep button interactions consistent.
+`src/components/` holds reusable UI pieces. `Button.js` exposes a `createButton` helper that applies design tokens and can prepend an optional icon. Typical pages import this module along with the `setupButtonEffects` helper to keep button interactions consistent.
 
 ## page modules
 

--- a/design/productRequirementsDocuments/prdRandomJudoka.md
+++ b/design/productRequirementsDocuments/prdRandomJudoka.md
@@ -132,7 +132,7 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 
 - **Top Bar**: minimal header with “Random Judoka” title centered.
 - **Central Card Area**: large placeholder card with question mark icon on initial state.
-- **Draw Button Area**: prominent pill-shaped “Draw New Judoka!” button with mute and animation toggles ~24px below the card.
+- **Draw Button Area**: prominent pill-shaped “Draw New Judoka!” button prefixed with a draw icon, with mute and animation toggles ~24px below the card.
 - **Fallback State**: placeholder card with error icon and explanatory text below.
 
 ---

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -4,21 +4,29 @@
  * @pseudocode
  * 1. Create a `button` element.
  * 2. Apply provided text and attributes such as `id`, `className` and `type`.
- * 3. Set inline styles referencing `--button-bg` and `--button-text-color`.
- * 4. Return the configured button element.
+ * 3. Optionally prepend an icon before the text when `icon` is provided.
+ * 4. Set inline styles referencing `--button-bg` and `--button-text-color`.
+ * 5. Return the configured button element.
  *
  * @param {string} text - The button label.
  * @param {object} [options] - Optional settings.
  * @param {string} [options.id] - Id attribute for the button.
  * @param {string} [options.className] - Additional class names.
  * @param {string} [options.type="button"] - Button type attribute.
+ * @param {string} [options.icon] - SVG markup inserted before the label.
  * @returns {HTMLButtonElement} The styled button element.
  */
 export function createButton(text, options = {}) {
-  const { id, className, type = "button" } = options;
+  const { id, className, type = "button", icon } = options;
   const button = document.createElement("button");
   button.type = type;
-  button.textContent = text;
+  if (icon) {
+    button.innerHTML = `${icon}<span class="button-label">${text}</span>`;
+    const svg = button.querySelector("svg");
+    if (svg) svg.setAttribute("aria-hidden", "true");
+  } else {
+    button.textContent = text;
+  }
   button.style.backgroundColor = "var(--button-bg)";
   button.style.color = "var(--button-text-color)";
   if (id) button.id = id;

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -21,9 +21,19 @@ export function createButton(text, options = {}) {
   const button = document.createElement("button");
   button.type = type;
   if (icon) {
-    button.innerHTML = `${icon}<span class="button-label">${text}</span>`;
-    const svg = button.querySelector("svg");
-    if (svg) svg.setAttribute("aria-hidden", "true");
+    const parser = new DOMParser();
+    const svgDoc = parser.parseFromString(icon, "image/svg+xml");
+    const svgElement = svgDoc.querySelector("svg");
+    if (svgElement) {
+      svgElement.setAttribute("aria-hidden", "true");
+      button.appendChild(svgElement);
+    } else {
+      console.warn("Invalid SVG markup provided for icon.");
+    }
+    const labelSpan = document.createElement("span");
+    labelSpan.className = "button-label";
+    labelSpan.textContent = text;
+    button.appendChild(labelSpan);
   } else {
     button.textContent = text;
   }

--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -15,6 +15,9 @@ import { DATA_DIR } from "./constants.js";
 import { createButton } from "../components/Button.js";
 import { shouldReduceMotionSync } from "./motionUtils.js";
 
+const DRAW_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#1f1f1f"><path d="m600-200-56-57 143-143H300q-75 0-127.5-52.5T120-580q0-75 52.5-127.5T300-760h20v80h-20q-42 0-71 29t-29 71q0 42 29 71t71 29h387L544-624l56-56 240 240-240 240Z"/></svg>';
+
 export function setupRandomJudokaPage() {
   const prefersReducedMotion = shouldReduceMotionSync();
 
@@ -46,7 +49,8 @@ export function setupRandomJudokaPage() {
   const drawButton = createButton("Draw Card!", {
     id: "draw-card-btn",
     className: "draw-card-btn",
-    type: "button"
+    type: "button",
+    icon: DRAW_ICON
   });
   drawButton.dataset.testid = "draw-button";
   cardSection.appendChild(drawButton);

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -639,7 +639,10 @@ button .ripple {
 }
 
 .draw-card-btn {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
   margin: var(--space-large) auto; /* Updated token */
   width: 300px;
   max-width: 90vw;
@@ -651,6 +654,11 @@ button .ripple {
   border-radius: var(--radius-pill); /* Updated token */
   font-size: 1.25rem;
   font-weight: bold;
+}
+
+.draw-card-btn svg {
+  width: 24px;
+  height: 24px;
 }
 
 .card-section {

--- a/tests/helpers/buttonComponent.test.js
+++ b/tests/helpers/buttonComponent.test.js
@@ -21,4 +21,13 @@ describe("createButton", () => {
     const btn = createButton("Label");
     expect(btn.type).toBe("button");
   });
+
+  it("adds icon markup when provided", () => {
+    const icon = '<svg aria-hidden="true"></svg>';
+    const btn = createButton("Label", { icon });
+    expect(btn.innerHTML).toContain(icon);
+    expect(btn.textContent).toBe("Label");
+    const svg = btn.querySelector("svg");
+    expect(svg.getAttribute("aria-hidden")).toBe("true");
+  });
 });


### PR DESCRIPTION
## Summary
- extend `createButton` to support an optional `icon` parameter
- show a new draw icon on the Random Judoka page
- update button styles for icon layout
- document icon usage in the PRD and architecture guide
- format README with Prettier
- test new button icon behaviour

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_687396a018e083269b21a6f4cb92360b