### PR TITLE
Adjust random card layout spacing

### DIFF
--- a/design/productRequirementsDocuments/prdRandomJudoka.md
+++ b/design/productRequirementsDocuments/prdRandomJudoka.md
@@ -122,6 +122,7 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 - **Mobile (<600px)**: card fills ~70% of viewport; draw button spans nearly full width.
 - **Tablet/Desktop (>600px)**: card ~40% of viewport; centered draw button with spacing.
 - **Landscape Support**: components reposition vertically or side-by-side.
+- Card container uses `min-height: 50vh` to keep the Draw button visible on small screens.
 
 #### Audio Feedback (Optional Enhancement)
 

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -69,4 +69,12 @@ test.describe("View Judoka screen", () => {
     expect(styles.bg).toBe(hexToRgb(vars.bg));
     expect(styles.color).toBe(hexToRgb(vars.color));
   });
+
+  test("draw button remains within viewport", async ({ page }) => {
+    const { bottom, innerHeight } = await page.evaluate(() => {
+      const rect = document.querySelector('[data-testid="draw-button"]').getBoundingClientRect();
+      return { bottom: rect.bottom, innerHeight: window.innerHeight };
+    });
+    expect(bottom).toBeLessThanOrEqual(innerHeight);
+  });
 });

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -170,8 +170,8 @@ button .ripple {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: var(--space-lg); /* Updated token */
-  min-height: 500px;
+  padding: var(--space-lg) var(--space-lg) 0; /* 24px bottom gap handled by button */
+  min-height: 50vh;
 }
 
 .judoka-card {


### PR DESCRIPTION
## Summary
- make `.card-container` responsive using viewport units
- document use of `min-height: 50vh` in PRD
- verify the draw button stays in view with Playwright

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot spec)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68775b8a1be48326a5e57643f2d52f54