### PR TITLE
Add integration notes on carousel padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
+
   - `game.js`
   - `helpers/`
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -218,20 +219,25 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
+
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
+
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
+
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
+
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
+
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -189,6 +189,13 @@ The design must be attractive and **minimize cognitive load**—presenting stats
 - **Portrait Priority:** On narrow devices, prioritize portrait and name placement; wrap stats below if needed.
 - **Text Scaling:** Allow dynamic font sizing to avoid clipping on smaller screens.
 
+## Integration Notes
+
+Carousels displaying judoka cards **must not** add horizontal padding around each
+card. Any spacing between cards should rely on the `gap` property defined in the
+[carousel CSS](../../src/styles/carousel.css). This ensures consistent card
+widths across screens and matches the rule introduced in the stylesheet.
+
 ---
 
 ## Tasks


### PR DESCRIPTION
## Summary
- document that carousels shouldn't pad individual cards
- format README with Prettier to satisfy repo checks

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diff)*

------
https://chatgpt.com/codex/tasks/task_e_68769259c1a48326bb9ab0413d04ab9d