### PR TITLE
Fix nested lists in PRD markdown parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 - **CSS3**: For styling and layout.
 - **JavaScript (ES6)**: For game logic and interactivity.
 - **Vite**: For building and bundling the project.
-- **Marked**: Minimal parser for headings, paragraphs and lists used in the PRD reader.
+- **Marked**: Minimal parser used in the PRD reader that now supports nested lists.
 - **GitHub Pages**: For hosting the live demo.
 
 ## Known Issues

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -29,7 +29,7 @@ initialize page-specific behavior.
 `src/helpers/prdReaderPage.js` to display the Product Requirements
 Documents. The Markdown files live in
 `design/productRequirementsDocuments`. The helper fetches each file,
-parses it through the **Marked** library (supporting headings, paragraphs and lists) and injects the HTML into the
+parses it through the **Marked** library (supporting headings, paragraphs and nested lists) and injects the HTML into the
 `#prd-content` container. Next/previous buttons, arrow keys and swipe
 gestures cycle through the loaded documents.
 

--- a/tests/helpers/markdownParser.test.js
+++ b/tests/helpers/markdownParser.test.js
@@ -15,6 +15,18 @@ describe("marked.parse", () => {
     expect(html).toBe("<ol><li>first</li><li>second</li></ol>");
   });
 
+  it("parses nested lists", () => {
+    const md = "- a\n  - b";
+    const html = marked.parse(md);
+    expect(html).toBe("<ul><li>a<ul><li>b</li></ul></li></ul>");
+  });
+
+  it("handles checkbox lists", () => {
+    const md = "- [ ] task one\n- [x] task two";
+    const html = marked.parse(md);
+    expect(html).toBe("<ul><li>task one</li><li>task two</li></ul>");
+  });
+
   it("handles headings followed by lists", () => {
     const md = "# Title\n\n- a\n- b";
     const html = marked.parse(md);


### PR DESCRIPTION
## Summary
- extend `marked.esm.js` to support nested and checkbox lists
- document nested list support in README and architecture docs
- test new parser behaviour

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6878123a4f6083268ef147a7b48f3f06