### PR TITLE
Add horizontal rule support to markdown parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -236,25 +235,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 
@@ -275,7 +269,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 - **CSS3**: For styling and layout.
 - **JavaScript (ES6)**: For game logic and interactivity.
 - **Vite**: For building and bundling the project.
-- **Marked**: Minimal parser used in the PRD reader that now supports nested lists.
+- **Marked**: Minimal parser used in the PRD reader that now supports nested lists and horizontal rules.
 - **GitHub Pages**: For hosting the live demo.
 
 ## Known Issues

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -29,7 +29,7 @@ initialize page-specific behavior.
 `src/helpers/prdReaderPage.js` to display the Product Requirements
 Documents. The Markdown files live in
 `design/productRequirementsDocuments`. The helper fetches each file,
-parses it through the **Marked** library (supporting headings, paragraphs and nested lists) and injects the HTML into the
+parses it through the **Marked** library (supporting headings, paragraphs, nested lists and horizontal rules) and injects the HTML into the
 `#prd-content` container. Next/previous buttons, arrow keys and swipe
 gestures cycle through the loaded documents.
 

--- a/src/vendor/marked.esm.js
+++ b/src/vendor/marked.esm.js
@@ -1,6 +1,7 @@
 export const marked = {
   /**
-   * Very small markdown parser supporting headings, paragraphs and lists.
+   * Very small markdown parser supporting headings, paragraphs, lists
+   * and horizontal rules.
    *
    * @param {string} md - Markdown string.
    * @returns {string} HTML string.
@@ -49,6 +50,9 @@ export const marked = {
       .trim()
       .split(/\n\n+/)
       .map((block) => {
+        if (/^(-{3,}|\*{3,}|_{3,})$/.test(block.trim())) {
+          return "<hr/>";
+        }
         if (block.startsWith("# ")) {
           return `<h1>${block.slice(2).trim()}</h1>`;
         }

--- a/tests/helpers/markdownParser.test.js
+++ b/tests/helpers/markdownParser.test.js
@@ -32,4 +32,10 @@ describe("marked.parse", () => {
     const html = marked.parse(md);
     expect(html).toBe("<h1>Title</h1><ul><li>a</li><li>b</li></ul>");
   });
+
+  it("parses horizontal rules", () => {
+    const md = "one\n\n----\n\ntwo";
+    const html = marked.parse(md);
+    expect(html).toBe("<p>one</p><hr/><p>two</p>");
+  });
 });


### PR DESCRIPTION
## Summary
- support horizontal rules in the simple `marked` parser
- document horizontal rules in architecture and README
- test horizontal rule parsing

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68781596d17483268bbd801a9c133903