### PR TITLE
Add slider color tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ don't interfere with the centered content. Users can return to the main menu via
 - `base.css` – tokens, resets, and global typography.
 - `layout.css` – overall page layout/grid.
 - `components.css` – reusable UI components. All `<button>` elements
-  use design tokens such as `--button-bg` and `--button-text-color`.
+  use design tokens such as `--button-bg`, `--button-text-color`,
+  `--color-slider-dot`, and `--color-slider-active`.
   `setupButtonEffects()` adds a Material-style ripple when buttons are
   clicked. An optional `.secondary-button` class provides a lighter
   variant.

--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -331,20 +331,22 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 
 ## 10. Tokens
 
-| Token Name          | Value                      | Purpose                                   |
-| ------------------- | -------------------------- | ----------------------------------------- |
-| --radius-sm         | 4px                        | Inputs, badges                            |
-| --radius-md         | 8px                        | Buttons                                   |
-| --radius-lg         | 12px                       | Cards, modals                             |
-| --radius-pill       | 9999px                     | Capsule buttons                           |
-| --button-bg         | #CB2504                    | Primary button background                 |
-| --button-hover-bg   | #0B5BB0                    | Hover state for buttons; adds drop shadow |
-| --button-active-bg  | #0C3F7A                    | Active button state                       |
-| --button-text-color | #ffffff                    | Button text                               |
-| --switch-off-bg     | #878787                    | Toggle off state background               |
-| --switch-on-bg      | #08A700                    | Toggle on state background                |
-| --shadow-base       | 0 4px 12px rgba(0,0,0,0.1) | Elevation; hover drop-shadow              |
-| --transition-fast   | all 150ms ease             | UI animations                             |
+| Token Name            | Value                      | Purpose                                   |
+| --------------------- | -------------------------- | ----------------------------------------- |
+| --radius-sm           | 4px                        | Inputs, badges                            |
+| --radius-md           | 8px                        | Buttons                                   |
+| --radius-lg           | 12px                       | Cards, modals                             |
+| --radius-pill         | 9999px                     | Capsule buttons                           |
+| --button-bg           | #CB2504                    | Primary button background                 |
+| --button-hover-bg     | #0B5BB0                    | Hover state for buttons; adds drop shadow |
+| --button-active-bg    | #0C3F7A                    | Active button state                       |
+| --button-text-color   | #ffffff                    | Button text                               |
+| --switch-off-bg       | #878787                    | Toggle off state background               |
+| --switch-on-bg        | #08A700                    | Toggle on state background                |
+| --shadow-base         | 0 4px 12px rgba(0,0,0,0.1) | Elevation; hover drop-shadow              |
+| --transition-fast     | all 150ms ease             | UI animations                             |
+| --color-slider-dot    | #BBB                       | Carousel indicator default                |
+| --color-slider-active | #717171                    | Active/hover indicator                    |
 
 ---
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -18,6 +18,8 @@
   --button-text-color: #ffffff;
   --switch-off-bg: #707070; /* Toggle off state background */
   --switch-on-bg: #08a700; /* Toggle on state background */
+  --color-slider-dot: #bbb; /* Carousel indicator default */
+  --color-slider-active: #717171; /* Active indicator */
   --radius-pill: 9999px; /* capsule */
 
   /* Updated spacing tokens */

--- a/src/styles/mockupViewer.css
+++ b/src/styles/mockupViewer.css
@@ -15,7 +15,6 @@ body {
 }
 
 .slideshow-container {
-  max-width: 100dvh;
   max-width: 100vh;
   position: relative;
   /* margin: auto; */
@@ -92,7 +91,7 @@ body {
   height: 15px;
   width: 15px;
   margin: 0 2px;
-  background-color: #bbb;
+  background-color: var(--color-slider-dot);
   border-radius: 50%;
   display: inline-block;
   transition: background-color 0.6s ease;
@@ -100,7 +99,7 @@ body {
 
 .active,
 .dot:hover {
-  background-color: #717171;
+  background-color: var(--color-slider-active);
 }
 
 .fade {


### PR DESCRIPTION
## Summary
- add `--color-slider-dot` and `--color-slider-active` variables
- use these tokens in `mockupViewer.css`
- document slider tokens in code standards and README
- clean up redundant max-width value

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: PRD Reader page › page basics)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687e1a52d8b48326b712ce48c9bd59bb