### PR TITLE
Add obscured stats option

### DIFF
--- a/src/helpers/cardUtils.js
+++ b/src/helpers/cardUtils.js
@@ -107,18 +107,26 @@ export async function displayJudokaCard(judoka, gokyo, gameArea) {
  * 1. Validate `judoka` with `hasRequiredJudokaFields`.
  *    - If invalid, log an error and exit early.
  * 2. Ensure `container` exists before proceeding.
- * 3. Generate the card element using `generateJudokaCardHTML`.
- * 4. Replace the container contents with the generated card.
- * 5. When `animate` is true, add the `animate-card` class on the next frame.
+ * 3. When `useObscuredStats` is true, clone `judoka` and replace name and stats
+ *    with "?".
+ * 4. Generate the card element using `generateJudokaCardHTML`.
+ * 5. Replace the container contents with the generated card.
+ * 6. When `animate` is true, add the `animate-card` class on the next frame.
  *
  * @param {Judoka} judoka - Judoka data to render.
  * @param {Object<string, GokyoEntry>} gokyoLookup - Lookup of gokyo moves.
  * @param {HTMLElement} container - Element where the card is injected.
  * @param {Object} [options] - Render options.
  * @param {boolean} [options.animate=false] - Whether to apply animation.
+ * @param {boolean} [options.useObscuredStats=false] - Obscure stats when true.
  * @returns {Promise<HTMLElement|null>} The rendered card element or `null`.
  */
-export async function renderJudokaCard(judoka, gokyoLookup, container, { animate = false } = {}) {
+export async function renderJudokaCard(
+  judoka,
+  gokyoLookup,
+  container,
+  { animate = false, useObscuredStats = false } = {}
+) {
   if (!container) return null;
   if (!hasRequiredJudokaFields(judoka)) {
     console.error("Invalid judoka object:", judoka);
@@ -126,7 +134,19 @@ export async function renderJudokaCard(judoka, gokyoLookup, container, { animate
   }
 
   try {
-    const card = await generateJudokaCardHTML(judoka, gokyoLookup);
+    let cardData = judoka;
+    if (useObscuredStats) {
+      cardData = structuredClone(judoka);
+      cardData.firstname = "?";
+      cardData.surname = "?";
+      if (cardData.stats && typeof cardData.stats === "object") {
+        for (const key of Object.keys(cardData.stats)) {
+          cardData.stats[key] = "?";
+        }
+      }
+    }
+
+    const card = await generateJudokaCardHTML(cardData, gokyoLookup);
     if (!card) return null;
     container.innerHTML = "";
     container.appendChild(card);

--- a/tests/helpers/renderJudokaCard.test.js
+++ b/tests/helpers/renderJudokaCard.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+
+let generateMock;
+let setupLazyPortraitsMock;
+
+vi.mock("../../src/helpers/cardBuilder.js", () => ({
+  generateJudokaCardHTML: (...args) => generateMock(...args)
+}));
+vi.mock("../../src/helpers/lazyPortrait.js", () => ({
+  setupLazyPortraits: (...args) => setupLazyPortraitsMock(...args)
+}));
+
+import { renderJudokaCard } from "../../src/helpers/cardUtils.js";
+
+const judoka = {
+  id: 2,
+  firstname: "Jane",
+  surname: "Smith",
+  country: "USA",
+  countryCode: "us",
+  stats: { power: 8, speed: 7, technique: 6, kumikata: 5, newaza: 4 },
+  weightClass: "-78kg",
+  signatureMoveId: 1,
+  rarity: "common",
+  gender: "female"
+};
+
+describe("renderJudokaCard", () => {
+  it("obscures stats and name when useObscuredStats is true", async () => {
+    generateMock = vi.fn(async () => document.createElement("div"));
+    setupLazyPortraitsMock = vi.fn();
+    const container = document.createElement("div");
+    await renderJudokaCard(judoka, {}, container, { useObscuredStats: true });
+    const calledJudoka = generateMock.mock.calls[0][0];
+    expect(calledJudoka.firstname).toBe("?");
+    expect(calledJudoka.surname).toBe("?");
+    Object.values(calledJudoka.stats).forEach((v) => expect(v).toBe("?"));
+  });
+});


### PR DESCRIPTION
## Summary
- add `useObscuredStats` flag to `renderJudokaCard`
- clone judoka and replace name/stats when obscuring
- test that obscured judoka is passed to card builder

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: randomJudoka signature screenshot diff)*

------
https://chatgpt.com/codex/tasks/task_e_687d487b328483269910d0e50d170866