### PR TITLE
Update classic battle tests for new info bar

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -7,8 +7,10 @@ test.describe("Classic battle flow", () => {
       window.setInterval = (fn, ms, ...args) => orig(fn, Math.min(ms, 10), ...args);
     });
     await page.goto("/src/pages/battleJudoka.html");
-    await page.waitForSelector("#next-round-timer");
-    const result = page.locator("#round-message");
+    await page.waitForSelector(".battle-info-bar #next-round-timer");
+    const countdown = page.locator(".battle-info-bar #next-round-timer");
+    await expect(countdown).toHaveText(/\d+/);
+    const result = page.locator(".battle-info-bar #round-message");
     await expect(result).not.toHaveText("", { timeout: 1200 });
   });
 
@@ -18,7 +20,7 @@ test.describe("Classic battle flow", () => {
       window.setInterval = (fn, ms, ...args) => orig(fn, Math.max(ms, 3600000), ...args);
     });
     await page.goto("/src/pages/battleJudoka.html");
-    await page.waitForSelector("#next-round-timer");
+    await page.waitForSelector(".battle-info-bar #next-round-timer");
     await page.evaluate(() => {
       document.querySelector("#player-card").innerHTML =
         `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;
@@ -26,13 +28,16 @@ test.describe("Classic battle flow", () => {
         `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;
     });
     await page.locator("button[data-stat='power']").click();
-    await expect(page.locator("#round-message")).toHaveText(/Tie/);
+    const msg = page.locator(".battle-info-bar #round-message");
+    const timer = page.locator(".battle-info-bar #next-round-timer");
+    await expect(msg).toHaveText(/Tie/);
+    await expect(timer).toHaveText(/\d+/);
   });
 
   test("quit match confirmation", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
     page.on("dialog", (dialog) => dialog.accept());
     await page.locator("#quit-btn").click();
-    await expect(page.locator("#round-message")).toHaveText(/quit/i);
+    await expect(page.locator(".battle-info-bar #round-message")).toHaveText(/quit/i);
   });
 });

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -28,9 +28,11 @@ describe("classicBattle", () => {
     document.body.innerHTML = `
       <div id="player-card"></div>
       <div id="computer-card"></div>
-      <p id="score-display"></p>
-      <p id="round-message"></p>
-      <p id="next-round-timer"></p>`;
+      <div class="battle-info-bar">
+        <p id="round-message"></p>
+        <p id="next-round-timer"></p>
+        <p id="score-display"></p>
+      </div>`;
     timerSpy = vi.useFakeTimers();
     generateRandomCardMock = vi.fn(async (data, g, container, _pm, cb) => {
       container.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>5</span></li><li class="stat"><strong>Speed</strong> <span>5</span></li><li class="stat"><strong>Technique</strong> <span>5</span></li><li class="stat"><strong>Kumi-kata</strong> <span>5</span></li><li class="stat"><strong>Ne-waza</strong> <span>5</span></li></ul>`;
@@ -52,7 +54,8 @@ describe("classicBattle", () => {
     const { startRound } = await import("../../src/helpers/classicBattle.js");
     await startRound();
     timerSpy.advanceTimersByTime(31000);
-    const score = document.getElementById("score-display").textContent;
+    timerSpy.advanceTimersByTime(800);
+    const score = document.querySelector(".battle-info-bar #score-display").textContent;
     expect(score).not.toBe("You: 0 Computer: 0");
   });
 
@@ -66,8 +69,10 @@ describe("classicBattle", () => {
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     _resetForTest();
     handleStatSelection("power");
-    expect(document.getElementById("round-message").textContent).toMatch(/Tie/);
-    expect(document.getElementById("score-display").textContent).toBe("You: 0 Computer: 0");
+    expect(document.querySelector(".battle-info-bar #round-message").textContent).toMatch(/Tie/);
+    expect(document.querySelector(".battle-info-bar #score-display").textContent).toBe(
+      "You: 0 Computer: 0"
+    );
   });
 
   it("quits match after confirmation", async () => {
@@ -75,7 +80,7 @@ describe("classicBattle", () => {
     const { quitMatch } = await import("../../src/helpers/classicBattle.js");
     quitMatch();
     expect(confirmSpy).toHaveBeenCalled();
-    expect(document.getElementById("round-message").textContent).toMatch(/quit/i);
+    expect(document.querySelector(".battle-info-bar #round-message").textContent).toMatch(/quit/i);
   });
 
   it("ends the match when player reaches 10 wins", async () => {
@@ -90,8 +95,12 @@ describe("classicBattle", () => {
         `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
       handleStatSelection("power");
     }
-    expect(document.getElementById("score-display").textContent).toBe("You: 10 Computer: 0");
-    expect(document.getElementById("round-message").textContent).toMatch(/win the match/i);
+    expect(document.querySelector(".battle-info-bar #score-display").textContent).toBe(
+      "You: 10 Computer: 0"
+    );
+    expect(document.querySelector(".battle-info-bar #round-message").textContent).toMatch(
+      /win the match/i
+    );
 
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
@@ -99,7 +108,9 @@ describe("classicBattle", () => {
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     handleStatSelection("power");
 
-    expect(document.getElementById("score-display").textContent).toBe("You: 10 Computer: 0");
+    expect(document.querySelector(".battle-info-bar #score-display").textContent).toBe(
+      "You: 10 Computer: 0"
+    );
   });
 
   it("draws a different card for the computer", async () => {


### PR DESCRIPTION
## Summary
- update unit tests to use message and score elements inside `.battle-info-bar`
- wait up to 800ms for score updates
- adjust Playwright selectors for the info bar and assert countdown text

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: signatureMove screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687c9eda2b988326a3e1d7c024fb8c1f