### PR TITLE
Add aria-live settings and ensure contrast

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -48,7 +48,10 @@ constructs the `.card-stats` section used within judoka cards. `Card.js`
 provides a reusable content panel styled with the `.card` class.
 `InfoBar.js` builds a real-time bar for classic battles. `classicBattle.js` updates it
 each round via `startCountdown` and by passing the latest scores to `updateScore`
-so players see messages, the countdown timer, and the current score.
+so players see messages, the countdown timer, and the current score. The
+`#round-message` and `#next-round-timer` elements have `aria-live="polite"` so
+screen readers announce updates, while `#score-display` uses `aria-live="off"` to
+prevent repetitive announcements of the score.
 
 After each round, `classicBattle.js` calls `battleEngine.getScores()` and forwards
 the returned values to `InfoBar.updateScore`. The helper module `setupBattleInfoBar.js`

--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -74,6 +74,9 @@ The round message, timer, and score now sit directly inside the page header rath
 - **Accessibility**
   - All text meets **WCAG 2.1 AA** standards.
   - Screen reader labels for dynamic messages.
+  - `#round-message` and `#next-round-timer` use `aria-live="polite"` so
+    announcements occur automatically. `#score-display` sets `aria-live="off"`
+    to avoid repeated score announcements.
  
 ---
 

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -30,8 +30,8 @@
     <div class="home-screen">
       <header class="header battle-header">
         <div class="info-left">
-          <p id="round-message"></p>
-          <p id="next-round-timer"></p>
+          <p id="round-message" aria-live="polite"></p>
+          <p id="next-round-timer" aria-live="polite"></p>
         </div>
         <div class="logo-container">
           <a href="../../index.html" data-testid="home-link">
@@ -39,7 +39,7 @@
           </a>
         </div>
         <div class="info-right">
-          <p id="score-display">You: 0 Computer: 0</p>
+          <p id="score-display" aria-live="off">You: 0 Computer: 0</p>
         </div>
       </header>
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -68,6 +68,7 @@
   --color-surface: #121212;
   --color-background: #000000;
   --color-text: #ffffff;
+  --color-tertiary: #333333;
   --color-text-inverted: #ffffff;
 }
 


### PR DESCRIPTION
## Summary
- enable aria-live on battle info elements
- tweak dark theme contrast by overriding `--color-tertiary`
- document aria-live behaviour in architecture and PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(1 failing screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687fbc406e50832695893b0dcbb48f97