### PR TITLE
Update settings layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ signature move band stack directly against each other in Safari and Chrome.
 The bottom navbar uses `env(safe-area-inset-bottom)` with a `constant()` fallback to add extra padding and height. This prevents it from overlapping the iOS home indicator and keeps content visible.
 
 Layout containers should include a `vh` fallback declared before the `dvh` rule so browsers without dynamic viewport support still size elements correctly.
-The settings screen previously had its first controls hidden behind the header; wrapping the page in this `.home-screen` container resolves the issue. The classic battle page now also uses this wrapper so the judoka cards appear fully below the header.
+The settings screen previously had its first controls hidden behind the header; wrapping the page in this `.home-screen` container resolves the issue. The page now starts with an `<h1>` heading and two `<fieldset>` sections labeled **General Settings** and **Game Modes**. The classic battle page also uses this wrapper so the judoka cards appear fully below the header.
 
 ## Future Plans
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -148,7 +148,7 @@ As a user of the game _ju-do-kon!_, I want to be able to change settings such as
 
   - Tab order should proceed top-to-bottom: sound → nav map → motion → display mode → game mode toggles.
   - Users can navigate and activate each control without needing a mouse.
-  - **Section layout:** Both the general settings and game mode toggle list use the `.game-mode-toggle-container` grid for consistent spacing.
+  - **Section layout:** The page begins with an `<h1>` heading followed by two `<fieldset>` sections—**General Settings** and **Game Modes**—each using the `.game-mode-toggle-container` grid. The second fieldset keeps `id="game-mode-toggle-container"` so scripts can find it.
 
   | **Settings Menu Mockup 1**                                         | **Settings Menu Mockup 2**                                         | **Settings Menu Mockup 2**                                         |
   | ------------------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
@@ -166,6 +166,8 @@ As a user of the game _ju-do-kon!_, I want to be able to change settings such as
 ---
 
 ## Wireframe
+
+The page begins with an `<h1>` heading labeled "Settings". Two `<fieldset>` sections follow—one for **General Settings** and one for **Game Modes**.
 
 ───────────────────────────────  
 | SETTINGS |  

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -39,12 +39,13 @@
       </header>
 
       <main class="container" role="main">
-        <form id="settings-form" class="game-mode-toggle-container settings-form">
+        <h1>Settings</h1>
+        <form id="settings-form" class="settings-form">
           <fieldset
             id="general-settings-container"
             class="game-mode-toggle-container settings-form"
           >
-            <legend class="visually-hidden">Game Settings</legend>
+            <legend>General Settings</legend>
             <div class="settings-item">
               <label for="sound-toggle" class="switch">
                 <input type="checkbox" id="sound-toggle" name="sound" aria-label="Sound" />
@@ -85,15 +86,13 @@
               </select>
             </div>
           </fieldset>
-        </form>
-        <form>
-          <section
+          <fieldset
             id="game-mode-toggle-container"
             class="game-mode-toggle-container settings-form"
             aria-label="Game Mode Selector"
           >
-            <span>Game Modes</span>
-          </section>
+            <legend>Game Modes</legend>
+          </fieldset>
         </form>
       </main>
 


### PR DESCRIPTION
## Summary
- add heading and two fieldsets to settings page
- document settings layout updates
- clarify settings info in README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diff for settings page)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_687a9847183883268cfa90886f62653c