### PR TITLE
Update PRD reader navigation selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
+
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -239,20 +240,25 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
+
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
+
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
+
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
+
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
+
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/playwright/prd-reader.spec.js
+++ b/playwright/prd-reader.spec.js
@@ -14,7 +14,7 @@ test.describe("PRD Reader page", () => {
     await expect(container).not.toHaveText("");
     const original = await container.innerHTML();
 
-    await page.getByRole("button", { name: /next/i }).click();
+    await page.getByRole("banner").getByRole("button", { name: /next/i }).click();
     hasOverflow = await page.evaluate(
       () => document.documentElement.scrollWidth > document.documentElement.clientWidth
     );
@@ -22,7 +22,10 @@ test.describe("PRD Reader page", () => {
     const afterNext = await page.locator("#prd-content").innerHTML();
     expect(afterNext).not.toBe(original);
 
-    await page.getByRole("button", { name: /previous/i }).click();
+    await page
+      .getByRole("banner")
+      .getByRole("button", { name: /previous/i })
+      .click();
     const afterPrev = await page.locator("#prd-content").innerHTML();
     expect(afterPrev).toBe(original);
   });


### PR DESCRIPTION
## Summary
- point PRD Reader tests at header banner when clicking nav buttons
- format README with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diff for browseJudoka/randomJudoka)*

------
https://chatgpt.com/codex/tasks/task_e_6878c33fde5883269110947cd6d4fd73