### PR TITLE
Fix PRD viewer navigation buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -160,10 +159,11 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
 Product Requirements Documents live in `design/productRequirementsDocuments`.
 Add new Markdown files there and include the filename in the `FILES` array of
 `src/helpers/prdReaderPage.js`. Open `src/pages/prdViewer.html` in your browser
-to browse the documents with next/previous navigation. The page now imports
-`base.css` and `layout.css` so wide elements stay wrapped inside the viewport.
-Navigation buttons remain left-aligned with a gap so they don't interfere with
-the centered content.
+to browse the documents with next/previous navigation. Buttons tagged with
+`data-nav="prev"` and `data-nav="next"` appear in both the header and footer.
+The page now imports `base.css` and `layout.css` so wide elements stay wrapped
+inside the viewport. Navigation buttons remain left-aligned with a gap so they
+don't interfere with the centered content.
 
 ### CSS Organization
 
@@ -240,25 +240,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -30,8 +30,9 @@ initialize page-specific behavior.
 Documents. The Markdown files live in
 `design/productRequirementsDocuments`. The helper fetches each file,
 parses it through the **Marked** library (supporting headings, paragraphs, bold text, nested lists, tables, and horizontal rules) and injects the HTML into the
-`#prd-content` container. Next/previous buttons, arrow keys and swipe
-gestures cycle through the loaded documents.
+`#prd-content` container. Buttons marked with `data-nav="prev"` or `data-nav="next"`
+appear in both the header and footer. Arrow keys and swipe gestures cycle through
+the loaded documents.
 
 ## components/
 

--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -9,6 +9,7 @@ import { marked } from "../vendor/marked.esm.js";
  * 2. Convert each file to HTML with `marked.parse`.
  * 3. Display the first document inside the content container.
  * 4. Provide next/previous navigation with wrap-around.
+ *    - Attach click handlers to all navigation buttons.
  * 5. Support arrow key and swipe gestures for navigation.
  *
  * @param {Record<string, string>} [docsMap] Optional preloaded docs for testing.
@@ -59,8 +60,8 @@ export async function setupPrdReaderPage(docsMap, markedLib) {
     }
   }
   const container = document.getElementById("prd-content");
-  const nextBtn = document.getElementById("next-doc");
-  const prevBtn = document.getElementById("prev-doc");
+  const nextButtons = document.querySelectorAll('[data-nav="next"]');
+  const prevButtons = document.querySelectorAll('[data-nav="prev"]');
 
   if (!container || documents.length === 0) return;
 
@@ -80,8 +81,8 @@ export async function setupPrdReaderPage(docsMap, markedLib) {
     render();
   }
 
-  nextBtn?.addEventListener("click", showNext);
-  prevBtn?.addEventListener("click", showPrev);
+  nextButtons.forEach((btn) => btn.addEventListener("click", showNext));
+  prevButtons.forEach((btn) => btn.addEventListener("click", showPrev));
 
   document.addEventListener("keydown", (e) => {
     if (e.key === "ArrowRight") showNext();

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -75,8 +75,8 @@
       <div class="logo">JU-DO-KON!</div>
       <br />
       <div class="nav-buttons">
-        <button id="prev-doc" aria-label="Previous document">Prev</button>
-        <button id="next-doc" aria-label="Next document">Next</button>
+        <button data-nav="prev" aria-label="Previous document">Prev</button>
+        <button data-nav="next" aria-label="Next document">Next</button>
       </div>
     </header>
 
@@ -87,8 +87,8 @@
     <script type="module" src="../helpers/prdReaderPage.js"></script>
     <footer>
       <div class="nav-buttons">
-        <button id="prev-doc" aria-label="Previous document">Prev</button>
-        <button id="next-doc" aria-label="Next document">Next</button>
+        <button data-nav="prev" aria-label="Previous document">Prev</button>
+        <button data-nav="next" aria-label="Next document">Next</button>
       </div>
     </footer>
   </body>

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -15,8 +15,10 @@ describe("prdReaderPage", () => {
 
     document.body.innerHTML = `
       <div id="prd-content"></div>
-      <button id="prev-doc">Prev</button>
-      <button id="next-doc">Next</button>
+      <button data-nav="prev">Prev</button>
+      <button data-nav="next">Next</button>
+      <button data-nav="prev">Prev bottom</button>
+      <button data-nav="next">Next bottom</button>
     `;
 
     globalThis.SKIP_PRD_AUTO_INIT = true;
@@ -25,15 +27,15 @@ describe("prdReaderPage", () => {
     await setupPrdReaderPage(docs, marked);
 
     const container = document.getElementById("prd-content");
-    const nextBtn = document.getElementById("next-doc");
-    const prevBtn = document.getElementById("prev-doc");
+    const nextBtns = document.querySelectorAll('[data-nav="next"]');
+    const prevBtns = document.querySelectorAll('[data-nav="prev"]');
 
     expect(container.innerHTML).toContain("First doc");
-    nextBtn.click();
+    nextBtns[0].click();
     expect(container.innerHTML).toContain("Second doc");
-    nextBtn.click();
+    nextBtns[1].click();
     expect(container.innerHTML).toContain("First doc");
-    prevBtn.click();
+    prevBtns[1].click();
     expect(container.innerHTML).toContain("Second doc");
   });
 });


### PR DESCRIPTION
## Summary
- wire up all prev/next buttons in PRD viewer
- mark buttons with `data-nav` attribute
- document navigation updates
- adjust architecture guide
- update PRD reader unit test

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68790c4561f48326ad621d1a3c25aec0