### PR TITLE
Remove duplicate test cleanup

### DIFF
--- a/tests/card/cardTopBar.test.js
+++ b/tests/card/cardTopBar.test.js
@@ -22,10 +22,6 @@ beforeEach(() => {
   vi.spyOn(countryUtils, "getCountryNameFromCode").mockResolvedValue("France");
 });
 
-afterEach(() => {
-  vi.restoreAllMocks();
-});
-
 describe("generateCardTopBar", () => {
   it("should render top bar with placeholder flag when no flagUrl is provided", async () => {
     const expectedHtml = `

--- a/tests/card/judokaCardHtmlFallback.test.js
+++ b/tests/card/judokaCardHtmlFallback.test.js
@@ -20,10 +20,6 @@ const gokyoLookup = {
   1: { id: 1, name: "Uchi-mata" }
 };
 
-afterEach(() => {
-  vi.restoreAllMocks();
-});
-
 describe("generateJudokaCardHTML fallback containers", () => {
   it("adds fallback when portrait generation throws", async () => {
     vi.spyOn(cardRender, "generateCardPortrait").mockImplementation(() => {

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   createInfoBar,
   initInfoBar,
@@ -6,9 +6,7 @@ import {
   startCountdown,
   updateScore
 } from "../../src/components/InfoBar.js";
-import { createInfoBarHeader, resetDom } from "../utils/testUtils.js";
-
-afterEach(resetDom);
+import { createInfoBarHeader } from "../utils/testUtils.js";
 
 describe("InfoBar component", () => {
   it("creates DOM structure with proper aria attributes", () => {

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -27,14 +27,11 @@ function setupDom() {
 }
 
 afterEach(() => {
-  document.body.innerHTML = "";
-  vi.restoreAllMocks();
   global.fetch = originalFetch;
   global.navigator = originalNavigator;
   if (global.localStorage) {
     global.localStorage.clear();
   }
-  vi.resetModules();
 });
 
 describe("toggleExpandedMapView", () => {
@@ -90,10 +87,6 @@ describe("togglePortraitTextMenu", () => {
   beforeEach(() => {
     navBar = setupDom();
     stubLogoQuery();
-  });
-  afterEach(() => {
-    document.body.innerHTML = "";
-    vi.restoreAllMocks();
   });
 
   it("creates list items for valid game modes", async () => {

--- a/tests/helpers/browseJudokaPage.test.js
+++ b/tests/helpers/browseJudokaPage.test.js
@@ -1,7 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { resetDom } from "../utils/testUtils.js";
-
-afterEach(resetDom);
+import { describe, it, expect, vi } from "vitest";
 
 describe("browseJudokaPage helpers", () => {
   it("setupCountryToggle toggles panel and loads flags once", async () => {

--- a/tests/helpers/buttonEffects.test.js
+++ b/tests/helpers/buttonEffects.test.js
@@ -1,8 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { setupButtonEffects } from "../../src/helpers/buttonEffects.js";
 import * as motionUtils from "../../src/helpers/motionUtils.js";
-import { resetDom } from "../utils/testUtils.js";
-
 let button;
 
 describe("setupButtonEffects", () => {
@@ -19,8 +17,6 @@ describe("setupButtonEffects", () => {
       dispatchEvent: vi.fn()
     }));
   });
-
-  afterEach(resetDom);
 
   it("creates and removes a ripple on mousedown", () => {
     setupButtonEffects();

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -47,9 +47,7 @@ describe("classicBattle", () => {
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
     timerSpy.clearAllTimers();
-    document.body.innerHTML = "";
   });
 
   it("clears selected class on stat buttons after each round", async () => {

--- a/tests/helpers/countrySlider.test.js
+++ b/tests/helpers/countrySlider.test.js
@@ -1,10 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.resetModules();
-  document.body.innerHTML = "";
-});
+import { describe, it, expect, vi } from "vitest";
 
 describe("createCountrySlider", () => {
   it("renders flag buttons using populateCountryList", async () => {

--- a/tests/helpers/dataUtils.test.js
+++ b/tests/helpers/dataUtils.test.js
@@ -4,9 +4,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 const originalFetch = global.fetch;
 
 afterEach(() => {
-  vi.restoreAllMocks();
   global.fetch = originalFetch;
-  vi.resetModules();
 });
 
 describe("fetchJson", () => {

--- a/tests/helpers/displayMode.test.js
+++ b/tests/helpers/displayMode.test.js
@@ -17,8 +17,6 @@ describe("applyDisplayMode", () => {
   });
 
   afterEach(() => {
-    document.body.removeAttribute("data-theme");
-    document.body.className = "";
     style.remove();
   });
 

--- a/tests/helpers/domReady.test.js
+++ b/tests/helpers/domReady.test.js
@@ -1,7 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { resetDom } from "../utils/testUtils.js";
-
-afterEach(resetDom);
+import { describe, it, expect, vi } from "vitest";
 
 describe("onDomReady", () => {
   it("runs callback immediately when document is ready", async () => {

--- a/tests/helpers/gameRandom.test.js
+++ b/tests/helpers/gameRandom.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 let showRandom;
 let gameArea;
@@ -21,12 +21,6 @@ function setupDom() {
 }
 
 describe("game.js", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-    vi.resetModules();
-    document.body.innerHTML = "";
-  });
-
   it("passes motion preference to generateRandomCard", async () => {
     setupDom();
     const generateRandomCard = vi.fn();

--- a/tests/helpers/motionUtils.test.js
+++ b/tests/helpers/motionUtils.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { shouldReduceMotionSync, applyMotionPreference } from "../../src/helpers/motionUtils.js";
 
 const matchMediaMock = (matches) =>
@@ -14,12 +14,6 @@ const matchMediaMock = (matches) =>
 
 describe("motionUtils", () => {
   beforeEach(() => {
-    localStorage.clear();
-    document.body.className = "";
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
     localStorage.clear();
     document.body.className = "";
   });

--- a/tests/helpers/populateCountryList.test.js
+++ b/tests/helpers/populateCountryList.test.js
@@ -3,11 +3,8 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 const originalFetch = global.fetch;
 
 afterEach(() => {
-  vi.restoreAllMocks();
   global.fetch = originalFetch;
   localStorage.clear();
-  document.body.innerHTML = "";
-  vi.resetModules();
 });
 
 describe("populateCountryList", () => {

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -1,7 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { resetDom } from "../utils/testUtils.js";
-
-afterEach(resetDom);
+import { describe, it, expect } from "vitest";
 
 describe("prdReaderPage", () => {
   it("navigates documents with wrap-around", async () => {

--- a/tests/helpers/pseudoJapanese.test.js
+++ b/tests/helpers/pseudoJapanese.test.js
@@ -10,10 +10,7 @@ const originalFetch = global.fetch;
 
 describe("convertToPseudoJapanese", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
-    vi.useRealTimers();
     global.fetch = originalFetch;
-    vi.resetModules();
   });
 
   it("converts letters using the JSON mapping", async () => {

--- a/tests/helpers/quoteBuilder.test.js
+++ b/tests/helpers/quoteBuilder.test.js
@@ -1,12 +1,10 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { waitFor } from "../waitFor.js";
-import { resetDom } from "../utils/testUtils.js";
 
 const originalFetch = global.fetch;
 
 afterEach(() => {
   global.fetch = originalFetch;
-  resetDom();
 });
 
 describe("displayRandomQuote", () => {

--- a/tests/helpers/randomCard.test.js
+++ b/tests/helpers/randomCard.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 let getRandomJudokaMock;
 let generateJudokaCardHTMLMock;
@@ -59,11 +59,6 @@ const gokyoData = [
   { id: 1, name: "Throw1" },
   { id: 2, name: "Throw2" }
 ];
-
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.resetModules();
-});
 
 describe("generateRandomCard", () => {
   it("selects a random judoka and updates the DOM", async () => {

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -1,7 +1,5 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { createRandomCardDom, resetDom } from "../utils/testUtils.js";
-
-afterEach(resetDom);
+import { describe, it, expect, vi } from "vitest";
+import { createRandomCardDom } from "../utils/testUtils.js";
 
 describe("randomJudokaPage module", () => {
   it("passes reduced motion flag when generating cards", async () => {

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const baseSettings = {
   sound: true,
@@ -17,13 +17,6 @@ describe("settingsPage module", () => {
       <select id="display-mode-select"></select>
       <section id="game-mode-toggle-container"></section>
     `;
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-    vi.useRealTimers();
-    vi.resetModules();
-    document.body.innerHTML = "";
   });
 
   it("loads settings and game modes on DOMContentLoaded", async () => {

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -23,7 +23,6 @@ describe("settings utils", () => {
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
     if (global.localStorage) {
       global.localStorage.clear();
     }
@@ -32,8 +31,6 @@ describe("settings utils", () => {
       configurable: true,
       writable: true
     });
-    vi.resetModules();
-    vi.useRealTimers();
   });
 
   /**

--- a/tests/helpers/setupBattleInfoBar.test.js
+++ b/tests/helpers/setupBattleInfoBar.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { createInfoBarHeader, resetDom } from "../utils/testUtils.js";
+import { createInfoBarHeader } from "../utils/testUtils.js";
 
 const originalReadyState = Object.getOwnPropertyDescriptor(document, "readyState");
 
@@ -9,7 +9,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  resetDom();
   if (originalReadyState) {
     Object.defineProperty(document, "readyState", originalReadyState);
   }

--- a/tests/helpers/setupBottomNavbar.test.js
+++ b/tests/helpers/setupBottomNavbar.test.js
@@ -31,11 +31,6 @@ describe("setupBottomNavbar module", () => {
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
-    vi.useRealTimers();
-    document.body.innerHTML = "";
-
-    // Restore the original descriptor of document.readyState
     if (originalReadyStateDescriptor) {
       Object.defineProperty(document, "readyState", originalReadyStateDescriptor);
     }

--- a/tests/helpers/showSettingsError.test.js
+++ b/tests/helpers/showSettingsError.test.js
@@ -1,13 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { showSettingsError } from "../../src/helpers/showSettingsError.js";
 import { SETTINGS_FADE_MS, SETTINGS_REMOVE_MS } from "../../src/helpers/constants.js";
-import { resetDom } from "../utils/testUtils.js";
 
 beforeEach(() => {
   document.body.innerHTML = "";
 });
-
-afterEach(resetDom);
 
 describe("showSettingsError", () => {
   it("shows and then removes the error popup", () => {

--- a/tests/helpers/svgFallback.test.js
+++ b/tests/helpers/svgFallback.test.js
@@ -1,9 +1,5 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { applySvgFallback, DEFAULT_FALLBACK } from "../../src/helpers/svgFallback.js";
-
-afterEach(() => {
-  document.body.innerHTML = "";
-});
 
 describe("applySvgFallback", () => {
   it("replaces broken SVG source with fallback", () => {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,5 @@
-import { expect } from "vitest";
+import { expect, afterEach } from "vitest";
+import { resetDom } from "./utils/testUtils.js";
 
 expect.extend({
   toHaveAttribute(element, attribute, expected) {
@@ -22,4 +23,8 @@ expect.extend({
             : `expected element attribute ${attribute} to be ${expected}, but got ${actual}`
     };
   }
+});
+
+afterEach(() => {
+  resetDom();
 });


### PR DESCRIPTION
## Summary
- add afterEach cleanup hook in `tests/setup.js`
- drop per-file DOM cleanup hooks, leaving only custom logic when needed

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: 2 warnings)*
- `npx vitest run` *(fails: 1 failing test)*
- `npx playwright test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_687e73c813f4832683e76fdbdaeb6ad4