### PR TITLE
Fix signature move layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,25 +174,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -184,9 +184,8 @@ function createStatsSection(judoka, cardType) {
 function createSignatureMoveSection(judoka, gokyoLookup, cardType) {
   try {
     const signatureMoveHTML = generateCardSignatureMove(judoka, gokyoLookup, cardType);
-    const signatureMoveElement = document.createElement("div");
-    signatureMoveElement.innerHTML = signatureMoveHTML;
-    return signatureMoveElement;
+    const fragment = document.createRange().createContextualFragment(signatureMoveHTML);
+    return fragment.firstElementChild;
   } catch (error) {
     console.error("Failed to generate signature move:", error);
     return createNoDataContainer();

--- a/tests/card/judokaCardSignatureMove.test.js
+++ b/tests/card/judokaCardSignatureMove.test.js
@@ -1,0 +1,27 @@
+import { generateJudokaCardHTML } from "../../src/helpers/cardBuilder.js";
+
+const judoka = {
+  id: 1,
+  firstname: "John",
+  surname: "Doe",
+  country: "USA",
+  countryCode: "us",
+  stats: { power: 5, speed: 5, technique: 5, kumikata: 5, newaza: 5 },
+  weightClass: "-100kg",
+  signatureMoveId: 1,
+  rarity: "common",
+  gender: "male"
+};
+
+const gokyoLookup = {
+  1: { id: 1, name: "Uchi-mata" }
+};
+
+describe("signature move placement", () => {
+  it("adds the signature move as a direct child of the judoka card", async () => {
+    const container = await generateJudokaCardHTML(judoka, gokyoLookup);
+    const card = container.querySelector(".judoka-card");
+    const direct = card.querySelector(":scope > .signature-move-container");
+    expect(direct).toBeInstanceOf(HTMLElement);
+  });
+});


### PR DESCRIPTION
## Summary
- render signature move container without extra wrapper
- keep repository formatting consistent with Prettier
- test that signature move is a direct child of judoka card

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden retrieving vitest)*
- `npx playwright test` *(fails: 403 Forbidden retrieving playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6873bab2269483268f85e1af0b7b4cf9