### PR TITLE
Fix Safari carousel scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Mobile Safari 18.5 may also add vertical scroll if fixed headers and footers use
 
 Safari 18.5 positions `.signature-move-container` text at the bottom edge unless the container uses standard flex alignment. Set `display: flex` with `align-items: center` so the label and value remain vertically centered.
 
-Safari 18.5 sometimes shrinks the random judoka card, causing text overlap. The width rule now uses `clamp(200px, 70vw, 300px)` so cards occupy about 70% of the viewport on mobile.
+Safari 18.5 sometimes shrinks judoka cards, causing text overlap. The width rule now uses `clamp(200px, 70vw, 300px)` so cards occupy about 70% of the viewport on mobile. This applies to both the random card view and the browse carousel.
 
 The bottom navbar uses `env(safe-area-inset-bottom)` with a `constant()` fallback to add extra padding and height. This prevents it from overlapping the iOS home indicator and keeps content visible.
 

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -19,9 +19,9 @@
 .card-carousel .judoka-card {
   /* Use clamp to set a responsive width for judoka cards:
      - Minimum width: 200px ensures cards are not too small on very narrow screens.
-     - Preferred width: 40vw adapts to 40% of the viewport width for medium screens.
+     - Preferred width: 70vw adapts to 70% of the viewport width on mobile Safari.
      - Maximum width: 300px matches the fixed width defined on line 24 for larger screens. */
-  flex: 0 0 clamp(200px, 40vw, 300px);
+  flex: 0 0 clamp(200px, 70vw, 300px);
 }
 
 .judoka-card {


### PR DESCRIPTION
## Summary
- keep card width consistent on Safari mobile
- document the fix

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6878b7efc720832697119e4746822f43