### PR TITLE
Adjust signature move layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
+
   - `game.js`
   - `helpers/`
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -218,20 +219,25 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
+
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
+
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
+
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
+
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
+
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -441,11 +441,11 @@ button .ripple {
   align-items: center;
   flex-direction: row;
   width: 100%;
-  /* Maintain ~10% (~45px) height while accounting for padding on children */
-  height: calc(max(12%, var(--touch-target-size)) - (var(--space-small) * 2));
+  /* Maintain ~10% (~45px) height as specified in the PRD */
+  height: max(10%, var(--touch-target-size));
   font-weight: bold;
   /* Ensure visible at small screen sizes */
-  flex: 0 0 calc(max(12%, var(--touch-target-size)) - (var(--space-small) * 2));
+  flex: 0 0 max(10%, var(--touch-target-size));
   box-sizing: border-box;
   border-top: 1px solid var(--color-text-inverted, var(--color-secondary));
 }
@@ -459,7 +459,6 @@ button .ripple {
   white-space: nowrap;
   padding: min(var(--space-sm), 2.3vw) var(--space-sm);
   font-size: min(14px, 4vw);
-  max-width: 150px;
   flex: 1 1 0;
   height: 100%;
   align-items: center;
@@ -469,7 +468,6 @@ button .ripple {
   background-color: var(--color-tertiary);
   color: var(--color-secondary);
   border: 1px solid var(--color-tertiary);
-  min-width: 90px;
 }
 
 .signature-move-value {


### PR DESCRIPTION
## Summary
- tweak `.signature-move-container` sizing
- let `.signature-move-label` and `.signature-move-value` flex without width limits
- format README with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch due to network)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_6876b043501c83268e02c2743e957215