### PR TITLE
Adjust HR rendering in PRD viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 - **CSS3**: For styling and layout.
 - **JavaScript (ES6)**: For game logic and interactivity.
 - **Vite**: For building and bundling the project.
-- **Marked**: Minimal parser used in the PRD reader that now supports nested ordered and unordered lists, bold text, tables, and horizontal rules.
+- **Marked**: Minimal parser used in the PRD reader that now supports nested ordered and unordered lists, bold text, tables, and horizontal rules rendered as `<hr/><br/>` for extra spacing.
 - **GitHub Pages**: For hosting the live demo.
 
 ## Known Issues

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -29,7 +29,7 @@ initialize page-specific behavior.
 `src/helpers/prdReaderPage.js` to display the Product Requirements
 Documents. The Markdown files live in
 `design/productRequirementsDocuments`. The helper fetches each file,
-parses it through the **Marked** library (supporting headings, paragraphs, bold text, mixed ordered and unordered lists, tables, and horizontal rules) and injects the HTML into the
+parses it through the **Marked** library (supporting headings, paragraphs, bold text, mixed ordered and unordered lists, tables, and horizontal rules rendered as `<hr/><br/>` for extra spacing) and injects the HTML into the
 `#prd-content` container. Buttons marked with `data-nav="prev"` or `data-nav="next"`
 appear in both the header and footer. Arrow keys and swipe gestures cycle through
 the loaded documents. A Home button in the header returns to `index.html`.

--- a/src/vendor/marked.esm.js
+++ b/src/vendor/marked.esm.js
@@ -1,7 +1,7 @@
 export const marked = {
   /**
-   * Very small markdown parser supporting headings, bold text paragraphs, lists,
-   * tables and horizontal rules.
+  * Very small markdown parser supporting headings, bold text paragraphs, lists,
+  * tables and horizontal rules (each rule followed by a line break for spacing).
    *
    * @param {string} md - Markdown string.
    * @returns {string} HTML string.
@@ -83,7 +83,7 @@ export const marked = {
       .split(/\n\n+/)
       .map((block) => {
         if (/^(-{3,}|\*{3,}|_{3,})$/.test(block.trim())) {
-          return "<hr/>";
+          return "<hr/><br/>";
         }
         if (block.startsWith("# ")) {
           return `<h1>${renderInline(block.slice(2).trim())}</h1>`;

--- a/tests/helpers/markdownParser.test.js
+++ b/tests/helpers/markdownParser.test.js
@@ -48,7 +48,7 @@ describe("marked.parse", () => {
   it("parses horizontal rules", () => {
     const md = "one\n\n----\n\ntwo";
     const html = marked.parse(md);
-    expect(html).toBe("<p>one</p><hr/><p>two</p>");
+    expect(html).toBe("<p>one</p><hr/><br/><p>two</p>");
   });
 
   it("parses basic tables", () => {


### PR DESCRIPTION
## Summary
- add a trailing `<br/>` when markdown horizontal rules are parsed
- document the change in architecture docs and README
- update markdown parser unit test

## Testing
- `npx prettier . --check` *(fails: Cannot find module 'prettier')*
- `npx eslint .` *(fails to load '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_687a9d40dfc483269463764c8e3f93d1