### PR TITLE
Add JSDoc header for cssVariableParser

### DIFF
--- a/src/helpers/cssVariableParser.js
+++ b/src/helpers/cssVariableParser.js
@@ -1,18 +1,14 @@
 import postcss from "postcss";
 
 /**
- * Parse CSS custom properties from a CSS string using PostCSS.
+ * Parses CSS variables from a CSS string using PostCSS for robust parsing.
+ * This replaces the fragile regex-based approach with a proper CSS parser.
  *
  * @pseudocode
  * 1. Parse the provided CSS content with PostCSS.
  * 2. Walk the `:root` rule and gather declarations.
  * 3. Record any declaration whose property starts with `--`.
  * 4. Return an object of collected variables.
- */
-
-/**
- * Parses CSS variables from a CSS string using PostCSS for robust parsing.
- * This replaces the fragile regex-based approach with a proper CSS parser.
  *
  * @param {string} cssContent - The CSS content to parse
  * @returns {Object} Object containing CSS variables as key-value pairs


### PR DESCRIPTION
## Summary
- document cssVariableParser utility

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: page.goto Test ended)*

------
https://chatgpt.com/codex/tasks/task_e_6875448cfc9883269fccc6b45cbb38f9