### PR TITLE
Reset stat button after round

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -250,25 +249,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/src/helpers/battleJudokaPage.js
+++ b/src/helpers/battleJudokaPage.js
@@ -5,8 +5,8 @@
  * 1. Import `startRound`, `handleStatSelection`, and `quitMatch` from
  *    `classicBattle.js`.
  * 2. Define `setupBattleJudokaPage` to:
- *    a. Attach a click listener to each stat button that calls
- *       `handleStatSelection` with the button's data attribute.
+ *    a. Attach a click listener to each stat button that highlights the button
+ *       and calls `handleStatSelection` with the button's data attribute.
  *    b. Attach a click listener to the home logo that calls `quitMatch` and
  *       navigates to the home screen on confirmation.
  *    c. Invoke `startRound` to begin the match.
@@ -16,9 +16,12 @@ import { startRound, handleStatSelection, quitMatch } from "./classicBattle.js";
 import { onDomReady } from "./domReady.js";
 
 export function setupBattleJudokaPage() {
-  document
-    .querySelectorAll("#stat-buttons button")
-    .forEach((btn) => btn.addEventListener("click", () => handleStatSelection(btn.dataset.stat)));
+  document.querySelectorAll("#stat-buttons button").forEach((btn) =>
+    btn.addEventListener("click", () => {
+      btn.classList.add("selected");
+      handleStatSelection(btn.dataset.stat);
+    })
+  );
 
   const homeLink = document.querySelector("[data-testid='home-link']");
   if (homeLink) {

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -17,8 +17,20 @@ import { updateScore, startCountdown } from "./setupBattleInfoBar.js";
 let judokaData = null;
 let gokyoLookup = null;
 
+/**
+ * Remove highlight and focus from all stat buttons.
+ *
+ * @pseudocode
+ * 1. Select all stat buttons within `#stat-buttons`.
+ * 2. For each button:
+ *    a. Call `blur()` to drop focus.
+ *    b. Remove the `selected` class to clear highlight.
+ */
 function resetStatButtons() {
-  document.querySelectorAll("#stat-buttons button").forEach((btn) => btn.blur());
+  document.querySelectorAll("#stat-buttons button").forEach((btn) => {
+    btn.blur();
+    btn.classList.remove("selected");
+  });
 }
 
 function getStatValue(container, stat) {
@@ -66,13 +78,14 @@ function startTimer() {
  * Start a new battle round by drawing cards for both players.
  *
  * @pseudocode
- * 1. Load judoka and gokyo data if not already cached.
- * 2. Draw a random card for the player using `generateRandomCard` and capture
+ * 1. Clear any previously selected stat button.
+ * 2. Load judoka and gokyo data if not already cached.
+ * 3. Draw a random card for the player using `generateRandomCard` and capture
  *    the selected judoka.
- * 3. Select a random judoka for the computer.
+ * 4. Select a random judoka for the computer.
  *    - If it matches the player's judoka, retry up to a safe limit.
  *    - Display the chosen judoka with `renderJudokaCard`.
- * 4. Initialize the round timer.
+ * 5. Initialize the round timer.
  *
  * @returns {Promise<void>} Resolves when cards are displayed.
  */
@@ -122,7 +135,8 @@ export async function startRound() {
  *    - End when either player reaches `CLASSIC_BATTLE_POINTS_TO_WIN`.
  *    - End after `CLASSIC_BATTLE_MAX_ROUNDS` rounds.
  * 6. Display the result message.
- * 7. Begin the next round after a short delay if the match continues.
+ * 7. Remove the highlight from all stat buttons.
+ * 8. Begin the next round after a short delay if the match continues.
  *
  * @param {string} stat - The stat name to compare.
  */

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -103,6 +103,10 @@ button:active {
   transform: scale(0.95);
 }
 
+#stat-buttons button.selected {
+  background-color: var(--button-active-bg);
+}
+
 button:focus,
 button:focus-visible {
   outline-offset: 2px;

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -50,6 +50,19 @@ describe("classicBattle", () => {
     document.body.innerHTML = "";
   });
 
+  it("clears selected class on stat buttons after each round", async () => {
+    document.body.innerHTML +=
+      '<div id="stat-buttons"><button data-stat="power"></button><button data-stat="speed"></button><button data-stat="technique"></button><button data-stat="kumikata"></button><button data-stat="newaza"></button></div>';
+    const { handleStatSelection, _resetForTest } = await import(
+      "../../src/helpers/classicBattle.js"
+    );
+    _resetForTest();
+    const btn = document.querySelector("[data-stat='power']");
+    btn.classList.add("selected");
+    handleStatSelection("power");
+    expect(btn.classList.contains("selected")).toBe(false);
+  });
+
   it("auto-selects a stat when timer expires", async () => {
     const { startRound } = await import("../../src/helpers/classicBattle.js");
     await startRound();


### PR DESCRIPTION
## Summary
- highlight selected stat buttons when clicked and reset each round
- ensure stat buttons lose the `.selected` class
- style selected stat buttons
- test stat button reset behaviour
- run Prettier formatting

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_687cbd37ca508326b25488937593a0bb