### PR TITLE
Implement classic battle page wrapper

### DIFF
--- a/src/helpers/battleJudokaPage.js
+++ b/src/helpers/battleJudokaPage.js
@@ -1,41 +1,10 @@
 /**
- * Setup logic for the Battle Judoka page.
+ * Utility helpers for the Battle Judoka screen.
  *
  * @pseudocode
- * 1. Import battle engine functions for round, stat selection, timer, and quitting.
- * 2. Define `setupBattleJudokaPage` to:
- *    a. Attach click and keyboard listeners to each stat button for accessibility.
- *    b. Start the stat selection timer on round start; update UI with remaining time.
- *    c. If timer expires, auto-select a random enabled stat and trigger selection.
- *    d. Disable stat buttons after selection or auto-selection.
- *    e. Attach a click listener to the home logo that calls `quitMatch` and navigates to the home screen on confirmation.
- *    f. Before each round, disable stat buttons and wait for the computer card to render.
- *    g. Invoke `startRound` to begin the match.
- * 3. Use `onDomReady` to run `setupBattleJudokaPage` when the DOM is ready.
- * 4. Block stat selection until the Mystery Judoka card is fully rendered using `waitForComputerCard` (see PRD: Mystery Card).
+ * Export `waitForComputerCard` which resolves once a `.judoka-card` element
+ * appears inside `#computer-card`.
  */
-import {
-  startRound,
-  handleStatSelection as engineHandleStatSelection,
-  quitMatch
-} from "./battleEngine.js";
-import { onDomReady } from "./domReady.js";
-
-function enableStatButtons(enable = true) {
-  document.querySelectorAll("#stat-buttons button").forEach((btn) => {
-    btn.disabled = !enable;
-    btn.tabIndex = enable ? 0 : -1;
-    btn.classList.toggle("disabled", !enable);
-  });
-}
-
-function getRandomEnabledStat() {
-  const enabled = Array.from(document.querySelectorAll("#stat-buttons button:not(:disabled)"));
-  if (enabled.length === 0) return null;
-  const idx = Math.floor(Math.random() * enabled.length);
-  return enabled[idx];
-}
-
 export function waitForComputerCard() {
   const container = document.getElementById("computer-card");
   if (!container) return Promise.resolve();
@@ -52,74 +21,3 @@ export function waitForComputerCard() {
     observer.observe(container, { childList: true, subtree: true });
   });
 }
-
-export function setupBattleJudokaPage() {
-  const statButtons = document.querySelectorAll("#stat-buttons button");
-  const timerDisplay = document.getElementById("next-round-timer");
-  let statSelected = false;
-
-  function onStatSelect(stat, btn) {
-    if (statSelected) return;
-    statSelected = true;
-    btn.classList.add("selected");
-    enableStatButtons(false);
-    // TODO: Get actual stat values from card data
-    const playerVal = 0; // placeholder
-    const computerVal = 0; // placeholder
-    engineHandleStatSelection(playerVal, computerVal);
-    timerDisplay.textContent = "";
-  }
-
-  statButtons.forEach((btn) => {
-    btn.style.minWidth = "44px";
-    btn.style.minHeight = "44px";
-    btn.addEventListener("click", () => onStatSelect(btn.dataset.stat, btn));
-    btn.addEventListener("keydown", (e) => {
-      if ((e.key === "Enter" || e.key === " ") && !btn.disabled) {
-        e.preventDefault();
-        onStatSelect(btn.dataset.stat, btn);
-      }
-    });
-  });
-
-  async function startStatSelectionPhase() {
-    statSelected = false;
-    enableStatButtons(false);
-    await waitForComputerCard();
-    enableStatButtons(true);
-    timerDisplay.textContent = "Time left: 30s";
-    startRound(
-      (remaining) => {
-        if (remaining > 0) {
-          timerDisplay.textContent = `Time left: ${remaining}s`;
-        } else {
-          timerDisplay.textContent = "";
-        }
-      },
-      () => {
-        // Auto-select random stat if timer expires
-        const autoBtn = getRandomEnabledStat();
-        if (autoBtn) {
-          autoBtn.focus();
-          onStatSelect(autoBtn.dataset.stat, autoBtn);
-          timerDisplay.textContent = "Auto-selected!";
-        }
-      },
-      30
-    );
-  }
-
-  const homeLink = document.querySelector("[data-testid='home-link']");
-  if (homeLink) {
-    homeLink.addEventListener("click", (e) => {
-      if (!quitMatch()) {
-        e.preventDefault();
-      }
-    });
-  }
-
-  // Start the first stat selection phase
-  startStatSelectionPhase();
-}
-
-onDomReady(setupBattleJudokaPage);

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -1,0 +1,65 @@
+/**
+ * Page wrapper for Classic Battle mode.
+ *
+ * @pseudocode
+ * 1. Import battle helpers and DOM ready utility.
+ * 2. Define `enableStatButtons` to toggle disabled state on all stat buttons.
+ * 3. Define `startRoundWrapper` that:
+ *    a. Disables stat buttons.
+ *    b. Calls `startRound` from `classicBattle.js`.
+ *    c. Waits for the Mystery card to render using `waitForComputerCard`.
+ *    d. Enables stat buttons.
+ * 4. Define `setupClassicBattlePage` to:
+ *    a. Attach click and keyboard listeners on stat buttons that call
+ *       `handleStatSelection`.
+ *    b. Set `window.startRoundOverride` to `startRoundWrapper` so the battle
+ *       module uses it for subsequent rounds.
+ *    c. Invoke `startRoundWrapper` to begin the match.
+ * 5. Execute `setupClassicBattlePage` with `onDomReady`.
+ */
+import { startRound as classicStartRound, handleStatSelection } from "./classicBattle.js";
+import { onDomReady } from "./domReady.js";
+import { waitForComputerCard } from "./battleJudokaPage.js";
+
+function enableStatButtons(enable = true) {
+  document.querySelectorAll("#stat-buttons button").forEach((btn) => {
+    btn.disabled = !enable;
+    btn.tabIndex = enable ? 0 : -1;
+    btn.classList.toggle("disabled", !enable);
+  });
+}
+
+async function startRoundWrapper() {
+  enableStatButtons(false);
+  await classicStartRound();
+  await waitForComputerCard();
+  enableStatButtons(true);
+}
+
+export function setupClassicBattlePage() {
+  const statButtons = document.querySelectorAll("#stat-buttons button");
+  statButtons.forEach((btn) => {
+    btn.style.minWidth = "44px";
+    btn.style.minHeight = "44px";
+    btn.addEventListener("click", () => {
+      if (!btn.disabled) {
+        enableStatButtons(false);
+        btn.classList.add("selected");
+        handleStatSelection(btn.dataset.stat);
+      }
+    });
+    btn.addEventListener("keydown", (e) => {
+      if ((e.key === "Enter" || e.key === " ") && !btn.disabled) {
+        e.preventDefault();
+        enableStatButtons(false);
+        btn.classList.add("selected");
+        handleStatSelection(btn.dataset.stat);
+      }
+    });
+  });
+
+  window.startRoundOverride = startRoundWrapper;
+  startRoundWrapper();
+}
+
+onDomReady(setupClassicBattlePage);

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -46,17 +46,64 @@
       <main class="container" role="main">
         <section id="battle-area">
           <div id="player-card" class="card-slot"></div>
-          <div id="computer-card" class="card-slot" aria-label="Mystery Judoka: hidden card"><!--
+          <div id="computer-card" class="card-slot" aria-label="Mystery Judoka: hidden card">
+            <!--
   Mystery Judoka card is rendered here. ARIA attributes and stat labels should be set dynamically for accessibility compliance (see PRD: Mystery Card).
---></div>
+-->
+          </div>
 
           <div id="controls">
-            <div id="stat-buttons" role="group" aria-label="Select a stat to battle" class="responsive-stat-buttons">
-              <button data-stat="power" type="button" tabindex="0" aria-label="Select Power" style="min-width:44px;min-height:44px;">Power</button>
-              <button data-stat="speed" type="button" tabindex="0" aria-label="Select Speed" style="min-width:44px;min-height:44px;">Speed</button>
-              <button data-stat="technique" type="button" tabindex="0" aria-label="Select Technique" style="min-width:44px;min-height:44px;">Technique</button>
-              <button data-stat="kumikata" type="button" tabindex="0" aria-label="Select Kumi-kata" style="min-width:44px;min-height:44px;">Kumi-kata</button>
-              <button data-stat="newaza" type="button" tabindex="0" aria-label="Select Ne-waza" style="min-width:44px;min-height:44px;">Ne-waza</button>
+            <div
+              id="stat-buttons"
+              role="group"
+              aria-label="Select a stat to battle"
+              class="responsive-stat-buttons"
+            >
+              <button
+                data-stat="power"
+                type="button"
+                tabindex="0"
+                aria-label="Select Power"
+                style="min-width: 44px; min-height: 44px"
+              >
+                Power
+              </button>
+              <button
+                data-stat="speed"
+                type="button"
+                tabindex="0"
+                aria-label="Select Speed"
+                style="min-width: 44px; min-height: 44px"
+              >
+                Speed
+              </button>
+              <button
+                data-stat="technique"
+                type="button"
+                tabindex="0"
+                aria-label="Select Technique"
+                style="min-width: 44px; min-height: 44px"
+              >
+                Technique
+              </button>
+              <button
+                data-stat="kumikata"
+                type="button"
+                tabindex="0"
+                aria-label="Select Kumi-kata"
+                style="min-width: 44px; min-height: 44px"
+              >
+                Kumi-kata
+              </button>
+              <button
+                data-stat="newaza"
+                type="button"
+                tabindex="0"
+                aria-label="Select Ne-waza"
+                style="min-width: 44px; min-height: 44px"
+              >
+                Ne-waza
+              </button>
             </div>
 
             <p id="round-result" aria-live="polite" aria-atomic="true"></p>
@@ -83,7 +130,7 @@
       </script>
       <script type="module" src="../helpers/setupSvgFallback.js"></script>
       <script type="module" src="../helpers/setupBattleInfoBar.js"></script>
-      <script type="module" src="../helpers/battleJudokaPage.js"></script>
+      <script type="module" src="../helpers/classicBattlePage.js"></script>
     </div>
   </body>
 </html>

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -41,10 +41,20 @@
       <div class="card-section">
         <div id="card-container" data-testid="card-container" class="card-container"></div>
         <!-- PRD: Draw Card button and toggles per prdRandomJudoka.md & prdDrawRandomCard.md -->
-        <div id="draw-controls" class="draw-controls" aria-label="Draw controls" style="display: flex; flex-direction: column; align-items: center; margin-top: 24px;">
+        <div
+          id="draw-controls"
+          class="draw-controls"
+          aria-label="Draw controls"
+          style="display: flex; flex-direction: column; align-items: center; margin-top: 24px"
+        >
           <!-- Button and toggles are injected by randomJudokaPage.js -->
           <!-- Error message container for accessibility -->
-          <div id="draw-error-message" role="alert" aria-live="assertive" style="color: #b00020; font-size: 1.1rem; margin-top: 12px;"></div>
+          <div
+            id="draw-error-message"
+            role="alert"
+            aria-live="assertive"
+            style="color: #b00020; font-size: 1.1rem; margin-top: 12px"
+          ></div>
         </div>
       </div>
 

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -62,7 +62,13 @@
             <legend>General Settings</legend>
             <div class="settings-item">
               <label for="sound-toggle" class="switch">
-                <input type="checkbox" id="sound-toggle" name="sound" aria-label="Sound" tabindex="2" />
+                <input
+                  type="checkbox"
+                  id="sound-toggle"
+                  name="sound"
+                  aria-label="Sound"
+                  tabindex="2"
+                />
                 <div class="slider round"></div>
                 <span>Sound</span>
               </label>
@@ -105,7 +111,13 @@
             <a href="../pages/changeLog.html" id="changelog-link" tabindex="99">View Change Log</a>
           </div>
         </form>
-        <div id="settings-error-popup" class="settings-error-popup" role="alert" aria-live="assertive" style="display:none;"></div>
+        <div
+          id="settings-error-popup"
+          class="settings-error-popup"
+          role="alert"
+          aria-live="assertive"
+          style="display: none"
+        ></div>
       </main>
 
       <footer>


### PR DESCRIPTION
## Summary
- add new wrapper `classicBattlePage.js` that hooks up classic battle logic
- simplify `battleJudokaPage.js` to only export `waitForComputerCard`
- load the new wrapper from `battleJudoka.html`
- format remaining pages with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: settings.spec, random-judoka.spec, screenshot.spec)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68800e83749c8326afae0a65921996b3