### PR TITLE
Center signature move text

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -456,6 +456,7 @@ button .ripple {
   box-sizing: border-box;
   border-top: 1px solid var(--color-text-inverted, var(--color-secondary));
   margin-top: auto;
+  justify-content: center;
 }
 
 .signature-move-label,
@@ -469,7 +470,6 @@ button .ripple {
   padding: min(var(--space-sm), 2.3vw) var(--space-sm);
   font-size: min(14px, 4vw);
   flex: 1 1 0;
-  height: 100%;
   align-items: center;
   line-height: 1;
 }


### PR DESCRIPTION
## Summary
- center the contents of signature move rows
- remove fixed height from signature move cells

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 3 tests failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6878bb4c06048326b474b01e932bd52d