### PR TITLE
Fix judoka card spacing in Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,11 @@ Safari 18.5 positions `.signature-move-container` text at the bottom edge unless
 
 Safari 18.5 sometimes shrinks the random judoka card, causing text overlap. The width rule now uses `clamp(200px, 70vw, 300px)` so cards occupy about 70% of the viewport on mobile.
 
+Chrome may show a small gap below the stats panel when the combined height of
+card sections is less than 100%. Ensure `.card-top-bar`, `.card-portrait`,
+`.card-stats`, and `.signature-move-container` together fill the card height to
+avoid this issue.
+
 The bottom navbar uses `env(safe-area-inset-bottom)` with a `constant()` fallback to add extra padding and height. This prevents it from overlapping the iOS home indicator and keeps content visible.
 
 Layout containers should include a `vh` fallback declared before the `dvh` rule so browsers without dynamic viewport support still size elements correctly.

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -282,8 +282,8 @@ button .ripple {
   padding: var(--space-medium) var(--space-small); /* Updated tokens */
   flex-direction: row;
   /* Maintain ~14% of card height accounting for padding */
-  flex: 0 0 calc(15% - (var(--space-small) * 2));
-  height: calc(15% - (var(--space-small) * 2));
+  flex: 0 0 calc(14% - (var(--space-small) * 2));
+  height: calc(14% - (var(--space-small) * 2));
   box-sizing: border-box;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.12);
 }
@@ -343,8 +343,8 @@ button .ripple {
   justify-content: center;
   align-items: flex-start;
   width: 100%;
-  height: 41%;
-  flex: 0 0 41%;
+  height: 42%;
+  flex: 0 0 42%;
   overflow: hidden;
   margin-bottom: 0;
   background: linear-gradient(
@@ -394,8 +394,8 @@ button .ripple {
   font-size: var(--font-medium);
   flex-direction: column;
   /* Stats area ~34% of card height accounting for padding */
-  height: 33%;
-  flex: 0 0 33%;
+  height: 34%;
+  flex: 0 0 34%;
 }
 
 .card-stats ul {


### PR DESCRIPTION
## Summary
- fix `.card-top-bar`, `.card-portrait`, and `.card-stats` heights so card sections total 100%
- document Chrome gap issue in Browser Compatibility notes

## Testing
- `npx prettier . --check` *(fails: registry access blocked)*
- `npx eslint .` *(fails: cannot find package '@eslint/js')*
- `npx vitest run` *(fails: package installation forbidden)*
- `npx playwright test` *(fails: package installation forbidden)*
- `npm run check:contrast` *(fails: pa11y not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878bb856dc88326b218c96236d7461c