### PR TITLE
Fix settings page layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,25 +174,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 
@@ -253,6 +248,7 @@ Setting `width: 100%` on both `.kodokan-grid` and `.kodokan-screen`
 keeps the carousel from stretching beyond the viewport.
 Safari counts scrollbars in the `vw` unit, which can lead to unexpected layout behavior. For example, a wrapper with `min-width: 100vw` may become wider than the page and cause horizontal scrolling. To prevent this, set `width: 100%` on the body and navbars. Optionally, use `overflow-x: hidden` to ensure the layout stays within the viewport.
 Mobile Safari 18.5 may also add vertical scroll if fixed headers and footers use `vh` units. The navbar height CSS variables now use `dvh` to match the dynamic viewport height and avoid extra scrolling. Pages with fixed headers or footers should set container heights to `calc(100dvh - var(--header-height) - var(--footer-height))` (or equivalent) so content isn't hidden when the viewport shrinks. The `.home-screen` container implements this rule.
+The settings screen previously had its first controls hidden behind the header; wrapping the page in this `.home-screen` container resolves the issue.
 
 ## Future Plans
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -59,6 +59,7 @@ As a user of the game _ju-do-kon!_, I want to be able to change settings such as
 - All data reads/writes should use asynchronous, promise-based functions with error handling.
 - `settings.json` must persist in localStorage/sessionStorage for session retention.
 - Updates should debounce writes to avoid excessive file operations if toggles are changed rapidly.
+- Wrap the page contents in a `.home-screen` container so the fixed header does not cover the first settings control.
 
 ---
 

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -27,81 +27,91 @@
   </head>
 
   <body>
-    <header class="header">
-      <div class="character-slot left"></div>
-      <div class="logo-container">
-        <a href="../../index.html" data-testid="home-link">
-          <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
-        </a>
-      </div>
-      <div class="character-slot right"></div>
-    </header>
+    <div class="home-screen">
+      <header class="header">
+        <div class="character-slot left"></div>
+        <div class="logo-container">
+          <a href="../../index.html" data-testid="home-link">
+            <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
+          </a>
+        </div>
+        <div class="character-slot right"></div>
+      </header>
 
-    <main class="container" role="main">
-      <form id="settings-form" class="settings-form">
-        <fieldset id="general-settings-container" class="game-mode-toggle-container settings-form">
-          <legend class="visually-hidden">Game Settings</legend>
-          <div class="settings-item">
-            <label for="sound-toggle" class="switch">
-              <input type="checkbox" id="sound-toggle" name="sound" aria-label="Sound" />
-              <div class="slider round"></div>
-              <span>Sound</span>
-            </label>
-          </div>
-          <div class="settings-item">
-            <label for="navmap-toggle" class="switch">
-              <input
-                type="checkbox"
-                id="navmap-toggle"
-                name="navmap"
-                aria-label="Full Navigation Map"
-              />
-              <div class="slider round"></div>
-              <span>Full Navigation Map</span>
-            </label>
-          </div>
-          <div class="settings-item">
-            <label for="motion-toggle" class="switch">
-              <input type="checkbox" id="motion-toggle" name="motion" aria-label="Motion Effects" />
-              <div class="slider round"></div>
-              <span>Motion Effects</span>
-            </label>
-          </div>
-          <div class="settings-item">
-            <label for="display-mode-select">Display Mode</label>
-            <select id="display-mode-select">
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-              <option value="gray">Gray</option>
-            </select>
-          </div>
-        </fieldset>
-        <section
-          id="game-mode-toggle-container"
-          class="game-mode-toggle-container settings-form"
-          aria-label="Game Mode Selector"
-        ></section>
-      </form>
-    </main>
+      <main class="container" role="main">
+        <form id="settings-form" class="settings-form">
+          <fieldset
+            id="general-settings-container"
+            class="game-mode-toggle-container settings-form"
+          >
+            <legend class="visually-hidden">Game Settings</legend>
+            <div class="settings-item">
+              <label for="sound-toggle" class="switch">
+                <input type="checkbox" id="sound-toggle" name="sound" aria-label="Sound" />
+                <div class="slider round"></div>
+                <span>Sound</span>
+              </label>
+            </div>
+            <div class="settings-item">
+              <label for="navmap-toggle" class="switch">
+                <input
+                  type="checkbox"
+                  id="navmap-toggle"
+                  name="navmap"
+                  aria-label="Full Navigation Map"
+                />
+                <div class="slider round"></div>
+                <span>Full Navigation Map</span>
+              </label>
+            </div>
+            <div class="settings-item">
+              <label for="motion-toggle" class="switch">
+                <input
+                  type="checkbox"
+                  id="motion-toggle"
+                  name="motion"
+                  aria-label="Motion Effects"
+                />
+                <div class="slider round"></div>
+                <span>Motion Effects</span>
+              </label>
+            </div>
+            <div class="settings-item">
+              <label for="display-mode-select">Display Mode</label>
+              <select id="display-mode-select">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="gray">Gray</option>
+              </select>
+            </div>
+          </fieldset>
+          <section
+            id="game-mode-toggle-container"
+            class="game-mode-toggle-container settings-form"
+            aria-label="Game Mode Selector"
+          ></section>
+        </form>
+      </main>
 
-    <footer>
-      <nav class="bottom-navbar" data-testid="bottom-nav" aria-label="Bottom Navigation"></nav>
-    </footer>
-    <script type="module" src="../helpers/setupBottomNavbar.js"></script>
-    <script type="module" src="../helpers/setupDisplaySettings.js"></script>
+      <footer>
+        <nav class="bottom-navbar" data-testid="bottom-nav" aria-label="Bottom Navigation"></nav>
+      </footer>
+      <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+      <script type="module" src="../helpers/setupDisplaySettings.js"></script>
 
-    <noscript>
-      <p class="noscript-warning">
-        JU-DO-KON! requires JavaScript to run. Please enable JavaScript to play.
-      </p>
-    </noscript>
+      <noscript>
+        <p class="noscript-warning">
+          JU-DO-KON! requires JavaScript to run. Please enable JavaScript to play.
+        </p>
+      </noscript>
 
-    <script type="module" src="../helpers/settingsPage.js"></script>
-    <script nomodule>
-      alert(
-        "Your browser does not support modern JavaScript. Please update your browser to play JU-DO-KON!"
-      );
-    </script>
-    <script type="module" src="../helpers/setupSvgFallback.js"></script>
+      <script type="module" src="../helpers/settingsPage.js"></script>
+      <script nomodule>
+        alert(
+          "Your browser does not support modern JavaScript. Please update your browser to play JU-DO-KON!"
+        );
+      </script>
+      <script type="module" src="../helpers/setupSvgFallback.js"></script>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add `.home-screen` wrapper to settings page
- document header overlap fix in README and PRD

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6873c62c35bc8326b77191255447273e