### PR TITLE
Adjust touch target size for signature band

### DIFF
--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -178,6 +178,8 @@ The design must be attractive and **minimize cognitive load**—presenting stats
   - Stats text uses `--font-medium` and line-height `1.2` to remain legible without increasing panel height.
 - **Signature Move Band:** `height: max(10%, var(--touch-target-size))` keeps the 44px tap target while maintaining the card's 2:3 ratio.
 - The label and value are centered vertically within that band.
+- `.judoka-card` overrides `--touch-target-size` to `44px` so the band stays
+  45px tall on a 300×450 card without leaving gaps above or below it.
 - **Padding Adjustments:** Section percentages already account for vertical padding because `.judoka-card` uses `box-sizing: border-box`. No `calc()` subtraction is necessary.
 - **Rarity Border Colors:**
   - Common → Blue (#337AFF)

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -182,6 +182,8 @@ button .ripple {
     This prevents the card text from overflowing on mobile Safari.
   */
   --card-width: clamp(200px, 70vw, 300px);
+  /* Override the global touch target to maintain 10% proportions */
+  --touch-target-size: 44px;
   width: var(--card-width);
   height: calc(var(--card-width) * 1.5);
   aspect-ratio: 2 / 3;


### PR DESCRIPTION
## Summary
- specify `--touch-target-size` for `.judoka-card`
- explain the variable override in the PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch for signature band)*
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_687a7f9d3bd083269c4654937fc91892