### PR TITLE
Fix Safari stat button reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Safari may expand flex items if `min-width` isn't explicitly set. Set
 Safari 18.5 positions `.signature-move-container` text at the bottom edge unless the container uses standard flex alignment. The container now applies `line-height: max(10%, var(--touch-target-size))` along with `align-items: center` and `justify-content: center`. Setting `width: 100%` on the child spans prevents stretching so the label and value remain vertically centered.
 
 Safari 18.5 sometimes shrinks judoka cards, causing text overlap. The width rule now uses `clamp(200px, 70vw, 300px)` so cards occupy about 70% of the viewport on mobile. This applies to both the random card view and the browse carousel.
-Safari 18.5 may keep a stat button highlighted between rounds. The reset logic now clears the inline background color and sets `backgroundColor` to an empty string before the button loses focus so Safari repaints the buttons correctly.
+Safari 18.5 may keep a stat button highlighted between rounds. The reset logic now clears the inline background color, reads `offsetWidth` to trigger a reflow, and sets `backgroundColor` to an empty string before the button loses focus so Safari repaints the buttons correctly.
 
 Chrome may show a small gap below the stats panel when the combined height of
 card sections is less than 100%. Ensure `.card-top-bar`, `.card-portrait`,

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -25,13 +25,16 @@ let gokyoLookup = null;
  * 2. For each button:
  *    a. Remove the `selected` class so the button style resets.
  *    b. Clear any inline background color to force a repaint in Safari.
- *    c. Set `backgroundColor` to an empty string before blurring.
- *    d. Call `blur()` to drop focus.
+ *    c. Read `offsetWidth` to trigger a reflow.
+ *    d. Set `backgroundColor` to an empty string before blurring.
+ *    e. Call `blur()` to drop focus.
  */
 function resetStatButtons() {
   document.querySelectorAll("#stat-buttons button").forEach((btn) => {
     btn.classList.remove("selected");
     btn.style.removeProperty("background-color");
+    // trigger reflow so Safari repaints correctly
+    void btn.offsetWidth;
     btn.style.backgroundColor = "";
     btn.blur();
   });


### PR DESCRIPTION
## Summary
- ensure stat button reset triggers reflow before blur
- document Safari stat button bug fix

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: randomJudoka-signature-linux.png diff)*

------
https://chatgpt.com/codex/tasks/task_e_687ce9efb3d88326ab8a3ec8095cb18f