### PR TITLE
Update draw card PRD tasks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ test-results/
 src/vendor/ajv6.min.js
 design/productRequirementsDocuments/*.md
 design/codeStandards/*.md
+README.md

--- a/design/productRequirementsDocuments/prdDrawRandomCard.md
+++ b/design/productRequirementsDocuments/prdDrawRandomCard.md
@@ -251,5 +251,9 @@ Motion** enabled, ensuring the card appears instantly without movement.
   - [ ] 4.1 Support Reduced Motion settings.
   - [ ] 4.2 Ensure color contrast on cards meets WCAG AA standards.
   - [ ] 4.3 Set all tap targets to ≥44px, recommended 64px for better kid usability (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness)).
-- [ ] 4.4 Add sound and animation toggle options for user preferences.
+  - [ ] 4.4 Implement animation and sound toggle controls with settings persistence.
+  - [ ] 4.5 Play card-draw audio when sound is enabled and provide a mute option.
+  - [ ] 4.6 Disable the “Draw Card” button while loading or animating a card.
+  - [ ] 4.7 Add orientation-based layout rules for portrait vs. landscape.
+  - [ ] 4.8 Write automated tests verifying color contrast and tap target sizes.
 \n[Back to Game Modes Overview](prdGameModes.md)


### PR DESCRIPTION
## Summary
- ignore README in Prettier checks
- add more draw-card tasks for sound and animation options

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687fc3ffa26483269b486473f1e0c012