### PR TITLE
Implement lazy portrait loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
 - `src/` – contains the game logic and assets:
 
   - `game.js`
-  - `helpers/`
+  - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
 
     ```javascript
@@ -130,6 +130,14 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
     ```
 
     Call `open()` on a user action and focus stays trapped until `close()` runs.
+
+    `lazyPortrait.js` enables IntersectionObserver-based image loading.
+
+    ```javascript
+    import { setupLazyPortraits } from "./src/helpers/lazyPortrait.js";
+    // Run after cards are inserted into the DOM
+    setupLazyPortraits();
+    ```
 
   - `pages/`
     HTML pages. Each page imports a matching module from

--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -70,6 +70,7 @@ Players currently lack a tangible sense of progression and connection to elite j
 - Portrait images should use optimized formats (e.g., WebP) to balance quality and performance.
 - Card slide/reveal animations must use hardware-accelerated CSS transforms for smooth performance (**≥60 fps**).
 - Placeholder assets for missing portraits/flags should be bundled with the client for offline scenarios.
+- Cards initially display `judokaPortrait-1.png` and lazy-load the real portrait when the card enters the viewport.
 - All judoka portraits and card sizing calculations must consistently maintain a **2:3 aspect ratio** to ensure visual uniformity and avoid layout shifts. Portraits should be pre-cropped as needed, and `.card-portrait` uses `object-fit: cover` to handle similarly shaped images. Card sizing calculations must account for screen aspect ratios and resolutions to preserve this ratio.
 - Hover and focus scaling must stay at or below **1.05x** to prevent cards from
   being clipped inside scroll wrappers.

--- a/src/helpers/cardRender.js
+++ b/src/helpers/cardRender.js
@@ -18,9 +18,10 @@ import { createStatsPanel } from "../components/StatsPanel.js";
  * 3. Construct the portrait HTML:
  *    - Create a `<div>` element with the class `card-portrait`.
  *    - Add an `<img>` element:
- *      a. Set the `src` attribute to the portrait URL based on `id`.
- *      b. Set the `alt` attribute to include the escaped name.
- *      c. Add an `onerror` handler to fallback to the placeholder portrait (PLACEHOLDER_ID) if the image fails to load.
+ *      a. Set the `src` attribute to a generic placeholder portrait (id=1).
+ *      b. Store the real portrait URL in a `data-portrait-src` attribute.
+ *      c. Set the `alt` attribute to include the escaped name.
+ *      d. Add an `onerror` handler to fallback to the placeholder portrait (PLACEHOLDER_ID) if the image fails to load.
  *
  * 4. Return the constructed HTML string.
  *
@@ -44,9 +45,10 @@ export function generateCardPortrait(card) {
   const { id, firstname, surname } = card;
   const escapedFirstname = escapeHTML(firstname);
   const escapedSurname = escapeHTML(surname);
+  const realSrc = `../assets/judokaPortraits/judokaPortrait-${id}.png`;
   return `
     <div class="card-portrait">
-      <img src="../assets/judokaPortraits/judokaPortrait-${id}.png" alt="${escapedFirstname} ${escapedSurname}" loading="lazy" onerror="this.onerror=null; this.src='../assets/judokaPortraits/judokaPortrait-${PLACEHOLDER_ID}.png'">
+      <img src="../assets/judokaPortraits/judokaPortrait-1.png" data-portrait-src="${realSrc}" alt="${escapedFirstname} ${escapedSurname}" loading="lazy" onerror="this.onerror=null; this.src='../assets/judokaPortraits/judokaPortrait-${PLACEHOLDER_ID}.png'">
     </div>
   `;
 }

--- a/src/helpers/lazyPortrait.js
+++ b/src/helpers/lazyPortrait.js
@@ -1,0 +1,39 @@
+/**
+ * Lazily swap judoka portrait placeholders with the real image.
+ *
+ * @pseudocode
+ * 1. Define an IntersectionObserver callback:
+ *      - For each entry that is intersecting,
+ *        a. Read `data-portrait-src` from the `<img>` element.
+ *        b. Replace the `src` attribute with that value.
+ *        c. Remove `data-portrait-src` and unobserve the element.
+ * 2. Export `setupLazyPortraits` which:
+ *      - Queries all `<img>` elements with `data-portrait-src` within the provided root (default `document`).
+ *      - Creates the observer and starts observing each image.
+ *
+ * @param {ParentNode} [root=document] - Root element containing card images.
+ */
+export function setupLazyPortraits(root = document) {
+  const images = root.querySelectorAll("img[data-portrait-src]");
+  if (!images.length) return;
+
+  const onIntersect = (entries, observer) => {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        const img = entry.target;
+        const realSrc = img.getAttribute("data-portrait-src");
+        if (realSrc) {
+          img.src = realSrc;
+          img.removeAttribute("data-portrait-src");
+        }
+        observer.unobserve(img);
+      }
+    }
+  };
+
+  const observer = new IntersectionObserver(onIntersect, {
+    rootMargin: "0px 0px 50px 0px"
+  });
+
+  images.forEach((img) => observer.observe(img));
+}

--- a/tests/card/cardBuilder.test.js
+++ b/tests/card/cardBuilder.test.js
@@ -161,4 +161,11 @@ describe("generateCardPortrait", () => {
     const result = generateCardPortrait(card);
     expect(result).toContain('alt="Jane Smith"');
   });
+
+  it("uses placeholder src and stores real portrait in data attribute", () => {
+    const card = { id: 5, firstname: "Joe", surname: "Bloggs" };
+    const result = generateCardPortrait(card);
+    expect(result).toContain('src="../assets/judokaPortraits/judokaPortrait-1.png"');
+    expect(result).toContain('data-portrait-src="../assets/judokaPortraits/judokaPortrait-5.png"');
+  });
 });


### PR DESCRIPTION
## Summary
- show placeholder art in `generateCardPortrait` and keep the real URL in `data-portrait-src`
- add `lazyPortrait.js` IntersectionObserver helper
- test new placeholder behaviour
- document lazy loading in PRD and README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diff)*

------
https://chatgpt.com/codex/tasks/task_e_6876cf428aec832691ee616298939180