### PR TITLE
Clean up token comments in CSS

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -192,9 +192,9 @@ button .ripple {
   height: calc(var(--card-width) * 1.5);
   aspect-ratio: 2 / 3;
   border: 12px solid var(--card-border-color);
-  border-radius: var(--radius-lg); /* Updated token */
+  border-radius: var(--radius-lg);
   background-color: var(--card-bg-color);
-  box-shadow: var(--shadow-base); /* Updated token */
+  box-shadow: var(--shadow-base);
   overflow: hidden;
   display: grid;
   grid-template-rows:
@@ -207,7 +207,7 @@ button .ripple {
     auto;
   transition:
     box-shadow var(--transition-fast),
-    transform 0.1s ease-in-out; /* Updated token */
+    transform 0.1s ease-in-out;
 }
 
 .judoka-card::before {
@@ -381,14 +381,14 @@ button .ripple {
 
 .card-weight-class {
   position: absolute;
-  margin-top: var(--space-small); /* Updated token */
-  right: var(--space-small); /* Updated token */
+  margin-top: var(--space-small);
+  right: var(--space-small);
   background-color: transparent;
-  border-radius: var(--radius-sm); /* Updated token */
+  border-radius: var(--radius-sm);
   color: #fff;
   font-weight: bold;
-  padding: var(--space-small) var(--space-medium); /* Updated tokens */
-  font-size: var(--font-medium); /* Updated token */
+  padding: var(--space-small) var(--space-medium);
+  font-size: var(--font-medium);
   z-index: 2;
 }
 
@@ -712,15 +712,15 @@ button .ripple {
   align-items: center;
   justify-content: center;
   gap: var(--space-sm);
-  margin: var(--space-large) auto; /* Updated token */
+  margin: var(--space-large) auto;
   width: 300px;
   max-width: 90vw;
   min-height: 64px;
-  padding: var(--space-md) var(--space-lg); /* Updated tokens */
+  padding: var(--space-md) var(--space-lg);
   color: var(--button-text-color);
   background-color: var(--button-bg);
-  border: 2px solid var(--color-surface); /* Updated token */
-  border-radius: var(--radius-pill); /* Updated token */
+  border: 2px solid var(--color-surface);
+  border-radius: var(--radius-pill);
   font-size: 1.25rem;
   font-weight: bold;
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -62,8 +62,8 @@ body {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  background-color: var(--color-tertiary); /* Updated token */
-  box-shadow: var(--shadow-base); /* Updated token */
+  background-color: var(--color-tertiary);
+  box-shadow: var(--shadow-base);
   width: 100%;
   min-height: var(--header-height);
 }
@@ -85,8 +85,8 @@ body {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(2, 1fr);
-  gap: var(--space-lg); /* Updated token */
-  padding: var(--space-large) var(--space-xl); /* Updated token */
+  gap: var(--space-lg);
+  padding: var(--space-large) var(--space-xl);
   flex: 1 1 auto;
   height: calc(100vh - var(--header-height) - var(--footer-height));
   height: calc(100dvh - var(--header-height) - var(--footer-height));
@@ -99,9 +99,9 @@ body {
   }
 }
 .homeHelperContainer {
-  background: var(--color-tertiary); /* Updated token */
-  border: 2px solid var(--color-tertiary); /* Updated token */
-  border-radius: var(--radius-md); /* Updated token */
+  background: var(--color-tertiary);
+  border: 2px solid var(--color-tertiary);
+  border-radius: var(--radius-md);
   text-align: center;
 }
 
@@ -111,14 +111,14 @@ body {
   border-radius: 4px;
 }
 .card-preview {
-  margin-top: var(--space-md); /* Updated token */
-  background: var(--color-tertiary); /* Updated token */
-  border: 1px solid var(--color-secondary); /* Updated token */
+  margin-top: var(--space-md);
+  background: var(--color-tertiary);
+  border: 1px solid var(--color-secondary);
 }
 .locationTileContainer {
-  padding: var(--space-md); /* Updated token */
+  padding: var(--space-md);
   display: inline-flex;
-  gap: var(--space-lg); /* Updated token */
+  gap: var(--space-lg);
   flex: 1 1 auto;
   list-style-type: none;
 }
@@ -126,7 +126,7 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: var(--space-large); /* Updated token */
+  padding: var(--space-large);
   backdrop-filter: blur(10px);
 }
 .country-flag-slider {
@@ -146,7 +146,7 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: var(--space-sm) var(--space-lg); /* Updated tokens */
+  padding: var(--space-sm) var(--space-lg);
   text-align: center;
   max-width: 45vw;
   white-space: pre;
@@ -154,8 +154,8 @@ body {
 
 .country-flag-slider .flag-image {
   max-height: 5dvh;
-  margin: var(--space-sm); /* Updated token */
-  border-radius: var(--radius-sm); /* Updated token */
+  margin: var(--space-sm);
+  border-radius: var(--radius-sm);
 }
 
 /* Game mode toggles layout on settings page */

--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -4,26 +4,26 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--space-lg); /* Updated token */
-  padding: var(--space-xl) var(--space-md); /* Updated tokens */
+  gap: var(--space-lg);
+  padding: var(--space-xl) var(--space-md);
 }
 
 .meditation-title {
   font-family: "Russo One", sans-serif;
-  font-size: clamp(32px, 5vw, 40px); /* Updated token */
+  font-size: clamp(32px, 5vw, 40px);
   color: var(--color-text-inverted);
   text-align: center;
   /* margin: var(--space-lg);  */
   padding: var(--space-md) var(--space-lg);
   background-color: var(--color-primary);
-  border-radius: var(--radius-lg); /* Updated token */
+  border-radius: var(--radius-lg);
 }
 
 .quote-container,
 .meditation-container {
   display: flex;
   align-items: flex-start;
-  gap: var(--space-md); /* Updated token */
+  gap: var(--space-md);
   width: 100%;
 }
 
@@ -53,7 +53,7 @@
 
 .quote-loader {
   height: 6rem;
-  border-radius: var(--radius-md); /* Updated token */
+  border-radius: var(--radius-md);
   background: linear-gradient(90deg, #444 25%, #666 50%, #444 75%);
   background-size: 200% 100%;
   animation: loading 1.2s infinite;
@@ -71,7 +71,7 @@
 .quote {
   font-size: clamp(18px, 2vw, 24px);
   color: var(--color-text-inverted);
-  line-height: 1.4; /* Updated token */
+  line-height: 1.4;
   max-width: 70ch;
   margin: 0 auto;
   text-align: justify;
@@ -96,20 +96,20 @@
   padding: 5dvh 5dvw;
   max-width: 70ch;
   margin: 0 auto;
-  border-radius: var(--radius-md); /* Updated token */
+  border-radius: var(--radius-md);
 }
 
 /* cta button styles */
 .cta-button {
   display: inline-block;
   min-height: 48px;
-  padding: var(--space-md) var(--space-lg); /* Updated tokens */
-  font-size: var(--font-medium); /* Updated token */
+  padding: var(--space-md) var(--space-lg);
+  font-size: var(--font-medium);
   color: var(--button-text-color);
   background-color: var(--button-bg);
   text-decoration: none;
-  border-radius: var(--radius-md); /* Updated token */
-  margin-top: var(--space-md); /* Updated token */
+  border-radius: var(--radius-md);
+  margin-top: var(--space-md);
 }
 
 .cta-button:link,
@@ -199,12 +199,12 @@
 .language-toggle {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-small); /* Updated token */
-  background-color: var(--color-secondary); /* Updated token */
+  gap: var(--space-small);
+  background-color: var(--color-secondary);
   color: var(--color-text-inverted);
   border: none;
-  border-radius: var(--radius-md); /* Updated token */
-  padding: var(--space-medium) var(--space-medium); /* Updated tokens */
+  border-radius: var(--radius-md);
+  padding: var(--space-medium) var(--space-medium);
   /* margin-top: var(--space-small); */
   cursor: pointer;
   transition:
@@ -215,15 +215,15 @@
 .language-toggle:hover,
 .language-toggle:focus,
 .language-toggle:focus-visible {
-  background-color: var(--color-secondary); /* Updated token */
+  background-color: var(--color-secondary);
 }
 
 .flag-icon {
   display: inline-block;
-  font-size: var(--font-medium); /* Updated token */
+  font-size: var(--font-medium);
   line-height: 1;
-  border-radius: var(--radius-sm); /* Updated token */
-  border: 1px solid var(--color-secondary); /* Updated token for better contrast */
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-secondary);
   padding: 0 0.1rem;
 }
 

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -1,6 +1,6 @@
 /* Updated to align with the design standards */
 .noscript-warning {
-  color: var(--color-primary); /* Updated token */
+  color: var(--color-primary);
   font-weight: bold;
 }
 
@@ -31,8 +31,8 @@
 .long-form {
   max-width: 70ch;
   margin-inline: auto;
-  line-height: 1.4; /* Updated token */
-  color: var(--color-text); /* Updated token */
+  line-height: 1.4;
+  color: var(--color-text);
 }
 
 /* Add Reduced Motion support */


### PR DESCRIPTION
## Summary
- remove leftover "Updated token" comments from CSS files
- run project linters and tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: PRD Reader page basics, Signature move screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687e1a62e8c883268e069344b34293ea