### PR TITLE
Fix card stats alignment

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -384,7 +384,7 @@ button .ripple {
   display: flex;
   justify-content: space-between;
   width: 100%;
-  align-items: flex-end;
+  align-items: stretch;
   font-size: var(--font-medium);
   flex-direction: column;
   /* Stats area ~34% of card height accounting for padding */


### PR DESCRIPTION
## Summary
- ensure card stats area stretches across width

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68769bc330a483268ed91f60f29f3cf0