### PR TITLE
Implement stat button blocking until mystery card renders

### DIFF
--- a/design/productRequirementsDocuments/prdMysteryCard.md
+++ b/design/productRequirementsDocuments/prdMysteryCard.md
@@ -147,7 +147,7 @@ Currently, the computer’s card is visible before the player chooses a stat. Th
   - [ ] 3.2 Ensure name “Mystery Judoka” is readable by screen readers
   - [ ] 3.3 Prevent layout jump or scroll on reveal
 - [ ] **4.0 Game Logic Safeguards**
-  - [ ] 4.1 Block stat selection until card fully rendered [NOT YET IMPLEMENTED]
+  - [x] 4.1 Block stat selection until card fully rendered
 - [x] **5.0 Code Integration**
   - [x] 5.1 Extend `renderJudokaCard()` with `useObscuredStats` flag
   - [ ] 5.2 Use animation helper for swap timing (ease-out, 400ms)

--- a/src/helpers/battleJudokaPage.js
+++ b/src/helpers/battleJudokaPage.js
@@ -9,12 +9,25 @@
  *       and calls `handleStatSelection` with the button's data attribute.
  *    b. Attach a click listener to the home logo that calls `quitMatch` and
  *       navigates to the home screen on confirmation.
- *    c. Invoke `startRound` to begin the match.
+ *    c. Disable all stat buttons and invoke `startRound`.
+ *    d. Re-enable the buttons once the Mystery card is rendered.
+ *    e. Override `startRound` for subsequent rounds to apply the same blocking.
  * 3. Use `onDomReady` to run `setupBattleJudokaPage` when the DOM is ready.
- * 4. Block stat selection until the Mystery Judoka card is fully rendered (see PRD: Mystery Card). [TODO]
  */
 import { startRound, handleStatSelection, quitMatch } from "./classicBattle.js";
 import { onDomReady } from "./domReady.js";
+
+function toggleStatButtons(disabled) {
+  document.querySelectorAll("#stat-buttons button").forEach((btn) => {
+    btn.disabled = disabled;
+  });
+}
+
+async function startRoundWithBlocking() {
+  toggleStatButtons(true);
+  await startRound();
+  toggleStatButtons(false);
+}
 
 export function setupBattleJudokaPage() {
   document.querySelectorAll("#stat-buttons button").forEach((btn) =>
@@ -33,7 +46,8 @@ export function setupBattleJudokaPage() {
     });
   }
 
-  startRound();
+  window.startRoundOverride = startRoundWithBlocking;
+  startRoundWithBlocking();
 }
 
 onDomReady(setupBattleJudokaPage);

--- a/tests/helpers/battleJudokaPage.test.js
+++ b/tests/helpers/battleJudokaPage.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+
+describe("battleJudokaPage", () => {
+  it("blocks stat selection until the mystery card is rendered", async () => {
+    const statContainer = document.createElement("div");
+    statContainer.id = "stat-buttons";
+    const btn = document.createElement("button");
+    btn.dataset.stat = "power";
+    statContainer.appendChild(btn);
+    document.body.appendChild(statContainer);
+    const link = document.createElement("a");
+    link.dataset.testid = "home-link";
+    document.body.appendChild(link);
+
+    let resolveRound;
+    const startRound = vi.fn(() => new Promise((r) => { resolveRound = r; }));
+    const handleStatSelection = vi.fn();
+    const quitMatch = vi.fn();
+
+    vi.doMock("../../src/helpers/classicBattle.js", () => ({
+      startRound,
+      handleStatSelection,
+      quitMatch
+    }));
+    vi.doMock("../../src/helpers/domReady.js", () => ({
+      onDomReady: (fn) => fn()
+    }));
+
+    const { setupBattleJudokaPage } = await import(
+      "../../src/helpers/battleJudokaPage.js"
+    );
+
+    setupBattleJudokaPage();
+
+    expect(btn.disabled).toBe(true);
+    resolveRound();
+    await Promise.resolve();
+    expect(btn.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- block stat selection while the mystery card renders and override startRound for later rounds
- mark blocking task complete in PRD
- test battleJudokaPage blocking behavior

## Testing
- `npx prettier . --check` *(fails: could not run without dependencies)*
- `npx eslint .` *(fails: cannot find module)*
- `npx vitest run` *(fails: network access blocked)*
- `npx playwright test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688004f866c08326b1b306c9364a6dab