### PR TITLE
Update judoka card grid layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ card sections is less than 100%. Ensure `.card-top-bar`, `.card-portrait`,
 `.card-stats`, and `.signature-move-container` together fill the card height to
 avoid this issue.
 
+The card layout now uses CSS grid rows (`calc(var(--card-width) * 0.14)`,
+`42%`, `38.67%`, `max(10%, var(--touch-target-size))`) so the stats panel and
+signature move band stack directly against each other in Safari and Chrome.
+
 The bottom navbar uses `env(safe-area-inset-bottom)` with a `constant()` fallback to add extra padding and height. This prevents it from overlapping the iOS home indicator and keeps content visible.
 
 Layout containers should include a `vh` fallback declared before the `dvh` rule so browsers without dynamic viewport support still size elements correctly.

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -192,9 +192,12 @@ button .ripple {
   background-color: var(--card-bg-color);
   box-shadow: var(--shadow-base); /* Updated token */
   overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
+  display: grid;
+  grid-template-rows:
+    calc(var(--card-width) * 0.14)
+    42%
+    38.67%
+    max(10%, var(--touch-target-size));
   transition:
     box-shadow var(--transition-fast),
     transform 0.1s ease-in-out; /* Updated token */
@@ -397,9 +400,9 @@ button .ripple {
   align-items: stretch;
   font-size: var(--font-medium);
   flex-direction: column;
-  /* Stats area ~34% of card height accounting for padding */
-  height: 34%;
-  flex: 0 0 34%;
+  /* Stats area ~38.67% of card height accounting for padding */
+  height: 38.67%;
+  flex: 0 0 38.67%;
 }
 
 .card-stats ul {
@@ -460,7 +463,6 @@ button .ripple {
   flex: 0 0 max(10%, var(--touch-target-size));
   box-sizing: border-box;
   border-top: 1px solid var(--color-text-inverted, var(--color-secondary));
-  margin-top: auto;
   justify-content: center;
 }
 


### PR DESCRIPTION
## Summary
- convert judoka card to CSS grid
- rebalance stats panel height
- drop margin-top auto on signature move row
- document Safari/Chrome fix for card layout

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatches)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687a85cba6d0832681467692cdd8bca9