### PR TITLE
Fix card stats padding

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -380,7 +380,7 @@ button .ripple {
 .card-stats {
   background-color: var(--card-stats-bg, var(--color-secondary));
   color: var(--color-text-inverted);
-  padding: 0, var(--space-small);
+  padding: 0 var(--space-small);
   margin: 0;
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- ensure `.card-stats` uses `padding: 0 var(--space-small)`

## Testing
- `npx prettier src/styles/components.css --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6876bd22846c8326b0efbea83f4e00aa