### PR TITLE
Fix Safari stat button highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Safari may expand flex items if `min-width` isn't explicitly set. Set
 Safari 18.5 positions `.signature-move-container` text at the bottom edge unless the container uses standard flex alignment. The container now applies `line-height: max(10%, var(--touch-target-size))` along with `align-items: center` and `justify-content: center`. Setting `width: 100%` on the child spans prevents stretching so the label and value remain vertically centered.
 
 Safari 18.5 sometimes shrinks judoka cards, causing text overlap. The width rule now uses `clamp(200px, 70vw, 300px)` so cards occupy about 70% of the viewport on mobile. This applies to both the random card view and the browse carousel.
-Safari 18.5 may keep a stat button highlighted between rounds. The reset logic now forces a reflow, sets `-webkit-tap-highlight-color: transparent`, disables the button, then on the next frame re-enables it, removes the property, clears `backgroundColor`, and blurs the element so the highlight disappears.
+Safari 18.5 may keep a stat button highlighted between rounds. The rule `#stat-buttons button { -webkit-tap-highlight-color: transparent; }` works with the reset logic to force a reflow and blur the element so the red overlay disappears.
 
 Chrome may show a small gap below the stats panel when the combined height of
 card sections is less than 100%. Ensure `.card-top-bar`, `.card-portrait`,

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -100,7 +100,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Player can quit mid-match; confirmation prompt appears; if confirmed, match ends with player loss recorded.
 - If AI difficulty affects stat selection, AI uses correct logic per difficulty setting.
 - Animation flow: transitions between card reveal, stat selection, and result screens complete smoothly without stalling (**each ≤400 ms at ≥60 fps**).
- - Stat buttons reset between rounds so no previous selection remains highlighted. Safari 18.5 requires toggling `-webkit-tap-highlight-color` to fully clear the red touch overlay.
+- Stat buttons reset between rounds so no previous selection remains highlighted. The CSS rule `#stat-buttons button { -webkit-tap-highlight-color: transparent; }` combined with a reflow ensures Safari clears the red touch overlay.
 - If the Judoka dataset fails to load, an error message appears with option to reload.
 
 ---

--- a/playwright/statReset.spec.js
+++ b/playwright/statReset.spec.js
@@ -16,4 +16,19 @@ test.describe("Classic battle button reset", () => {
     });
     await expect(page.locator("#stat-buttons .selected")).toHaveCount(0);
   });
+
+  test("tap highlight color cleared after reset", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.startCountdownOverride = (_s, cb) => cb();
+    });
+    await page.goto("/src/pages/battleJudoka.html");
+    const btn = page.locator("#stat-buttons button[data-stat='power']");
+    await btn.click();
+    await page.waitForFunction(() => {
+      const msg = document.getElementById("round-message");
+      return msg && msg.textContent.includes("Select your move");
+    });
+    const highlight = await btn.evaluate((el) => getComputedStyle(el).webkitTapHighlightColor);
+    expect(highlight).toBe("rgba(0, 0, 0, 0)");
+  });
 });

--- a/playwright/tooltip.spec.js
+++ b/playwright/tooltip.spec.js
@@ -21,7 +21,7 @@ test.describe("Tooltip behavior", () => {
       })
     );
     await page.setContent(pageContent, { baseURL: "http://localhost:5000" });
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(1000);
   });
 
   test("tooltip appears on hover and hides on mouse leave", async ({ page }) => {

--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -28,6 +28,10 @@ button:active {
   transform: scale(0.95);
 }
 
+#stat-buttons button {
+  -webkit-tap-highlight-color: transparent;
+}
+
 #stat-buttons button.selected {
   background-color: var(--button-active-bg);
 }


### PR DESCRIPTION
## Summary
- disable webkit tap highlight color for stats buttons
- document Safari workaround in README and PRD
- test highlight reset in Playwright
- allow tooltip spec to wait a bit longer

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test --reporter=line` *(fails: tooltip behavior)*

------
https://chatgpt.com/codex/tasks/task_e_687ff40e9df08326b4fa1a310dc6136c