### PR TITLE
Remove countdown collapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
   use relative paths (e.g., `../../index.html`) so the site can be served from
   any base URL.
 - `src/` – contains the game logic and assets:
-
   - `game.js`
   - `helpers/` – small utilities (for example `lazyPortrait.js` replaces the placeholder card portraits once they enter view)
   - `components/` – small DOM factories like `Button`, `ToggleSwitch`, `Card`, the `Modal` dialog, and `StatsPanel`
@@ -257,25 +256,20 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 ### 🥋 The Rules:
 
 1. **You vs. Computer**
-
    - Each match starts with both players receiving **25 random cards** from a 99-card deck.
 
 2. **Start the Battle**
-
    - In each round, you and the computer each draw your top card.
 
 3. **Choose Your Stat**
-
    - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
 
 4. **Compare Stats**
-
    - The chosen stat is compared with the computer’s card.
    - **Highest value wins the round**.
    - If both stats are equal, it’s a **draw** — no one scores.
 
 5. **Scoring**
-
    - Each round win gives you **1 point**.
    - The cards used in that round are **discarded** (not reused).
 

--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -70,7 +70,6 @@ The round message, timer, and score now sit directly inside the page header rath
   - Color coding: green (win), red (loss), neutral grey (countdown).
 - **Responsiveness**
   - Stacked layout on narrow screens (<375px width).
-  - Collapse countdown if less than 2s remains.
 - **Accessibility**
   - All text meets **WCAG 2.1 AA** standards.
   - Screen reader labels for dynamic messages.
@@ -100,7 +99,6 @@ The round message, timer, and score now sit directly inside the page header rath
 
 ---
 
-- Countdown timer truncates if less than 2s remains.
 - Text size min 16sp; win/loss messages bold and color-coded.
 
 ### Additional Details:
@@ -165,7 +163,6 @@ The round message, timer, and score now sit directly inside the page header rath
 
 - [ ] 3.0 Handle Responsive Layout
   - [ ] 3.1 Detect screen width <375px and switch to stacked layout
-  - [ ] 3.2 Collapse countdown timer if <2 seconds remain
 
 - [ ] 4.0 Implement Accessibility Features
   - [ ] 4.1 Ensure text contrast meets 4.5:1 ratio

--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -71,12 +71,10 @@ export function showMessage(text) {
  * Start a countdown timer that updates once per second.
  *
  * @pseudocode
- * 1. Clear any existing countdown interval and remove collapse styling.
+ * 1. Clear any existing countdown interval.
  * 2. Display "Next round in: {seconds}s" in the timer element.
- * 3. If the starting value is below 2s, add the collapse class immediately.
- * 4. Each second decrement the value and update the element using the same format.
- * 5. When remaining time drops below 2s, add the collapse class to hide the element.
- * 6. When the value reaches zero, set "Next round in: 0s", stop the interval and invoke `onFinish`.
+ * 3. Each second decrement the value and update the element using the same format.
+ * 4. When the value reaches zero, set "Next round in: 0s", stop the interval and invoke `onFinish`.
  *
  * @param {number} seconds - Seconds to count down from.
  * @param {Function} [onFinish] - Optional callback when countdown ends.
@@ -85,16 +83,9 @@ export function showMessage(text) {
 export function startCountdown(seconds, onFinish) {
   if (!timerEl) return;
   clearInterval(intervalId);
-  timerEl.classList.remove("timer-collapsed");
   timerEl.textContent = `Next round in: ${seconds}s`;
-  if (seconds < 2) {
-    timerEl.classList.add("timer-collapsed");
-  }
   intervalId = setInterval(() => {
     seconds -= 1;
-    if (seconds < 2) {
-      timerEl.classList.add("timer-collapsed");
-    }
     if (seconds <= 0) {
       clearInterval(intervalId);
       timerEl.textContent = "Next round in: 0s";

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -23,19 +23,6 @@
   margin: 0;
 }
 
-.battle-header #next-round-timer {
-  max-height: 2em;
-  overflow: hidden;
-  transition:
-    opacity var(--transition-fast),
-    max-height var(--transition-fast);
-}
-
-.battle-header #next-round-timer.timer-collapsed {
-  opacity: 0;
-  max-height: 0;
-}
-
 @media (max-width: 374px) {
   .battle-header {
     grid-template-columns: 1fr;

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -40,21 +40,6 @@ describe("InfoBar component", () => {
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 0s");
   });
 
-  it("collapses timer when less than 2s remain", () => {
-    vi.useFakeTimers();
-    const header = document.createElement("header");
-    createInfoBar(header);
-    document.body.appendChild(header);
-
-    startCountdown(2);
-    const timer = document.getElementById("next-round-timer");
-    expect(timer.classList.contains("timer-collapsed")).toBe(false);
-    vi.advanceTimersByTime(1000);
-    expect(timer.classList.contains("timer-collapsed")).toBe(true);
-    vi.advanceTimersByTime(1000);
-    expect(timer.classList.contains("timer-collapsed")).toBe(true);
-  });
-
   it("initializes from existing DOM", () => {
     vi.useFakeTimers();
     const header = createInfoBarHeader();


### PR DESCRIPTION
## Summary
- keep the next-round timer visible until the countdown ends
- drop timer collapse CSS and tests
- update product requirements
- reformat README with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npx playwright test` *(fails: 403 Forbidden fetching playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_687fbef4f964832686ef335bce5251f1