### PR TITLE
Fix carousel lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
     Call `open()` on a user action and focus stays trapped until `close()` runs.
 
     `lazyPortrait.js` enables IntersectionObserver-based image loading. The
-    `renderJudokaCard` helper automatically calls `setupLazyPortraits()` so
-    portraits swap in when the card enters view. Import and call it manually only
-    if you build card markup yourself.
+    `renderJudokaCard` and `buildCardCarousel` helpers automatically call
+    `setupLazyPortraits()` so portraits swap in when cards enter view. Import and
+    call it manually only if you build card markup yourself.
 
   - `pages/`
     HTML pages. Each page imports a matching module from

--- a/design/productRequirementsDocuments/prdCardCarousel.md
+++ b/design/productRequirementsDocuments/prdCardCarousel.md
@@ -111,6 +111,8 @@ wrappers (the element returned by `buildCardCarousel`) **must not** apply
 padding that would change the width of the cards. Any extra spacing should be
 handled by the carousel's gap settings so that card sizing remains
 consistent.
+`buildCardCarousel` automatically invokes `setupLazyPortraits()` on the
+generated carousel so each card's real portrait loads once it becomes visible.
 
 ---
 

--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -71,7 +71,7 @@ Players currently lack a tangible sense of progression and connection to elite j
 - Card slide/reveal animations must use hardware-accelerated CSS transforms for smooth performance (**≥60 fps**).
 - Placeholder assets for missing portraits/flags should be bundled with the client for offline scenarios.
 - Cards initially display `judokaPortrait-1.png` and lazy-load the real portrait when the card enters the viewport.
-- The `renderJudokaCard` helper runs `setupLazyPortraits()` automatically so the
+- The `renderJudokaCard` and `buildCardCarousel` helpers run `setupLazyPortraits()` automatically so the
   real portrait loads as soon as the card is visible.
 - All judoka portraits and card sizing calculations must consistently maintain a **2:3 aspect ratio** to ensure visual uniformity and avoid layout shifts. Portraits should be pre-cropped as needed, and `.card-portrait` uses `object-fit: cover` to handle similarly shaped images. Card sizing calculations must account for screen aspect ratios and resolutions to preserve this ratio.
 - Hover and focus scaling must stay at or below **1.05x** to prevent cards from

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -1,6 +1,7 @@
 import { createGokyoLookup } from "./utils.js";
 import { generateJudokaCard } from "./cardBuilder.js";
 import { getFallbackJudoka } from "./judokaUtils.js";
+import { setupLazyPortraits } from "./lazyPortrait.js";
 import {
   CAROUSEL_SCROLL_DISTANCE,
   CAROUSEL_SWIPE_THRESHOLD,
@@ -406,6 +407,7 @@ export async function buildCardCarousel(judokaList, gokyoData) {
   setupKeyboardNavigation(container);
   setupSwipeNavigation(container);
   applyAccessibilityImprovements(wrapper);
+  setupLazyPortraits(container);
 
   return wrapper;
 }

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -91,7 +91,9 @@
             id="game-mode-toggle-container"
             class="game-mode-toggle-container settings-form"
             aria-label="Game Mode Selector"
-          >              <label for="display-mode-select">Game Modes</label></section>
+          >
+            <label for="display-mode-select">Game Modes</label>
+          </section>
         </form>
       </main>
 


### PR DESCRIPTION
## Summary
- ensure card carousel triggers lazy portrait loading
- document lazy loading behavior
- format settings page with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: unable to fetch vitest)*
- `npx playwright test` *(fails: unable to fetch playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6877da73c85c832685e6789b38ba2590