### PR TITLE
Update carousel sizing

### DIFF
--- a/design/productRequirementsDocuments/prdCardCarousel.md
+++ b/design/productRequirementsDocuments/prdCardCarousel.md
@@ -106,7 +106,11 @@ Failure to provide an efficient browsing experience may impact core gameplay —
 
 The carousel is built by `buildCardCarousel` in `src/helpers/carouselBuilder.js`.
 Pages such as `src/pages/browseJudoka.html` call this helper and append the
-returned element to an empty container (e.g., `#carousel-container`).
+returned element to an empty container (e.g., `#carousel-container`). Carousel
+wrappers (the element returned by `buildCardCarousel`) **must not** apply
+padding that would change the width of the cards. Any extra spacing should be
+handled by the carousel's gap settings so that card sizing remains
+consistent.
 
 ---
 

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -17,6 +17,10 @@
 
 /* Card width within the carousel */
 .card-carousel .judoka-card {
+  /* Use clamp to set a responsive width for judoka cards:
+     - Minimum width: 200px ensures cards are not too small on very narrow screens.
+     - Preferred width: 40vw adapts to 40% of the viewport width for medium screens.
+     - Maximum width: 300px matches the fixed width defined on line 24 for larger screens. */
   flex: 0 0 clamp(200px, 40vw, 300px);
 }
 

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -11,9 +11,13 @@
   /* Safari flexbox quirk: set min-width to 0 so container doesn't expand */
   min-width: 0;
   max-width: 100%; /* Prevent overflow */
-  padding: var(--space-md); /* Add padding for visual spacing */
   flex: 1 1 auto;
   -webkit-overflow-scrolling: touch;
+}
+
+/* Card width within the carousel */
+.card-carousel .judoka-card {
+  flex: 0 0 clamp(200px, 40vw, 300px);
 }
 
 .judoka-card {
@@ -50,7 +54,6 @@
 
   .card-carousel {
     gap: var(--space-sm); /* Compact whitespace */
-    padding: var(--space-sm); /* Reduced padding on mobile */
   }
 }
 


### PR DESCRIPTION
## Summary
- remove padding from `.card-carousel`
- set `.card-carousel .judoka-card` width via `clamp(200px, 40vw, 300px)`
- document not adding padding in carousel wrappers

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot /src/pages/browseJudoka.html)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68768bfb86588326bc02d54677027366