### PR TITLE
Fix settings tab order

### DIFF
--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -46,14 +46,6 @@
           >
             <legend class="visually-hidden">Game Settings</legend>
             <div class="settings-item">
-              <label for="display-mode-select">Display Mode</label>
-              <select id="display-mode-select">
-                <option value="light">Light</option>
-                <option value="dark">Dark</option>
-                <option value="gray">Gray</option>
-              </select>
-            </div>
-            <div class="settings-item">
               <label for="sound-toggle" class="switch">
                 <input type="checkbox" id="sound-toggle" name="sound" aria-label="Sound" />
                 <div class="slider round"></div>
@@ -84,6 +76,14 @@
                 <span>Motion Effects</span>
               </label>
             </div>
+            <div class="settings-item">
+              <label for="display-mode-select">Display Mode</label>
+              <select id="display-mode-select">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="gray">Gray</option>
+              </select>
+            </div>
           </fieldset>
         </form>
         <form>
@@ -91,7 +91,9 @@
             id="game-mode-toggle-container"
             class="game-mode-toggle-container settings-form"
             aria-label="Game Mode Selector"
-          >              <label for="display-mode-select">Game Modes</label></section>
+          >
+            <span>Game Modes</span>
+          </section>
         </form>
       </main>
 


### PR DESCRIPTION
## Summary
- reorder settings HTML to match tab order spec
- remove stray label around the game mode section

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6877daa7f1e4832697d144c9665dd726