### PR TITLE
Fix signature move band sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,20 +174,25 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
+
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
+
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
+
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
+
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
+
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -257,6 +257,8 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 
 - Background: #003B88
 - Text: Yellow (#FED843), left-aligned label + centered move name
+- Size: `min-height: var(--touch-target-size)` and `flex: 0 0 auto` to prevent
+  clipping on mobile
 
 #### Rarity Markers
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -407,10 +407,10 @@ button .ripple {
   align-items: center;
   flex-direction: row;
   width: 100%;
-  max-height: 45px;
+  min-height: var(--touch-target-size);
   font-weight: bold;
-  /* Signature move ~10% of card height */
-  flex: 0 0 10%;
+  /* Ensure visible at small screen sizes */
+  flex: 0 0 auto;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- adjust `.signature-move-container` to keep the band visible at mobile widths
- document signature move band sizing rule
- run Prettier

## Testing
- `npm run check:contrast`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch for randomJudoka.html)*

------
https://chatgpt.com/codex/tasks/task_e_6873c1d10e988326bfae14c733384893