### PR TITLE
Fix prdViewer width overflow

### DIFF
--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -19,6 +19,7 @@
         flex-direction: column;
         align-items: center;
         line-height: 1.5;
+        width: auto;
       }
 
       header {


### PR DESCRIPTION
## Summary
- override body width in PRD reader

## Testing
- `npx prettier . --check` *(fails: README.md not formatted)*
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 1 failing test in prd-reader.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6878bbcea3948326bd3b6e2fd4ac7ef5