### PR TITLE
Add tooltip documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ npx ajv validate -s src/schemas/judoka.schema.json -d src/data/judoka.json
 See [design/dataSchemas/README.md](design/dataSchemas/README.md) for full details
 and instructions on updating schemas when data changes.
 
+## Tooltip Helper
+
+Add lightweight help text anywhere by tagging elements with
+`data-tooltip-id`. The `initTooltips()` helper reads messages from
+`src/data/tooltips.json` and displays them on hover or focus.
+
 The repository specifies commenting standards in design/codeStandards. JSDoc comments and @pseudocode blocks must remain intact, as shown in documentation excerpts.
 
 ## Features
@@ -237,6 +243,7 @@ The repository specifies commenting standards in design/codeStandards. JSDoc com
 - Header bar displays real-time round results, countdown timer and score
 - Mockup viewer page with next/back controls for design screenshots (includes a Home link)
 - Change Log page accessible from Settings, showing recent judoka updates
+- Contextual tooltips explain stats and buttons on hover or focus
 
 ## About JU-DO-KON!
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -67,6 +67,12 @@ document.body.appendChild(card);
 
 Structured gameplay data lives in `src/data`. Matching JSON Schemas in `src/schemas` describe and validate these files. The `npm run validate:data` script uses Ajv to ensure data integrity.
 
+## tooltip helper
+
+`src/helpers/tooltip.js` displays contextual help when elements with
+`data-tooltip-id` gain hover or focus. The helper loads text from
+`src/data/tooltips.json` and positions a small popup near the target.
+
 ## tests
 
 Unit tests under `tests/` run in the Vitest `jsdom` environment. The `playwright/` directory contains end‑to‑end tests and screenshot comparisons to prevent UI regressions.


### PR DESCRIPTION
## Summary
- document tooltip helper usage in README
- note that tooltip text lives in `src/data/tooltips.json`
- add feature bullet mentioning contextual tooltips
- outline tooltip helper in architecture doc

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Signature move screenshots – random judoka page)*

------
https://chatgpt.com/codex/tasks/task_e_687fe4d4a7fc83268dff5a37ddfa064d