### PR TITLE
Fix card hover scaling

### DIFF
--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -71,6 +71,8 @@ Players currently lack a tangible sense of progression and connection to elite j
 - Card slide/reveal animations must use hardware-accelerated CSS transforms for smooth performance (**≥60 fps**).
 - Placeholder assets for missing portraits/flags should be bundled with the client for offline scenarios.
 - Ensure card sizing calculations consistently maintain 2:3 ratio on all screen aspect ratios and resolutions.
+- Hover and focus scaling must stay at or below **1.05x** to prevent cards from
+  being clipped inside scroll wrappers.
 
 ---
 

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -32,7 +32,7 @@
 
 /* Hover effect for desktop */
 .judoka-card:hover {
-  transform: scale(1.1); /* Interactive feedback */
+  transform: scale(1.05); /* Interactive feedback */
 }
 
 /* Styles for tablets */

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -219,14 +219,14 @@ button .ripple {
 
 .judoka-card:hover {
   box-shadow: var(--shadow-hover);
-  transform: scale(1.1); /* Updated token */
+  transform: scale(1.05); /* Match PRD max scale */
 }
 
 /* Keyboard focus outline */
 .judoka-card:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 4px;
-  transform: scale(1.1);
+  transform: scale(1.05);
   box-shadow: var(--shadow-hover);
 }
 
@@ -543,7 +543,10 @@ button .ripple {
   justify-content: center;
   align-items: center;
   z-index: 10;
-  transition: background-color scale box-shadow 0.9s ease-in-out;
+  transition:
+    background-color 0.9s ease-in-out,
+    transform 0.9s ease-in-out,
+    box-shadow 0.9s ease-in-out;
 }
 
 .scroll-button svg {
@@ -617,7 +620,7 @@ button .ripple {
   justify-content: center;
 }
 
-<button id="country-toggle" class="filter-bar-button" > Toggle Country</button > #country-toggle {
+#country-toggle {
   width: var(--touch-target-size, 48px);
   height: var(--touch-target-size, 48px);
   padding: 0;


### PR DESCRIPTION
## Summary
- limit hover/focus scaling to 1.05
- fix scroll button transition
- remove stray markup in components.css
- document scale limit in judoka card PRD

## Testing
- `npx prettier src/styles/components.css src/styles/carousel.css design/productRequirementsDocuments/prdJudokaCard.md --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6874158455ac832692ec2875dfecca47