### PR TITLE
Improve landscape layout for random card page

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -197,3 +197,17 @@ body {
     flex-direction: column;
   }
 }
+
+/* Landscape layout for Random Judoka page */
+@media (orientation: landscape) and (min-width: 600px) {
+  .card-section {
+    flex-direction: row;
+    justify-content: center;
+    align-items: flex-start;
+    gap: var(--space-lg);
+  }
+
+  .card-section .draw-card-btn {
+    margin: var(--space-large) 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add landscape-specific card layout in `layout.css`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot /src/pages/randomJudoka.html, randomJudoka-signature.png)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687fbf40ecec8326b51b8ac9f826db26