### PR TITLE
Reorder display mode setting

### DIFF
--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -47,6 +47,14 @@
           >
             <legend>General Settings</legend>
             <div class="settings-item">
+              <label for="display-mode-select">Display Mode</label>
+              <select id="display-mode-select">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="gray">Gray</option>
+              </select>
+            </div>
+            <div class="settings-item">
               <label for="sound-toggle" class="switch">
                 <input type="checkbox" id="sound-toggle" name="sound" aria-label="Sound" />
                 <div class="slider round"></div>
@@ -76,14 +84,6 @@
                 <div class="slider round"></div>
                 <span>Motion Effects</span>
               </label>
-            </div>
-            <div class="settings-item">
-              <label for="display-mode-select">Display Mode</label>
-              <select id="display-mode-select">
-                <option value="light">Light</option>
-                <option value="dark">Dark</option>
-                <option value="gray">Gray</option>
-              </select>
             </div>
           </fieldset>
           <fieldset


### PR DESCRIPTION
## Summary
- move display mode selector to the top of General Settings

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_687b7e239c9c8326ade11a3fe1393752