### PR TITLE
Fix card top bar height

### DIFF
--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -177,7 +177,7 @@ The design must be attractive and **minimize cognitive load**—presenting stats
   - Stats text uses `--font-medium` and line-height `1.2` to remain legible without increasing panel height.
 - **Signature Move Band:** `height: max(10%, var(--touch-target-size))` keeps the 44px tap target while maintaining the card's 2:3 ratio.
 - The label and value are centered vertically within that band.
-- **Padding Adjustments:** Section heights use `calc()` to subtract vertical padding so the total fits within the card's 2:3 ratio.
+- **Padding Adjustments:** Section percentages already account for vertical padding because `.judoka-card` uses `box-sizing: border-box`. No `calc()` subtraction is necessary.
 - **Rarity Border Colors:**
   - Common → Blue (#337AFF)
   - Rare → Red (#FF3333)

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -281,9 +281,8 @@ button .ripple {
   align-items: center;
   padding: var(--space-medium) var(--space-small);
   flex-direction: row;
-  /* Maintain ~14% of card height accounting for padding */
-  flex: 0 0 calc(14% - (var(--space-medium) * 2));
-  height: calc(14% - (var(--space-medium) * 2));
+  flex: 0 0 14%;
+  height: 14%;
   box-sizing: border-box;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.12);
 }


### PR DESCRIPTION
## Summary
- adjust card top bar height to be 14%
- update PRD to mention that section percentages include padding

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6879323824008326bf78d2d655292b5c