### PR TITLE
Fix signature move text display

### DIFF
--- a/src/helpers/cardRender.js
+++ b/src/helpers/cardRender.js
@@ -1,7 +1,7 @@
 // Constants
 const PLACEHOLDER_ID = 0;
 
-import { escapeHTML } from "./utils.js";
+import { escapeHTML, decodeHTML } from "./utils.js";
 import { createStatsPanel } from "../components/StatsPanel.js";
 
 /**


### PR DESCRIPTION
## Summary
- import `decodeHTML` alongside `escapeHTML` in `cardRender`
- rely on imported `decodeHTML` to correctly show signature move labels

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875530e36188326ab992f44e8dfbea5