### PR TITLE
Fix stat button highlighting

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -94,6 +94,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Player can quit mid-match; confirmation prompt appears; if confirmed, match ends with player loss recorded.
 - If AI difficulty affects stat selection, AI uses correct logic per difficulty setting.
 - Animation flow: transitions between card reveal, stat selection, and result screens complete smoothly without stalling (**each ≤400 ms at ≥60 fps**).
+- Stat buttons reset between rounds so no previous selection remains highlighted.
 - If the Judoka dataset fails to load, an error message appears with option to reload.
 
 ---

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -17,6 +17,10 @@ import { updateScore, startCountdown } from "./setupBattleInfoBar.js";
 let judokaData = null;
 let gokyoLookup = null;
 
+function resetStatButtons() {
+  document.querySelectorAll("#stat-buttons button").forEach((btn) => btn.blur());
+}
+
 function getStatValue(container, stat) {
   const index = STATS.indexOf(stat) + 1;
   const span = container.querySelector(`li.stat:nth-child(${index}) span`);
@@ -73,6 +77,7 @@ function startTimer() {
  * @returns {Promise<void>} Resolves when cards are displayed.
  */
 export async function startRound() {
+  resetStatButtons();
   if (!judokaData) {
     judokaData = await fetchJson(`${DATA_DIR}judoka.json`);
   }
@@ -130,6 +135,7 @@ export function handleStatSelection(stat) {
   if (result.message) {
     showResult(result.message);
   }
+  resetStatButtons();
   updateScoreDisplay();
   if (!result.matchEnded) {
     const attemptStart = async () => {


### PR DESCRIPTION
## Summary
- blur stat buttons on new rounds
- document reset behavior in Classic Battle PRD

## Testing
- `npx prettier . --write`
- `npx prettier design/productRequirementsDocuments/prdClassicBattle.md src/helpers/classicBattle.js --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: package missing due to offline environment)*
- `npx playwright test` *(fails: package missing due to offline environment)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_687caaafd7088326bcfcc240210b85c3