### PR TITLE
Add reusable DOM helpers for tests

### DIFF
--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createBattleHeader, createBattleCardContainers } from "../utils/testUtils.js";
 
 let generateRandomCardMock;
 
@@ -26,14 +27,10 @@ vi.mock("../../src/helpers/utils.js", () => ({
 describe("classicBattle", () => {
   let timerSpy;
   beforeEach(() => {
-    document.body.innerHTML = `
-      <div id="player-card"></div>
-      <div id="computer-card"></div>
-      <header>
-        <p id="round-message"></p>
-        <p id="next-round-timer"></p>
-        <p id="score-display"></p>
-      </header>`;
+    document.body.innerHTML = "";
+    const { playerCard, computerCard } = createBattleCardContainers();
+    const header = createBattleHeader();
+    document.body.append(playerCard, computerCard, header);
     timerSpy = vi.useFakeTimers();
     fetchJsonMock = vi.fn(async () => []);
     generateRandomCardMock = vi.fn(async (data, g, container, _pm, cb) => {
@@ -98,6 +95,7 @@ describe("classicBattle", () => {
     await startRound();
     timerSpy.advanceTimersByTime(31000);
     timerSpy.advanceTimersByTime(800);
+    await vi.runAllTimersAsync();
     const score = document.querySelector("header #score-display").textContent;
     expect(score).not.toBe("You: 0\nComputer: 0");
   });

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createSettingsDom } from "../utils/testUtils.js";
 
 const baseSettings = {
   sound: true,
@@ -10,13 +11,7 @@ const baseSettings = {
 
 describe("settingsPage module", () => {
   beforeEach(() => {
-    document.body.innerHTML = `
-      <input id="sound-toggle" type="checkbox">
-      <input id="navmap-toggle" type="checkbox">
-      <input id="motion-toggle" type="checkbox">
-      <select id="display-mode-select"></select>
-      <section id="game-mode-toggle-container"></section>
-    `;
+    document.body.appendChild(createSettingsDom());
   });
 
   it("loads settings and game modes on DOMContentLoaded", async () => {

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -8,6 +8,16 @@ export function createInfoBarHeader() {
   return header;
 }
 
+export function createBattleHeader() {
+  const header = document.createElement("header");
+  header.innerHTML = `
+    <p id="round-message"></p>
+    <p id="next-round-timer"></p>
+    <p id="score-display"></p>
+  `;
+  return header;
+}
+
 export function createRandomCardDom() {
   const section = document.createElement("div");
   section.className = "card-section";
@@ -22,6 +32,31 @@ export function createBattleCardContainers() {
   const computerCard = document.createElement("div");
   computerCard.id = "computer-card";
   return { playerCard, computerCard };
+}
+
+export function createSettingsDom() {
+  const fragment = document.createDocumentFragment();
+  const soundToggle = document.createElement("input");
+  soundToggle.id = "sound-toggle";
+  soundToggle.type = "checkbox";
+  const navmapToggle = document.createElement("input");
+  navmapToggle.id = "navmap-toggle";
+  navmapToggle.type = "checkbox";
+  const motionToggle = document.createElement("input");
+  motionToggle.id = "motion-toggle";
+  motionToggle.type = "checkbox";
+  const displayModeSelect = document.createElement("select");
+  displayModeSelect.id = "display-mode-select";
+  const gameModeToggleContainer = document.createElement("section");
+  gameModeToggleContainer.id = "game-mode-toggle-container";
+  fragment.append(
+    soundToggle,
+    navmapToggle,
+    motionToggle,
+    displayModeSelect,
+    gameModeToggleContainer
+  );
+  return fragment;
 }
 
 export function resetDom() {


### PR DESCRIPTION
## Summary
- expand `testUtils` with battle and settings DOM helpers
- refactor `classicBattle` and `settingsPage` tests to use new utilities
- adjust timer-based test to flush queued timers

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_687e77867f1c832683431b7fbd8fb6bb