### PR TITLE
Add extra table parsing test

### DIFF
--- a/tests/helpers/markdownParser.test.js
+++ b/tests/helpers/markdownParser.test.js
@@ -52,4 +52,12 @@ describe("marked.parse", () => {
       "<table><thead><tr><th>a</th><th>b</th></tr></thead><tbody><tr><td>c</td><td>d</td></tr></tbody></table>"
     );
   });
+
+  it("parses multi-row tables", () => {
+    const md = "| a | b |\n| --- | --- |\n| c | d |\n| e | f |";
+    const html = marked.parse(md);
+    expect(html).toBe(
+      "<table><thead><tr><th>a</th><th>b</th></tr></thead><tbody><tr><td>c</td><td>d</td></tr><tr><td>e</td><td>f</td></tr></tbody></table>"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend markdown parser tests with a multi-row table case

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_687828e7045483269d1e7335bdf90276