### PR TITLE
Fix settings tab-order test

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -54,6 +54,10 @@ test.describe("Settings page", () => {
     );
     await expect(page.locator("#motion-toggle")).toHaveAttribute("aria-label", "Motion Effects");
 
+    await expect(page.locator("#game-mode-toggle-container input[type=checkbox]")).toHaveCount(
+      sortedNames.length
+    );
+
     for (const name of sortedNames) {
       await expect(page.getByLabel(name)).toHaveAttribute("aria-label", name);
     }


### PR DESCRIPTION
## Summary
- wait for game mode toggles to render before running tab order assertions

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/settings.spec.js --grep "controls expose"` *(fails: expect(received).toEqual(expected))*

------
https://chatgpt.com/codex/tasks/task_e_68800ea4ea748326a0db9196488f97ad