### PR TITLE
Add language toggle live announcement

### DIFF
--- a/design/productRequirementsDocuments/prdMeditationScreen.md
+++ b/design/productRequirementsDocuments/prdMeditationScreen.md
@@ -225,7 +225,7 @@ Provides agency without pressure. Allows the player to re-enter gameplay at thei
   - [ ] 6.1 Use a `.fade-in` class so the KG image and quote block fade in within
         300ms once both assets load (class removed via JS).
   - [ ] 6.2 Ensure quote text scales smoothly across breakpoints.
-  - [ ] 6.3 Announce language toggle with aria-live and shift focus when it becomes visible.
+  - [x] 6.3 Announce language toggle with aria-live and shift focus when it becomes visible.
 
 ---
 

--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -129,6 +129,12 @@ function displayFable(fable) {
   const toggleBtn = document.getElementById("language-toggle");
   if (toggleBtn) {
     toggleBtn.classList.remove("hidden");
+    toggleBtn.setAttribute("aria-live", "polite");
+    toggleBtn.focus();
+    const liveRegion = document.getElementById("language-announcement");
+    if (liveRegion) {
+      liveRegion.textContent = "language toggle available";
+    }
   }
 }
 

--- a/src/pages/meditation.html
+++ b/src/pages/meditation.html
@@ -48,6 +48,7 @@
               <span class="jp-flag flag-icon"></span> 日本語風 / English
               <span class="uk-flag flag-icon"></span>
             </button>
+            <div id="language-announcement" class="visually-hidden" aria-live="polite"></div>
             <div id="quote-loader" class="quote-loader" aria-live="polite" aria-busy="true">
               <span class="visually-hidden">Loading quote…</span>
             </div>

--- a/tests/helpers/quoteBuilder.test.js
+++ b/tests/helpers/quoteBuilder.test.js
@@ -17,7 +17,9 @@ describe("displayRandomQuote", () => {
     const toggle = document.createElement("button");
     toggle.id = "language-toggle";
     toggle.className = "hidden";
-    document.body.append(quoteDiv, loader, toggle);
+    const liveRegion = document.createElement("div");
+    liveRegion.id = "language-announcement";
+    document.body.append(quoteDiv, loader, toggle, liveRegion);
 
     const storyData = [{ id: 1, story: "B" }];
     const metaData = [{ id: 1, title: "A" }];
@@ -37,6 +39,9 @@ describe("displayRandomQuote", () => {
     expect(loader.classList.contains("hidden")).toBe(true);
     expect(quoteDiv.innerHTML).toContain("A");
     expect(toggle.classList.contains("hidden")).toBe(false);
+    expect(toggle.getAttribute("aria-live")).toBe("polite");
+    expect(document.activeElement).toBe(toggle);
+    expect(liveRegion.textContent).toBe("language toggle available");
   });
 
   it("shows fallback text when fetching fails", async () => {


### PR DESCRIPTION
## Summary
- focus language toggle and announce when revealed
- announce language toggle in a hidden live region
- mark PRD task 6.3 complete
- update unit test for new aria-live behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot suite & signature move screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687fcd3b6bd4832684f7274cac7e686d