### PR TITLE
Implement tooltip text parser

### DIFF
--- a/src/helpers/tooltip.js
+++ b/src/helpers/tooltip.js
@@ -1,5 +1,6 @@
 import { fetchJson } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
+import { escapeHTML } from "./utils.js";
 
 let tooltipDataPromise;
 let cachedData;
@@ -28,8 +29,22 @@ async function loadTooltips() {
   return cachedData;
 }
 
-function parseMarkdown(text) {
-  return text
+/**
+ * Converts tooltip markdown to sanitized HTML.
+ *
+ * @pseudocode
+ * 1. Escape HTML in `text` using `escapeHTML`.
+ * 2. Replace newline characters with `<br>`.
+ * 3. Replace `**bold**` with `<strong>` elements.
+ * 4. Replace `_italic_` with `<em>` elements.
+ * 5. Return the transformed string.
+ *
+ * @param {string} text - Raw tooltip text to parse.
+ * @returns {string} HTML markup for the tooltip.
+ */
+export function parseTooltipText(text) {
+  const safe = escapeHTML(text || "");
+  return safe
     .replace(/\n/g, "<br>")
     .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
     .replace(/_(.*?)_/g, "<em>$1</em>");
@@ -76,7 +91,7 @@ export async function initTooltips(root = document) {
       }
       return;
     }
-    tip.innerHTML = parseMarkdown(text);
+    tip.innerHTML = parseTooltipText(text);
     tip.style.display = "block";
     const rect = e.currentTarget.getBoundingClientRect();
     let top = rect.bottom + window.scrollY;

--- a/src/pages/changeLog.html
+++ b/src/pages/changeLog.html
@@ -1,1 +1,3 @@
-<body>tbc</body>
+<body>
+  tbc
+</body>

--- a/tests/helpers/parseTooltipText.test.js
+++ b/tests/helpers/parseTooltipText.test.js
@@ -1,0 +1,20 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { parseTooltipText } from "../../src/helpers/tooltip.js";
+
+describe("parseTooltipText", () => {
+  it("parses bold, italic and newlines", () => {
+    const result = parseTooltipText("**Bold**\n_italic_");
+    expect(result).toBe("<strong>Bold</strong><br><em>italic</em>");
+  });
+
+  it("escapes HTML before parsing", () => {
+    const result = parseTooltipText("<span>test</span> **ok**");
+    expect(result).toBe("&lt;span&gt;test&lt;/span&gt; <strong>ok</strong>");
+  });
+
+  it("handles empty and null input", () => {
+    expect(parseTooltipText("")).toBe("");
+    expect(parseTooltipText(null)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- escape HTML in tooltip text before injecting markup
- replace markdown parser with `parseTooltipText`
- add test coverage for new parser
- run Prettier on changelog page

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(1 failing screenshot test)*

------
https://chatgpt.com/codex/tasks/task_e_687fdec5bd90832689ae95cd83845065