### PR TITLE
Add list support to markdown parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 - **CSS3**: For styling and layout.
 - **JavaScript (ES6)**: For game logic and interactivity.
 - **Vite**: For building and bundling the project.
-- **Marked**: Renders Markdown documentation in the PRD reader.
+- **Marked**: Minimal parser for headings, paragraphs and lists used in the PRD reader.
 - **GitHub Pages**: For hosting the live demo.
 
 ## Known Issues

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -29,7 +29,7 @@ initialize page-specific behavior.
 `src/helpers/prdReaderPage.js` to display the Product Requirements
 Documents. The Markdown files live in
 `design/productRequirementsDocuments`. The helper fetches each file,
-parses it through the **Marked** library and injects the HTML into the
+parses it through the **Marked** library (supporting headings, paragraphs and lists) and injects the HTML into the
 `#prd-content` container. Next/previous buttons, arrow keys and swipe
 gestures cycle through the loaded documents.
 

--- a/src/styles/mockupViewer.css
+++ b/src/styles/mockupViewer.css
@@ -3,15 +3,15 @@
 }
 
 .body {
-        font-family: sans-serif;
-        background: #f5f5f5;
-        margin: 0;
-        padding: 2rem;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-      }
-      
+  font-family: sans-serif;
+  background: #f5f5f5;
+  margin: 0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .slideshow-container {
   max-width: 100dvh;
   max-width: 100vh;

--- a/src/vendor/marked.esm.js
+++ b/src/vendor/marked.esm.js
@@ -1,6 +1,6 @@
 export const marked = {
   /**
-   * Very small markdown parser supporting headings and paragraphs.
+   * Very small markdown parser supporting headings, paragraphs and lists.
    *
    * @param {string} md - Markdown string.
    * @returns {string} HTML string.
@@ -18,6 +18,15 @@ export const marked = {
         }
         if (block.startsWith("### ")) {
           return `<h3>${block.slice(4).trim()}</h3>`;
+        }
+        const lines = block.split("\n");
+        if (lines.every((l) => /^[-*] /.test(l))) {
+          return `<ul>${lines.map((l) => `<li>${l.slice(2).trim()}</li>`).join("")}</ul>`;
+        }
+        if (lines.every((l) => /^\d+\. /.test(l))) {
+          return `<ol>${lines
+            .map((l) => `<li>${l.replace(/^\d+\.\s*/, "").trim()}</li>`)
+            .join("")}</ol>`;
         }
         return `<p>${block.trim()}</p>`;
       })

--- a/tests/helpers/markdownParser.test.js
+++ b/tests/helpers/markdownParser.test.js
@@ -1,0 +1,23 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { marked } from "../../src/vendor/marked.esm.js";
+
+describe("marked.parse", () => {
+  it("parses unordered lists", () => {
+    const md = "- one\n- two";
+    const html = marked.parse(md);
+    expect(html).toBe("<ul><li>one</li><li>two</li></ul>");
+  });
+
+  it("parses ordered lists", () => {
+    const md = "1. first\n2. second";
+    const html = marked.parse(md);
+    expect(html).toBe("<ol><li>first</li><li>second</li></ol>");
+  });
+
+  it("handles headings followed by lists", () => {
+    const md = "# Title\n\n- a\n- b";
+    const html = marked.parse(md);
+    expect(html).toBe("<h1>Title</h1><ul><li>a</li><li>b</li></ul>");
+  });
+});


### PR DESCRIPTION
## Summary
- add list parsing in marked.esm.js
- document list support in README and architecture docs
- format mockupViewer.css with Prettier
- add tests covering unordered and ordered lists

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6878077a292483268bf8f94350bce163