### PR TITLE
Cross-reference Mystery Card in Classic Battle PRD

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -139,6 +139,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 - Judoka dataset loaded from `judoka.json`.
 - Uses the shared random card draw module (`generateRandomCard`) as detailed in [prdDrawRandomCard.md](prdDrawRandomCard.md) (see `src/helpers/randomCard.js`).
+- Uses the Mystery Card placeholder outlined in [prdMysteryCard.md](prdMysteryCard.md), which relies on the `useObscuredStats` flag added to `renderJudokaCard()`.
 
 ---
 


### PR DESCRIPTION
## Summary
- link Mystery Card PRD from Classic Battle dependencies

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(1 failing screenshot diff)*

------
https://chatgpt.com/codex/tasks/task_e_687d4bae344c8326b66e6011d907c716