### PR TITLE
Add interactive card flip

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
     `src/helpers` (for example `randomJudokaPage.js`) that wires up its
     interactive behavior.
   - `data/`
-  - `schemas/`  
+  - `schemas/`
     JSON Schema definitions used to validate the data files.
   - `assets/`
+    Card art and UI graphics, including `cardBacks/cardBack-2.png` used when a card flips.
   - `styles/`
 - `tests/` – Vitest unit tests.
 - `design/` – documentation and code standards.
@@ -213,7 +214,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 ## Known Issues
 
 - The game currently does not support mobile devices.
-- Animations for card flips are not yet implemented.
+- Animations for card flips are now implemented.
 - Difficulty levels for the computer opponent are under development.
 
 ## Display Modes
@@ -254,7 +255,7 @@ The settings screen previously had its first controls hidden behind the header; 
 
 - Get feedback on current cards and stat points
 - Take submissions/suggestions on new card designs and stats
-- Add animations for card flips and stat comparisons
+- Add stat comparison animations
 - Implement difficulty levels for the computer opponent
 - Expand the card deck with more judoka and stats
 

--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -4,6 +4,7 @@ import { generateCardPortrait, generateCardSignatureMove } from "./cardRender.js
 import { createStatsPanel } from "../components/StatsPanel.js";
 import { safeGenerate } from "./errorUtils.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
+import { enableCardFlip } from "./cardFlip.js";
 
 /**
  * Generates the "last updated" HTML for a judoka card.
@@ -139,7 +140,10 @@ function validateJudoka(judoka) {
  *    - Generate signature move HTML using `generateCardSignatureMove` and append it.
  *    - If generation fails, append an empty signature move container.
  *
- * 10. Return the complete card container:
+ * 10. Enable card interactivity:
+ *    - Attach click and keyboard handlers to toggle `.show-card-back`.
+ *
+ * 11. Return the complete card container:
  *    - Append the `judoka-card` to the `card-container`.
  *
  * @param {Object} judoka - The judoka object containing data for the card.
@@ -246,6 +250,8 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup) {
 
   const signatureMoveElement = createSignatureMoveSection(judoka, gokyoLookup, cardType);
   judokaCard.appendChild(signatureMoveElement);
+
+  enableCardFlip(judokaCard);
 
   cardContainer.appendChild(judokaCard);
 

--- a/src/helpers/cardFlip.js
+++ b/src/helpers/cardFlip.js
@@ -1,0 +1,13 @@
+export function enableCardFlip(cardElement) {
+  if (!cardElement) return;
+  const toggle = () => {
+    cardElement.classList.toggle("show-card-back");
+  };
+  cardElement.addEventListener("click", toggle);
+  cardElement.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      toggle();
+    }
+  });
+}

--- a/tests/card/judokaCardFlip.test.js
+++ b/tests/card/judokaCardFlip.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { generateJudokaCardHTML } from "../../src/helpers/cardBuilder.js";
+
+const judoka = {
+  id: 1,
+  firstname: "John",
+  surname: "Doe",
+  country: "USA",
+  countryCode: "us",
+  stats: { power: 5, speed: 5, technique: 5, kumikata: 5, newaza: 5 },
+  weightClass: "-100kg",
+  signatureMoveId: 1,
+  rarity: "common",
+  gender: "male"
+};
+
+const gokyoLookup = { 1: { id: 1, name: "Uchi-mata" } };
+
+describe("judoka card flip interactivity", () => {
+  it("toggles show-card-back on click", async () => {
+    const container = await generateJudokaCardHTML(judoka, gokyoLookup);
+    const card = container.querySelector(".judoka-card");
+    card.click();
+    expect(card.classList.contains("show-card-back")).toBe(true);
+    card.click();
+    expect(card.classList.contains("show-card-back")).toBe(false);
+  });
+
+  it("toggles show-card-back on Enter key", async () => {
+    const container = await generateJudokaCardHTML(judoka, gokyoLookup);
+    const card = container.querySelector(".judoka-card");
+    const event = new KeyboardEvent("keydown", { key: "Enter" });
+    card.dispatchEvent(event);
+    expect(card.classList.contains("show-card-back")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- flip cards on click or keyboard interaction
- document new cardBack asset
- update README about card flip support
- test card flip handlers

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6873fd8defd8832687cba1e535528058