### PR TITLE
Fix name spacing on judoka cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/`
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -219,25 +218,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -250,6 +250,7 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 
 - First Name: Smaller, sentence case
 - Surname: Larger, uppercase, bold
+- Spacing: Minimal line height (≈1) to keep the two lines visually connected
 - Alignment: Stat block always bottom-aligned
 - Background: Dark blue (#0C3F7A)
 

--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -87,6 +87,7 @@ No player-configurable display or animation settings are included at this time. 
 Each card consists of elements stored in `judoka.json`:
 
 - Judoka Name (first + surname)
+- First and surname appear tightly spaced (line-height about 1) so there is breathing room above and below
 - Nationality (depicted via flag)
 - Weight class (one of the 14 official IJF classes: 7 male, 7 female)
 - Portrait of the judoka’s likeness

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -299,11 +299,15 @@ button .ripple {
   font-size: min(5vw, 1.1rem);
   font-weight: normal;
   display: block;
+  line-height: 1;
+  margin: 0;
 }
 
 .card-name .surname {
   font-size: min(6vw, 1.5rem);
   font-weight: bold;
+  line-height: 1;
+  margin: 0;
 }
 
 .card-flag {


### PR DESCRIPTION
## Summary
- tighten line spacing for card names so first and last name sit closer
- document name spacing guidance in the UI standards and PRD
- run Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68767a3ae5848326a81b0da79eeb97a9