### PR TITLE
Add meditation asset preload helper

### DIFF
--- a/src/helpers/preload.js
+++ b/src/helpers/preload.js
@@ -1,0 +1,25 @@
+/**
+ * Preload assets used on the Meditation page.
+ *
+ * @pseudocode
+ * 1. Request the helper image and JSON data in parallel.
+ *    - Use `fetch` for the image.
+ *    - Use `fetchJson` with `DATA_DIR` for `aesopsFables.json` and `aesopsMeta.json`.
+ * 2. Await all requests and quietly log errors.
+ *
+ * @returns {Promise<void>} Resolves once all preload requests complete.
+ */
+import { DATA_DIR } from "./constants.js";
+import { fetchJson } from "./dataUtils.js";
+
+export async function preloadMeditationAssets() {
+  try {
+    await Promise.all([
+      fetch(new URL("../assets/helperKG/helperKG1.png", import.meta.url)),
+      fetchJson(`${DATA_DIR}aesopsFables.json`),
+      fetchJson(`${DATA_DIR}aesopsMeta.json`)
+    ]);
+  } catch (error) {
+    console.error("Failed to preload meditation assets:", error);
+  }
+}

--- a/src/pages/meditation.html
+++ b/src/pages/meditation.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ju-Do-Kon!</title>
+    <link rel="preload" as="image" href="../assets/helperKG/helperKG1.png" />
+    <link rel="preload" as="fetch" href="../data/aesopsFables.json" type="application/json" />
+    <link rel="preload" as="fetch" href="../data/aesopsMeta.json" type="application/json" />
     <link rel="stylesheet" href="../styles/fonts.css" />
     <link rel="stylesheet" href="../styles/base.css" />
     <link rel="stylesheet" href="../styles/layout.css" />
@@ -82,6 +85,10 @@
         alert(
           "Your browser does not support modern JavaScript. Please update your browser to play JU-DO-KON!"
         );
+      </script>
+      <script type="module">
+        import { preloadMeditationAssets } from "../helpers/preload.js";
+        preloadMeditationAssets();
       </script>
       <script type="module" src="../helpers/quoteBuilder.js"></script>
       <script type="module" src="../helpers/meditationPage.js"></script>


### PR DESCRIPTION
## Summary
- preload KG image and fable JSON data on meditation page
- add `preloadMeditationAssets` helper for early fetch
- ensure the meditation HTML requests these assets early

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_687fc4a15a6883268ebf0a79e1071317