### PR TITLE
Add country slider helper

### DIFF
--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -1,5 +1,5 @@
 import { buildCardCarousel, addScrollMarkers } from "./carouselBuilder.js";
-import { populateCountryList } from "./countryUtils.js";
+import { createCountrySlider } from "./countrySlider.js";
 import { toggleCountryPanel, toggleCountryPanelMode } from "./countryPanel.js";
 import { fetchJson } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
@@ -102,7 +102,7 @@ export function setupBrowseJudokaPage() {
       const wasOpen = countryPanel.classList.contains("open");
       toggleCountryPanel(toggleBtn, countryPanel);
       if (!wasOpen && !countriesLoaded) {
-        await populateCountryList(countryListContainer);
+        await createCountrySlider(countryListContainer);
         countriesLoaded = true;
       }
     });

--- a/src/helpers/countrySlider.js
+++ b/src/helpers/countrySlider.js
@@ -1,0 +1,16 @@
+import { populateCountryList } from "./countryUtils.js";
+
+/**
+ * Build a horizontally scrolling slider of country flags.
+ *
+ * @pseudocode
+ * 1. Use `populateCountryList` to render flag buttons inside the provided container.
+ *
+ * @param {HTMLElement} container - The slide track element that receives the flag buttons.
+ * @returns {Promise<void>} Resolves when the slider has been created.
+ */
+export async function createCountrySlider(container) {
+  if (!container) return;
+
+  await populateCountryList(container);
+}

--- a/tests/helpers/countrySlider.test.js
+++ b/tests/helpers/countrySlider.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  document.body.innerHTML = "";
+});
+
+describe("createCountrySlider", () => {
+  it("renders flag buttons using populateCountryList", async () => {
+    const track = document.createElement("div");
+
+    const slideA = document.createElement("button");
+    slideA.className = "slide";
+    const slideB = document.createElement("button");
+    slideB.className = "slide";
+
+    const populateCountryList = vi.fn(async (c) => {
+      c.appendChild(slideA);
+      c.appendChild(slideB);
+    });
+
+    vi.doMock("../../src/helpers/countryUtils.js", () => ({ populateCountryList }));
+
+    const { createCountrySlider } = await import("../../src/helpers/countrySlider.js");
+
+    await createCountrySlider(track);
+
+    expect(populateCountryList).toHaveBeenCalledWith(track);
+    const slides = track.querySelectorAll(".slide");
+    expect(slides).toHaveLength(2);
+    expect(slides[0]).toBe(slideA);
+    expect(slides[1]).toBe(slideB);
+  });
+});


### PR DESCRIPTION
## Summary
- add `createCountrySlider` helper for rendering flag slider
- use it in `browseJudokaPage`
- test `createCountrySlider`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_687544c87b108326a7aa06bcd1333d58