### PR TITLE
Update docs with modular coding reminder

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,7 @@ This file guides GitHub Copilot agents contributing to the JU-DO-KON! repository
 - Format code with Prettier and lint with ESLint (`eslint.config.mjs`)
 - **Preserve all JSDoc comments and `@pseudocode` blocks**; update them when the code changes
 - Public functions require JSDoc following the design docs
+- Always refactor complex logic into smaller helpers and keep modules focused on a single responsibility.
 
 ## Required Programmatic Checks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This repository contains the source for **JU-DO-KON!**, a browser-based card gam
 - **JSDoc comments and pseudocode blocks must remain intact**. Keep `@pseudocode` blocks in place, but update them if the code changes so the description stays accurate.
 - Public functions should have JSDoc documentation following the examples in `design/codeStandards`.
 - Favor small, single-purpose functions and avoid monolithic implementations.
+- Always refactor complex logic into smaller helpers and keep modules focused on a single responsibility.
 
 ## Programmatic Checks
 


### PR DESCRIPTION
## Summary
- clarify coding standards in `AGENTS.md`
- keep copilot instructions consistent

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 2 failed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687d26c28e14832682cb9e69fad0a187