### PR TITLE
Update judoka card width

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -181,7 +181,9 @@ button .ripple {
     maintaining the fixed 300px size on larger displays.
     This prevents the card text from overflowing on mobile Safari.
   */
-  width: clamp(200px, 70vw, 300px);
+  --card-width: clamp(200px, 70vw, 300px);
+  width: var(--card-width);
+  height: calc(var(--card-width) * 1.5);
   aspect-ratio: 2 / 3;
   border: 13px solid var(--card-border-color);
   border-radius: var(--radius-lg); /* Updated token */


### PR DESCRIPTION
## Summary
- use a CSS variable for judoka card width
- set explicit height to preserve fallback ratio

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Signature move screenshots › random judoka page)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68793a998b4883268a0dab42fd96813a