### PR TITLE
Improve Playwright reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ npm run test:screenshot
 ```
 
 The screenshot suite now runs once for **each browser project** configured in
-`playwright.config.js`. Snapshot images are saved under
+`playwright.config.js`. Tests within the suite execute in parallel for faster
+feedback. Snapshot images are saved under
 `playwright/<spec>.spec.js-snapshots/<project>/`.
 
 Remember **not** to commit files in `playwright/*-snapshots` when screenshots
@@ -92,7 +93,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -160,6 +160,7 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   - `styles/`
 
 - `tests/` – Vitest unit tests.
+- `playwright/` – end‑to‑end tests powered by Playwright. The `commonSetup` fixture mocks network requests with local fixtures for deterministic runs.
   - `design/` – documentation and code standards.
   - [Architecture Overview](design/architecture.md) – summary of key modules.
 
@@ -250,25 +251,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/playwright/battleJudoka.spec.js
+++ b/playwright/battleJudoka.spec.js
@@ -1,28 +1,20 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/commonSetup.js";
+import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 test.describe("Battle Judoka page", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
   });
 
-  test("page loads", async ({ page }) => {
-    await expect(page).toHaveTitle(/Ju-Do-Kon!/i);
-  });
-
-  test("essential elements visible", async ({ page }) => {
-    await expect(page.getByRole("navigation")).toBeVisible();
-    await expect(page.getByRole("img", { name: "JU-DO-KON! Logo" })).toBeVisible();
-    await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
-    // 'Update Judoka' link is hidden in the current game modes configuration
-    // so only visible links are asserted
-    await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
+  test("page loads and nav visible", async ({ page }) => {
+    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
   });
 
   test("navigation links work", async ({ page }) => {
-    await page.getByRole("link", { name: /view judoka/i }).click();
+    await page.getByTestId("nav-randomJudoka").click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
     await page.goBack({ waitUntil: "load" });
-    await page.getByRole("link", { name: /classic battle/i }).click();
+    await page.getByTestId("nav-classicBattle").click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 });

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures/commonSetup.js";
+import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 async function setCarouselWidth(page, width) {
   await page.evaluate((w) => {
@@ -24,12 +25,11 @@ test.describe("Browse Judoka screen", () => {
       "aria-label",
       /country filter/i
     );
-    await expect(page.getByRole("navigation")).toBeVisible();
-    await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
+    await verifyPageBasics(page, ["nav-classicBattle"]);
   });
 
   test("battle link navigates", async ({ page }) => {
-    await page.getByRole("link", { name: /classic battle/i }).click();
+    await page.getByTestId("nav-classicBattle").click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 

--- a/playwright/createJudoka.spec.js
+++ b/playwright/createJudoka.spec.js
@@ -1,27 +1,20 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/commonSetup.js";
+import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 test.describe("Create Judoka page", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/createJudoka.html");
   });
 
-  test("page loads", async ({ page }) => {
-    await expect(page).toHaveTitle(/Ju-Do-Kon!/i);
-  });
-
-  test("essential elements visible", async ({ page }) => {
-    await expect(page.getByRole("navigation")).toBeVisible();
-    await expect(page.getByRole("img", { name: "JU-DO-KON! Logo" })).toBeVisible();
-    await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
-    // 'Update Judoka' is currently hidden via game modes configuration
-    await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
+  test("page loads and nav visible", async ({ page }) => {
+    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
   });
 
   test("navigation links work", async ({ page }) => {
-    await page.getByRole("link", { name: /view judoka/i }).click();
+    await page.getByTestId("nav-randomJudoka").click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
     await page.goBack({ waitUntil: "load" });
-    await page.getByRole("link", { name: /classic battle/i }).click();
+    await page.getByTestId("nav-classicBattle").click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 });

--- a/playwright/fixtures/navigationChecks.js
+++ b/playwright/fixtures/navigationChecks.js
@@ -1,0 +1,21 @@
+import { expect } from "@playwright/test";
+
+/**
+ * Verify common page elements like title, navigation bar and logo.
+ *
+ * @pseudocode
+ * 1. Assert the page title contains "Ju-Do-Kon!".
+ * 2. Ensure the `<nav>` element and logo image are visible.
+ * 3. For each id in `linkIds`, assert the corresponding `data-testid` link is visible.
+ *
+ * @param {import('@playwright/test').Page} page - The Playwright page.
+ * @param {string[]} [linkIds=[]] - Navigation link test IDs to verify.
+ */
+export async function verifyPageBasics(page, linkIds = []) {
+  await expect(page).toHaveTitle(/Ju-Do-Kon!/i);
+  await expect(page.getByRole("navigation")).toBeVisible();
+  await expect(page.getByRole("img", { name: "JU-DO-KON! Logo" })).toBeVisible();
+  for (const id of linkIds) {
+    await expect(page.getByTestId(id)).toBeVisible();
+  }
+}

--- a/playwright/homepage-layout.spec.js
+++ b/playwright/homepage-layout.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/commonSetup.js";
 
 test.describe("Homepage layout", () => {
   test.describe("desktop", () => {

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -1,4 +1,5 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/commonSetup.js";
+import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 test.describe("Homepage", () => {
   test.beforeEach(async ({ page }) => {
@@ -6,7 +7,7 @@ test.describe("Homepage", () => {
   });
 
   test("page loads", async ({ page }) => {
-    await expect(page).toHaveTitle(/Ju-Do-Kon!/i);
+    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
   });
 
   test("logo has alt text", async ({ page }) => {
@@ -16,11 +17,7 @@ test.describe("Homepage", () => {
 
   test("navigation links visible", async ({ page }) => {
     await page.waitForSelector("footer .bottom-navbar a");
-    await expect(page.getByRole("navigation")).toBeVisible();
-    await expect(page.locator("footer").getByRole("link", { name: /view judoka/i })).toBeVisible();
-    await expect(
-      page.locator("footer").getByRole("link", { name: /classic battle/i })
-    ).toBeVisible();
+    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
   });
 
   test("footer navigation links present", async ({ page }) => {
@@ -29,10 +26,7 @@ test.describe("Homepage", () => {
   });
 
   test("view judoka link navigates", async ({ page }) => {
-    await page
-      .locator("footer")
-      .getByRole("link", { name: /view judoka/i })
-      .click();
+    await page.getByTestId("nav-randomJudoka").click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
   });
 

--- a/playwright/meditation-screen.spec.js
+++ b/playwright/meditation-screen.spec.js
@@ -1,8 +1,13 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/commonSetup.js";
+import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 test.describe("Meditation screen", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/meditation.html");
+  });
+
+  test("page basics", async ({ page }) => {
+    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
   });
 
   test("elements are visible", async ({ page }) => {

--- a/playwright/prd-reader.spec.js
+++ b/playwright/prd-reader.spec.js
@@ -1,8 +1,13 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/commonSetup.js";
+import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 test.describe("PRD Reader page", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/prdViewer.html");
+  });
+
+  test("page basics", async ({ page }) => {
+    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
   });
 
   test("forward and back navigation", async ({ page }) => {

--- a/playwright/pseudo-japanese-toggle.spec.js
+++ b/playwright/pseudo-japanese-toggle.spec.js
@@ -1,6 +1,7 @@
 import * as path from "path";
 import { fileURLToPath } from "url";
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/commonSetup.js";
+import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const STORY_FIXTURE = path.resolve(__dirname, "../tests/fixtures/aesopsFables.json");
@@ -19,6 +20,10 @@ test.describe("Pseudo-Japanese toggle", () => {
     );
     await page.goto("/src/pages/meditation.html");
     await page.waitForSelector("#quote .quote-content");
+  });
+
+  test("page basics", async ({ page }) => {
+    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
   });
 
   test("toggle updates quote text", async ({ page }) => {

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures/commonSetup.js";
+import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 test.describe("View Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
@@ -8,11 +9,11 @@ test.describe("View Judoka screen", () => {
   test("essential elements visible", async ({ page }) => {
     await page.getByTestId("draw-button").waitFor();
     await expect(page.getByTestId("draw-button")).toBeVisible();
-    await expect(page.getByRole("navigation")).toBeVisible();
+    await verifyPageBasics(page, ["nav-classicBattle"]);
   });
 
   test("battle link navigates", async ({ page }) => {
-    const battleLink = page.getByRole("link", { name: /classic battle/i });
+    const battleLink = page.getByTestId("nav-classicBattle");
     await battleLink.waitFor();
     await battleLink.click();
     await expect(page).toHaveURL(/battleJudoka\.html/);

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -4,7 +4,7 @@ import fs from "fs";
 // Allow skipping screenshots via the SKIP_SCREENSHOTS environment variable
 const runScreenshots = process.env.SKIP_SCREENSHOTS !== "true";
 
-test.describe(runScreenshots ? "Screenshot suite" : "Screenshot suite (skipped)", () => {
+test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (skipped)", () => {
   test.use({ viewport: { width: 1280, height: 720 } });
   test.skip(!runScreenshots);
   // List of pages to capture screenshots for

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures/commonSetup.js";
+import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 test.describe("Settings page", () => {
   test.beforeEach(async ({ page }) => {
@@ -9,7 +10,7 @@ test.describe("Settings page", () => {
   });
 
   test("page loads", async ({ page }) => {
-    await expect(page).toHaveTitle(/Ju-Do-Kon!/i);
+    await verifyPageBasics(page, ["nav-classicBattle", "nav-randomJudoka"]);
   });
 
   test("mode toggle visible", async ({ page }) => {
@@ -18,8 +19,7 @@ test.describe("Settings page", () => {
   });
 
   test("essential elements visible", async ({ page }) => {
-    await expect(page.getByRole("navigation")).toBeVisible();
-    await expect(page.getByRole("img", { name: "JU-DO-KON! Logo" })).toBeVisible();
+    await verifyPageBasics(page, ["nav-classicBattle", "nav-randomJudoka"]);
     await expect(page.getByLabel(/sound/i)).toBeVisible();
     await expect(page.getByLabel(/full navigation map/i)).toBeVisible();
     await expect(page.getByLabel(/motion effects/i)).toBeVisible();

--- a/playwright/updateJudoka.spec.js
+++ b/playwright/updateJudoka.spec.js
@@ -1,4 +1,5 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/commonSetup.js";
+import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 test.describe("Update Judoka page", () => {
   test.beforeEach(async ({ page }) => {
@@ -9,28 +10,20 @@ test.describe("Update Judoka page", () => {
   });
 
   test("page loads", async ({ page }) => {
-    await expect(page).toHaveTitle(/Ju-Do-Kon!/i);
-  });
-
-  test("essential elements visible", async ({ page }) => {
-    await expect(page.getByRole("navigation")).toBeVisible();
-    await expect(page.getByRole("img", { name: "JU-DO-KON! Logo" })).toBeVisible();
-    await expect(page.getByRole("link", { name: /view judoka/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /update judoka/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /classic battle/i })).toBeVisible();
+    await verifyPageBasics(page, ["nav-randomJudoka", "nav-updateJudoka", "nav-classicBattle"]);
   });
 
   test("navigation links work", async ({ page }) => {
-    await page.getByRole("link", { name: /view judoka/i }).click();
+    await page.getByTestId("nav-randomJudoka").click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
     // Wait for bottom navigation links to populate
-    await page.getByRole("link", { name: /update judoka/i }).waitFor();
+    await page.getByTestId("nav-updateJudoka").waitFor();
     await page.goBack({ waitUntil: "load" });
 
-    await page.getByRole("link", { name: /update judoka/i }).click();
+    await page.getByTestId("nav-updateJudoka").click();
     await expect(page).toHaveURL(/updateJudoka\.html/);
 
-    const battleLink = page.getByRole("link", { name: /classic battle/i });
+    const battleLink = page.getByTestId("nav-classicBattle");
     await battleLink.waitFor();
     await expect(battleLink).toHaveCount(1);
   });

--- a/src/helpers/navigationBar.js
+++ b/src/helpers/navigationBar.js
@@ -211,7 +211,10 @@ export async function populateNavbar() {
 
     const ul = document.createElement("ul");
     ul.innerHTML = activeModes
-      .map((mode) => `<li><a href="${BASE_PATH}${mode.url}">${mode.name}</a></li>`)
+      .map(
+        (mode) =>
+          `<li><a href="${BASE_PATH}${mode.url}" data-testid="nav-${mode.id}">${mode.name}</a></li>`
+      )
       .join("");
     navBar.appendChild(ul);
 
@@ -244,7 +247,10 @@ export async function populateNavbar() {
 
     const ul = document.createElement("ul");
     ul.innerHTML = fallbackItems
-      .map((item) => `<li><a href="${item.url}">${item.name}</a></li>`)
+      .map(
+        (item) =>
+          `<li><a href="${item.url}" data-testid="nav-${item.name.replace(/\s+/g, "")}">${item.name}</a></li>`
+      )
       .join("");
     navBar.appendChild(ul);
 


### PR DESCRIPTION
## Summary
- add `verifyPageBasics` helper and use across Playwright specs
- move all specs to `commonSetup` for mocked routes
- tag nav links with test ids for stable selectors
- run screenshot suite in parallel
- document Playwright fixtures and parallel runs

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_687d69b6211083268dd365ca859da791