### PR TITLE
Add debug.js file-level documentation

### DIFF
--- a/src/helpers/debug.js
+++ b/src/helpers/debug.js
@@ -1,4 +1,17 @@
 /**
+ * Debug logging utilities for the game.
+ *
+ * The `DEBUG_LOGGING` flag controls whether messages are printed. It can be set
+ * via `process.env.DEBUG_LOGGING` in Node environments or `window.DEBUG_LOGGING`
+ * in the browser. When enabled, the `debugLog` helper forwards arguments to
+ * `console.log`.
+ *
+ * @pseudocode
+ * 1. Check both `process.env` and `window` for the `DEBUG_LOGGING` flag.
+ * 2. Export a function that logs arguments only when the flag is true.
+ */
+
+/**
  * Indicates whether debug messages should be printed.
  * Set `DEBUG_LOGGING=true` in the environment or on `window` to enable.
  * @type {boolean}


### PR DESCRIPTION
## Summary
- document debug helper with file-level JSDoc

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_687544928dcc83268455ba464e6db3b4