### PR TITLE
Add overflow checks to PRD reader

### DIFF
--- a/playwright/prd-reader.spec.js
+++ b/playwright/prd-reader.spec.js
@@ -7,10 +7,18 @@ test.describe("PRD Reader page", () => {
 
   test("forward and back navigation", async ({ page }) => {
     const container = page.locator("#prd-content");
+    let hasOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+    );
+    expect(hasOverflow).toBe(false);
     await expect(container).not.toHaveText("");
     const original = await container.innerHTML();
 
     await page.getByRole("button", { name: /next/i }).click();
+    hasOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+    );
+    expect(hasOverflow).toBe(false);
     const afterNext = await page.locator("#prd-content").innerHTML();
     expect(afterNext).not.toBe(original);
 


### PR DESCRIPTION
## Summary
- ensure PRD reader page never overflows the viewport
- verify after moving to next page

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_687828f814308326aee01c5482d1feb8