### PR TITLE
Insert line break in score display

### DIFF
--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -100,8 +100,9 @@ export function startCountdown(seconds, onFinish) {
  * Display the current match score.
  *
  * @pseudocode
- * 1. Format the score string with player and computer values.
- * 2. Update the score element when present.
+ * 1. Format the score string with player and computer values separated by a
+ *    line break.
+ * 2. Insert the HTML into the score element when present.
  *
  * @param {number} playerScore - Player's score.
  * @param {number} computerScore - Computer's score.
@@ -109,6 +110,6 @@ export function startCountdown(seconds, onFinish) {
  */
 export function updateScore(playerScore, computerScore) {
   if (scoreEl) {
-    scoreEl.textContent = `You: ${playerScore} Computer: ${computerScore}`;
+    scoreEl.innerHTML = `You: ${playerScore}<br>\nComputer: ${computerScore}`;
   }
 }

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -54,7 +54,7 @@ function updateScoreDisplay() {
   updateScore(playerScore, computerScore);
   const el = document.getElementById("score-display");
   if (el) {
-    el.textContent = `You: ${playerScore} Computer: ${computerScore}`;
+    el.innerHTML = `You: ${playerScore}<br>\nComputer: ${computerScore}`;
   }
 }
 

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -34,7 +34,7 @@ describe("InfoBar component", () => {
     expect(document.getElementById("round-message").textContent).toBe("Hello");
 
     updateScore(1, 2);
-    expect(document.getElementById("score-display").textContent).toBe("You: 1 Computer: 2");
+    expect(document.getElementById("score-display").textContent).toBe("You: 1\nComputer: 2");
 
     startCountdown(2);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 2s");
@@ -56,7 +56,7 @@ describe("InfoBar component", () => {
     showMessage("Hi");
     expect(document.getElementById("round-message").textContent).toBe("Hi");
     updateScore(2, 3);
-    expect(document.getElementById("score-display").textContent).toBe("You: 2 Computer: 3");
+    expect(document.getElementById("score-display").textContent).toBe("You: 2\nComputer: 3");
     startCountdown(1);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
     vi.advanceTimersByTime(1000);

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -97,7 +97,7 @@ describe("classicBattle", () => {
     timerSpy.advanceTimersByTime(31000);
     timerSpy.advanceTimersByTime(800);
     const score = document.querySelector("header #score-display").textContent;
-    expect(score).not.toBe("You: 0 Computer: 0");
+    expect(score).not.toBe("You: 0\nComputer: 0");
   });
 
   it("shows tie message when values are equal", async () => {
@@ -111,7 +111,7 @@ describe("classicBattle", () => {
     _resetForTest();
     handleStatSelection("power");
     expect(document.querySelector("header #round-message").textContent).toMatch(/Tie/);
-    expect(document.querySelector("header #score-display").textContent).toBe("You: 0 Computer: 0");
+    expect(document.querySelector("header #score-display").textContent).toBe("You: 0\nComputer: 0");
   });
 
   it("quits match after confirmation", async () => {
@@ -135,7 +135,9 @@ describe("classicBattle", () => {
         `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
       handleStatSelection("power");
     }
-    expect(document.querySelector("header #score-display").textContent).toBe("You: 10 Computer: 0");
+    expect(document.querySelector("header #score-display").textContent).toBe(
+      "You: 10\nComputer: 0"
+    );
     expect(document.querySelector("header #round-message").textContent).toMatch(/win the match/i);
 
     document.getElementById("player-card").innerHTML =
@@ -144,7 +146,9 @@ describe("classicBattle", () => {
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     handleStatSelection("power");
 
-    expect(document.querySelector("header #score-display").textContent).toBe("You: 10 Computer: 0");
+    expect(document.querySelector("header #score-display").textContent).toBe(
+      "You: 10\nComputer: 0"
+    );
   });
 
   it("draws a different card for the computer", async () => {

--- a/tests/helpers/setupBattleInfoBar.test.js
+++ b/tests/helpers/setupBattleInfoBar.test.js
@@ -34,7 +34,7 @@ describe("setupBattleInfoBar", () => {
     expect(document.getElementById("round-message").textContent).toBe("Hi");
 
     mod.updateScore(1, 2);
-    expect(document.getElementById("score-display").textContent).toBe("You: 1 Computer: 2");
+    expect(document.getElementById("score-display").textContent).toBe("You: 1\nComputer: 2");
 
     mod.startCountdown(1);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
@@ -57,7 +57,7 @@ describe("setupBattleInfoBar", () => {
     mod.showMessage("Hello");
     expect(document.getElementById("round-message").textContent).toBe("Hello");
     mod.updateScore(3, 4);
-    expect(document.getElementById("score-display").textContent).toBe("You: 3 Computer: 4");
+    expect(document.getElementById("score-display").textContent).toBe("You: 3\nComputer: 4");
     vi.useFakeTimers();
     mod.startCountdown(1);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");


### PR DESCRIPTION
## Summary
- update InfoBar score display to use `<br>` and newline
- adjust classicBattle score updates
- update unit tests for newline check

## Testing
- `npx prettier . --check`
- `npx eslint .` *(shows 1 warning)*
- `npx vitest run`
- `npx playwright test` *(fails: Signature move screenshots > random judoka page)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687d201ee4e483269af6115d766bbed6