### PR TITLE
Fix classic battle score display test

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
+
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -249,20 +250,25 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
+
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
+
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
+
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
+
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
+
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -160,7 +160,7 @@ describe("classicBattle", () => {
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     const result = evaluateRound("power");
     expect(result.message).toMatch(/win/);
-    expect(document.querySelector("header #score-display").textContent).toBe("You: 1 Computer: 0");
+    expect(document.querySelector("header #score-display").textContent).toBe("You: 1\nComputer: 0");
   });
 
   it("scheduleNextRound triggers a countdown", async () => {


### PR DESCRIPTION
## Summary
- update classicBattle score assertion
- format README via Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle.test.js` *(fails: scheduleNextRound triggers a countdown)*
- `npx playwright test` *(fails: signatureMove.spec.js screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687d3442305883269af9eecf79c52838