### PR TITLE
Fix Safari stat button highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Safari may expand flex items if `min-width` isn't explicitly set. Set
 Safari 18.5 positions `.signature-move-container` text at the bottom edge unless the container uses standard flex alignment. The container now applies `line-height: max(10%, var(--touch-target-size))` along with `align-items: center` and `justify-content: center`. Setting `width: 100%` on the child spans prevents stretching so the label and value remain vertically centered.
 
 Safari 18.5 sometimes shrinks judoka cards, causing text overlap. The width rule now uses `clamp(200px, 70vw, 300px)` so cards occupy about 70% of the viewport on mobile. This applies to both the random card view and the browse carousel.
-Safari 18.5 may keep a stat button highlighted between rounds. The reset logic now clears the inline background color, reads `offsetWidth` to trigger a reflow, and sets `backgroundColor` to an empty string before the button loses focus so Safari repaints the buttons correctly.
+Safari 18.5 may keep a stat button highlighted between rounds. The reset logic now clears the inline background color, briefly disables the button so Safari drops the highlight, reads `offsetWidth` to trigger a reflow, then re-enables the button and clears `backgroundColor` before it loses focus so Safari repaints correctly.
 
 Chrome may show a small gap below the stats panel when the combined height of
 card sections is less than 100%. Ensure `.card-top-bar`, `.card-portrait`,

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -25,16 +25,19 @@ let gokyoLookup = null;
  * 2. For each button:
  *    a. Remove the `selected` class so the button style resets.
  *    b. Clear any inline background color to force a repaint in Safari.
- *    c. Read `offsetWidth` to trigger a reflow.
- *    d. Set `backgroundColor` to an empty string before blurring.
- *    e. Call `blur()` to drop focus.
+ *    c. Temporarily disable the button so Safari drops the `:active` highlight.
+ *    d. Read `offsetWidth` to trigger a reflow.
+ *    e. Re-enable the button, set `backgroundColor` to an empty string, and
+ *       call `blur()` to drop focus.
  */
 function resetStatButtons() {
   document.querySelectorAll("#stat-buttons button").forEach((btn) => {
     btn.classList.remove("selected");
     btn.style.removeProperty("background-color");
+    btn.disabled = true;
     // trigger reflow so Safari repaints correctly
     void btn.offsetWidth;
+    btn.disabled = false;
     btn.style.backgroundColor = "";
     btn.blur();
   });

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -63,6 +63,20 @@ describe("classicBattle", () => {
     expect(btn.classList.contains("selected")).toBe(false);
   });
 
+  it("re-enables stat button after selection", async () => {
+    document.body.innerHTML +=
+      '<div id="stat-buttons"><button data-stat="power"></button></div>';
+    const { handleStatSelection, _resetForTest } = await import(
+      "../../src/helpers/classicBattle.js"
+    );
+    _resetForTest();
+    const btn = document.querySelector("[data-stat='power']");
+    btn.classList.add("selected");
+    handleStatSelection("power");
+    expect(btn.classList.contains("selected")).toBe(false);
+    expect(btn.disabled).toBe(false);
+  });
+
   it("clears inline background color with selected class", async () => {
     document.body.innerHTML +=
       '<div id="stat-buttons"><button data-stat="power"></button><button data-stat="speed"></button><button data-stat="technique"></button><button data-stat="kumikata"></button><button data-stat="newaza"></button></div>';


### PR DESCRIPTION
## Summary
- blur Safari's active state by toggling `disabled`
- update Safari README notes
- test that stat buttons are re-enabled

## Testing
- `npx prettier . --check` *(fails: `npx: command not found`)*
- `npx eslint .` *(fails: `npx: command not found`)*
- `npx vitest run` *(fails: `npx: command not found`)*
- `npx playwright test` *(fails: `npx: command not found`)*
- `npm run check:contrast` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687d020f6c748326b2d18a274c087c0c