### PR TITLE
Fix cross-browser card layout

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -279,11 +279,11 @@ button .ripple {
   justify-content: space-around;
   display: inline-flex;
   align-items: center;
-  padding: var(--space-medium) var(--space-small); /* Updated tokens */
+  padding: var(--space-medium) var(--space-small);
   flex-direction: row;
   /* Maintain ~14% of card height accounting for padding */
-  flex: 0 0 calc(14% - (var(--space-small) * 2));
-  height: calc(14% - (var(--space-small) * 2));
+  flex: 0 0 calc(14% - (var(--space-medium) * 2));
+  height: calc(14% - (var(--space-medium) * 2));
   box-sizing: border-box;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.12);
 }
@@ -450,7 +450,6 @@ button .ripple {
   width: 100%;
   /* Maintain ~10% (~45px) height as specified in the PRD */
   height: max(10%, var(--touch-target-size));
-  line-height: max(10%, var(--touch-target-size));
   font-weight: bold;
   /* Ensure visible at small screen sizes */
   flex: 0 0 max(10%, var(--touch-target-size));
@@ -463,7 +462,7 @@ button .ripple {
 .signature-move-label,
 .signature-move-value {
   display: flex;
-  width: 100%;
+  flex: 1 1 auto;
   justify-content: center;
   border-radius: 0;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- adjust `.card-top-bar` height calc to account for its vertical padding
- remove `line-height` and fix child flex properties in `.signature-move-container`

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npx playwright test` *(fails: 403 Forbidden fetching playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6879257401488326be99b55ae3250807