### PR TITLE
Refactor classic battle stat handling

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -133,24 +133,18 @@ export async function startRound() {
 }
 
 /**
- * Compare the chosen stat and update scores.
+ * Evaluate the selected stat values and update the match state.
  *
  * @pseudocode
- * 1. Stop the round timer to prevent duplicate selections.
- * 2. Read the selected stat value from both cards.
- * 3. Compare the values and update scores accordingly.
- *    - When values are equal, show "Tie – no score" and skip score changes.
- * 4. Increment the round counter and update the score display.
- * 5. Check if the match should end:
- *    - End when either player reaches `CLASSIC_BATTLE_POINTS_TO_WIN`.
- *    - End after `CLASSIC_BATTLE_MAX_ROUNDS` rounds.
- * 6. Display the result message.
- * 7. Remove the highlight from all stat buttons.
- * 8. Begin the next round after a short delay if the match continues.
+ * 1. Retrieve the stat values from both player and computer cards.
+ * 2. Let the battle engine compare the values to update scores.
+ * 3. Display the result message and refresh the score display.
+ * 4. Return the comparison result to the caller.
  *
  * @param {string} stat - The stat name to compare.
+ * @returns {{message: string, matchEnded: boolean}}
  */
-export function handleStatSelection(stat) {
+export function evaluateRound(stat) {
   const playerContainer = document.getElementById("player-card");
   const computerContainer = document.getElementById("computer-card");
   const playerVal = getStatValue(playerContainer, stat);
@@ -159,23 +153,55 @@ export function handleStatSelection(stat) {
   if (result.message) {
     showResult(result.message);
   }
-  resetStatButtons();
   updateScoreDisplay();
-  if (!result.matchEnded) {
-    const attemptStart = async () => {
-      try {
-        await startRound();
-      } catch {
-        showResult("Waiting...");
-        setTimeout(attemptStart, 1000);
-      }
-    };
-    startCountdown(3, () => {
-      if (!isMatchEnded()) {
-        attemptStart();
-      }
-    });
-  }
+  return result;
+}
+
+/**
+ * Begin the next round after a countdown if the match continues.
+ *
+ * @pseudocode
+ * 1. Exit immediately when the match has ended.
+ * 2. Attempt to start the next round after a short countdown.
+ *    - Retry the start if the round cannot begin immediately.
+ *    - Display "Waiting..." while retrying.
+ * 3. Stop scheduling if the match ends during the countdown.
+ *
+ * @param {{matchEnded: boolean}} result - Result from evaluateRound.
+ */
+export function scheduleNextRound(result) {
+  if (result.matchEnded) return;
+
+  const attemptStart = async () => {
+    try {
+      await startRound();
+    } catch {
+      showResult("Waiting...");
+      setTimeout(attemptStart, 1000);
+    }
+  };
+
+  startCountdown(3, () => {
+    if (!isMatchEnded()) {
+      attemptStart();
+    }
+  });
+}
+
+/**
+ * Compare the chosen stat and trigger the next round.
+ *
+ * @pseudocode
+ * 1. Evaluate the round using `evaluateRound` to update scores.
+ * 2. Clear the selected state from all stat buttons.
+ * 3. Call `scheduleNextRound` with the evaluation result.
+ *
+ * @param {string} stat - The stat name to compare.
+ */
+export function handleStatSelection(stat) {
+  const result = evaluateRound(stat);
+  resetStatButtons();
+  scheduleNextRound(result);
 }
 
 /**

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -147,6 +147,28 @@ describe("classicBattle", () => {
     expect(document.querySelector("header #score-display").textContent).toBe("You: 10 Computer: 0");
   });
 
+  it("evaluateRound updates the score", async () => {
+    const { evaluateRound, _resetForTest } = await import("../../src/helpers/classicBattle.js");
+    _resetForTest();
+    document.getElementById("player-card").innerHTML =
+      `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
+    document.getElementById("computer-card").innerHTML =
+      `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
+    const result = evaluateRound("power");
+    expect(result.message).toMatch(/win/);
+    expect(document.querySelector("header #score-display").textContent).toBe("You: 1 Computer: 0");
+  });
+
+  it("scheduleNextRound triggers a countdown", async () => {
+    const battleMod = await import("../../src/helpers/classicBattle.js");
+    const infoMod = await import("../../src/helpers/setupBattleInfoBar.js");
+    const startSpy = vi.spyOn(battleMod, "startRound").mockResolvedValue();
+    const cdSpy = vi.spyOn(infoMod, "startCountdown").mockImplementation((_s, cb) => cb());
+    battleMod.scheduleNextRound({ matchEnded: false });
+    expect(cdSpy).toHaveBeenCalledWith(3, expect.any(Function));
+    expect(startSpy).toHaveBeenCalled();
+  });
+
   it("draws a different card for the computer", async () => {
     generateRandomCardMock = vi.fn(async (d, g, c, _pm, cb) => {
       c.innerHTML = "<ul></ul>";


### PR DESCRIPTION
## Summary
- split `handleStatSelection` into `evaluateRound` and `scheduleNextRound`
- expose new helper functions
- test score evaluation and countdown helpers

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run --reporter=dot`
- `npx playwright test` *(fails: randomJudoka-signature screenshot diff)*

------
https://chatgpt.com/codex/tasks/task_e_687d26e081f08326b07d4f88fdb47d1d