### PR TITLE
Fix Safari stat button highlight reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Safari may expand flex items if `min-width` isn't explicitly set. Set
 Safari 18.5 positions `.signature-move-container` text at the bottom edge unless the container uses standard flex alignment. The container now applies `line-height: max(10%, var(--touch-target-size))` along with `align-items: center` and `justify-content: center`. Setting `width: 100%` on the child spans prevents stretching so the label and value remain vertically centered.
 
 Safari 18.5 sometimes shrinks judoka cards, causing text overlap. The width rule now uses `clamp(200px, 70vw, 300px)` so cards occupy about 70% of the viewport on mobile. This applies to both the random card view and the browse carousel.
-Safari 18.5 may keep a stat button highlighted between rounds. The reset logic now clears the inline background color, disables the button, then waits one animation frame before re-enabling it, clearing `backgroundColor`, and blurring the element so the highlight disappears.
+Safari 18.5 may keep a stat button highlighted between rounds. The reset logic now forces a reflow, sets `-webkit-tap-highlight-color: transparent`, disables the button, then on the next frame re-enables it, removes the property, clears `backgroundColor`, and blurs the element so the highlight disappears.
 
 Chrome may show a small gap below the stats panel when the combined height of
 card sections is less than 100%. Ensure `.card-top-bar`, `.card-portrait`,

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -100,7 +100,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Player can quit mid-match; confirmation prompt appears; if confirmed, match ends with player loss recorded.
 - If AI difficulty affects stat selection, AI uses correct logic per difficulty setting.
 - Animation flow: transitions between card reveal, stat selection, and result screens complete smoothly without stalling (**each ≤400 ms at ≥60 fps**).
-- Stat buttons reset between rounds so no previous selection remains highlighted.
+ - Stat buttons reset between rounds so no previous selection remains highlighted. Safari 18.5 requires toggling `-webkit-tap-highlight-color` to fully clear the red touch overlay.
 - If the Judoka dataset fails to load, an error message appears with option to reload.
 
 ---

--- a/playwright/statReset.spec.js
+++ b/playwright/statReset.spec.js
@@ -1,0 +1,19 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+
+/**
+ * Verify stat buttons are cleared after the next round begins.
+ */
+test.describe("Classic battle button reset", () => {
+  test("no button stays selected after countdown", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.startCountdownOverride = (_s, cb) => cb();
+    });
+    await page.goto("/src/pages/battleJudoka.html");
+    await page.locator("#stat-buttons button[data-stat='power']").click();
+    await page.waitForFunction(() => {
+      const msg = document.getElementById("round-message");
+      return msg && msg.textContent.includes("Select your move");
+    });
+    await expect(page.locator("#stat-buttons .selected")).toHaveCount(0);
+  });
+});

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -42,17 +42,23 @@ let computerJudoka = null;
  *    a. Remove the `selected` class so the button style resets.
  *    b. Clear any inline background color to force a repaint in Safari.
  *    c. Disable the button to break the `:active` highlight.
- *    d. On the next animation frame, re-enable the button,
- *       clear `backgroundColor`, and call `blur()` so Safari
- *       drops the highlight.
+ *    d. Force a reflow and set `-webkit-tap-highlight-color` to
+ *       `transparent` so Safari clears its touch overlay.
+ *    e. On the next animation frame, re-enable the button,
+ *       remove the temporary style, clear `backgroundColor`,
+ *       and call `blur()` so Safari drops the highlight.
  */
 function resetStatButtons() {
   document.querySelectorAll("#stat-buttons button").forEach((btn) => {
     btn.classList.remove("selected");
     btn.style.removeProperty("background-color");
     btn.disabled = true;
+    // Force reflow so Safari drops the touch highlight
+    void btn.offsetWidth;
+    btn.style.setProperty("-webkit-tap-highlight-color", "transparent");
     requestAnimationFrame(() => {
       btn.disabled = false;
+      btn.style.removeProperty("-webkit-tap-highlight-color");
       btn.style.backgroundColor = "";
       btn.blur();
     });


### PR DESCRIPTION
## Summary
- reset Safari touch highlight when disabling stat buttons
- document Safari highlight workaround
- describe highlight workaround in the Classic Battle PRD
- test stat button reset with Playwright

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `SKIP_SCREENSHOTS=true npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_687fe48d7ad08326aece1509eeb3e8ac