### PR TITLE
Fix browse Judoka layout on small screens

### DIFF
--- a/design/productRequirementsDocuments/prdBrowseJudoka.md
+++ b/design/productRequirementsDocuments/prdBrowseJudoka.md
@@ -171,6 +171,7 @@ Search will be included in a future update to keep the initial scope focused.
 - Messages: Area below markers for dynamic feedback such as “No cards available” or error messages.
 - Touch Targets: Cards and buttons sized ≥44px for accessibility compliance. See [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness) for full guidelines.
 - Responsive Adaptation: On mobile, 1–2 cards visible; on desktop, 3–5 cards visible.
+- On screens below 768px the filter bar stacks above the carousel to avoid card shrinkage.
 
 ---
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -40,6 +40,17 @@ body {
   width: 100%;
 }
 
+@media (max-width: 768px) {
+  .kodokan-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .kodokan-grid .filter-bar,
+  .kodokan-grid #carousel-container {
+    grid-column: 1;
+  }
+}
+
 /* .helper-container {
   grid-column: 1/1;
 } */


### PR DESCRIPTION
## Summary
- tweak `.kodokan-grid` for single-column layout on small screens
- ensure filter bar and carousel span full width when stacked
- document layout change in PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot regression for browseJudoka and randomJudoka)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687686b0e660832689ac27451b4cb3e5