### PR TITLE
Fix portrait layout

### DIFF
--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -155,21 +155,21 @@ async function createTopBar(judoka, flagUrl) {
 }
 
 function createPortraitSection(judoka) {
-  const portraitElement = document.createElement("div");
-  portraitElement.className = "card-portrait";
-
   try {
-    portraitElement.innerHTML = generateCardPortrait(judoka);
+    // generateCardPortrait returns a complete `.card-portrait` wrapper
+    const fragment = document.createRange().createContextualFragment(generateCardPortrait(judoka));
+    const portraitElement = fragment.firstElementChild;
+
     const weightClassElement = document.createElement("div");
     weightClassElement.className = "card-weight-class";
     weightClassElement.textContent = judoka.weightClass;
     portraitElement.appendChild(weightClassElement);
+
+    return portraitElement;
   } catch (error) {
     console.error("Failed to generate portrait:", error);
     return createNoDataContainer();
   }
-
-  return portraitElement;
 }
 
 function createStatsSection(judoka, cardType) {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -595,8 +595,7 @@ button .ripple {
   justify-content: center;
 }
 
-<button id="country-toggle" class="filter-bar-button">Toggle Country</button>
-#country-toggle {
+<button id="country-toggle" class="filter-bar-button" > Toggle Country</button > #country-toggle {
   width: var(--touch-target-size, 48px);
   height: var(--touch-target-size, 48px);
   padding: 0;


### PR DESCRIPTION
## Summary
- avoid nested card-portrait wrapper so judoka portraits can fill the intended space
- run Prettier on styles to satisfy formatting rules

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6873a5ad022083268605040fc59836c4