### PR TITLE
Improve classic battle message flow

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -44,7 +44,7 @@ The round message, timer, and score now sit directly inside the page header rath
 
 - [ ] Match score is updated within **800ms** after round ends.
 - [ ] Win/loss message is shown within **1s** of round end and remains visible for **2s**.
-- [ ] Countdown timer starts after result message, aligned with server round start delay.
+- [ ] Countdown timer begins once the 2s result message fade-out completes, aligned with server round start delay.
 - [ ] Action prompt appears during user input phases and disappears after interaction.
 - [ ] Top bar content adapts responsively to different screen sizes and orientations.
 - [ ] All messages meet minimum contrast ratio of **4.5:1** and are screen reader compatible.

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -72,6 +72,22 @@ function showResult(message) {
   }
 }
 
+/**
+ * Display a persistent prompt instructing the player to choose a stat.
+ *
+ * @pseudocode
+ * 1. Locate the `#round-message` element.
+ * 2. Set the text to "Select your move".
+ * 3. Add the fade transition class and ensure the element is fully visible.
+ */
+export function showSelectionPrompt() {
+  const el = document.getElementById("round-message");
+  if (!el) return;
+  el.classList.add("fade-transition");
+  el.textContent = "Select your move";
+  el.classList.remove("fading");
+}
+
 function startTimer() {
   const timerEl = document.getElementById("next-round-timer");
   engineStartRound(
@@ -116,7 +132,7 @@ export async function revealComputerCard() {
  * 5. Select a random judoka for the computer from the filtered list.
  *    - If it matches the player's judoka, retry up to a safe limit.
  *    - Render the mystery placeholder card (`judokaId=1`) with obscured stats.
- * 6. Initialize the round timer.
+ * 6. Display the selection prompt and initialize the round timer.
  *
  * @returns {Promise<void>} Resolves when cards are displayed.
  */
@@ -152,7 +168,7 @@ export async function startRound() {
     animate: false,
     useObscuredStats: true
   });
-  showResult("");
+  showSelectionPrompt();
   updateScoreDisplay();
   startTimer();
 }
@@ -187,10 +203,11 @@ export function evaluateRound(stat) {
  *
  * @pseudocode
  * 1. Exit immediately when the match has ended.
- * 2. Attempt to start the next round after a short countdown.
+ * 2. Wait 2 seconds for the result message to fade out.
+ * 3. Start a 3-second countdown before attempting the next round.
  *    - Retry the start if the round cannot begin immediately.
  *    - Display "Waiting..." while retrying.
- * 3. Stop scheduling if the match ends during the countdown.
+ * 4. Stop scheduling if the match ends during the countdown.
  *
  * @param {{matchEnded: boolean}} result - Result from evaluateRound.
  */
@@ -208,11 +225,13 @@ export function scheduleNextRound(result) {
   };
 
   const countdown = getCountdown();
-  countdown(3, () => {
-    if (!isMatchEnded()) {
-      attemptStart();
-    }
-  });
+  setTimeout(() => {
+    countdown(3, () => {
+      if (!isMatchEnded()) {
+        attemptStart();
+      }
+    });
+  }, 2000);
 }
 
 /**

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -100,6 +100,29 @@ describe("classicBattle match flow", () => {
     vi.spyOn(battleMod, "startRound").mockResolvedValue();
     const cdSpy = vi.spyOn(infoMod, "startCountdown").mockImplementation((_s, cb) => cb());
     battleMod.scheduleNextRound({ matchEnded: false });
+    expect(cdSpy).not.toHaveBeenCalled();
+    timerSpy.advanceTimersByTime(1999);
+    expect(cdSpy).not.toHaveBeenCalled();
+    timerSpy.advanceTimersByTime(1);
     expect(cdSpy).toHaveBeenCalledWith(3, expect.any(Function));
+  });
+
+  it("shows selection prompt until a stat is chosen", async () => {
+    const { startRound, handleStatSelection, _resetForTest } = await import(
+      "../../../src/helpers/classicBattle.js"
+    );
+    _resetForTest();
+    await startRound();
+    expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
+    timerSpy.advanceTimersByTime(5000);
+    expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
+    document.getElementById("player-card").innerHTML =
+      `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
+    document.getElementById("computer-card").innerHTML =
+      `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
+    await handleStatSelection("power");
+    expect(document.querySelector("header #round-message").textContent).not.toBe(
+      "Select your move"
+    );
   });
 });


### PR DESCRIPTION
## Summary
- ensure the battle info bar countdown waits for the result fade-out
- provide `showSelectionPrompt` helper
- document delayed countdown in the PRD
- test countdown delay and selection prompt

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: randomJudoka-signature.png mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687ebc060954832693a702a4279d1f4c