### PR TITLE
Move quit flow to header logo

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -112,7 +112,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 - Use consistent color coding for player (blue) vs computer (red) as shown in attached mockups.
 - Display clear, large call-to-action text for "Choose an attribute to challenge!" to guide new players.
-- Include visible "Quit Match" button in the match UI with clear, child-friendly language like “Quit and Go Back to Menu.”
+- Provide a quit confirmation when the player clicks the logo in the header to return to the Home screen.
 - Match screens should follow the style and layouts demonstrated in shared mockups:
   - Player and computer cards side-by-side.
   - Central score prominently displayed.
@@ -158,7 +158,7 @@ _Resolved in [Future Considerations](#7-future-considerations):_ AI difficulty w
 
 - [ ] 2.0 Add Early Quit Functionality
 
-  - [ ] 2.1 Add "Quit Match" button to match UI
+  - [ ] 2.1 Trigger quit confirmation when the header logo is clicked
   - [ ] 2.2 Create confirmation prompt flow
   - [ ] 2.3 Record match as player loss upon quit confirmation
 

--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -37,7 +37,7 @@ test.describe("Classic battle flow", () => {
   test("quit match confirmation", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
     page.on("dialog", (dialog) => dialog.accept());
-    await page.locator("#quit-btn").click();
-    await expect(page.locator("header #round-message")).toHaveText(/quit/i);
+    await page.locator("[data-testid='home-link']").click();
+    await expect(page).toHaveURL(/index.html/);
   });
 });

--- a/src/helpers/battleJudokaPage.js
+++ b/src/helpers/battleJudokaPage.js
@@ -7,7 +7,8 @@
  * 2. Define `setupBattleJudokaPage` to:
  *    a. Attach a click listener to each stat button that calls
  *       `handleStatSelection` with the button's data attribute.
- *    b. Attach a click listener to the quit button that calls `quitMatch`.
+ *    b. Attach a click listener to the home logo that calls `quitMatch` and
+ *       navigates to the home screen on confirmation.
  *    c. Invoke `startRound` to begin the match.
  * 3. Use `onDomReady` to run `setupBattleJudokaPage` when the DOM is ready.
  */
@@ -19,9 +20,13 @@ export function setupBattleJudokaPage() {
     .querySelectorAll("#stat-buttons button")
     .forEach((btn) => btn.addEventListener("click", () => handleStatSelection(btn.dataset.stat)));
 
-  const quitBtn = document.getElementById("quit-btn");
-  if (quitBtn) {
-    quitBtn.addEventListener("click", quitMatch);
+  const homeLink = document.querySelector("[data-testid='home-link']");
+  if (homeLink) {
+    homeLink.addEventListener("click", (e) => {
+      if (!quitMatch()) {
+        e.preventDefault();
+      }
+    });
   }
 
   startRound();

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -161,12 +161,15 @@ export function handleStatSelection(stat) {
  * 1. Display a confirmation dialog.
  * 2. When confirmed, stop the timer and mark the match as ended.
  * 3. Show a loss message in the result area.
+ * 4. Return `true` when the player confirms quitting, otherwise `false`.
  */
 export function quitMatch() {
   if (confirm("Quit the match?")) {
     const result = engineQuitMatch();
     showResult(result.message);
+    return true;
   }
+  return false;
 }
 
 export function _resetForTest() {

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -58,7 +58,6 @@
             </div>
 
             <p id="round-result" aria-live="polite"></p>
-            <button id="quit-btn" type="button">Quit Match</button>
           </div>
         </section>
       </main>

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -76,8 +76,9 @@ describe("classicBattle", () => {
   it("quits match after confirmation", async () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const { quitMatch } = await import("../../src/helpers/classicBattle.js");
-    quitMatch();
+    const result = quitMatch();
     expect(confirmSpy).toHaveBeenCalled();
+    expect(result).toBe(true);
     expect(document.querySelector("header #round-message").textContent).toMatch(/quit/i);
   });
 


### PR DESCRIPTION
## Summary
- remove Quit Match button from Battle Judoka page
- trigger `quitMatch` when clicking the logo
- return a boolean from `quitMatch`
- update unit and Playwright tests
- adjust PRD for new quit flow

## Testing
- `npx prettier . --check` *(fails: Code style issues found in the above file. Run Prettier with --write to fix.)*
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_687cb89c439483268c0ff29d63c5b467