### PR TITLE
Fix signature move clipping in judoka cards

### DIFF
--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -169,6 +169,7 @@ The design must be attractive and **minimize cognitive load**—presenting stats
 - **Portrait Container:** `.card-portrait` now uses `width: 100%` and `height: 45%` so it matches its flex-basis and keeps the aspect ratio consistent.
 - **Stats Container:** `.card-stats` uses `height: 35%` to align with the vertical proportions.
 - **Signature Move Band:** `height: max(10%, var(--touch-target-size))` keeps the 44px tap target while maintaining the card's 2:3 ratio.
+- **Padding Adjustments:** Section heights use `calc()` to subtract vertical padding so the total fits within the card's 2:3 ratio.
 - **Rarity Border Colors:**
   - Common → Blue (#337AFF)
   - Rare → Red (#FF3333)

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -276,9 +276,9 @@ button .ripple {
   align-items: center;
   padding: var(--space-small) var(--space-medium); /* Updated tokens */
   flex-direction: row;
-  /* Maintain ~10% of card height */
-  flex: 0 0 10%;
-  height: 10%;
+  /* Maintain ~10% of card height accounting for padding */
+  flex: 0 0 calc(10% - (var(--space-small) * 2));
+  height: calc(10% - (var(--space-small) * 2));
   box-sizing: border-box;
 }
 
@@ -381,9 +381,9 @@ button .ripple {
   align-items: flex-end;
   font-size: var(--font-medium);
   flex-direction: column;
-  height: 35%;
-  /* Stats area ~35% of card height */
-  flex: 0 0 35%;
+  /* Stats area ~35% of card height accounting for padding */
+  height: calc(35% - (var(--space-small) * 2));
+  flex: 0 0 calc(35% - (var(--space-small) * 2));
 }
 
 .card-stats ul {
@@ -429,10 +429,11 @@ button .ripple {
   align-items: center;
   flex-direction: row;
   width: 100%;
-  height: max(10%, var(--touch-target-size));
+  /* Maintain ~10% height while accounting for padding on children */
+  height: calc(max(10%, var(--touch-target-size)) - (var(--space-small) * 2));
   font-weight: bold;
   /* Ensure visible at small screen sizes */
-  flex: 0 0 max(10%, var(--touch-target-size));
+  flex: 0 0 calc(max(10%, var(--touch-target-size)) - (var(--space-small) * 2));
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- tweak judoka card section heights using `calc()` so padding doesn't break the 2:3 layout
- document section height calculations in the PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatches)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68742faa38cc83269cc01bc15dcc25c6