### PR TITLE
Initialize and export battle info bar

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -12,7 +12,7 @@ import {
   STATS,
   _resetForTest as engineReset
 } from "./battleEngine.js";
-import { updateScore, startCountdown } from "../components/InfoBar.js";
+import { updateScore, startCountdown } from "./setupBattleInfoBar.js";
 
 let judokaData = null;
 let gokyoLookup = null;

--- a/src/helpers/setupBattleInfoBar.js
+++ b/src/helpers/setupBattleInfoBar.js
@@ -1,4 +1,4 @@
-import { createInfoBar } from "../components/InfoBar.js";
+import { createInfoBar, showMessage, updateScore, startCountdown } from "../components/InfoBar.js";
 import { onDomReady } from "./domReady.js";
 
 /**
@@ -10,12 +10,15 @@ import { onDomReady } from "./domReady.js";
  *    a. Create one with `createInfoBar()`.
  *    b. Insert it immediately after the header.
  */
-export function setupBattleInfoBar() {
+function setupBattleInfoBar() {
   const header = document.querySelector("header");
   if (!header) return;
-  if (document.querySelector(".battle-info-bar")) return;
-  const bar = createInfoBar();
-  header.insertAdjacentElement("afterend", bar);
+  if (!document.querySelector(".battle-info-bar")) {
+    const bar = createInfoBar();
+    header.insertAdjacentElement("afterend", bar);
+  }
 }
 
 onDomReady(setupBattleInfoBar);
+
+export { showMessage, updateScore, startCountdown };

--- a/tests/helpers/setupBattleInfoBar.test.js
+++ b/tests/helpers/setupBattleInfoBar.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+const originalReadyState = Object.getOwnPropertyDescriptor(document, "readyState");
+
+beforeEach(() => {
+  vi.resetModules();
+  document.body.innerHTML = "<header></header>";
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+  if (originalReadyState) {
+    Object.defineProperty(document, "readyState", originalReadyState);
+  }
+});
+
+describe("setupBattleInfoBar", () => {
+  it("inserts bar on DOMContentLoaded and proxies methods", async () => {
+    Object.defineProperty(document, "readyState", { value: "loading", configurable: true });
+    vi.useFakeTimers();
+
+    const mod = await import("../../src/helpers/setupBattleInfoBar.js");
+
+    expect(document.querySelector(".battle-info-bar")).toBeNull();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+
+    const bar = document.querySelector(".battle-info-bar");
+    expect(bar).toBeTruthy();
+
+    mod.showMessage("Hi");
+    expect(document.getElementById("round-message").textContent).toBe("Hi");
+
+    mod.updateScore(1, 2);
+    expect(document.getElementById("score-display").textContent).toBe("You: 1 Computer: 2");
+
+    mod.startCountdown(1);
+    expect(document.getElementById("next-round-timer").textContent).toBe("1");
+    vi.advanceTimersByTime(1000);
+    expect(document.getElementById("next-round-timer").textContent).toBe("0");
+  });
+
+  it("initializes immediately when DOM already loaded", async () => {
+    Object.defineProperty(document, "readyState", { value: "complete", configurable: true });
+
+    await import("../../src/helpers/setupBattleInfoBar.js");
+
+    expect(document.querySelector(".battle-info-bar")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- instantiate InfoBar on DOM ready
- export `showMessage`, `updateScore`, and `startCountdown` from the setup module
- update `classicBattle.js` to import helpers from the new module
- test battle info bar initialization and helper methods

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Signature move screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687c8d84140083269b4566fc419d87b2