### PR TITLE
Center signature move text

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
+
   - `game.js`
   - `helpers/`
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -219,20 +220,25 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
+
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
+
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
+
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
+
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
+
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -262,6 +262,7 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
   maintain a 44px tap target without breaking the 2:3 ratio
 - Label and value share the same padding and font size so the band height
   remains consistent. Both corners are square (no border radius).
+- Label and value should use `line-height: 1` to keep the text vertically centered.
 
 #### Rarity Markers
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -462,6 +462,7 @@ button .ripple {
   flex: 1 1 0;
   height: 100%;
   align-items: center;
+  line-height: 1;
 }
 
 .signature-move-label {


### PR DESCRIPTION
## Summary
- set `line-height` for signature move label and value
- document `line-height` rule for signature move band in UIDesign standards
- run formatters and tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diffs for browseJudoka.html and randomJudoka.html)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6876c83c86848326910de13a15d480b2