### PR TITLE
Fix Safari viewport scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,25 +174,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 
@@ -252,6 +247,9 @@ Safari may expand grid columns when the container width is undefined.
 Setting `width: 100%` on both `.kodokan-grid` and `.kodokan-screen`
 keeps the carousel from stretching beyond the viewport.
 Safari counts scrollbars in the `vw` unit, which can lead to unexpected layout behavior. For example, a wrapper with `min-width: 100vw` may become wider than the page and cause horizontal scrolling. To prevent this, set `width: 100%` on the body and navbars. Optionally, use `overflow-x: hidden` to ensure the layout stays within the viewport.
+Mobile Safari 18.5 may also add vertical scroll if fixed headers and footers use
+`vh` units. The navbar height CSS variables now use `dvh` to match the dynamic
+viewport height and avoid extra scrolling.
 
 ## Future Plans
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -33,9 +33,13 @@
   --space-large: var(--space-lg);
 
   /* Navbar heights adjusted for mobile Safari */
-  --header-height: 8dvh;
-  --footer-height: 8dvh;
+  --header-height: 8vh;
+  --footer-height: 8vh;
 
+  @supports (height: 1dvh) {
+    --header-height: 8dvh;
+    --footer-height: 8dvh;
+  }
   /* Touch target and breakpoints */
   --touch-target-size: 48px;
   --breakpoint-lg: 1024px;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -32,9 +32,9 @@
   --space-medium: var(--space-md);
   --space-large: var(--space-lg);
 
-  /* Navbar heights */
-  --header-height: 8vh;
-  --footer-height: 8vh;
+  /* Navbar heights adjusted for mobile Safari */
+  --header-height: 8dvh;
+  --footer-height: 8dvh;
 
   /* Touch target and breakpoints */
   --touch-target-size: 48px;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -13,7 +13,7 @@ body {
 .home-screen {
   display: grid;
   grid-template-rows: auto 1fr auto;
-  height: 100dvh;
+  min-height: 100dvh;
   padding-top: var(--header-height);
   padding-bottom: var(--footer-height);
   max-width: 100%;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -8,25 +8,29 @@ body {
   background-image: url("./assets/images/bgTileBlue.png");
   background-repeat: repeat;
   background-size: 50vw auto;
-  padding-top: var(--header-height);
-  padding-bottom: var(--footer-height);
 }
 
 .home-screen {
   display: grid;
   grid-template-rows: auto 1fr auto;
-  min-height: 100dvh;
+  height: 100dvh;
+  padding-top: var(--header-height);
+  padding-bottom: var(--footer-height);
   max-width: 100%;
   align-items: center;
+  box-sizing: border-box;
 }
 
 .kodokan-screen {
   display: grid;
   grid-template-rows: auto 1fr auto auto;
-  min-height: 100dvh;
+  height: 100dvh;
+  padding-top: var(--header-height);
+  padding-bottom: var(--footer-height);
   width: 100%;
   max-width: 100%;
   align-items: center;
+  box-sizing: border-box;
 }
 
 .kodokan-grid {


### PR DESCRIPTION
## Summary
- prevent mobile Safari from scrolling index, browse, and random judoka pages
- use `dvh` units for navbars
- document Safari workaround for viewport units

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6873989adc5083268bbdda79bfd405cf