### PR TITLE
Implement fade-in for meditation assets

### DIFF
--- a/design/productRequirementsDocuments/prdMeditationScreen.md
+++ b/design/productRequirementsDocuments/prdMeditationScreen.md
@@ -222,7 +222,8 @@ Provides agency without pressure. Allows the player to re-enter gameplay at thei
   - [ ] 5.2 Capture asset load times and log results to console for performance tracking.
   - [x] 5.3 Implement responsive grid and flexbox for various screen sizes (portrait/landscape).
 - [ ] **6.0 Visual & Accessibility Polish**
-  - [ ] 6.1 Fade KG image and quote in within 300ms on initial load.
+  - [ ] 6.1 Use a `.fade-in` class so the KG image and quote block fade in within
+        300ms once both assets load (class removed via JS).
   - [ ] 6.2 Ensure quote text scales smoothly across breakpoints.
   - [ ] 6.3 Announce language toggle with aria-live and shift focus when it becomes visible.
 

--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -22,6 +22,16 @@
  */
 import { DATA_DIR } from "./constants.js";
 
+let kgImageLoaded = false;
+let quoteLoaded = false;
+
+function checkAssetsReady() {
+  if (kgImageLoaded && quoteLoaded) {
+    document.querySelector(".kg-sprite img")?.classList.remove("fade-in");
+    document.querySelector(".quote-block")?.classList.remove("fade-in");
+  }
+}
+
 async function fetchFables() {
   const [storyRes, metaRes] = await Promise.all([
     fetch(`${DATA_DIR}aesopsFables.json`),
@@ -141,6 +151,8 @@ function displayFable(fable) {
  *
  * 4. Automatically call the function when the DOM is fully loaded:
  *    - Use the `DOMContentLoaded` event to ensure the function runs after the DOM is ready.
+ * 5. When both the KG image and quote have loaded:
+ *    - Remove the `fade-in` class from the image and quote container so they fade into view.
  *
  * @throws {Error} If fetching the fables data fails.
  */
@@ -154,10 +166,25 @@ async function displayRandomQuote() {
   } catch (error) {
     console.error("Error fetching or displaying the fable:", error);
     displayFable(null);
+  } finally {
+    quoteLoaded = true;
+    checkAssetsReady();
   }
 }
 
 // Automatically call displayRandomQuote when the DOM is fully loaded
 document.addEventListener("DOMContentLoaded", () => {
+  const kgImg = document.querySelector(".kg-sprite img");
+  if (kgImg) {
+    if (kgImg.complete) {
+      kgImageLoaded = true;
+      checkAssetsReady();
+    } else {
+      kgImg.addEventListener("load", () => {
+        kgImageLoaded = true;
+        checkAssetsReady();
+      });
+    }
+  }
   displayRandomQuote();
 });

--- a/src/pages/meditation.html
+++ b/src/pages/meditation.html
@@ -32,10 +32,14 @@
 
         <section id="meditation-container" class="meditation-container">
           <div class="kg-sprite">
-            <img src="../assets/helperKG/helperKG1.png" alt="KG is ready to meditate" />
+            <img
+              src="../assets/helperKG/helperKG1.png"
+              alt="KG is ready to meditate"
+              class="fade-in"
+            />
           </div>
 
-          <div class="quote-block">
+          <div class="quote-block fade-in">
             <button
               id="language-toggle"
               data-testid="language-toggle"

--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -195,6 +195,12 @@
   opacity: 0;
 }
 
+/* Elements start invisible until assets load */
+.fade-in {
+  opacity: 0;
+  transition: opacity 300ms;
+}
+
 /* This toggle keeps its accent colors intentionally */
 .language-toggle {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- add `.fade-in` utility to quote stylesheet
- apply fade-in to KG image and quote container
- remove fade-in class in `quoteBuilder.js` after image and quote load
- clarify PRD task about the fade-in animation

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: randomJudoka signature screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687fc9e50f148326935537ff0910e363