### PR TITLE
Fix mobile stats layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -249,25 +248,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -45,15 +45,15 @@
             id="general-settings-container"
             class="game-mode-toggle-container settings-form"
           >
-          <legend>Display Settings</legend>
-          <div class="settings-item">
-            <label for="display-mode-select">Display Mode</label>
-            <select id="display-mode-select">
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-              <option value="gray">Gray</option>
-            </select>
-          </div>    
+            <legend>Display Settings</legend>
+            <div class="settings-item">
+              <label for="display-mode-select">Display Mode</label>
+              <select id="display-mode-select">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="gray">Gray</option>
+              </select>
+            </div>
             <legend>General Settings</legend>
             <div class="settings-item">
               <label for="sound-toggle" class="switch">

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -296,7 +296,7 @@ button .ripple {
   min-height: var(--touch-target-size, 44px);
   box-sizing: border-box;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.12);
-    /* border: 2px solid red; */
+  /* border: 2px solid red; */
 }
 
 .card-name {
@@ -358,7 +358,7 @@ button .ripple {
   flex: 0 0 42%;
   overflow: hidden;
   margin-bottom: 0;
-    /* border: 2px solid red; */
+  /* border: 2px solid red; */
   background: linear-gradient(
     to bottom,
     var(--card-portrait-gradient-start),
@@ -421,7 +421,7 @@ button .ripple {
   flex-direction: column;
   justify-content: space-between;
   height: 100%;
-    /* border: 2px solid red; */
+  /* border: 2px solid red; */
 }
 
 .card-stats li {
@@ -429,8 +429,8 @@ button .ripple {
   padding: 4px min(1px, 0.6vh);
   border-top: 1px solid var(--color-text-inverted, var(--color-secondary));
   font-family: "Open Sans", sans-serif;
-  font-size: var(--font-medium);
-  line-height: 1.4;
+  font-size: min(5vw, var(--font-medium));
+  line-height: 1.2;
   font-weight: bold;
 }
 
@@ -448,7 +448,7 @@ button .ripple {
   display: flex;
   justify-content: space-around;
   margin-bottom: 0;
-    /* border-bottom: 1px solid red; */
+  /* border-bottom: 1px solid red; */
 }
 
 .card-stats .stat strong {
@@ -475,7 +475,7 @@ button .ripple {
   border-top: 1px solid var(--color-text-inverted, var(--color-secondary));
   justify-content: center;
   /* border: 2px solid var(--card-stats-bg); */
-  border: 2px solid var(--card-signature-move-bg);  
+  border: 2px solid var(--card-signature-move-bg);
 }
 
 .signature-move-label,


### PR DESCRIPTION
## Summary
- tweak stats font size and line height for judoka cards
- format README and settings page with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden for vitest package)*
- `npx playwright test` *(fails: 403 Forbidden for playwright package)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_687bf0a5dfb483269afff17fbc4bdbf2