### PR TITLE
Fix header overlap on battle page

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/`
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -219,25 +218,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 
@@ -298,7 +292,7 @@ Setting `width: 100%` on both `.kodokan-grid` and `.kodokan-screen`
 keeps the carousel from stretching beyond the viewport.
 Safari counts scrollbars in the `vw` unit, which can lead to unexpected layout behavior. For example, a wrapper with `min-width: 100vw` may become wider than the page and cause horizontal scrolling. To prevent this, set `width: 100%` on the body and navbars. Optionally, use `overflow-x: hidden` to ensure the layout stays within the viewport.
 Mobile Safari 18.5 may also add vertical scroll if fixed headers and footers use `vh` units. The navbar height CSS variables now use `dvh` to match the dynamic viewport height and avoid extra scrolling. Pages with fixed headers or footers should set container heights to `calc(100dvh - var(--header-height) - var(--footer-height))` (or equivalent) so content isn't hidden when the viewport shrinks. The `.home-screen` container implements this rule.
-The settings screen previously had its first controls hidden behind the header; wrapping the page in this `.home-screen` container resolves the issue.
+The settings screen previously had its first controls hidden behind the header; wrapping the page in this `.home-screen` container resolves the issue. The classic battle page now also uses this wrapper so the judoka cards appear fully below the header.
 
 ## Future Plans
 

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -27,57 +27,59 @@
   </head>
 
   <body>
-    <header class="header">
-      <div class="character-slot left"></div>
-      <div class="logo-container">
-        <a href="../../index.html" data-testid="home-link">
-          <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
-        </a>
-      </div>
-      <div class="character-slot right"></div>
-    </header>
-
-    <main class="container" role="main">
-      <section id="battle-area">
-        <div id="player-card" class="card-slot"></div>
-        <div id="computer-card" class="card-slot"></div>
-
-        <div id="controls">
-          <p id="timer">Time: <span id="round-timer"></span></p>
-          <p id="score-display">You: 0 Computer: 0</p>
-
-          <div id="stat-buttons">
-            <button data-stat="power" type="button">Power</button>
-            <button data-stat="speed" type="button">Speed</button>
-            <button data-stat="technique" type="button">Technique</button>
-            <button data-stat="kumikata" type="button">Kumi-kata</button>
-            <button data-stat="newaza" type="button">Ne-waza</button>
-          </div>
-
-          <p id="round-result" aria-live="polite"></p>
-          <button id="quit-btn" type="button">Quit Match</button>
+    <div class="home-screen">
+      <header class="header">
+        <div class="character-slot left"></div>
+        <div class="logo-container">
+          <a href="../../index.html" data-testid="home-link">
+            <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
+          </a>
         </div>
-      </section>
-    </main>
+        <div class="character-slot right"></div>
+      </header>
 
-    <footer>
-      <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
-    </footer>
-    <script type="module" src="../helpers/setupBottomNavbar.js"></script>
-    <script type="module" src="../helpers/setupDisplaySettings.js"></script>
+      <main class="container" role="main">
+        <section id="battle-area">
+          <div id="player-card" class="card-slot"></div>
+          <div id="computer-card" class="card-slot"></div>
 
-    <noscript>
-      <p class="noscript-warning">
-        JU-DO-KON! requires JavaScript to run. Please enable JavaScript to play.
-      </p>
-    </noscript>
+          <div id="controls">
+            <p id="timer">Time: <span id="round-timer"></span></p>
+            <p id="score-display">You: 0 Computer: 0</p>
 
-    <script nomodule>
-      alert(
-        "Your browser does not support modern JavaScript. Please update your browser to play JU-DO-KON!"
-      );
-    </script>
-    <script type="module" src="../helpers/setupSvgFallback.js"></script>
-    <script type="module" src="../helpers/battleJudokaPage.js"></script>
+            <div id="stat-buttons">
+              <button data-stat="power" type="button">Power</button>
+              <button data-stat="speed" type="button">Speed</button>
+              <button data-stat="technique" type="button">Technique</button>
+              <button data-stat="kumikata" type="button">Kumi-kata</button>
+              <button data-stat="newaza" type="button">Ne-waza</button>
+            </div>
+
+            <p id="round-result" aria-live="polite"></p>
+            <button id="quit-btn" type="button">Quit Match</button>
+          </div>
+        </section>
+      </main>
+
+      <footer>
+        <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
+      </footer>
+      <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+      <script type="module" src="../helpers/setupDisplaySettings.js"></script>
+
+      <noscript>
+        <p class="noscript-warning">
+          JU-DO-KON! requires JavaScript to run. Please enable JavaScript to play.
+        </p>
+      </noscript>
+
+      <script nomodule>
+        alert(
+          "Your browser does not support modern JavaScript. Please update your browser to play JU-DO-KON!"
+        );
+      </script>
+      <script type="module" src="../helpers/setupSvgFallback.js"></script>
+      <script type="module" src="../helpers/battleJudokaPage.js"></script>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap battleJudoka page in `.home-screen` to avoid header overlap
- document the fix in README

## Testing
- `npx prettier src/pages/battleJudoka.html README.md --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: network access disabled during package install)*
- `npx playwright test` *(fails: 403 Forbidden fetching Playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6876b6ed9de48326a0fd005ba1644abd