### PR TITLE
Refactor score updates in classic battle

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -47,8 +47,12 @@ pass it to `createModal()`, and call `open()` when needed. `StatsPanel.js`
 constructs the `.card-stats` section used within judoka cards. `Card.js`
 provides a reusable content panel styled with the `.card` class.
 `InfoBar.js` builds a real-time bar for classic battles. `classicBattle.js` updates it
-each round via `updateScore` and `startCountdown` so players see messages,
-the countdown timer, and the current score.
+each round via `startCountdown` and by passing the latest scores to `updateScore`
+so players see messages, the countdown timer, and the current score.
+
+After each round, `classicBattle.js` calls `battleEngine.getScores()` and forwards
+the returned values to `InfoBar.updateScore`. The helper module `setupBattleInfoBar.js`
+exposes this method for pages, keeping UI updates decoupled from engine logic.
 
 ```javascript
 import { createCard } from "./src/components/Card.js";

--- a/src/helpers/battle/score.js
+++ b/src/helpers/battle/score.js
@@ -1,17 +1,9 @@
-import { STATS, getScores } from "../battleEngine.js";
+import { STATS } from "../battleEngine.js";
 
 function getStatValue(container, stat) {
   const index = STATS.indexOf(stat) + 1;
   const span = container.querySelector(`li.stat:nth-child(${index}) span`);
   return span ? parseInt(span.textContent, 10) : 0;
-}
-
-export function updateScoreDisplay() {
-  const { playerScore, computerScore } = getScores();
-  const el = document.getElementById("score-display");
-  if (el) {
-    el.innerHTML = `You: ${playerScore}<br>\nComputer: ${computerScore}`;
-  }
 }
 
 export { getStatValue };

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -14,7 +14,7 @@ import {
 } from "./battleEngine.js";
 import * as infoBar from "./setupBattleInfoBar.js";
 
-import { getStatValue, updateScoreDisplay } from "./battle/index.js";
+import { getStatValue } from "./battle/index.js";
 function getCountdown() {
   if (typeof window !== "undefined" && window.startCountdownOverride) {
     return window.startCountdownOverride;
@@ -169,7 +169,8 @@ export async function startRound() {
     useObscuredStats: true
   });
   showSelectionPrompt();
-  updateScoreDisplay();
+  const { playerScore, computerScore } = getScores();
+  infoBar.updateScore(playerScore, computerScore);
   startTimer();
 }
 
@@ -194,7 +195,10 @@ export function evaluateRound(stat) {
   if (result.message) {
     showResult(result.message);
   }
-  updateScoreDisplay();
+  {
+    const { playerScore, computerScore } = getScores();
+    infoBar.updateScore(playerScore, computerScore);
+  }
   return result;
 }
 
@@ -282,7 +286,10 @@ export function _resetForTest() {
   if (timerEl) timerEl.textContent = "";
   const resultEl = document.getElementById("round-message");
   if (resultEl) resultEl.textContent = "";
-  updateScoreDisplay();
+  {
+    const { playerScore, computerScore } = getScores();
+    infoBar.updateScore(playerScore, computerScore);
+  }
 }
 
 export function getComputerJudoka() {


### PR DESCRIPTION
## Summary
- call `InfoBar.updateScore` rather than `updateScoreDisplay`
- drop the unused `updateScoreDisplay` helper
- document how scores flow from the engine to the InfoBar

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_687ebe721f5c8326a4853a75320c9719