### PR TITLE
Fix card sizing on mobile Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -237,25 +236,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 
@@ -319,6 +313,8 @@ Safari counts scrollbars in the `vw` unit, which can lead to unexpected layout b
 Mobile Safari 18.5 may also add vertical scroll if fixed headers and footers use `vh` units. The navbar height CSS variables now use `dvh` to match the dynamic viewport height and avoid extra scrolling. Pages with fixed headers or footers should set container heights to `calc(100dvh - var(--header-height) - var(--footer-height))` (or equivalent) so content isn't hidden when the viewport shrinks. The `.home-screen` container implements this rule.
 
 Safari 18.5 positions `.signature-move-container` text at the bottom edge unless the container uses standard flex alignment. Set `display: flex` with `align-items: center` so the label and value remain vertically centered.
+
+Safari 18.5 sometimes shrinks the random judoka card, causing text overlap. The width rule now uses `clamp(200px, 70vw, 300px)` so cards occupy about 70% of the viewport on mobile.
 
 The bottom navbar uses `env(safe-area-inset-bottom)` with a `constant()` fallback to add extra padding and height. This prevents it from overlapping the iOS home indicator and keeps content visible.
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -176,7 +176,12 @@ button .ripple {
 
 .judoka-card {
   position: relative;
-  width: clamp(200px, 40vw, 300px);
+  /*
+    Fill roughly 70% of the viewport on small screens while
+    maintaining the fixed 300px size on larger displays.
+    This prevents the card text from overflowing on mobile Safari.
+  */
+  width: clamp(200px, 70vw, 300px);
   aspect-ratio: 2 / 3;
   border: 13px solid var(--card-border-color);
   border-radius: var(--radius-lg); /* Updated token */


### PR DESCRIPTION
## Summary
- widen judoka cards on mobile screens so text scales correctly
- document Safari 18.5 rendering quirk

## Testing
- `npx prettier README.md src/styles/components.css --write`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden)*
- `npx playwright test` *(fails: 403 Forbidden)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6878b30e11f08326809d9d955d8d90bd