### PR TITLE
Add layout overlap tests

### DIFF
--- a/playwright/homepage-layout.spec.js
+++ b/playwright/homepage-layout.spec.js
@@ -7,6 +7,7 @@ test.describe("Homepage layout", () => {
     test.beforeEach(async ({ page }) => {
       await page.goto("/index.html");
       await page.waitForSelector(".game-mode-grid");
+      await page.waitForSelector("footer .bottom-navbar a");
     });
 
     test("grid has two columns", async ({ page }) => {
@@ -15,6 +16,20 @@ test.describe("Homepage layout", () => {
         return style.gridTemplateColumns.split(/\s+/).filter(Boolean).length;
       });
       expect(columnCount).toBe(2);
+    });
+
+    test("grid does not overlap footer", async ({ page }, testInfo) => {
+      const gridBox = await page.locator(".game-mode-grid").boundingBox();
+      const navBox = await page.locator(".bottom-navbar").boundingBox();
+
+      expect(gridBox).not.toBeNull();
+      expect(navBox).not.toBeNull();
+      expect(gridBox.y + gridBox.height).toBeLessThanOrEqual(navBox.y);
+
+      await page.screenshot({
+        path: testInfo.outputPath("desktop-layout.png"),
+        fullPage: true
+      });
     });
   });
 
@@ -28,6 +43,23 @@ test.describe("Homepage layout", () => {
         return style.gridTemplateColumns.split(/\s+/).filter(Boolean).length;
       });
       expect(columnCount).toBe(1);
+    });
+
+    test("grid does not overlap footer", async ({ page }, testInfo) => {
+      await page.goto("/index.html");
+      await page.waitForSelector("footer .bottom-navbar a");
+
+      const gridBox = await page.locator(".game-mode-grid").boundingBox();
+      const navBox = await page.locator(".bottom-navbar").boundingBox();
+
+      expect(gridBox).not.toBeNull();
+      expect(navBox).not.toBeNull();
+      expect(gridBox.y + gridBox.height).toBeLessThanOrEqual(navBox.y);
+
+      await page.screenshot({
+        path: testInfo.outputPath("mobile-layout.png"),
+        fullPage: true
+      });
     });
   });
 });

--- a/src/styles/bottom-navbar.css
+++ b/src/styles/bottom-navbar.css
@@ -3,7 +3,8 @@
   bottom: 0;
   left: 0;
   z-index: 100;
-  min-height: max(var(--footer-height), 12px);
+  height: var(--footer-height);
+  min-height: var(--footer-height);
   display: inline-flex;
   background-color: var(--color-secondary); /* Buttons, highlights */
   text-align: center;


### PR DESCRIPTION
## Summary
- ensure `.bottom-navbar` has consistent height
- add layout overlap checks for desktop and mobile

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6877922e7df483268ef9ee7bf09e8f66