### PR TITLE
Fix grid height fallback on homepage

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -89,6 +89,7 @@ body {
   gap: var(--space-lg); /* Updated token */
   padding: 0 var(--space-xl); /* Updated token */
   flex: 1 1 auto;
+  height: calc(100vh - var(--header-height) - var(--footer-height));
   height: calc(100dvh - var(--header-height) - var(--footer-height));
 }
 


### PR DESCRIPTION
## Summary
- add `vh` fallback before the `dvh` rule in `.game-mode-grid`
- verified `.kodokan-screen` and `.mockup-image` rules don't need updates

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68776a8f6e7c8326ad0f58083b4467fd