### PR TITLE
Refactor carousel and card helpers

### DIFF
--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -1,10 +1,13 @@
 import { getFlagUrl } from "./countryUtils.js";
 import { generateCardTopBar, createNoDataContainer } from "./cardTopBar.js";
-import { generateCardPortrait, generateCardSignatureMove } from "./cardRender.js";
-import { createStatsPanel } from "../components/StatsPanel.js";
 import { safeGenerate } from "./errorUtils.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
 import { enableCardFlip } from "./cardFlip.js";
+import {
+  createPortraitSection,
+  createStatsSection,
+  createSignatureMoveSection
+} from "./cardSections.js";
 
 /**
  * Generates the "last updated" HTML for a judoka card.
@@ -156,44 +159,6 @@ async function createTopBar(judoka, flagUrl) {
     "Failed to generate top bar:",
     createNoDataContainer()
   );
-}
-
-function createPortraitSection(judoka) {
-  try {
-    // generateCardPortrait returns a complete `.card-portrait` wrapper
-    const fragment = document.createRange().createContextualFragment(generateCardPortrait(judoka));
-    const portraitElement = fragment.firstElementChild;
-
-    const weightClassElement = document.createElement("div");
-    weightClassElement.className = "card-weight-class";
-    weightClassElement.textContent = judoka.weightClass;
-    portraitElement.appendChild(weightClassElement);
-
-    return portraitElement;
-  } catch (error) {
-    console.error("Failed to generate portrait:", error);
-    return createNoDataContainer();
-  }
-}
-
-function createStatsSection(judoka, cardType) {
-  try {
-    return createStatsPanel(judoka.stats, { type: cardType });
-  } catch (error) {
-    console.error("Failed to generate stats:", error);
-    return createNoDataContainer();
-  }
-}
-
-function createSignatureMoveSection(judoka, gokyoLookup, cardType) {
-  try {
-    const signatureMoveHTML = generateCardSignatureMove(judoka, gokyoLookup, cardType);
-    const fragment = document.createRange().createContextualFragment(signatureMoveHTML);
-    return fragment.firstElementChild;
-  } catch (error) {
-    console.error("Failed to generate signature move:", error);
-    return createNoDataContainer();
-  }
 }
 
 /**

--- a/src/helpers/cardSections.js
+++ b/src/helpers/cardSections.js
@@ -1,0 +1,40 @@
+import { generateCardPortrait, generateCardSignatureMove } from "./cardRender.js";
+import { createStatsPanel } from "../components/StatsPanel.js";
+import { createNoDataContainer } from "./cardTopBar.js";
+
+export function createPortraitSection(judoka) {
+  try {
+    const fragment = document.createRange().createContextualFragment(generateCardPortrait(judoka));
+    const portraitElement = fragment.firstElementChild;
+
+    const weightClassElement = document.createElement("div");
+    weightClassElement.className = "card-weight-class";
+    weightClassElement.textContent = judoka.weightClass;
+    portraitElement.appendChild(weightClassElement);
+
+    return portraitElement;
+  } catch (error) {
+    console.error("Failed to generate portrait:", error);
+    return createNoDataContainer();
+  }
+}
+
+export function createStatsSection(judoka, cardType) {
+  try {
+    return createStatsPanel(judoka.stats, { type: cardType });
+  } catch (error) {
+    console.error("Failed to generate stats:", error);
+    return createNoDataContainer();
+  }
+}
+
+export function createSignatureMoveSection(judoka, gokyoLookup, cardType) {
+  try {
+    const signatureMoveHTML = generateCardSignatureMove(judoka, gokyoLookup, cardType);
+    const fragment = document.createRange().createContextualFragment(signatureMoveHTML);
+    return fragment.firstElementChild;
+  } catch (error) {
+    console.error("Failed to generate signature move:", error);
+    return createNoDataContainer();
+  }
+}

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -2,74 +2,13 @@ import { createGokyoLookup } from "./utils.js";
 import { generateJudokaCard } from "./cardBuilder.js";
 import { getFallbackJudoka } from "./judokaUtils.js";
 import { setupLazyPortraits } from "./lazyPortrait.js";
+import { createScrollButton, updateScrollButtonState } from "./carouselScroll.js";
 import {
   CAROUSEL_SCROLL_DISTANCE,
   CAROUSEL_SWIPE_THRESHOLD,
   SPINNER_DELAY_MS
 } from "./constants.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
-
-/**
- * Creates a scroll button with the specified direction and functionality.
- *
- * @pseudocode
- * 1. Validate the input parameters:
- *    - Ensure `direction` is either "left" or "right".
- *    - Ensure `container` is a valid DOM element.
- *    - Throw an error if validation fails.
- *
- * 2. Create a button element:
- *    - Assign a class based on the `direction` (e.g., "scroll-button left" or "scroll-button right").
- *    - Set the inner HTML to display an inline SVG chevron pointing left or right.
- *    - Add an accessible label (`aria-label`) for screen readers (e.g., "Scroll Left").
- *
- * 3. Add a click event listener to the button:
- *    - Scroll the `container` by the specified `scrollAmount`.
- *    - Use smooth scrolling for better user experience.
- *
- * 4. Return the created button element.
- *
- * @param {String} direction - Either "left" or "right".
- * @param {HTMLElement} container - The carousel container to scroll.
- * @param {Number} scrollAmount - The amount to scroll in pixels.
- * @returns {HTMLElement} The scroll button element.
- *
- * Note: The function assumes `scrollAmount` is a number and does not
- * perform validation. Invalid values will simply be passed to
- * `scrollBy` without throwing an error.
- */
-export function createScrollButton(direction, container, scrollAmount) {
-  if (direction !== "left" && direction !== "right") {
-    throw new Error("Invalid direction: must be 'left' or 'right'");
-  }
-
-  if (!container) {
-    throw new Error("Container is required");
-  }
-
-  const button = document.createElement("button");
-
-  button.className = `scroll-button ${direction}`;
-
-  button.innerHTML =
-    direction === "left"
-      ? '<svg xmlns="http://www.w3.org/2000/svg" height="24px" width="24px" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z"/></svg>'
-      : '<svg xmlns="http://www.w3.org/2000/svg" height="24px" width="24px" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z"/></svg>';
-
-  button.setAttribute(
-    "aria-label",
-    `Scroll ${direction.charAt(0).toUpperCase() + direction.slice(1)}`
-  );
-
-  button.addEventListener("click", () => {
-    container.scrollBy({
-      left: direction === "left" ? -scrollAmount : scrollAmount,
-      behavior: "smooth"
-    });
-  });
-
-  return button;
-}
 
 /**
  * Adds scroll markers to indicate the user's position in the carousel.
@@ -148,25 +87,6 @@ function validateGokyoData(gokyoData) {
     console.warn("No gokyo data provided. Defaulting to an empty lookup.");
   }
   return createGokyoLookup(gokyoData);
-}
-
-/**
- * Update scroll button disabled states based on container position.
- *
- * @pseudocode
- * 1. Calculate the maximum scroll value using `scrollWidth` and
- *    `clientWidth` of `container`.
- * 2. Disable `leftBtn` when `scrollLeft` is at or before the first card.
- * 3. Disable `rightBtn` when `scrollLeft` reaches the end of the carousel.
- *
- * @param {HTMLElement} container - The scrolling container element.
- * @param {HTMLButtonElement} leftBtn - Button that scrolls left.
- * @param {HTMLButtonElement} rightBtn - Button that scrolls right.
- */
-export function updateScrollButtonState(container, leftBtn, rightBtn) {
-  const maxLeft = container.scrollWidth - container.clientWidth;
-  leftBtn.disabled = container.scrollLeft <= 0;
-  rightBtn.disabled = container.scrollLeft >= maxLeft;
 }
 
 /**

--- a/src/helpers/carouselScroll.js
+++ b/src/helpers/carouselScroll.js
@@ -1,0 +1,80 @@
+/**
+ * Creates a scroll button with the specified direction and functionality.
+ *
+ * @pseudocode
+ * 1. Validate the input parameters:
+ *    - Ensure `direction` is either "left" or "right".
+ *    - Ensure `container` is a valid DOM element.
+ *    - Throw an error if validation fails.
+ *
+ * 2. Create a button element:
+ *    - Assign a class based on the `direction` (e.g., "scroll-button left" or "scroll-button right").
+ *    - Set the inner HTML to display an inline SVG chevron pointing left or right.
+ *    - Add an accessible label (`aria-label`) for screen readers (e.g., "Scroll Left").
+ *
+ * 3. Add a click event listener to the button:
+ *    - Scroll the `container` by the specified `scrollAmount`.
+ *    - Use smooth scrolling for better user experience.
+ *
+ * 4. Return the created button element.
+ *
+ * @param {String} direction - Either "left" or "right".
+ * @param {HTMLElement} container - The carousel container to scroll.
+ * @param {Number} scrollAmount - The amount to scroll in pixels.
+ * @returns {HTMLElement} The scroll button element.
+ *
+ * Note: The function assumes `scrollAmount` is a number and does not
+ * perform validation. Invalid values will simply be passed to
+ * `scrollBy` without throwing an error.
+ */
+export function createScrollButton(direction, container, scrollAmount) {
+  if (direction !== "left" && direction !== "right") {
+    throw new Error("Invalid direction: must be 'left' or 'right'");
+  }
+
+  if (!container) {
+    throw new Error("Container is required");
+  }
+
+  const button = document.createElement("button");
+
+  button.className = `scroll-button ${direction}`;
+
+  button.innerHTML =
+    direction === "left"
+      ? '<svg xmlns="http://www.w3.org/2000/svg" height="24px" width="24px" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z"/></svg>'
+      : '<svg xmlns="http://www.w3.org/2000/svg" height="24px" width="24px" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z"/></svg>';
+
+  button.setAttribute(
+    "aria-label",
+    `Scroll ${direction.charAt(0).toUpperCase() + direction.slice(1)}`
+  );
+
+  button.addEventListener("click", () => {
+    container.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth"
+    });
+  });
+
+  return button;
+}
+
+/**
+ * Update scroll button disabled states based on container position.
+ *
+ * @pseudocode
+ * 1. Calculate the maximum scroll value using `scrollWidth` and
+ *    `clientWidth` of `container`.
+ * 2. Disable `leftBtn` when `scrollLeft` is at or before the first card.
+ * 3. Disable `rightBtn` when `scrollLeft` reaches the end of the carousel.
+ *
+ * @param {HTMLElement} container - The scrolling container element.
+ * @param {HTMLButtonElement} leftBtn - Button that scrolls left.
+ * @param {HTMLButtonElement} rightBtn - Button that scrolls right.
+ */
+export function updateScrollButtonState(container, leftBtn, rightBtn) {
+  const maxLeft = container.scrollWidth - container.clientWidth;
+  leftBtn.disabled = container.scrollLeft <= 0;
+  rightBtn.disabled = container.scrollLeft >= maxLeft;
+}

--- a/tests/card/cardBuilder.test.js
+++ b/tests/card/cardBuilder.test.js
@@ -1,4 +1,4 @@
-import { createScrollButton } from "../../src/helpers/carouselBuilder.js";
+import { createScrollButton } from "../../src/helpers/carouselScroll.js";
 import { generateCardPortrait, generateCardStats } from "../../src/helpers/cardRender.js";
 import { vi } from "vitest";
 

--- a/tests/helpers/scrollButtonState.test.js
+++ b/tests/helpers/scrollButtonState.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { updateScrollButtonState } from "../../src/helpers/carouselBuilder.js";
+import { updateScrollButtonState } from "../../src/helpers/carouselScroll.js";
 
 describe("updateScrollButtonState", () => {
   it("disables left button at start", () => {


### PR DESCRIPTION
## Summary
- extract carousel scroll helpers
- move card section generators to new module
- update imports and tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Signature move screenshots › random judoka page)*

------
https://chatgpt.com/codex/tasks/task_e_687d547842f88326b0cdddf0cd08ba79