### PR TITLE
Fix judoka card border width

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -157,7 +157,7 @@ button .ripple {
   position: relative;
   width: clamp(200px, 40vw, 300px);
   aspect-ratio: 2 / 3;
-  border: max(13px, 1vh) solid var(--card-border-color);
+  border: 13px solid var(--card-border-color);
   border-radius: var(--radius-lg); /* Updated token */
   background-color: var(--card-bg-color);
   box-shadow: var(--shadow-base); /* Updated token */


### PR DESCRIPTION
## Summary
- keep card's outer ratio consistent by using a fixed border width

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: navigation link step interrupted due to network restrictions)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_6873d5df222c832687b79855338e9a4d