### PR TITLE
Add DOM color contrast test

### DIFF
--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { createRandomCardDom } from "../utils/testUtils.js";
+import { createRandomCardDom, getJudokaFixture } from "../utils/testUtils.js";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { parseCssVariables } from "../../src/helpers/cssVariableParser.js";
+import { hex } from "wcag-contrast";
 
 const baseSettings = {
   sound: false,
@@ -50,5 +54,69 @@ describe("randomJudokaPage module", () => {
     expect(applyMotionPreference).toHaveBeenCalledWith(baseSettings.motionEffects);
     expect(generateRandomCard.mock.calls[0][3]).toBe(false);
     expect(typeof setupRandomJudokaPage).toBe("function");
+  });
+
+  it("renders card text with sufficient color contrast", async () => {
+    vi.useFakeTimers();
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    const judoka = getJudokaFixture()[0];
+
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updateSetting = vi.fn();
+    const applyMotionPreference = vi.fn();
+
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
+    vi.doMock("../../src/components/Button.js", () => ({
+      createButton: () => document.createElement("button")
+    }));
+    vi.doMock("../../src/components/ToggleSwitch.js", () => ({
+      createToggleSwitch: () => document.createElement("div")
+    }));
+    vi.doMock("../../src/helpers/randomCard.js", async () => {
+      const { generateJudokaCardHTML } = await import("../../src/helpers/cardBuilder.js");
+      return {
+        generateRandomCard: async (_cards, _gokyo, container) => {
+          const card = await generateJudokaCardHTML(judoka, {});
+          container.appendChild(card);
+        }
+      };
+    });
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue([])
+    }));
+    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+
+    const { section, container } = createRandomCardDom();
+    document.body.append(section, container);
+
+    const vars = parseCssVariables(readFileSync(resolve("src/styles/base.css"), "utf8"));
+    const cardCss = readFileSync(resolve("src/styles/card.css"), "utf8");
+    const match = cardCss.match(/\.judoka-card\.common\s*{[^}]*--card-bg-color:\s*([^;]+);/);
+    const cardBg = match ? match[1].trim() : "#000";
+
+    document.documentElement.style.setProperty(
+      "--color-text-inverted",
+      vars["--color-text-inverted"]
+    );
+
+    await import("../../src/helpers/randomJudokaPage.js");
+
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const cardEl = container.querySelector(".judoka-card");
+    cardEl.style.setProperty("--card-bg-color", cardBg);
+
+    const bg = getComputedStyle(cardEl).getPropertyValue("--card-bg-color").trim();
+    const text = getComputedStyle(document.documentElement)
+      .getPropertyValue("--color-text-inverted")
+      .trim();
+    const ratio = hex(bg, text);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
   });
 });


### PR DESCRIPTION
## Summary
- add a new randomJudokaPage test to check text contrast of rendered card
- use wcag-contrast to verify minimum ratio

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_687fbc6473588326b3be3cb30153e8f1