### PR TITLE
Add naming pattern guidelines

### DIFF
--- a/design/codeStandards/codeNamingPatterns.md
+++ b/design/codeStandards/codeNamingPatterns.md
@@ -1,0 +1,15 @@
+# Function Naming Patterns
+
+Modules should group helpers by concern. Consistent prefixes make intent clear across the codebase.
+
+## createX
+
+Use `create` for factory functions that return DOM nodes. Modal factories and similar utilities that return `{ element, open, close }` also follow this pattern.
+
+## setupY
+
+Use `setup` for functions that attach event listeners or initialize page behavior.
+
+## isZ
+
+Use `is` for predicate helpers that return a boolean.


### PR DESCRIPTION
## Summary
- document naming conventions for helpers and modules

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_68754d9fe60883268f0fa09193a73c93