### PR TITLE
Center mockup viewer layout and align PRD nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
     interactive behavior. The directory also contains
     `mockupViewer.html`, a simple carousel for browsing the image files
     under `design/mockups/`. It displays the filename overlay, centers
-    each image, and scales it to fit the viewport.
+    each image, and scales it to fit the viewport. The page now
+    centers all of its content for a consistent layout.
   - `data/`
   - `schemas/`
     JSON Schema definitions used to validate the data files.
@@ -161,6 +162,8 @@ Add new Markdown files there and include the filename in the `FILES` array of
 `src/helpers/prdReaderPage.js`. Open `src/pages/prdViewer.html` in your browser
 to browse the documents with next/previous navigation. The page now imports
 `base.css` and `layout.css` so wide elements stay wrapped inside the viewport.
+Navigation buttons remain left-aligned with a gap so they don't interfere with
+the centered content.
 
 ### CSS Organization
 

--- a/src/pages/mockupViewer.html
+++ b/src/pages/mockupViewer.html
@@ -31,7 +31,7 @@
         </div>
         <div class="character-slot right"></div>
       </header>
-      <main class="kodokan-grid" role="main">
+      <main class="kodokan-grid center-content" role="main">
         <div class="slideshow-container">
           <img id="mockup-image" class="mockup-image" src="" alt="mockup" />
           <div id="mockup-filename" class="mockup-filename"></div>

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -65,6 +65,7 @@
         display: flex;
         gap: 2rem;
         align-items: center;
+        justify-content: flex-start;
       }
     </style>
   </head>

--- a/src/styles/mockupViewer.css
+++ b/src/styles/mockupViewer.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
 }
 
-.body {
+body {
   font-family: sans-serif;
   background: #f5f5f5;
   margin: 0;
@@ -10,6 +10,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 
 .slideshow-container {
@@ -113,4 +115,8 @@
   to {
     opacity: 1;
   }
+}
+
+.center-content {
+  justify-items: center;
 }


### PR DESCRIPTION
## Summary
- center body styles for `mockupViewer.html`
- add `.center-content` helper class and apply to mockup viewer
- keep PRD nav buttons left-aligned
- mention layout tweaks in README

## Testing
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: PRD Reader page forward and back navigation)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6878b31f5ff8832685db29dd16f8dc89