### PR TITLE
Update modal docs in architecture guide

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -27,9 +27,12 @@ initialize page-specific behavior.
 
 Factory functions that create reusable UI elements. `Button.js` and
 `ToggleSwitch.js` return styled controls. `Modal.js` builds an accessible
-dialog with focus trapping and open/close helpers. `StatsPanel.js` constructs
-the `.card-stats` section used within judoka cards. `Card.js` provides a
-reusable content panel styled with the `.card` class.
+dialog. The `createModal()` factory returns `{ element, open, close }` and
+automatically closes on backdrop clicks or when Escape is pressed while
+keeping focus trapped inside the dialog. Pages create their content fragment,
+pass it to `createModal()`, and call `open()` when needed. `StatsPanel.js`
+constructs the `.card-stats` section used within judoka cards. `Card.js`
+provides a reusable content panel styled with the `.card` class.
 
 ```javascript
 import { createCard } from "./src/components/Card.js";


### PR DESCRIPTION
## Summary
- expand Modal component description in `architecture.md`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot comparison for several pages)*

------
https://chatgpt.com/codex/tasks/task_e_68740945f7788326a2ec3d27020c4f16