### PR TITLE
Add schema IDs and stats ref

### DIFF
--- a/scripts/validateData.js
+++ b/scripts/validateData.js
@@ -17,10 +17,23 @@ for (const schemaPath of schemaFiles) {
     continue;
   }
   await new Promise((resolve) => {
-    const child = spawn("npx", ["ajv", "validate", "-s", schemaPath, "-d", dataPath], {
-      cwd: rootDir,
-      stdio: "inherit"
-    });
+    const child = spawn(
+      "npx",
+      [
+        "ajv",
+        "validate",
+        "-s",
+        schemaPath,
+        "-d",
+        dataPath,
+        "-r",
+        "src/schemas/commonDefinitions.schema.json"
+      ],
+      {
+        cwd: rootDir,
+        stdio: "inherit"
+      }
+    );
     child.on("exit", (code) => {
       if (code !== 0) {
         hasErrors = true;

--- a/src/schemas/aesopsFables.schema.json
+++ b/src/schemas/aesopsFables.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/aesopsFables.schema.json",
   "type": "array",
   "items": {
     "type": "object",

--- a/src/schemas/commonDefinitions.schema.json
+++ b/src/schemas/commonDefinitions.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://judokon.dev/schemas/commonDefinitions.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Stats": {
+      "type": "object",
+      "properties": {
+        "power": { "type": "integer" },
+        "speed": { "type": "integer" },
+        "technique": { "type": "integer" },
+        "kumikata": { "type": "integer" },
+        "newaza": { "type": "integer" }
+      },
+      "required": ["power", "speed", "technique", "kumikata", "newaza"]
+    }
+  }
+}

--- a/src/schemas/countryCodeMapping.schema.json
+++ b/src/schemas/countryCodeMapping.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/countryCodeMapping.schema.json",
   "type": "array",
   "items": {
     "type": "object",

--- a/src/schemas/gameModes.schema.json
+++ b/src/schemas/gameModes.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/gameModes.schema.json",
   "type": "array",
   "items": {
     "type": "object",

--- a/src/schemas/gokyo.schema.json
+++ b/src/schemas/gokyo.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/gokyo.schema.json",
   "title": "Gokyo Schema",
   "type": "array",
   "items": {

--- a/src/schemas/japaneseConverter.schema.json
+++ b/src/schemas/japaneseConverter.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/japaneseConverter.schema.json",
   "type": "object",
   "properties": {
     "letters": {

--- a/src/schemas/judoka.schema.json
+++ b/src/schemas/judoka.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/judoka.schema.json",
   "title": "Judoka",
   "type": "object",
   "properties": {
@@ -28,16 +29,8 @@
       "description": "Weight class of the judoka."
     },
     "stats": {
-      "type": "object",
-      "description": "Performance stats of the judoka.",
-      "properties": {
-        "power": { "type": "integer" },
-        "speed": { "type": "integer" },
-        "technique": { "type": "integer" },
-        "kumikata": { "type": "integer" },
-        "newaza": { "type": "integer" }
-      },
-      "required": ["power", "speed", "technique", "kumikata", "newaza"]
+      "$ref": "https://judokon.dev/schemas/commonDefinitions.schema.json#/definitions/Stats",
+      "description": "Performance stats of the judoka."
     },
     "signatureMoveId": {
       "type": "integer",

--- a/src/schemas/locations.schema.json
+++ b/src/schemas/locations.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/locations.schema.json",
   "type": "array",
   "items": {
     "type": "object",

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://judokon.dev/schemas/settings.schema.json",
     "type": "object",
     "properties": {
       "sound": {

--- a/src/schemas/weightCategories.schema.json
+++ b/src/schemas/weightCategories.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/weightCategories.schema.json",
   "type": "array",
   "items": {
     "type": "object",

--- a/tests/data/schemaValidation.test.js
+++ b/tests/data/schemaValidation.test.js
@@ -22,6 +22,10 @@ const pairs = [
 
 describe("data files conform to schemas", async () => {
   const ajv = await getAjv();
+  const commonDefs = JSON.parse(
+    await readFile(path.join(schemaDir, "commonDefinitions.schema.json"), "utf8")
+  );
+  ajv.addSchema(commonDefs);
   for (const [dataFile, schemaFile] of pairs) {
     it(`${dataFile} matches ${schemaFile}`, async () => {
       const data = JSON.parse(await readFile(path.join(dataDir, dataFile), "utf8"));


### PR DESCRIPTION
## Summary
- define reusable Stats object
- add `$id` to all schemas and reference Stats via `$ref`
- include common definitions in tests
- validate data with shared schema

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68767982975883268822d2ac428a5831