### PR TITLE
Update classic battle info bar integration

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -8,7 +8,7 @@ test.describe("Classic battle flow", () => {
     });
     await page.goto("/src/pages/battleJudoka.html");
     await page.waitForSelector("#next-round-timer");
-    const result = page.locator("#round-result");
+    const result = page.locator("#round-message");
     await expect(result).not.toHaveText("", { timeout: 1200 });
   });
 
@@ -26,13 +26,13 @@ test.describe("Classic battle flow", () => {
         `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;
     });
     await page.locator("button[data-stat='power']").click();
-    await expect(page.locator("#round-result")).toHaveText(/Tie/);
+    await expect(page.locator("#round-message")).toHaveText(/Tie/);
   });
 
   test("quit match confirmation", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
     page.on("dialog", (dialog) => dialog.accept());
     await page.locator("#quit-btn").click();
-    await expect(page.locator("#round-result")).toHaveText(/quit/i);
+    await expect(page.locator("#round-message")).toHaveText(/quit/i);
   });
 });

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -29,7 +29,7 @@ describe("classicBattle", () => {
       <div id="player-card"></div>
       <div id="computer-card"></div>
       <p id="score-display"></p>
-      <p id="round-result"></p>
+      <p id="round-message"></p>
       <p id="next-round-timer"></p>`;
     timerSpy = vi.useFakeTimers();
     generateRandomCardMock = vi.fn(async (data, g, container, _pm, cb) => {
@@ -66,7 +66,7 @@ describe("classicBattle", () => {
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     _resetForTest();
     handleStatSelection("power");
-    expect(document.getElementById("round-result").textContent).toMatch(/Tie/);
+    expect(document.getElementById("round-message").textContent).toMatch(/Tie/);
     expect(document.getElementById("score-display").textContent).toBe("You: 0 Computer: 0");
   });
 
@@ -75,7 +75,7 @@ describe("classicBattle", () => {
     const { quitMatch } = await import("../../src/helpers/classicBattle.js");
     quitMatch();
     expect(confirmSpy).toHaveBeenCalled();
-    expect(document.getElementById("round-result").textContent).toMatch(/quit/i);
+    expect(document.getElementById("round-message").textContent).toMatch(/quit/i);
   });
 
   it("ends the match when player reaches 10 wins", async () => {
@@ -91,7 +91,7 @@ describe("classicBattle", () => {
       handleStatSelection("power");
     }
     expect(document.getElementById("score-display").textContent).toBe("You: 10 Computer: 0");
-    expect(document.getElementById("round-result").textContent).toMatch(/win the match/i);
+    expect(document.getElementById("round-message").textContent).toMatch(/win the match/i);
 
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;


### PR DESCRIPTION
## Summary
- hook classic battle score updates to InfoBar updateScore()
- fade messages through InfoBar's `#round-message`
- countdown to next round using startCountdown()
- update references in unit and UI tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_687c22939e0083268bea00371c840bcd