### PR TITLE
Fix portrait lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -131,13 +130,10 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
 
     Call `open()` on a user action and focus stays trapped until `close()` runs.
 
-    `lazyPortrait.js` enables IntersectionObserver-based image loading.
-
-    ```javascript
-    import { setupLazyPortraits } from "./src/helpers/lazyPortrait.js";
-    // Run after cards are inserted into the DOM
-    setupLazyPortraits();
-    ```
+    `lazyPortrait.js` enables IntersectionObserver-based image loading. The
+    `renderJudokaCard` helper automatically calls `setupLazyPortraits()` so
+    portraits swap in when the card enters view. Import and call it manually only
+    if you build card markup yourself.
 
   - `pages/`
     HTML pages. Each page imports a matching module from
@@ -239,25 +235,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -71,6 +71,8 @@ Players currently lack a tangible sense of progression and connection to elite j
 - Card slide/reveal animations must use hardware-accelerated CSS transforms for smooth performance (**≥60 fps**).
 - Placeholder assets for missing portraits/flags should be bundled with the client for offline scenarios.
 - Cards initially display `judokaPortrait-1.png` and lazy-load the real portrait when the card enters the viewport.
+- The `renderJudokaCard` helper runs `setupLazyPortraits()` automatically so the
+  real portrait loads as soon as the card is visible.
 - All judoka portraits and card sizing calculations must consistently maintain a **2:3 aspect ratio** to ensure visual uniformity and avoid layout shifts. Portraits should be pre-cropped as needed, and `.card-portrait` uses `object-fit: cover` to handle similarly shaped images. Card sizing calculations must account for screen aspect ratios and resolutions to preserve this ratio.
 - Hover and focus scaling must stay at or below **1.05x** to prevent cards from
   being clipped inside scroll wrappers.

--- a/src/helpers/cardUtils.js
+++ b/src/helpers/cardUtils.js
@@ -1,6 +1,7 @@
 import { generateJudokaCardHTML } from "./cardBuilder.js";
 import { debugLog } from "./debug.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
+import { setupLazyPortraits } from "./lazyPortrait.js";
 
 /**
  * Selects a random judoka from the provided data array.
@@ -129,6 +130,7 @@ export async function renderJudokaCard(judoka, gokyoLookup, container, { animate
     if (!card) return null;
     container.innerHTML = "";
     container.appendChild(card);
+    setupLazyPortraits(card);
     if (animate) {
       requestAnimationFrame(() => {
         card.classList.add("animate-card");


### PR DESCRIPTION
## Summary
- trigger lazy image swapping inside `renderJudokaCard`
- clarify automatic portrait loading in README
- note lazy-loading helper in judoka card PRD

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden when fetching vitest)*
- `npx playwright test` *(fails: 403 Forbidden when fetching playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6877d5d28614832687027f3e16adb0bf