### PR TITLE
Fix scheduleNextRound countdown reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -250,25 +249,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -12,12 +12,14 @@ import {
   STATS,
   _resetForTest as engineReset
 } from "./battleEngine.js";
-import { updateScore, startCountdown as defaultCountdown } from "./setupBattleInfoBar.js";
+import * as infoBar from "./setupBattleInfoBar.js";
 
-const countdown =
-  typeof window !== "undefined" && window.startCountdownOverride
-    ? window.startCountdownOverride
-    : defaultCountdown;
+function getCountdown() {
+  if (typeof window !== "undefined" && window.startCountdownOverride) {
+    return window.startCountdownOverride;
+  }
+  return infoBar.startCountdown;
+}
 
 let judokaData = null;
 let gokyoLookup = null;
@@ -56,7 +58,7 @@ function getStatValue(container, stat) {
 
 function updateScoreDisplay() {
   const { playerScore, computerScore } = getScores();
-  updateScore(playerScore, computerScore);
+  infoBar.updateScore(playerScore, computerScore);
   const el = document.getElementById("score-display");
   if (el) {
     el.innerHTML = `You: ${playerScore}<br>\nComputer: ${computerScore}`;
@@ -186,7 +188,8 @@ export function scheduleNextRound(result) {
     }
   };
 
-  startCountdown(3, () => {
+  const countdown = getCountdown();
+  countdown(3, () => {
     if (!isMatchEnded()) {
       attemptStart();
     }


### PR DESCRIPTION
## Summary
- use `startCountdown` from `setupBattleInfoBar` at call time
- format README with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden)*
- `npx playwright test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687d30d174ec83268d2b1aadb6da9f37