### PR TITLE
Fix signature move vertical alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,3 +318,8 @@ Please format your code with **Prettier**, lint it with **ESLint**, run **Vitest
 ### 2025-07-15
 
 - Adjust signature move band height to `max(10%, var(--touch-target-size))` for consistent sizing across screens.
+
+### 2025-07-16
+
+- Ensure text within the signature-move band is vertically centered by adding
+  `box-sizing: border-box` to the `.signature-move-label` and `.signature-move-value` rules.

--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -172,7 +172,9 @@ The design must be attractive and **minimize cognitive load**—presenting stats
 - **Stats Padding & Typography:**
   - Horizontal padding should be minimal (use `var(--space-small)`).
   - Stats text uses `--font-medium` and line-height `1.2` to remain legible without increasing panel height.
-- **Signature Move Band:** `height: max(10%, var(--touch-target-size))` keeps the 44px tap target while maintaining the card's 2:3 ratio.
+- **Signature Move Band:** `height: max(10%, var(--touch-target-size))` keeps the
+  44px tap target while maintaining the card's 2:3 ratio. Text inside the band
+  must remain vertically centered.
 - **Padding Adjustments:** Section heights use `calc()` to subtract vertical padding so the total fits within the card's 2:3 ratio.
 - **Rarity Border Colors:**
   - Common → Blue (#337AFF)

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -457,6 +457,7 @@ button .ripple {
   justify-content: center;
   border-radius: 0;
   white-space: nowrap;
+  box-sizing: border-box;
   padding: min(var(--space-sm), 2.3vw) var(--space-sm);
   font-size: min(14px, 4vw);
   flex: 1 1 0;


### PR DESCRIPTION
## Summary
- center text vertically in the signature-move band
- document vertical centering requirement in PRD
- record change in the changelog

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 2 screenshot differences)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6876cc6427e48326a3f08dbda3a5796a