### PR TITLE
Fix judoka card layout gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/`
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -219,25 +218,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -185,7 +185,7 @@ button .ripple {
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-start;
   transition:
     box-shadow var(--transition-fast),
     transform 0.1s ease-in-out; /* Updated token */
@@ -388,8 +388,8 @@ button .ripple {
   font-size: var(--font-medium);
   flex-direction: column;
   /* Stats area ~34% of card height accounting for padding */
-  height: calc(34% - (var(--space-small) * 2));
-  flex: 0 0 calc(34% - (var(--space-small) * 2));
+  height: 34%;
+  flex: 0 0 34%;
 }
 
 .card-stats ul {


### PR DESCRIPTION
## Summary
- remove padding subtraction in `.card-stats`
- prevent flex spacing gaps by using `flex-start`
- format README with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6876a0ce09248326889b67e30d1a6d87