### PR TITLE
Update screenshot docs for multi-project tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,6 +45,9 @@ npm run test:screenshot              # run visual regression tests
 npx playwright test --update-snapshots  # update baseline screenshots when needed
 ```
 
+Playwright uses multiple browser projects. The screenshot suite runs separately
+for each project and stores snapshots under their respective folders.
+
 - **Do not commit files under `playwright/*-snapshots`.** Baseline screenshots
   are updated automatically by `.github/workflows/playwright-baseline.yml`.
   If Playwright tests fail because visuals changed, note the failure in the pull

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,10 @@ If a UI change is intended, update baseline screenshots with:
 npx playwright test --update-snapshots
 ```
 
+Playwright uses a **multi-project** setup, so the screenshot suite runs once per
+configured browser project (e.g., Chromium, Firefox). Each project writes its
+own snapshot files.
+
 Do **not** commit files under `playwright/*-snapshots`. Baseline screenshots are
 updated automatically by `.github/workflows/playwright-baseline.yml`. If Playwright tests fail because visuals changed, mention this in your pull request but
 avoid committing new snapshot images.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Run optional Playwright-based screenshot tests with:
 npm run test:screenshot
 ```
 
+The screenshot suite now runs once for **each browser project** configured in
+`playwright.config.js`. Snapshot images are saved under
+`playwright/<spec>.spec.js-snapshots/<project>/`.
+
+Remember **not** to commit files in `playwright/*-snapshots` when screenshots
+change. Use `npx playwright test --update-snapshots` to regenerate the baseline
+images locally.
+
 Set `SKIP_SCREENSHOTS=true` to skip the screenshot suite if you only want to run
 the other Playwright tests:
 


### PR DESCRIPTION
## Summary
- document per-project screenshot tests in `README.md`
- highlight Playwright multi-project setup and update-snapshot command in `CONTRIBUTING.md`
- sync copilot instructions about multi-project screenshots

## Testing
- `npx prettier . --check` *(fails: `npx` not found)*
- `npx eslint .` *(fails: `npx` not found)*
- `npx vitest run` *(fails: `npx` not found)*
- `npx playwright test` *(fails: `npx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792e781050832687d7f34732454193