### PR TITLE
Fix tooltip Playwright test

### DIFF
--- a/playwright/tooltip.spec.js
+++ b/playwright/tooltip.spec.js
@@ -14,12 +14,19 @@ const pageContent = `<!DOCTYPE html>
 
 test.describe("Tooltip behavior", () => {
   test.beforeEach(async ({ page }) => {
+    await page.route("**/src/helpers/tooltip.js", (route) =>
+      route.fulfill({
+        contentType: "application/javascript",
+        path: "src/helpers/tooltip.js"
+      })
+    );
     await page.route("**/src/data/tooltips.json", (route) =>
       route.fulfill({
         contentType: "application/json",
         path: "tests/fixtures/tooltips.json"
       })
     );
+    await page.goto("/");
     await page.setContent(pageContent, { baseURL: "http://localhost:5000" });
     await page.waitForFunction(() => window.initDone === true);
   });


### PR DESCRIPTION
## Summary
- serve tooltip.js via Playwright routing
- ensure page has correct origin before inserting test markup

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test tooltip.spec.js`
- `npx playwright test` *(fails: statReset.spec.js and others)*

------
https://chatgpt.com/codex/tasks/task_e_6880061e54d88326b843f8701b9eaeb1