### PR TITLE
Standardize PRD formatting

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -64,7 +64,7 @@ In battle game modes (e.g. Classic Battle), players currently receive no clear v
 |  "Round starts in: 3" (neutral grey) |                                             |
 -----------------------------------------------------------------------------------
 
-* Responsive Layout Notes:
+- Responsive Layout Notes:
 - On wide screens (>=375px): single horizontal bar with left and right content aligned.
 - On narrow screens (<375px): stacked vertically
 
@@ -74,8 +74,8 @@ In battle game modes (e.g. Classic Battle), players currently receive no clear v
 | Player: 2  –  CPU: 1         |
 --------------------------------
 
-* Countdown timer truncates if less than 1.5s remains.
-* Text size min 16sp; win/loss messages bold and color-coded.
+- Countdown timer truncates if less than 1.5s remains.
+- Text size min 16sp; win/loss messages bold and color-coded.
 
 ### Additional Details:
 Animation timing:

--- a/design/productRequirementsDocuments/prdGameModes.md
+++ b/design/productRequirementsDocuments/prdGameModes.md
@@ -10,7 +10,7 @@
 
 Returning players often exit after short sessions due to repetitive gameplay loops and limited creative expression.
 
-#### User Stories
+### User Stories
 
 - As a player who’s tired of pure competition, I want a Meditation mode so I can relax and still feel connected to the game.
 - As a player with a favorite judoka, I want to update their stats and appearance so they grow with me.
@@ -73,40 +73,40 @@ Improving session variety directly supports retention and encourages more person
 
 ## Classic Battle
 
-#### Overview
+### Overview
 
 **Japanese**: 試合 (バトルモード)
 **URL**: `battleJudoka.html`
 A 1v1 stat-based match against a CPU opponent using a deck of 25 random judoka cards. First to 10 points wins. [Read full PRD](prdClassicBattle.md)
 
-#### Goals
+### Goals
 
 - Deliver a quick head‑to‑head mode for new players **(battle loads in ≤2 s)**.
 - Encourage replay through a simple scoring system.
 
-#### Functional Requirements
+### Functional Requirements
 
 - Draw one random card from each deck per round.
 - Player selects a stat to compare.
 - Higher stat wins; score increases by one.
 - End match on 10 points or after 25 rounds.
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - Cards are revealed in correct sequence.
 - Player can select stat.
 - Score updates per round outcome.
 - Summary screen shown at end.
 
-#### Non‑Goals
+### Non‑Goals
 
 - Online multiplayer battles.
 
-#### Dependencies
+### Dependencies
 
 - Judoka dataset loaded from `judoka.json`.
 
-#### Open Questions
+### Open Questions
 
 _Resolved in [Classic Battle](prdClassicBattle.md#7-future-considerations):_ AI difficulty will determine stat selection strategy.
 
@@ -114,36 +114,36 @@ _Resolved in [Classic Battle](prdClassicBattle.md#7-future-considerations):_ AI 
 
 ## Team Battle Selection
 
-#### Overview
+### Overview
 
 **Japanese**: 団体戦選択
 **URL**: `teamBattleSelection.html`
 Choose between Male, Female or Mixed team battles. [Read full PRD](prdTeamBattleSelection.md)
 
-#### Goals
+### Goals
 
 - Guide players to the appropriate team format.
 
-#### Functional Requirements
+### Functional Requirements
 
 - Three options visible.
 - Routes correctly to selected battle variant.
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - Option buttons are interactive.
 - Click leads to the correct mode.
 - Invalid route fallback returns to selection screen.
 
-#### Non‑Goals
+### Non‑Goals
 
 - Team management beyond choosing a mode.
 
-#### Dependencies
+### Dependencies
 
 - Navigation map must provide a link to this screen.
 
-#### Open Questions
+### Open Questions
 
 - **Pending:** Decide whether the last chosen mode should be remembered.
 
@@ -151,7 +151,7 @@ Choose between Male, Female or Mixed team battles. [Read full PRD](prdTeamBattle
 
 ## Team Battle Modes
 
-#### Overview
+### Overview
 
 **Japanese**: 男子団体戦 / 女子団体戦 / 混合団体戦  
 **URLs**: `teamBattleMale.html`, `teamBattleFemale.html`, `teamBattleMixed.html`  
@@ -159,31 +159,31 @@ Team battles consist of sequential 1v1s between gender-filtered squads. The shar
 [PRD: Team Battle Rules](prdTeamBattleRules.md). Mode specifics:
 [Male](prdTeamBattleMale.md) / [Female](prdTeamBattleFemale.md) / [Mixed](prdTeamBattleMixed.md)
 
-#### Goals
+### Goals
 
 - Provide structured team competition with gender rules.
 
-#### Functional Requirements
+### Functional Requirements
 
 - Validate team composition by gender.
 - Follow team match sequence.
 - End state triggers win screen at score cap.
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - Team validated on gender before match.
 - Sub-match order shown as visual cue.
 - At score cap, show win animation and return to Village.
 
-#### Non‑Goals
+### Non‑Goals
 
 - Online matchmaking.
 
-#### Dependencies
+### Dependencies
 
 - Judoka data must include gender field.
 
-#### Open Questions
+### Open Questions
 
 - **Pending:** Decide whether Mixed mode will allow flexible team sizes.
 
@@ -191,36 +191,36 @@ Team battles consist of sequential 1v1s between gender-filtered squads. The shar
 
 ## Browse Judoka
 
-#### Overview
+### Overview
 
 **Japanese**: 柔道家を閲覧
 **URL**: `browseJudoka.html`
 View all available judoka with stats and visuals. [Read full PRD](prdBrowseJudoka.md)
 
-#### Goals
+### Goals
 
 - Allow players to explore the full roster.
 
-#### Functional Requirements
+### Functional Requirements
 
 - Scrollable card interface.
 - Stats sourced from `judoka.json`.
 - Responsive across screen sizes.
 - Invalid entries replaced with placeholder.
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - If list is empty, show “No cards available” message.
 
-#### Non‑Goals
+### Non‑Goals
 
 - Advanced filtering and sorting options.
 
-#### Dependencies
+### Dependencies
 
 - Carousel and card components.
 
-#### Open Questions
+### Open Questions
 
 _Resolved in [Browse Judoka](prdBrowseJudoka.md#open-questions):_ search will be considered in a later update.
 
@@ -228,36 +228,36 @@ _Resolved in [Browse Judoka](prdBrowseJudoka.md#open-questions):_ search will be
 
 ## Team Manager Mode (Admin Mode)
 
-#### Overview
+### Overview
 
 **Japanese**: 柔道家編集モード
 **URL**: `manageJudoka.html`
 Choose to create or edit a judoka.
 
-#### Goals
+### Goals
 
 - Provide an admin hub for judoka creation and updates.
 
-#### Functional Requirements
+### Functional Requirements
 
 - Two path options visible.
 - Routing to creation or update works.
 - Fallback if no judoka are available to edit.
 - Will be only available to access via an Admin entry point
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - Selecting a path leads to the correct screen.
 
-#### Non‑Goals
+### Non‑Goals
 
 - Deep stat editing beyond current fields.
 
-#### Dependencies
+### Dependencies
 
 - Backend for saving judoka data.
 
-#### Open Questions
+### Open Questions
 
 - **Pending:** Decide whether to warn players about unsaved changes before exiting.
 
@@ -265,17 +265,17 @@ Choose to create or edit a judoka.
 
 ## Create A Judoka (Admin Mode)
 
-#### Overview
+### Overview
 
 **Japanese**: 柔道家を作成
 **URL**: `createJudoka.html`
 Create a new judoka with custom stats and appearance.
 
-#### Goals
+### Goals
 
 - Let Admins add new characters to the game roster.
 
-#### Functional Requirements
+### Functional Requirements
 
 - Inputs for name, nationality, stats, weight class and signature move.
 - Live preview updates on change.
@@ -283,20 +283,20 @@ Create a new judoka with custom stats and appearance.
 - Invalid form fields trigger error indicators.
 - Will be only available to access via an Admin entry point
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - All inputs required before save.
 - Given completed form, when saved, judoka appears in `judoka.json`.
 
-#### Non‑Goals
+### Non‑Goals
 
 - Sharing created judoka online.
 
-#### Dependencies
+### Dependencies
 
 - Form validation utilities.
 
-#### Open Questions
+### Open Questions
 
 - **Pending:** Decide whether to limit the number of custom judoka.
 
@@ -304,17 +304,17 @@ Create a new judoka with custom stats and appearance.
 
 ## Update A Judoka (Admin Mode)
 
-#### Overview
+### Overview
 
 **Japanese**: 柔道家を更新
 **URL**: `updateJudoka.html`
 Edit an existing judoka. [Read full PRD](prdUpdateJudoka.md)
 
-#### Goals
+### Goals
 
 - Allow Admins to refine stats and appearance over time.
 
-#### Functional Requirements
+### Functional Requirements
 
 - Judoka list loads from dataset.
 - Edits persist after save.
@@ -322,15 +322,15 @@ Edit an existing judoka. [Read full PRD](prdUpdateJudoka.md)
 - If selected judoka is missing, display retry prompt.
 - Will be only available to access via an Admin entry point
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - Edits save correctly and persist on reload.
 
-#### Non‑Goals
+### Non‑Goals
 
 - Full version history of edits.
 
-#### Dependencies
+### Dependencies
 
 - Same storage used by the creation screen.
 
@@ -338,34 +338,34 @@ Edit an existing judoka. [Read full PRD](prdUpdateJudoka.md)
 
 ## Random Judoka
 
-#### Overview
+### Overview
 
 **Japanese**: ランダム柔道家
 **URL**: `randomJudoka.html`
 Display a random judoka profile. [Read full PRD](prdRandomJudoka.md)
 
-#### Goals
+### Goals
 
 - Give players quick inspiration for new team ideas **(random suggestion ≤1 s)**.
 
-#### Functional Requirements
+### Functional Requirements
 
 - Show one random judoka on load or refresh.
 - “Draw” button refreshes content.
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - Random judoka displayed each visit.
 
-#### Non‑Goals
+### Non‑Goals
 
 - Complex filters or search.
 
-#### Dependencies
+### Dependencies
 
 - Access to the full judoka list.
 
-#### Open Questions
+### Open Questions
 
 - **Pending:** Decide whether favourites influence random selection.
 
@@ -373,35 +373,35 @@ Display a random judoka profile. [Read full PRD](prdRandomJudoka.md)
 
 ## Meditation
 
-#### Overview
+### Overview
 
 **Japanese**: メディテーション
 **URL**: `meditation.html`
 A calm screen offering inspirational quotes and ambient visuals. [Read full PRD](prdMeditationScreen.md)
 
-#### Goals
+### Goals
 
 - Provide a restful break between battles.
 
-#### Functional Requirements
+### Functional Requirements
 
 - Load random quote per visit.
 - English/Japanese toggle.
 - Ambient visuals reinforce restful tone.
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - Text is legible and character art scales correctly.
 - Player exits via “Return” button confirming transition back to the map.
 
-#### Non‑Goals
+### Non‑Goals
 
 - Rewarding players with items or XP.
 
-#### Dependencies
+### Dependencies
 
 - Quote data set and language toggle component.
 
-#### Open Questions
+### Open Questions
 
 - **Pending:** Decide whether quotes rotate daily or on each visit.

--- a/design/productRequirementsDocuments/prdRandomJudoka.md
+++ b/design/productRequirementsDocuments/prdRandomJudoka.md
@@ -83,7 +83,7 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 
 ### Design and UX Considerations
 
-#### Layout and Interaction
+### Layout and Interaction
 
 - **Main Screen Structure**:
   - **Card Display Area**: Centered large card placeholder with dynamic content.
@@ -97,7 +97,7 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
   - Minimum: 64px height × 300px width for easy tapping, especially for kids.
   - Style: Capsule shape using `--radius-pill` for consistent branding.
 
-#### Animation and Transitions
+### Animation and Transitions
 
 - **Card Reveal Animation**:
   - Slide-in from bottom or fade-in (duration: 300–500ms).
@@ -108,7 +108,7 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
   - Press: Slight scale-in (95% size) for ~100ms.
   - Disabled state: Lower opacity (50%), disable input if judoka list is empty or draw is in progress.
 
-#### Accessibility
+### Accessibility
 
 - Detect OS-level Reduced Motion; disable animations if active.
 - Provide manual animation toggle (default ON).
@@ -117,19 +117,19 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 - Fallback card displays high-contrast “Oops! Try again” text if errors occur.
 - All buttons and states require clear text labels.
 
-#### Responsiveness
+### Responsiveness
 
 - **Mobile (<600px)**: card fills ~70% of viewport; draw button spans nearly full width.
 - **Tablet/Desktop (>600px)**: card ~40% of viewport; centered draw button with spacing.
 - **Landscape Support**: components reposition vertically or side-by-side.
 - Card container uses `min-height: 50vh` to keep the Draw button visible on small screens.
 
-#### Audio Feedback (Optional Enhancement)
+### Audio Feedback (Optional Enhancement)
 
 - Chime/swoosh sound <1 second, volume at 60% of system volume.
 - Mute option via toggle icon near the draw button (default: sound off).
 
-#### Visual Mockup Description
+### Visual Mockup Description
 
 - **Top Bar**: minimal header with “Random Judoka” title centered.
 - **Central Card Area**: large placeholder card with question mark icon on initial state.

--- a/src/styles/mockupViewer.css
+++ b/src/styles/mockupViewer.css
@@ -3,15 +3,15 @@
 }
 
 .body {
-        font-family: sans-serif;
-        background: #f5f5f5;
-        margin: 0;
-        padding: 2rem;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-      }
-      
+  font-family: sans-serif;
+  background: #f5f5f5;
+  margin: 0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .slideshow-container {
   max-width: 100dvh;
   max-width: 100vh;


### PR DESCRIPTION
## Summary
- convert H4 headings to H3 across PRD files
- use dash bullets in the Battle Info Bar PRD
- format mockupViewer.css with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68780807e52883269eec0bf337070f9b