### PR TITLE
Update settings form styles

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -857,6 +857,17 @@ button .ripple {
   padding: 10px;
 }
 
+.settings-form {
+  padding: var(--space-lg);
+}
+
+.settings-form legend {
+  font-family: "Russo One", sans-serif;
+  font-size: 32px;
+  font-weight: bold;
+  margin-block-end: var(--space-md);
+}
+
 /* Settings form controls */
 .settings-form label {
   display: flex;


### PR DESCRIPTION
## Summary
- pad the settings form and style the legend as a headline

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch for settings page)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687b7940f24083268e7c7afafdadcfda