### PR TITLE
Add additional JSON schemas

### DIFF
--- a/src/schemas/aesopsFables.schema.json
+++ b/src/schemas/aesopsFables.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "integer",
+        "description": "Unique identifier for the fable."
+      },
+      "title": {
+        "type": "string",
+        "description": "The title of the fable."
+      },
+      "story": {
+        "type": "string",
+        "description": "The full text of the fable."
+      }
+    },
+    "required": ["id", "story"],
+    "additionalProperties": false
+  }
+}
+

--- a/src/schemas/japaneseConverter.schema.json
+++ b/src/schemas/japaneseConverter.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "letters": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": ["letters"],
+  "additionalProperties": false
+}
+

--- a/src/schemas/locations.schema.json
+++ b/src/schemas/locations.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "integer",
+        "description": "Unique identifier for the location."
+      },
+      "name": {
+        "type": "string",
+        "description": "Location name in English."
+      },
+      "japaneseName": {
+        "type": "string",
+        "description": "Location name in Japanese."
+      },
+      "description": {
+        "type": "string",
+        "description": "A brief description of the location."
+      },
+      "externalLink": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL with more information about the location."
+      },
+      "active": {
+        "type": "boolean",
+        "description": "Whether the location is currently active."
+      }
+    },
+    "required": ["id", "name", "japaneseName", "description", "externalLink", "active"],
+    "additionalProperties": false
+  }
+}
+

--- a/tests/data/schemaValidation.test.js
+++ b/tests/data/schemaValidation.test.js
@@ -14,7 +14,10 @@ const pairs = [
   ["gameModes.json", "gameModes.schema.json"],
   ["gokyo.json", "gokyo.schema.json"],
   ["judoka.json", "judoka.schema.json"],
-  ["weightCategories.json", "weightCategories.schema.json"]
+  ["weightCategories.json", "weightCategories.schema.json"],
+  ["aesopsFables.json", "aesopsFables.schema.json"],
+  ["japaneseConverter.json", "japaneseConverter.schema.json"],
+  ["locations.json", "locations.schema.json"]
 ];
 
 describe("data files conform to schemas", async () => {


### PR DESCRIPTION
## Summary
- add schemas for Aesop's fables, Japanese converter, and locations
- validate new data files in the schema validation tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run validate:data` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68766cb7ab4c8326a196d7c14de0c204