### PR TITLE
Fix iOS safe area overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ keeps the carousel from stretching beyond the viewport.
 Safari counts scrollbars in the `vw` unit, which can lead to unexpected layout behavior. For example, a wrapper with `min-width: 100vw` may become wider than the page and cause horizontal scrolling. To prevent this, set `width: 100%` on the body and navbars. Optionally, use `overflow-x: hidden` to ensure the layout stays within the viewport.
 Mobile Safari 18.5 may also add vertical scroll if fixed headers and footers use `vh` units. The navbar height CSS variables now use `dvh` to match the dynamic viewport height and avoid extra scrolling. Pages with fixed headers or footers should set container heights to `calc(100dvh - var(--header-height) - var(--footer-height))` (or equivalent) so content isn't hidden when the viewport shrinks. The `.home-screen` container implements this rule.
 
+The bottom navbar uses `env(safe-area-inset-bottom)` with a `constant()` fallback to add extra padding and height. This prevents it from overlapping the iOS home indicator and keeps content visible.
+
 Layout containers should include a `vh` fallback declared before the `dvh` rule so browsers without dynamic viewport support still size elements correctly.
 The settings screen previously had its first controls hidden behind the header; wrapping the page in this `.home-screen` container resolves the issue. The classic battle page now also uses this wrapper so the judoka cards appear fully below the header.
 

--- a/src/styles/bottom-navbar.css
+++ b/src/styles/bottom-navbar.css
@@ -4,6 +4,11 @@
   left: 0;
   z-index: 100;
   min-height: max(var(--footer-height), 12px);
+  /* Extra space for iOS home indicator */
+  padding-bottom: constant(safe-area-inset-bottom);
+  padding-bottom: env(safe-area-inset-bottom);
+  height: calc(var(--footer-height) + constant(safe-area-inset-bottom));
+  height: calc(var(--footer-height) + env(safe-area-inset-bottom));
   display: inline-flex;
   background-color: var(--color-secondary); /* Buttons, highlights */
   text-align: center;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -16,7 +16,7 @@ body {
   min-height: 100vh;
   min-height: calc(100dvh - var(--header-height) - var(--footer-height));
   padding-top: var(--header-height);
-  padding-bottom: var(--footer-height);
+  padding-bottom: calc(var(--footer-height) + env(safe-area-inset-bottom));
   max-width: 100%;
   align-items: center;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- pad the bottom navbar for the safe area inset and adjust its height
- ensure `.home-screen` has extra padding for the safe-area
- document the safe-area inset handling in Browser Compatibility

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6877922bef348326916b17e74be55737