### PR TITLE
Adjust focus sequence in settings tests

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -40,10 +40,10 @@ test.describe("Settings page", () => {
       .map((m) => m.name);
 
     const expectedLabels = [
+      "Display Mode",
       "Sound",
       "Full Navigation Map",
       "Motion Effects",
-      "Display Mode",
       ...sortedNames
     ];
 
@@ -58,7 +58,7 @@ test.describe("Settings page", () => {
       await expect(page.getByLabel(name)).toHaveAttribute("aria-label", name);
     }
 
-    await page.focus("#sound-toggle");
+    await page.focus("#display-mode-select");
 
     const activeLabels = [];
     for (let i = 0; i < expectedLabels.length; i++) {


### PR DESCRIPTION
## Summary
- tweak the expected tab order in the settings Playwright test
- start tabbing from the Display Mode control

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diffs in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_687b825791d883269da9ea1e1f1af83a