### PR TITLE
Address PRD feedback

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -1,5 +1,8 @@
 # Battle Info Bar PRD
 
+## TL;DR
+Displays round messages, a countdown timer, and live match score in the page header so players always know the current battle status.
+
 ## Description
 
 In battle game modes (e.g. Classic Battle), players have a real need to  receive clear visual feedback between or after rounds. Without this info, it will leave users uncertain about match state, leading to confusion, reduced immersion, and increased risk of game abandonment. Players could feel "lost" due to a lack of timely updates about round outcomes, next steps, or overall progress.
@@ -149,4 +152,5 @@ Why: Forces the wireframe to handle edge cases, small screens, and overflow grac
   - [ ] 5.1 Show “Waiting…” if backend score sync fails
   - [ ] 5.2 Show “Waiting…” if countdown timer mismatches server start
   - [ ] 5.3 Truncate or stack content if resolution causes display issues
-  - [ ] 5.5 Define recovery logic for delayed player input
+  - [ ] 5.4 Define recovery logic for delayed player input
+\n[Back to Game Modes Overview](prdGameModes.md)

--- a/design/productRequirementsDocuments/prdBrowseJudoka.md
+++ b/design/productRequirementsDocuments/prdBrowseJudoka.md
@@ -2,7 +2,7 @@
 
 Game Mode ID: browseJudoka (URL: browseJudoka.html)
 
-**Browse Judoka** is accessible from the Main Page ([prdHomePageNavigation.md](prdHomePageNavigation.md)), Navigation Bar ([prdNavigationBarCollapsed.md](prdNavigationBarCollapsed.md)) or Navigation Map ([prdNavigationMap.md](prdNavigationMap.md)) and opens a full-screen roster view. Players first see a country filter panel alongside a card carousel. 
+**Browse Judoka** is accessible from the Main Page ([prdHomePageNavigation.md](prdHomePageNavigation.md)), Navigation Bar ([prdNavigationBar.md](prdNavigationBar.md)) or Navigation Map ([prdNavigationMap.md](prdNavigationMap.md)) and opens a full-screen roster view. Players first see a country filter panel alongside a card carousel. 
 
 The carousel relies on the `buildCardCarousel` helper ([prdCardCarousel.md](prdCardCarousel.md)) (see [PRD: Judoka Card Carousel](prdCardCarousel.md)) and filtering uses the Country Flag Picker ([prdCountryPickerFilter.md](prdCountryPickerFilter.md)).
 

--- a/design/productRequirementsDocuments/prdCardCarousel.md
+++ b/design/productRequirementsDocuments/prdCardCarousel.md
@@ -179,3 +179,4 @@ generated carousel so each card's real portrait loads once it becomes visible.
   - [ ] 3.3 Implement loading spinner for slow networks.
 - [ ] 4.0 Handle Edge Cases (P2)
   - [ ] 4.1 Fallback judoka card (judoka id=0) for broken card images.
+\n[Back to Game Modes Overview](prdGameModes.md)

--- a/design/productRequirementsDocuments/prdCardCodeGeneration.md
+++ b/design/productRequirementsDocuments/prdCardCodeGeneration.md
@@ -267,3 +267,4 @@ Code Generation and Sharing Flow
   - [ ] 4.2 Support copy-to-clipboard functionality.
   - [ ] 4.3 Add input validation for code entry screens.
   - [ ] 4.4 Implement auto-hyphenation as players type shared codes.
+\n[Back to Game Modes Overview](prdGameModes.md)

--- a/design/productRequirementsDocuments/prdCountryPickerFilter.md
+++ b/design/productRequirementsDocuments/prdCountryPickerFilter.md
@@ -202,3 +202,4 @@ Key Details:
 - [ ] 6.0 Add Visual Documentation
   - [ ] 6.1 Create annotated wireframes for the slide-in panel and full-grid views.
   - [ ] 6.2 Annotate wireframes with key UX and accessibility notes (tap sizes, highlight states, animation durations).
+\n[Back to Game Modes Overview](prdGameModes.md)

--- a/design/productRequirementsDocuments/prdDrawRandomCard.md
+++ b/design/productRequirementsDocuments/prdDrawRandomCard.md
@@ -253,3 +253,4 @@ Motion** enabled, ensuring the card appears instantly without movement.
   - [ ] 4.2 Ensure color contrast on cards meets WCAG AA standards.
   - [ ] 4.3 Set all tap targets to ≥44px, recommended 64px for better kid usability (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness)).
 - [ ] 4.4 Add sound and animation toggle options for user preferences.
+\n[Back to Game Modes Overview](prdGameModes.md)

--- a/design/productRequirementsDocuments/prdGameModes.md
+++ b/design/productRequirementsDocuments/prdGameModes.md
@@ -405,3 +405,4 @@ A calm screen offering inspirational quotes and ambient visuals. [Read full PRD]
 ### Open Questions
 
 - **Pending:** Decide whether quotes rotate daily or on each visit.
+\n[Back to Game Modes Overview](prdGameModes.md)

--- a/design/productRequirementsDocuments/prdHomePageNavigation.md
+++ b/design/productRequirementsDocuments/prdHomePageNavigation.md
@@ -1,5 +1,8 @@
 # PRD: Home Page Main Navigation Menu
 
+## TL;DR
+Provides a fast, 2x2 tile menu so players can reach Classic Battle, Random Judoka, Meditation, and Browse Judoka within two taps. Layout loads in under 2s, remains accessible and responsive across devices.
+
 ## Introduction
 
 This document describes the **Home Page Main Navigation Menu** for the JU-DO-KON! web-based judo-themed card battle game.
@@ -243,44 +246,6 @@ Each tile contains:
     - Edit Judoka
 
 - **Why**: Reduces visual clutter, eliminates duplicate tiles, and provides a single intuitive access point to all Judoka-related actions—grouped by function, not guesswork.
-
-## Technical Considerations
-
-### Responsiveness
-
-- The layout must adapt to different screen sizes:
-  - **Desktop (>=1024px):** 2 columns, 2 rows.
-  - **Tablet (>=768px and <1024px):** 2 columns, 2 rows.
-  - **Mobile (<768px):** Single column layout; tiles stack vertically.
-
-### Accessibility
-
-- Tiles must be:
-  - Focusable via keyboard (`tabindex=0` if needed).
-  - Activated via keyboard (`Enter` or `Space` key).
-- Labels must be screen-reader friendly (e.g., via `aria-label`).
-- SVG icons must have descriptive `title` or `aria-hidden="true"` if decorative.
-- Tap targets must meet WCAG minimum sizing standards (44px x 44px).
-
-### Performance
-
-- SVG icons must be **optimized** to minimize page load times (<50KB).
-- Navigation interactions must be **instantaneous**, with interaction latency <100ms.
-- Ensure fallback behavior if network fails to load SVGs.
-
----
-
-## Dependencies/Integrations
-
-- Uses Material Symbols icon set for tile icons.
-- Relies on routes defined in `judoka.json` for navigation targets.
-
-## Edge Cases
-
-- **Icon Load Failure**: Fall back to displaying a generic JU-DO-KON logo.
-- **Slow Network**: Navigation tiles and fallback icons should still be accessible.
-- **Broken Destination URL**: Log an error and redirect player to a default error page.
-- **Device Rotation During Navigation**: Maintain consistent layout after orientation change.
 
 ## Open Questions
 

--- a/design/productRequirementsDocuments/prdJudokaCard.md
+++ b/design/productRequirementsDocuments/prdJudokaCard.md
@@ -219,3 +219,4 @@ widths across screens and matches the rule introduced in the stylesheet.
   - [ ] 5.3 Support keyboard and screen reader navigation.
   - [ ] 5.4 Ensure ≥44px touch targets for interactive elements (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness)).
   - [ ] 5.5 Add `role="button"` with `aria-label` to card elements and style focus via `.judoka-card:focus-visible`.
+\n[Back to Game Modes Overview](prdGameModes.md)

--- a/design/productRequirementsDocuments/prdMysteryCard.md
+++ b/design/productRequirementsDocuments/prdMysteryCard.md
@@ -154,3 +154,5 @@ Currently, the computer’s card is visible before the player chooses a stat. Th
 - [ ] 5.0 Code Integration
   - [ ] 5.1 Extend `renderJudokaCard()` with `useObscuredStats` flag
   - [ ] 5.2 Use animation helper for swap timing (ease-out, 400ms)
+
+[Back to Game Modes Overview](prdGameModes.md)


### PR DESCRIPTION
## Summary
- add TL;DR sections to Battle Info Bar and Home Page Navigation PRDs
- clean duplicate sections in Home Page Navigation
- standardize footer links across PRDs
- update navigation reference in Browse Judoka PRD
- fix task numbering in Battle Info Bar PRD

## Testing
- `npx prettier . --check` *(fails: Unknown env config)*
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_687e74c490f48326a45befc77ba3586f