### PR TITLE
Fix Safari flex bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ keeps the carousel from stretching beyond the viewport.
 Safari counts scrollbars in the `vw` unit, which can lead to unexpected layout behavior. For example, a wrapper with `min-width: 100vw` may become wider than the page and cause horizontal scrolling. To prevent this, set `width: 100%` on the body and navbars. Optionally, use `overflow-x: hidden` to ensure the layout stays within the viewport.
 Mobile Safari 18.5 may also add vertical scroll if fixed headers and footers use `vh` units. The navbar height CSS variables now use `dvh` to match the dynamic viewport height and avoid extra scrolling. Pages with fixed headers or footers should set container heights to `calc(100dvh - var(--header-height) - var(--footer-height))` (or equivalent) so content isn't hidden when the viewport shrinks. The `.home-screen` container implements this rule.
 
-Safari 18.5 positions `.signature-move-container` text at the bottom edge unless the flex alignment is overridden. Set `align-items: center` on this container so the label and value remain vertically centered.
+Safari 18.5 positions `.signature-move-container` text at the bottom edge unless the container uses standard flex alignment. Set `display: flex` with `align-items: center` so the label and value remain vertically centered.
 
 The bottom navbar uses `env(safe-area-inset-bottom)` with a `constant()` fallback to add extra padding and height. This prevents it from overlapping the iOS home indicator and keeps content visible.
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -439,7 +439,7 @@ button .ripple {
 }
 
 .signature-move-container {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   flex-direction: row;
   width: 100%;

--- a/src/vendor/marked.esm.js
+++ b/src/vendor/marked.esm.js
@@ -17,9 +17,7 @@ export const marked = {
       let prev = 0;
 
       lines.forEach((line) => {
-        const regex = ordered
-          ? /^(\s*)\d+\.\s+(.*)$/
-          : /^(\s*)[-*]\s+(?:\[[xX ]\]\s+)?(.*)$/;
+        const regex = ordered ? /^(\s*)\d+\.\s+(.*)$/ : /^(\s*)[-*]\s+(?:\[[xX ]\]\s+)?(.*)$/;
         const match = line.match(regex);
         if (!match) return;
         const [, indent, text] = match;


### PR DESCRIPTION
## Summary
- fix `.signature-move-container` styling
- mention Safari 18.5 flex requirements in README
- format `src/vendor/marked.esm.js` with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68781e04360083268cc06a4e6399f268