### PR TITLE
Add image carousel to mockup viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   - `pages/`
     HTML pages. Each page imports a matching module from
     `src/helpers` (for example `randomJudokaPage.js`) that wires up its
-    interactive behavior.
+    interactive behavior. The directory also contains
+    `mockupViewer.html`, a simple carousel for browsing the image files
+    under `design/mockups/`.
   - `data/`
   - `schemas/`
     JSON Schema definitions used to validate the data files.
@@ -199,6 +201,7 @@ The repository specifies commenting standards in design/codeStandards. JSDoc com
   `aria-label` descriptions
 - Country picker panel appears below the fixed header for unobstructed viewing
 - Scroll buttons disable when the carousel reaches either end
+- Mockup viewer page with next/back controls for design screenshots
 
 ## About JU-DO-KON!
 

--- a/src/helpers/mockupViewerPage.js
+++ b/src/helpers/mockupViewerPage.js
@@ -1,0 +1,86 @@
+import { setupButtonEffects } from "./buttonEffects.js";
+import { onDomReady } from "./domReady.js";
+
+/**
+ * Initialize the mockup image carousel.
+ *
+ * @pseudocode
+ * 1. Select the image and navigation buttons.
+ * 2. Define an array of mockup filenames and compute their base URL.
+ * 3. Implement `showImage(index)` to update the image source and alt text.
+ * 4. Attach click handlers to cycle forward or backward with wraparound.
+ * 5. Support arrow key navigation for accessibility.
+ * 6. Show the first image and apply button ripple effects.
+ */
+export function setupMockupViewerPage() {
+  const imgEl = document.getElementById("mockup-image");
+  const prevBtn = document.getElementById("prev-btn");
+  const nextBtn = document.getElementById("next-btn");
+
+  if (!imgEl || !prevBtn || !nextBtn) {
+    return;
+  }
+
+  const basePath = new URL("../../design/mockups/", import.meta.url).href;
+
+  const files = [
+    "mockupBattleInfoBar1.png",
+    "mockupBattleInfoBar2.png",
+    "mockupBattleScreen1.jpg",
+    "mockupBattleScreen2.png",
+    "mockupBottomNavigation2.png",
+    "mockupButtonTypes1.jpeg",
+    "mockupCardCarousel1.png",
+    "mockupCardCarousel2.png",
+    "mockupCardCarousel3.png",
+    "mockupCardCode1.png",
+    "mockupCardCode2.png",
+    "mockupCountryPicker1.png",
+    "mockupCountryPicker2.png",
+    "mockupDrawCard1.png",
+    "mockupDrawCard2.png",
+    "mockupGameModes1.png",
+    "mockupGameModes2.png",
+    "mockupGameModes3.png",
+    "mockupGameModes4.png",
+    "mockupGameSettings1.png",
+    "mockupGameSettings2.png",
+    "mockupGameSettings3.png",
+    "mockupMapNavigation1.png",
+    "mockupMapNavigation2.png",
+    "mockupMapNavigation3.png",
+    "mockupNavigationMap1.png",
+    "mockupNavigationMap2.png",
+    "mockupNavigationMap3.png",
+    "mockupQuoteScreen.png",
+    "mockupQuoteScreen1.png",
+    "mockupQuoteScreen2.png",
+    "mockupQuoteScreen3.png",
+    "mockupQuoteScreen4.png",
+    "mockupUpdateJudoka1.png"
+  ];
+
+  let currentIndex = 0;
+
+  function showImage(index) {
+    currentIndex = (index + files.length) % files.length;
+    const file = files[currentIndex];
+    imgEl.src = `${basePath}${file}`;
+    imgEl.alt = file;
+    imgEl.classList.add("fade");
+    imgEl.style.display = "block";
+  }
+
+  prevBtn.addEventListener("click", () => showImage(currentIndex - 1));
+  nextBtn.addEventListener("click", () => showImage(currentIndex + 1));
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "ArrowLeft") showImage(currentIndex - 1);
+    if (e.key === "ArrowRight") showImage(currentIndex + 1);
+  });
+
+  showImage(0);
+  setupButtonEffects();
+}
+
+onDomReady(setupMockupViewerPage);

--- a/src/pages/mockupViewer.html
+++ b/src/pages/mockupViewer.html
@@ -3,96 +3,53 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Ju-Do-Kon! Menu Wireframe</title>
+    <meta name="keywords" content="judo, card game, web game, judoka" />
+    <meta name="author" content="Marc Scheimann" />
+    <meta name="description" content="JU-DO-KON! design mockup viewer" />
+    <meta property="og:title" content="JU-DO-KON!" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://cyanautomation.github.io/judokon/" />
+    <meta property="og:description" content="JU-DO-KON! design mockup viewer" />
+    <meta name="theme-color" content="#ffffff" />
+    <title>Ju-Do-Kon! Mockups</title>
     <link rel="stylesheet" href="../styles/fonts.css" />
-    <style>
-      body {
-        font-family: sans-serif;
-        background: #f5f5f5;
-        margin: 0;
-        padding: 2rem;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-      }
-
-      header {
-        text-align: center;
-        margin-bottom: 2rem;
-      }
-
-      .logo {
-        font-size: 2.5rem;
-        font-weight: bold;
-      }
-
-      .grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 1rem;
-        max-width: 1000px;
-        width: 100%;
-        margin-bottom: 2rem;
-      }
-
-      .tile {
-        background: #fff;
-        border: 2px solid #ccc;
-        border-radius: 12px;
-        padding: 1.5rem;
-        text-align: center;
-        font-size: 1rem;
-        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-        cursor: pointer;
-        transition: transform 0.15s ease-in-out;
-      }
-
-      .tile:hover {
-        transform: scale(1.05);
-      }
-
-      .tile.red {
-        background: #e94f37;
-        color: white;
-      }
-      .tile.teal {
-        background: #2cb1bc;
-        color: white;
-      }
-      .tile.blue {
-        background: #3c7dc4;
-        color: white;
-      }
-      .tile.purple {
-        background: #6a4bc9;
-        color: white;
-      }
-      .tile.gold {
-        background: #efaf1b;
-        color: white;
-      }
-
-      .card-of-the-day {
-        background: white;
-        border: 2px dashed #aaa;
-        padding: 1.5rem;
-        border-radius: 12px;
-        text-align: center;
-      }
-    </style>
+    <link rel="stylesheet" href="../styles/base.css" />
+    <link rel="stylesheet" href="../styles/layout.css" />
+    <link rel="stylesheet" href="../styles/components.css" />
+    <link rel="stylesheet" href="../styles/mockupViewer.css" />
+    <link rel="stylesheet" href="../styles/utilities.css" />
+    <link rel="icon" type="image/png" href="../assets/images/favicon.ico" />
   </head>
   <body>
-    <header>
-      <div class="logo">JU-DO-KON!</div>
-      <div style="font-size: 1.25rem; margin-top: 0.5rem">Choose Your Path</div>
-    </header>
-
-    <section class="grid">
-      <div class="tile red">🔥 Classic Battle</div>
-      <div class="tile purple">👥 Team Battle</div>
-      <div class="tile teal">✏️ Create Judoka</div>
-      <div class="tile gold">🧘 Meditation Mode</div>
-      <div class="tile blue" style="grid-column: span 2">📚 Browse Judoka</div>
-    </section>
+    <div class="home-screen">
+      <header class="header">
+        <div class="character-slot left"></div>
+        <div class="logo-container">
+          <a href="../../index.html" data-testid="home-link">
+            <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
+          </a>
+        </div>
+        <div class="character-slot right"></div>
+      </header>
+      <main class="kodokan-grid" role="main">
+        <div class="slideshow-container">
+          <img id="mockup-image" class="mockup-image" src="" alt="mockup" />
+          <button class="prev" id="prev-btn" aria-label="Previous image">&#10094;</button>
+          <button class="next" id="next-btn" aria-label="Next image">&#10095;</button>
+        </div>
+      </main>
+      <footer>
+        <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
+      </footer>
+      <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+      <script type="module" src="../helpers/setupDisplaySettings.js"></script>
+      <script type="module" src="../helpers/mockupViewerPage.js"></script>
+      <script type="module" src="../helpers/setupSvgFallback.js"></script>
+      <noscript>
+        <p class="noscript-warning">
+          JU-DO-KON! requires JavaScript to run. Please enable JavaScript to view mockups.
+        </p>
+      </noscript>
+    </div>
   </body>
 </html>

--- a/src/styles/mockupViewer.css
+++ b/src/styles/mockupViewer.css
@@ -1,0 +1,89 @@
+* {
+  box-sizing: border-box;
+}
+
+.slideshow-container {
+  max-width: 1000px;
+  position: relative;
+  margin: auto;
+}
+
+.mockup-image {
+  display: none;
+  width: 100%;
+  height: auto;
+}
+
+.prev,
+.next {
+  cursor: pointer;
+  position: absolute;
+  top: 50%;
+  width: auto;
+  margin-top: -22px;
+  padding: var(--space-md);
+  color: var(--color-text-inverted);
+  font-weight: bold;
+  font-size: 18px;
+  transition: 0.6s ease;
+  border-radius: 0 3px 3px 0;
+  user-select: none;
+}
+
+.next {
+  right: 0;
+  border-radius: 3px 0 0 3px;
+}
+
+.prev:hover,
+.next:hover {
+  background-color: rgba(0, 0, 0, 0.8);
+}
+
+.text {
+  color: var(--color-text-inverted);
+  font-size: 15px;
+  padding: 8px 12px;
+  position: absolute;
+  bottom: 8px;
+  width: 100%;
+  text-align: center;
+}
+
+.numbertext {
+  color: var(--color-text-inverted);
+  font-size: 12px;
+  padding: 8px 12px;
+  position: absolute;
+  top: 0;
+}
+
+.dot {
+  cursor: pointer;
+  height: 15px;
+  width: 15px;
+  margin: 0 2px;
+  background-color: #bbb;
+  border-radius: 50%;
+  display: inline-block;
+  transition: background-color 0.6s ease;
+}
+
+.active,
+.dot:hover {
+  background-color: #717171;
+}
+
+.fade {
+  animation-name: fade;
+  animation-duration: 1.5s;
+}
+
+@keyframes fade {
+  from {
+    opacity: 0.4;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- implement mockup image carousel
- add styles for carousel
- wire up viewer page with new script
- document mockup viewer in README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6876ca6710c483268b4f4ab17d6b32c1