### PR TITLE
Add hover shadow token and card transitions

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -51,6 +51,7 @@
 
   /* Updated shadows and transitions */
   --shadow-base: 0 4px 12px rgba(0, 0, 0, 0.1); /* Elevation */
+  --shadow-hover: 0 8px 24px rgba(0, 0, 0, 0.2);
   --transition-fast: all 150ms ease; /* UI animations */
 
   /* Font sizes */

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -9,7 +9,9 @@
   text-align: center;
   box-shadow: var(--shadow-base);
   cursor: pointer;
-  transition: transform var(--transition-fast);
+  transition:
+    transform var(--transition-fast),
+    box-shadow var(--transition-fast);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -19,6 +21,11 @@
 
 .card:hover {
   transform: scale(1.05);
+  box-shadow: var(--shadow-hover);
+}
+
+.card:focus-visible {
+  box-shadow: var(--shadow-hover);
 }
 
 .tile-content h2 {
@@ -197,7 +204,7 @@ button .ripple {
 }
 
 .judoka-card:hover {
-  box-shadow: 8px 8px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-hover);
   transform: scale(1.1); /* Updated token */
 }
 
@@ -206,7 +213,7 @@ button .ripple {
   outline: 2px solid var(--color-primary);
   outline-offset: 4px;
   transform: scale(1.1);
-  box-shadow: 8px 8px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-hover);
 }
 
 /* Fallback for older browsers */


### PR DESCRIPTION
## Summary
- add `--shadow-hover` token for card shadows
- smooth card hover transitions
- apply the token to card and judoka card focus/hover states

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687402c141188326a849f3ccdc24e1b7