### PR TITLE
Label countdown timer

### DIFF
--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -72,9 +72,9 @@ export function showMessage(text) {
  *
  * @pseudocode
  * 1. Clear any existing countdown interval.
- * 2. Display "Time Left: {seconds}s" in the timer element.
+ * 2. Display "Next round in: {seconds}s" in the timer element.
  * 3. Each second decrement the value and update the element using the same format.
- * 4. When the value reaches zero, set "Time Left: 0s", stop the interval and invoke `onFinish`.
+ * 4. When the value reaches zero, set "Next round in: 0s", stop the interval and invoke `onFinish`.
  *
  * @param {number} seconds - Seconds to count down from.
  * @param {Function} [onFinish] - Optional callback when countdown ends.
@@ -83,15 +83,15 @@ export function showMessage(text) {
 export function startCountdown(seconds, onFinish) {
   if (!timerEl) return;
   clearInterval(intervalId);
-  timerEl.textContent = `Time Left: ${seconds}s`;
+  timerEl.textContent = `Next round in: ${seconds}s`;
   intervalId = setInterval(() => {
     seconds -= 1;
     if (seconds <= 0) {
       clearInterval(intervalId);
-      timerEl.textContent = "Time Left: 0s";
+      timerEl.textContent = "Next round in: 0s";
       if (typeof onFinish === "function") onFinish();
     } else {
-      timerEl.textContent = `Time Left: ${seconds}s`;
+      timerEl.textContent = `Next round in: ${seconds}s`;
     }
   }, 1000);
 }

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -37,11 +37,11 @@ describe("InfoBar component", () => {
     expect(document.getElementById("score-display").textContent).toBe("You: 1 Computer: 2");
 
     startCountdown(2);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Time Left: 2s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 2s");
     vi.advanceTimersByTime(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Time Left: 1s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
     vi.advanceTimersByTime(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Time Left: 0s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 0s");
   });
 
   it("initializes from existing DOM", () => {
@@ -58,8 +58,8 @@ describe("InfoBar component", () => {
     updateScore(2, 3);
     expect(document.getElementById("score-display").textContent).toBe("You: 2 Computer: 3");
     startCountdown(1);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Time Left: 1s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
     vi.advanceTimersByTime(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Time Left: 0s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 0s");
   });
 });

--- a/tests/helpers/setupBattleInfoBar.test.js
+++ b/tests/helpers/setupBattleInfoBar.test.js
@@ -37,9 +37,9 @@ describe("setupBattleInfoBar", () => {
     expect(document.getElementById("score-display").textContent).toBe("You: 1 Computer: 2");
 
     mod.startCountdown(1);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Time Left: 1s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
     vi.advanceTimersByTime(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Time Left: 0s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 0s");
   });
 
   it("initializes immediately when DOM already loaded", async () => {
@@ -60,8 +60,8 @@ describe("setupBattleInfoBar", () => {
     expect(document.getElementById("score-display").textContent).toBe("You: 3 Computer: 4");
     vi.useFakeTimers();
     mod.startCountdown(1);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Time Left: 1s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
     vi.advanceTimersByTime(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Time Left: 0s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 0s");
   });
 });


### PR DESCRIPTION
## Summary
- prefix countdown timer updates with "Next round in"
- document new timer label in pseudocode
- expect new timer text in component tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Classic battle flow timer auto-select and signature move screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687d1e5300888326ab769a62746b52dd