### PR TITLE
Add tooltip support

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" href="./src/styles/layout.css" />
     <link rel="stylesheet" href="./src/styles/components.css" />
     <link rel="stylesheet" href="./src/styles/utilities.css" />
+    <link rel="stylesheet" href="./src/styles/tooltip.css" />
     <link rel="icon" type="image/png" href="./src/assets/images/favicon.ico" />
   </head>
 
@@ -110,6 +111,8 @@
       </footer>
       <script type="module" src="./src/helpers/setupBottomNavbar.js"></script>
       <script type="module" src="./src/helpers/setupDisplaySettings.js"></script>
+
+      <script type="module" src="./src/helpers/tooltip.js"></script>
 
       <noscript>
         <p class="noscript-warning">

--- a/src/game.js
+++ b/src/game.js
@@ -3,6 +3,7 @@ import { buildCardCarousel, addScrollMarkers } from "./helpers/carouselBuilder.j
 import { generateRandomCard } from "./helpers/randomCard.js";
 import { DATA_DIR } from "./helpers/constants.js";
 import { shouldReduceMotionSync } from "./helpers/motionUtils.js";
+import { initTooltips } from "./helpers/tooltip.js";
 
 /**
  * Wire up the carousel toggle button.
@@ -146,4 +147,5 @@ document.addEventListener("DOMContentLoaded", () => {
   setupCarouselToggle(showCarouselButton, carouselContainer);
   setupHideCardButton(hideCard);
   setupRandomCardButton(showRandom, gameArea);
+  initTooltips();
 });


### PR DESCRIPTION
## Summary
- include tooltip stylesheet and script in homepage
- initialize tooltips on DOM ready in game.js

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Signature move screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_687fe25953f08326a304e479511dd51d