### PR TITLE
Add Home button for PRD viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Add new Markdown files there and include the filename in the `FILES` array of
 to browse the documents with next/previous navigation. The page now imports
 `base.css` and `layout.css` so wide elements stay wrapped inside the viewport.
 Navigation buttons remain left-aligned with a gap so they don't interfere with
-the centered content.
+the centered content. Users can return to the main menu via the Home button.
 
 ### CSS Organization
 
@@ -219,7 +219,7 @@ The repository specifies commenting standards in design/codeStandards. JSDoc com
   `aria-label` descriptions
 - Country picker panel appears below the fixed header for unobstructed viewing
 - Scroll buttons disable when the carousel reaches either end
-- Mockup viewer page with next/back controls for design screenshots
+- Mockup viewer page with next/back controls for design screenshots (includes a Home link)
 
 ## About JU-DO-KON!
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -31,7 +31,7 @@ Documents. The Markdown files live in
 `design/productRequirementsDocuments`. The helper fetches each file,
 parses it through the **Marked** library (supporting headings, paragraphs, bold text, nested lists, tables, and horizontal rules) and injects the HTML into the
 `#prd-content` container. Next/previous buttons, arrow keys and swipe
-gestures cycle through the loaded documents.
+gestures cycle through the loaded documents. A Home button in the header returns to `index.html`.
 
 ## components/
 

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -77,6 +77,7 @@
       <div class="nav-buttons">
         <button id="prev-doc" aria-label="Previous document">Prev</button>
         <button id="next-doc" aria-label="Next document">Next</button>
+        <a href="../../index.html" data-testid="home-link">Home</a>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- add Home link to PRD viewer page
- document the new Home link in README and architecture docs
- note that the mockup viewer already includes a Home link

## Testing
- `npx prettier . --check` *(fails: `npx` not found)*
- `npx eslint .` *(fails: `npx` not found)*
- `npx vitest run` *(fails: `npx` not found)*
- `npx playwright test` *(fails: `npx` not found)*
- `npm run check:contrast` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879111cfaf483269267fbcb69b2255b