### PR TITLE
Add battle info bar

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -7,7 +7,7 @@ test.describe("Classic battle flow", () => {
       window.setInterval = (fn, ms, ...args) => orig(fn, Math.min(ms, 10), ...args);
     });
     await page.goto("/src/pages/battleJudoka.html");
-    await page.waitForSelector("#round-timer");
+    await page.waitForSelector("#next-round-timer");
     const result = page.locator("#round-result");
     await expect(result).not.toHaveText("", { timeout: 1200 });
   });
@@ -18,7 +18,7 @@ test.describe("Classic battle flow", () => {
       window.setInterval = (fn, ms, ...args) => orig(fn, Math.max(ms, 3600000), ...args);
     });
     await page.goto("/src/pages/battleJudoka.html");
-    await page.waitForSelector("#round-timer");
+    await page.waitForSelector("#next-round-timer");
     await page.evaluate(() => {
       document.querySelector("#player-card").innerHTML =
         `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -38,7 +38,7 @@ function showResult(message) {
 }
 
 function startTimer() {
-  const timerEl = document.getElementById("round-timer");
+  const timerEl = document.getElementById("next-round-timer");
   engineStartRound(
     (remaining) => {
       if (timerEl) timerEl.textContent = String(remaining);
@@ -151,7 +151,7 @@ export function _resetForTest() {
   judokaData = null;
   gokyoLookup = null;
   engineReset();
-  const timerEl = document.getElementById("round-timer");
+  const timerEl = document.getElementById("next-round-timer");
   if (timerEl) timerEl.textContent = "";
   const resultEl = document.getElementById("round-result");
   if (resultEl) resultEl.textContent = "";

--- a/src/helpers/setupBattleInfoBar.js
+++ b/src/helpers/setupBattleInfoBar.js
@@ -1,0 +1,21 @@
+import { createInfoBar } from "../components/InfoBar.js";
+import { onDomReady } from "./domReady.js";
+
+/**
+ * Insert the battle info bar after the page header if not already present.
+ *
+ * @pseudocode
+ * 1. Locate the `<header>` element.
+ * 2. If a `.battle-info-bar` element does not exist:
+ *    a. Create one with `createInfoBar()`.
+ *    b. Insert it immediately after the header.
+ */
+export function setupBattleInfoBar() {
+  const header = document.querySelector("header");
+  if (!header) return;
+  if (document.querySelector(".battle-info-bar")) return;
+  const bar = createInfoBar();
+  header.insertAdjacentElement("afterend", bar);
+}
+
+onDomReady(setupBattleInfoBar);

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -37,6 +37,11 @@
         </div>
         <div class="character-slot right"></div>
       </header>
+      <div class="battle-info-bar">
+        <p id="round-message"></p>
+        <p id="next-round-timer"></p>
+        <p id="score-display">You: 0 Computer: 0</p>
+      </div>
 
       <main class="container" role="main">
         <section id="battle-area">
@@ -44,9 +49,6 @@
           <div id="computer-card" class="card-slot"></div>
 
           <div id="controls">
-            <p id="timer">Time: <span id="round-timer"></span></p>
-            <p id="score-display">You: 0 Computer: 0</p>
-
             <div id="stat-buttons">
               <button data-stat="power" type="button">Power</button>
               <button data-stat="speed" type="button">Speed</button>
@@ -79,6 +81,7 @@
         );
       </script>
       <script type="module" src="../helpers/setupSvgFallback.js"></script>
+      <script type="module" src="../helpers/setupBattleInfoBar.js"></script>
       <script type="module" src="../helpers/battleJudokaPage.js"></script>
     </div>
   </body>

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -30,7 +30,7 @@ describe("classicBattle", () => {
       <div id="computer-card"></div>
       <p id="score-display"></p>
       <p id="round-result"></p>
-      <span id="round-timer"></span>`;
+      <p id="next-round-timer"></p>`;
     timerSpy = vi.useFakeTimers();
     generateRandomCardMock = vi.fn(async (data, g, container, _pm, cb) => {
       container.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>5</span></li><li class="stat"><strong>Speed</strong> <span>5</span></li><li class="stat"><strong>Technique</strong> <span>5</span></li><li class="stat"><strong>Kumi-kata</strong> <span>5</span></li><li class="stat"><strong>Ne-waza</strong> <span>5</span></li></ul>`;


### PR DESCRIPTION
## Summary
- add battle info bar markup
- load setupBattleInfoBar script and create module
- switch timer handling to `next-round-timer`
- update unit and Playwright tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: signatureMove screenshots diff)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687c16ae9b3883269d2dcabdc6918cdc