### PR TITLE
Fix battle info bar initialization

### DIFF
--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -38,6 +38,23 @@ export function createInfoBar() {
 }
 
 /**
+ * Initialize internal references using an existing info bar element.
+ *
+ * @pseudocode
+ * 1. Locate child elements within `container` by their IDs.
+ * 2. Store these nodes in module-scoped variables for later updates.
+ *
+ * @param {HTMLElement} container - Existing info bar element.
+ * @returns {void}
+ */
+export function initInfoBar(container) {
+  if (!container) return;
+  messageEl = container.querySelector("#round-message");
+  timerEl = container.querySelector("#next-round-timer");
+  scoreEl = container.querySelector("#score-display");
+}
+
+/**
  * Update the round message text.
  *
  * @pseudocode

--- a/src/helpers/setupBattleInfoBar.js
+++ b/src/helpers/setupBattleInfoBar.js
@@ -1,4 +1,10 @@
-import { createInfoBar, showMessage, updateScore, startCountdown } from "../components/InfoBar.js";
+import {
+  createInfoBar,
+  initInfoBar,
+  showMessage,
+  updateScore,
+  startCountdown
+} from "../components/InfoBar.js";
 import { onDomReady } from "./domReady.js";
 
 /**
@@ -13,9 +19,13 @@ import { onDomReady } from "./domReady.js";
 function setupBattleInfoBar() {
   const header = document.querySelector("header");
   if (!header) return;
-  if (!document.querySelector(".battle-info-bar")) {
+  const existing = document.querySelector(".battle-info-bar");
+  if (existing) {
+    initInfoBar(existing);
+  } else {
     const bar = createInfoBar();
     header.insertAdjacentElement("afterend", bar);
+    initInfoBar(bar);
   }
 }
 

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   createInfoBar,
+  initInfoBar,
   showMessage,
   startCountdown,
   updateScore
@@ -37,6 +38,25 @@ describe("InfoBar component", () => {
     startCountdown(2);
     expect(document.getElementById("next-round-timer").textContent).toBe("2");
     vi.advanceTimersByTime(1000);
+    expect(document.getElementById("next-round-timer").textContent).toBe("1");
+    vi.advanceTimersByTime(1000);
+    expect(document.getElementById("next-round-timer").textContent).toBe("0");
+  });
+
+  it("initializes from existing DOM", () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `
+      <div class="battle-info-bar">
+        <p id="round-message"></p>
+        <p id="next-round-timer"></p>
+        <p id="score-display"></p>
+      </div>`;
+    initInfoBar(document.querySelector(".battle-info-bar"));
+    showMessage("Hi");
+    expect(document.getElementById("round-message").textContent).toBe("Hi");
+    updateScore(2, 3);
+    expect(document.getElementById("score-display").textContent).toBe("You: 2 Computer: 3");
+    startCountdown(1);
     expect(document.getElementById("next-round-timer").textContent).toBe("1");
     vi.advanceTimersByTime(1000);
     expect(document.getElementById("next-round-timer").textContent).toBe("0");

--- a/tests/helpers/setupBattleInfoBar.test.js
+++ b/tests/helpers/setupBattleInfoBar.test.js
@@ -48,4 +48,19 @@ describe("setupBattleInfoBar", () => {
 
     expect(document.querySelector(".battle-info-bar")).toBeTruthy();
   });
+
+  it("attaches to pre-existing bar", async () => {
+    Object.defineProperty(document, "readyState", { value: "complete", configurable: true });
+    document.body.innerHTML = `<header></header><div class="battle-info-bar"><p id="round-message"></p><p id="next-round-timer"></p><p id="score-display"></p></div>`;
+    const mod = await import("../../src/helpers/setupBattleInfoBar.js");
+    mod.showMessage("Hello");
+    expect(document.getElementById("round-message").textContent).toBe("Hello");
+    mod.updateScore(3, 4);
+    expect(document.getElementById("score-display").textContent).toBe("You: 3 Computer: 4");
+    vi.useFakeTimers();
+    mod.startCountdown(1);
+    expect(document.getElementById("next-round-timer").textContent).toBe("1");
+    vi.advanceTimersByTime(1000);
+    expect(document.getElementById("next-round-timer").textContent).toBe("0");
+  });
 });


### PR DESCRIPTION
## Summary
- ensure battle info bar helpers bind to pre-existing markup
- expose `initInfoBar` helper
- update tests for new initialization path

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_687ca6bf60e48326adc7773c864f1930