### PR TITLE
Add signature move screenshot test

### DIFF
--- a/playwright/signatureMove.spec.js
+++ b/playwright/signatureMove.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+
+const runScreenshots = process.env.SKIP_SCREENSHOTS !== "true";
+
+test.describe(
+  runScreenshots ? "Signature move screenshots" : "Signature move screenshots (skipped)",
+  () => {
+    test.skip(!runScreenshots);
+
+    test("random judoka page", async ({ page }) => {
+      await page.goto("/src/pages/randomJudoka.html");
+      const sigMove = page.locator(".signature-move-container");
+      await sigMove.waitFor();
+      await expect(sigMove).toHaveScreenshot("randomJudoka-signature.png");
+    });
+
+    test("browse judoka page", async ({ page }) => {
+      await page.goto("/src/pages/browseJudoka.html");
+      const sigMove = page.locator(".signature-move-container").first();
+      await sigMove.waitFor();
+      await expect(sigMove).toHaveScreenshot("browseJudoka-signature.png");
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- add `signatureMove.spec.js` to verify signature move container rendering on both Random Judoka and Browse Judoka pages

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test --update-snapshots`


------
https://chatgpt.com/codex/tasks/task_e_6879107d46fc8326bd9b349f062a4084