### PR TITLE
Update tooltip test wait

### DIFF
--- a/playwright/tooltip.spec.js
+++ b/playwright/tooltip.spec.js
@@ -21,7 +21,7 @@ test.describe("Tooltip behavior", () => {
       })
     );
     await page.setContent(pageContent, { baseURL: "http://localhost:5000" });
-    await page.waitForTimeout(500);
+    await page.waitForFunction(() => window.initDone === true);
   });
 
   test("tooltip appears on hover and hides on mouse leave", async ({ page }) => {


### PR DESCRIPTION
## Summary
- replace timeout in Tooltip test with `waitForFunction`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: page.waitForFunction timeout)*

------
https://chatgpt.com/codex/tasks/task_e_687ff6681cf8832692ab2d0e00c42c0e