### PR TITLE
Fix countdown override handling

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -4,7 +4,7 @@ import { test, expect } from "./fixtures/commonSetup.js";
 test.describe("Classic battle flow", () => {
   test("timer auto-selects when expired", async ({ page }) => {
     await page.addInitScript(() => {
-      window.startCountdown = () => {};
+      window.startCountdownOverride = () => {};
       const orig = window.setInterval;
       window.setInterval = (fn, ms, ...args) => orig(fn, Math.min(ms, 10), ...args);
     });
@@ -18,7 +18,7 @@ test.describe("Classic battle flow", () => {
 
   test("tie message appears on equal stats", async ({ page }) => {
     await page.addInitScript(() => {
-      window.startCountdown = () => {};
+      window.startCountdownOverride = () => {};
       const orig = window.setInterval;
       window.setInterval = (fn, ms, ...args) => orig(fn, Math.max(ms, 3600000), ...args);
     });

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -12,7 +12,12 @@ import {
   STATS,
   _resetForTest as engineReset
 } from "./battleEngine.js";
-import { updateScore, startCountdown } from "./setupBattleInfoBar.js";
+import { updateScore, startCountdown as defaultCountdown } from "./setupBattleInfoBar.js";
+
+const countdown =
+  typeof window !== "undefined" && window.startCountdownOverride
+    ? window.startCountdownOverride
+    : defaultCountdown;
 
 let judokaData = null;
 let gokyoLookup = null;
@@ -170,7 +175,7 @@ export function handleStatSelection(stat) {
         setTimeout(attemptStart, 1000);
       }
     };
-    startCountdown(3, () => {
+    countdown(3, () => {
       if (!isMatchEnded()) {
         attemptStart();
       }


### PR DESCRIPTION
## Summary
- allow overriding `startCountdown` in classicBattle
- ensure Playwright tests override countdown on init

## Testing
- `npx prettier . --write` *(fails: `npx: command not found`)*
- `npx eslint . --fix` *(fails: `npx: command not found`)*
- `npx vitest run` *(fails: `npx: command not found`)*
- `npx playwright test` *(fails: `npx: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687d26a69b00832691bf06e1de0dff4d