### PR TITLE
Update horizontal rule formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 - **CSS3**: For styling and layout.
 - **JavaScript (ES6)**: For game logic and interactivity.
 - **Vite**: For building and bundling the project.
-- **Marked**: Minimal parser used in the PRD reader that now supports nested ordered and unordered lists, bold text, tables, and horizontal rules rendered as `<hr/><br/>` for extra spacing.
+- **Marked**: Minimal parser used in the PRD reader that now supports nested ordered and unordered lists, bold text, tables, and horizontal rules rendered as `<br/><hr/><br/>` for extra spacing.
 - **GitHub Pages**: For hosting the live demo.
 
 ## Known Issues

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -29,7 +29,7 @@ initialize page-specific behavior.
 `src/helpers/prdReaderPage.js` to display the Product Requirements
 Documents. The Markdown files live in
 `design/productRequirementsDocuments`. The helper fetches each file,
-parses it through the **Marked** library (supporting headings, paragraphs, bold text, mixed ordered and unordered lists, tables, and horizontal rules rendered as `<hr/><br/>` for extra spacing) and injects the HTML into the
+parses it through the **Marked** library (supporting headings, paragraphs, bold text, mixed ordered and unordered lists, tables, and horizontal rules rendered as `<br/><hr/><br/>` for extra spacing) and injects the HTML into the
 `#prd-content` container. Buttons marked with `data-nav="prev"` or `data-nav="next"`
 appear in both the header and footer. Arrow keys and swipe gestures cycle through
 the loaded documents. A Home button in the header returns to `index.html`.

--- a/tests/helpers/markdownParser.test.js
+++ b/tests/helpers/markdownParser.test.js
@@ -48,7 +48,7 @@ describe("marked.parse", () => {
   it("parses horizontal rules", () => {
     const md = "one\n\n----\n\ntwo";
     const html = marked.parse(md);
-    expect(html).toBe("<p>one</p><hr/><br/><p>two</p>");
+    expect(html).toBe("<p>one</p><br/><hr/><br/><p>two</p>");
   });
 
   it("parses basic tables", () => {


### PR DESCRIPTION
## Summary
- ensure test expects spacing before and after `<hr>`
- document `<br><hr><br>` behavior in architecture docs and README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_687bf3eda39c8326b00e29059464656a