### PR TITLE
Fix Safari signature move alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ keeps the carousel from stretching beyond the viewport.
 Safari counts scrollbars in the `vw` unit, which can lead to unexpected layout behavior. For example, a wrapper with `min-width: 100vw` may become wider than the page and cause horizontal scrolling. To prevent this, set `width: 100%` on the body and navbars. Optionally, use `overflow-x: hidden` to ensure the layout stays within the viewport.
 Mobile Safari 18.5 may also add vertical scroll if fixed headers and footers use `vh` units. The navbar height CSS variables now use `dvh` to match the dynamic viewport height and avoid extra scrolling. Pages with fixed headers or footers should set container heights to `calc(100dvh - var(--header-height) - var(--footer-height))` (or equivalent) so content isn't hidden when the viewport shrinks. The `.home-screen` container implements this rule.
 
+Safari 18.5 positions `.signature-move-container` text at the bottom edge unless the flex alignment is overridden. Set `align-items: center` on this container so the label and value remain vertically centered.
+
 The bottom navbar uses `env(safe-area-inset-bottom)` with a `constant()` fallback to add extra padding and height. This prevents it from overlapping the iOS home indicator and keeps content visible.
 
 Layout containers should include a `vh` fallback declared before the `dvh` rule so browsers without dynamic viewport support still size elements correctly.

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -438,7 +438,7 @@ button .ripple {
 
 .signature-move-container {
   display: inline-flex;
-  align-items: flex-end;
+  align-items: center;
   flex-direction: row;
   width: 100%;
   /* Maintain ~10% (~45px) height as specified in the PRD */


### PR DESCRIPTION
## Summary
- center items in `.signature-move-container` so text doesn't stick to the bottom in Safari
- document the Safari fix in the browser compatibility notes

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68780f31af3c8326b0e017804a776862