### PR TITLE
Update quote loader for split Aesop data

### DIFF
--- a/design/productRequirementsDocuments/prdMeditationScreen.md
+++ b/design/productRequirementsDocuments/prdMeditationScreen.md
@@ -63,7 +63,7 @@ Players benefit from rhythm and pacing. Periods of calm after periods of intensi
 ## Acceptance Criteria
 
 - AC-1 KG character appears on the meditation screen.
-- AC-2 Random quote displayed from `aesopsFables.json`; fallback reflection quote appears if the dataset is unavailable.
+- AC-2 Random quote displayed from `aesopsFables.json` with metadata from `aesopsMeta.json`; fallback reflection quote appears if the datasets are unavailable.
 - AC-3 Screen loads within 1 second.
 - AC-4 Quote text has ARIA markup and maintains contrast ratio of at least **4.5:1**.
 - AC-5 "Continue Your Journey" button uses `--radius-md`, stays ≥44px tall with tap target ≥44px × 44px, and is keyboard focusable. See [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness).
@@ -80,7 +80,7 @@ Players benefit from rhythm and pacing. Periods of calm after periods of intensi
 
 ## Dependencies / Integrations
 
-- Quote data from `aesopsFables.json`.
+- Quote data from `aesopsFables.json` and `aesopsMeta.json`.
 - KG character assets and image loader.
 - Linked from the main navigation menu.
 
@@ -174,7 +174,7 @@ Provides agency without pressure. Allows the player to re-enter gameplay at thei
 
 ## Dependencies and Integrations
 
-- Quote data file: `aesopsFables.json`.
+- Quote data files: `aesopsFables.json` and `aesopsMeta.json`.
 - KG character assets from the core game.
 - Navigation system for entering and exiting the screen.
 - Pseudo-Japanese Text Conversion Function for quote toggle ([prdPseudoJapanese.md](prdPseudoJapanese.md)).
@@ -196,7 +196,7 @@ Provides agency without pressure. Allows the player to re-enter gameplay at thei
 
 - [x] **2.0 Implement Quote Display Module**
 
-  - [x] 2.1 Randomly select a quote from `aesopsFables.json`.
+  - [x] 2.1 Randomly select a quote from `aesopsFables.json` and merge metadata from `aesopsMeta.json`.
   - [x] 2.2 Display the quote with dynamic, responsive text scaling.
   - [x] 2.3 Implement skeleton loader while fetching quote using the existing loading spinner styled with `var(--button-bg)`.
   - [x] 2.4 Fallback to default calm message if quote data fails.

--- a/playwright/pseudo-japanese-toggle.spec.js
+++ b/playwright/pseudo-japanese-toggle.spec.js
@@ -3,7 +3,8 @@ import { fileURLToPath } from "url";
 import { test, expect } from "@playwright/test";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const FIXTURE_PATH = path.resolve(__dirname, "../tests/fixtures/aesopsFables.json");
+const STORY_FIXTURE = path.resolve(__dirname, "../tests/fixtures/aesopsFables.json");
+const META_FIXTURE = path.resolve(__dirname, "../tests/fixtures/aesopsMeta.json");
 
 /**
  * Ensure the language toggle swaps between English and pseudo-Japanese text.
@@ -11,7 +12,10 @@ const FIXTURE_PATH = path.resolve(__dirname, "../tests/fixtures/aesopsFables.jso
 test.describe("Pseudo-Japanese toggle", () => {
   test.beforeEach(async ({ page }) => {
     await page.route("**/src/data/aesopsFables.json", (route) =>
-      route.fulfill({ path: FIXTURE_PATH })
+      route.fulfill({ path: STORY_FIXTURE })
+    );
+    await page.route("**/src/data/aesopsMeta.json", (route) =>
+      route.fulfill({ path: META_FIXTURE })
     );
     await page.goto("/src/pages/meditation.html");
     await page.waitForSelector("#quote .quote-content");

--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -1,19 +1,21 @@
 /**
- * Fetches Aesop's Fables data from a JSON file.
+ * Fetches Aesop's Fables story and metadata from JSON files and merges them.
  *
  * @pseudocode
- * 1. Send a GET request to retrieve the `aesopsFables.json` file using the `fetch` API.
- *    - Specify the relative path to the JSON file.
- *    - Await the server's response.
+ * 1. Send GET requests to retrieve both `aesopsFables.json` and
+ *    `aesopsMeta.json` using the `fetch` API.
+ *    - Await both responses concurrently.
  *
- * 2. Verify the response status:
- *    - Check if `response.ok` is `true`.
- *    - If the response is not successful, throw an error with a descriptive message.
+ * 2. Verify the response status for each request:
+ *    - Check that `response.ok` is `true` for both files.
+ *    - If either response fails, throw an error with a descriptive message.
  *
- * 3. Parse the JSON response:
- *    - Convert the response body into a JavaScript object using `response.json()`.
+ * 3. Parse the JSON responses:
+ *    - Convert both response bodies into JavaScript objects using `response.json()`.
  *
- * 4. Return the parsed JSON data.
+ * 4. Merge the metadata with the corresponding story using the shared `id`.
+ *
+ * 5. Return the combined array of fables.
  *
  * @returns {Promise<Object[]>} A promise that resolves to an array of fables.
  * @throws {Error} If the fetch request fails or the response is not successful.
@@ -21,11 +23,19 @@
 import { DATA_DIR } from "./constants.js";
 
 async function fetchFables() {
-  const response = await fetch(`${DATA_DIR}aesopsFables.json`);
-  if (!response.ok) {
-    throw new Error("Failed to fetch aesopsFables.json");
+  const [storyRes, metaRes] = await Promise.all([
+    fetch(`${DATA_DIR}aesopsFables.json`),
+    fetch(`${DATA_DIR}aesopsMeta.json`)
+  ]);
+
+  if (!storyRes.ok || !metaRes.ok) {
+    throw new Error("Failed to fetch Aesop's fables data");
   }
-  return response.json();
+
+  const [stories, metadata] = await Promise.all([storyRes.json(), metaRes.json()]);
+
+  const metaMap = new Map(metadata.map((m) => [m.id, m]));
+  return stories.map((story) => ({ ...story, ...metaMap.get(story.id) }));
 }
 
 /**

--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -35,7 +35,7 @@ async function fetchFables() {
   const [stories, metadata] = await Promise.all([storyRes.json(), metaRes.json()]);
 
   const metaMap = new Map(metadata.map((m) => [m.id, m]));
-  return stories.map((story) => ({ ...story, ...metaMap.get(story.id) }));
+  return stories.map((story) => ({ ...story, ...(metaMap.get(story.id) || {}) }));
 }
 
 /**

--- a/tests/fixtures/aesopsFables.json
+++ b/tests/fixtures/aesopsFables.json
@@ -1,7 +1,6 @@
 [
   {
     "id": 1,
-    "title": "The Wind and the Sun",
     "story": "The Wind and the Sun once had a contest."
   }
 ]

--- a/tests/fixtures/aesopsMeta.json
+++ b/tests/fixtures/aesopsMeta.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": 1,
+    "title": "The Wind and the Sun",
+    "tags": ["strength"],
+    "readingTime": "1 minute",
+    "moral": "Gentleness and kindness can achieve what force cannot.",
+    "haiku": "Warm rays melt the chill\nStrength in calm, not stormy gusts\nCloak falls in still peace."
+  }
+]


### PR DESCRIPTION
## Summary
- combine Aesop quote data from two JSON files
- update Playwright spec and unit tests for new data structure
- reference both JSON files in meditation PRD
- add fixture for quote metadata

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6876698df7cc8326884aee5b541eedba