### PR TITLE
Freeze random judoka screenshot

### DIFF
--- a/playwright/signatureMove.spec.js
+++ b/playwright/signatureMove.spec.js
@@ -8,6 +8,9 @@ test.describe(
     test.skip(!runScreenshots);
 
     test("random judoka page", async ({ page }) => {
+      await page.addInitScript(() => {
+        Math.random = () => 0.42;
+      });
       await page.goto("/src/pages/randomJudoka.html");
       const sigMove = page.locator(".signature-move-container");
       await sigMove.waitFor();


### PR DESCRIPTION
## Summary
- freeze `Math.random` for signature move screenshot test so the selected judoka is consistent

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_687fee48a37883269ac4cb96f520737f