### PR TITLE
Enable startRound override in classicBattle

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
+
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -249,20 +250,25 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
+
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
+
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
+
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
+
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
+
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -21,6 +21,13 @@ function getCountdown() {
   return infoBar.startCountdown;
 }
 
+export function getStartRound() {
+  if (typeof window !== "undefined" && window.startRoundOverride) {
+    return window.startRoundOverride;
+  }
+  return startRound;
+}
+
 let judokaData = null;
 let gokyoLookup = null;
 
@@ -181,7 +188,8 @@ export function scheduleNextRound(result) {
 
   const attemptStart = async () => {
     try {
-      await startRound();
+      const start = getStartRound();
+      await start();
     } catch {
       showResult("Waiting...");
       setTimeout(attemptStart, 1000);
@@ -234,6 +242,9 @@ export function _resetForTest() {
   judokaData = null;
   gokyoLookup = null;
   engineReset();
+  if (typeof window !== "undefined") {
+    delete window.startRoundOverride;
+  }
   const timerEl = document.getElementById("next-round-timer");
   if (timerEl) timerEl.textContent = "";
   const resultEl = document.getElementById("round-message");


### PR DESCRIPTION
## Summary
- format README with Prettier
- export `getStartRound` helper
- use `getStartRound()` within `scheduleNextRound`
- clear any startRound override in `_resetForTest`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: scheduleNextRound and scoreboard tests)*

------
https://chatgpt.com/codex/tasks/task_e_687d368d43b08326b2550b38920ab87a