### PR TITLE
Fix signature move alignment

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -448,6 +448,7 @@ button .ripple {
   flex: 0 0 max(10%, var(--touch-target-size));
   box-sizing: border-box;
   border-top: 1px solid var(--color-text-inverted, var(--color-secondary));
+  margin-top: auto;
 }
 
 .signature-move-label,


### PR DESCRIPTION
## Summary
- keep signature move container pinned to bottom of card

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package)*
- `npx vitest run` *(fails: 403 Forbidden)*
- `npx playwright test` *(fails: 403 Forbidden)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6877d51d6b988326baf99b90abdeee90