### PR TITLE
Add test utilities

### DIFF
--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -6,11 +6,9 @@ import {
   startCountdown,
   updateScore
 } from "../../src/components/InfoBar.js";
+import { createInfoBarHeader, resetDom } from "../utils/testUtils.js";
 
-afterEach(() => {
-  vi.useRealTimers();
-  document.body.innerHTML = "";
-});
+afterEach(resetDom);
 
 describe("InfoBar component", () => {
   it("creates DOM structure with proper aria attributes", () => {
@@ -46,13 +44,9 @@ describe("InfoBar component", () => {
 
   it("initializes from existing DOM", () => {
     vi.useFakeTimers();
-    document.body.innerHTML = `
-      <header>
-        <p id="round-message"></p>
-        <p id="next-round-timer"></p>
-        <p id="score-display"></p>
-      </header>`;
-    initInfoBar(document.querySelector("header"));
+    const header = createInfoBarHeader();
+    document.body.appendChild(header);
+    initInfoBar(header);
     showMessage("Hi");
     expect(document.getElementById("round-message").textContent).toBe("Hi");
     updateScore(2, 3);

--- a/tests/helpers/browseJudokaPage.test.js
+++ b/tests/helpers/browseJudokaPage.test.js
@@ -1,10 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { resetDom } from "../utils/testUtils.js";
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.resetModules();
-  document.body.innerHTML = "";
-});
+afterEach(resetDom);
 
 describe("browseJudokaPage helpers", () => {
   it("setupCountryToggle toggles panel and loads flags once", async () => {

--- a/tests/helpers/buttonEffects.test.js
+++ b/tests/helpers/buttonEffects.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { setupButtonEffects } from "../../src/helpers/buttonEffects.js";
 import * as motionUtils from "../../src/helpers/motionUtils.js";
+import { resetDom } from "../utils/testUtils.js";
 
 let button;
 
@@ -19,10 +20,7 @@ describe("setupButtonEffects", () => {
     }));
   });
 
-  afterEach(() => {
-    document.body.innerHTML = "";
-    vi.restoreAllMocks();
-  });
+  afterEach(resetDom);
 
   it("creates and removes a ripple on mousedown", () => {
     setupButtonEffects();

--- a/tests/helpers/domReady.test.js
+++ b/tests/helpers/domReady.test.js
@@ -1,10 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { resetDom } from "../utils/testUtils.js";
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.resetModules();
-  document.body.innerHTML = "";
-});
+afterEach(resetDom);
 
 describe("onDomReady", () => {
   it("runs callback immediately when document is ready", async () => {

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { resetDom } from "../utils/testUtils.js";
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  document.body.innerHTML = "";
-});
+afterEach(resetDom);
 
 describe("prdReaderPage", () => {
   it("navigates documents with wrap-around", async () => {

--- a/tests/helpers/quoteBuilder.test.js
+++ b/tests/helpers/quoteBuilder.test.js
@@ -1,13 +1,12 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { waitFor } from "../waitFor.js";
+import { resetDom } from "../utils/testUtils.js";
 
 const originalFetch = global.fetch;
 
 afterEach(() => {
-  vi.restoreAllMocks();
   global.fetch = originalFetch;
-  document.body.innerHTML = "";
-  vi.resetModules();
+  resetDom();
 });
 
 describe("displayRandomQuote", () => {

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -1,11 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { createRandomCardDom, resetDom } from "../utils/testUtils.js";
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.useRealTimers();
-  vi.resetModules();
-  document.body.innerHTML = "";
-});
+afterEach(resetDom);
 
 describe("randomJudokaPage module", () => {
   it("passes reduced motion flag when generating cards", async () => {
@@ -21,10 +17,8 @@ describe("randomJudokaPage module", () => {
     vi.doMock("../../src/components/Button.js", () => ({ createButton }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ shouldReduceMotionSync }));
 
-    document.body.innerHTML = `
-      <div class="card-section"></div>
-      <div id="card-container"></div>
-    `;
+    const { section, container } = createRandomCardDom();
+    document.body.append(section, container);
 
     const { setupRandomJudokaPage } = await import("../../src/helpers/randomJudokaPage.js");
 

--- a/tests/helpers/setupBattleInfoBar.test.js
+++ b/tests/helpers/setupBattleInfoBar.test.js
@@ -1,21 +1,15 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { createInfoBarHeader, resetDom } from "../utils/testUtils.js";
 
 const originalReadyState = Object.getOwnPropertyDescriptor(document, "readyState");
 
 beforeEach(() => {
   vi.resetModules();
-  document.body.innerHTML = `
-    <header>
-      <p id="round-message"></p>
-      <p id="next-round-timer"></p>
-      <p id="score-display"></p>
-    </header>`;
+  document.body.appendChild(createInfoBarHeader());
 });
 
 afterEach(() => {
-  vi.restoreAllMocks();
-  vi.useRealTimers();
-  document.body.innerHTML = "";
+  resetDom();
   if (originalReadyState) {
     Object.defineProperty(document, "readyState", originalReadyState);
   }
@@ -51,8 +45,12 @@ describe("setupBattleInfoBar", () => {
   });
 
   it("attaches to pre-existing elements", async () => {
-    Object.defineProperty(document, "readyState", { value: "complete", configurable: true });
-    document.body.innerHTML = `<header><p id="round-message"></p><p id="next-round-timer"></p><p id="score-display"></p></header>`;
+    Object.defineProperty(document, "readyState", {
+      value: "complete",
+      configurable: true
+    });
+    document.body.innerHTML = "";
+    document.body.appendChild(createInfoBarHeader());
     const mod = await import("../../src/helpers/setupBattleInfoBar.js");
     mod.showMessage("Hello");
     expect(document.getElementById("round-message").textContent).toBe("Hello");

--- a/tests/helpers/showSettingsError.test.js
+++ b/tests/helpers/showSettingsError.test.js
@@ -1,16 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { showSettingsError } from "../../src/helpers/showSettingsError.js";
 import { SETTINGS_FADE_MS, SETTINGS_REMOVE_MS } from "../../src/helpers/constants.js";
+import { resetDom } from "../utils/testUtils.js";
 
 beforeEach(() => {
   document.body.innerHTML = "";
 });
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.useRealTimers();
-  document.body.innerHTML = "";
-});
+afterEach(resetDom);
 
 describe("showSettingsError", () => {
   it("shows and then removes the error popup", () => {

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -1,0 +1,34 @@
+export function createInfoBarHeader() {
+  const header = document.createElement("header");
+  header.innerHTML = `
+    <p id="round-message"></p>
+    <p id="next-round-timer"></p>
+    <p id="score-display"></p>
+  `;
+  return header;
+}
+
+export function createRandomCardDom() {
+  const section = document.createElement("div");
+  section.className = "card-section";
+  const container = document.createElement("div");
+  container.id = "card-container";
+  return { section, container };
+}
+
+export function createBattleCardContainers() {
+  const playerCard = document.createElement("div");
+  playerCard.id = "player-card";
+  const computerCard = document.createElement("div");
+  computerCard.id = "computer-card";
+  return { playerCard, computerCard };
+}
+
+export function resetDom() {
+  if (typeof document !== "undefined" && document.body) {
+    document.body.innerHTML = "";
+  }
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  vi.resetModules();
+}


### PR DESCRIPTION
## Summary
- create DOM test helpers under `tests/utils`
- clean up test afterEach blocks with `resetDom`
- build common fixtures using new utils

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run --reporter verbose`
- `npx playwright test` *(fails: 1 failed, 1 skipped, 58 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687d4ebd82f8832690c80fe13e4be0e3