### PR TITLE
Add bold support to marked parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -236,25 +235,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 
@@ -275,7 +269,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 - **CSS3**: For styling and layout.
 - **JavaScript (ES6)**: For game logic and interactivity.
 - **Vite**: For building and bundling the project.
-- **Marked**: Minimal parser used in the PRD reader that now supports nested lists.
+- **Marked**: Minimal parser used in the PRD reader that now supports nested lists and bold text.
 - **GitHub Pages**: For hosting the live demo.
 
 ## Known Issues

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -29,7 +29,7 @@ initialize page-specific behavior.
 `src/helpers/prdReaderPage.js` to display the Product Requirements
 Documents. The Markdown files live in
 `design/productRequirementsDocuments`. The helper fetches each file,
-parses it through the **Marked** library (supporting headings, paragraphs and nested lists) and injects the HTML into the
+parses it through the **Marked** library (supporting headings, bold text, paragraphs and nested lists) and injects the HTML into the
 `#prd-content` container. Next/previous buttons, arrow keys and swipe
 gestures cycle through the loaded documents.
 

--- a/src/vendor/marked.esm.js
+++ b/src/vendor/marked.esm.js
@@ -1,11 +1,15 @@
 export const marked = {
   /**
-   * Very small markdown parser supporting headings, paragraphs and lists.
+   * Very small markdown parser supporting headings, bold text, paragraphs and lists.
    *
    * @param {string} md - Markdown string.
    * @returns {string} HTML string.
    */
   parse(md) {
+    function renderInline(text) {
+      return text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+    }
+
     function renderList(lines, ordered) {
       let html = "";
       const stack = [];
@@ -20,20 +24,20 @@ export const marked = {
         const type = ordered ? "ol" : "ul";
 
         if (stack.length === 0) {
-          html += `<${type}><li>${text}`;
+          html += `<${type}><li>${renderInline(text)}`;
           stack.push(type);
         } else if (level > prev) {
-          html += `<${type}><li>${text}`;
+          html += `<${type}><li>${renderInline(text)}`;
           stack.push(type);
         } else if (level === prev) {
-          html += `</li><li>${text}`;
+          html += `</li><li>${renderInline(text)}`;
         } else {
           while (prev > level) {
             const t = stack.pop();
             html += `</li></${t}>`;
             prev--;
           }
-          html += `</li><li>${text}`;
+          html += `</li><li>${renderInline(text)}`;
         }
         prev = level;
       });
@@ -50,13 +54,13 @@ export const marked = {
       .split(/\n\n+/)
       .map((block) => {
         if (block.startsWith("# ")) {
-          return `<h1>${block.slice(2).trim()}</h1>`;
+          return `<h1>${renderInline(block.slice(2).trim())}</h1>`;
         }
         if (block.startsWith("## ")) {
-          return `<h2>${block.slice(3).trim()}</h2>`;
+          return `<h2>${renderInline(block.slice(3).trim())}</h2>`;
         }
         if (block.startsWith("### ")) {
-          return `<h3>${block.slice(4).trim()}</h3>`;
+          return `<h3>${renderInline(block.slice(4).trim())}</h3>`;
         }
         const lines = block.split("\n");
         if (lines.every((l) => /^\s*[-*]/.test(l))) {
@@ -65,7 +69,7 @@ export const marked = {
         if (lines.every((l) => /^\s*\d+\./.test(l))) {
           return renderList(lines, true);
         }
-        return `<p>${block.trim()}</p>`;
+        return `<p>${renderInline(block.trim())}</p>`;
       })
       .join("");
   }

--- a/tests/helpers/markdownParser.test.js
+++ b/tests/helpers/markdownParser.test.js
@@ -32,4 +32,10 @@ describe("marked.parse", () => {
     const html = marked.parse(md);
     expect(html).toBe("<h1>Title</h1><ul><li>a</li><li>b</li></ul>");
   });
+
+  it("parses bold text", () => {
+    const md = "**bold** text";
+    const html = marked.parse(md);
+    expect(html).toBe("<p><strong>bold</strong> text</p>");
+  });
 });


### PR DESCRIPTION
## Summary
- extend `marked` to convert `**`bold`**` syntax
- document bold support in README and architecture notes
- test bold parsing

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68781665edb88326869a3524cfd86fdf