### PR TITLE
Fix card top bar dimensions

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -281,8 +281,9 @@ button .ripple {
   align-items: center;
   padding: var(--space-medium) var(--space-small);
   flex-direction: row;
-  flex: 0 0 14%;
-  height: 14%;
+  flex: 0 0 calc(var(--card-width) * 0.14);
+  height: calc(var(--card-width) * 0.14);
+  min-height: var(--touch-target-size, 44px);
   box-sizing: border-box;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.12);
 }


### PR DESCRIPTION
## Summary
- keep the card top bar fixed relative to the card width

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 4 failed snapshot tests)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68793aa14b7c832692d60a32f9b509e3