### PR TITLE
Fix Safari dynamic viewport note

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,7 @@ Safari may expand grid columns when the container width is undefined.
 Setting `width: 100%` on both `.kodokan-grid` and `.kodokan-screen`
 keeps the carousel from stretching beyond the viewport.
 Safari counts scrollbars in the `vw` unit, which can lead to unexpected layout behavior. For example, a wrapper with `min-width: 100vw` may become wider than the page and cause horizontal scrolling. To prevent this, set `width: 100%` on the body and navbars. Optionally, use `overflow-x: hidden` to ensure the layout stays within the viewport.
-Mobile Safari 18.5 may also add vertical scroll if fixed headers and footers use
-`vh` units. The navbar height CSS variables now use `dvh` to match the dynamic
-viewport height and avoid extra scrolling.
+Mobile Safari 18.5 may also add vertical scroll if fixed headers and footers use `vh` units. The navbar height CSS variables now use `dvh` to match the dynamic viewport height and avoid extra scrolling. Pages with fixed headers or footers should set container heights to `calc(100dvh - var(--header-height) - var(--footer-height))` (or equivalent) so content isn't hidden when the viewport shrinks. The `.home-screen` container implements this rule.
 
 ## Future Plans
 


### PR DESCRIPTION
## Summary
- document Safari 18.5 behaviour with fixed headers/footers
- note that `.home-screen` already uses calc(100dvh - header - footer)

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: meditation screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6873b3ddf76083268afec2fa296c7837