### PR TITLE
Add secondary button styles

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -109,6 +109,20 @@ button:focus-visible {
   text-decoration: underline;
 }
 
+.secondary-button {
+  background-color: var(--color-tertiary);
+  color: var(--color-secondary);
+  border: 1px solid var(--color-secondary);
+}
+
+.secondary-button:hover {
+  background-color: var(--button-hover-bg);
+}
+
+.secondary-button:active {
+  background-color: var(--button-active-bg);
+}
+
 a:focus,
 a:focus-visible {
   outline-offset: 2px;


### PR DESCRIPTION
## Summary
- add `.secondary-button` variants after base button rules
- include hover and active colors
- keep code formatted via Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687405fb467083269057a7cf1070bbc5