### PR TITLE
Implement collapsible settings sections

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -7,6 +7,10 @@ test.describe("Settings page", () => {
       route.fulfill({ path: "tests/fixtures/gameModes.json" })
     );
     await page.goto("/src/pages/settings.html", { waitUntil: "domcontentloaded" });
+    await page.waitForSelector("#mode-classicBattle", { state: "attached" });
+    await page.locator("#display-settings-toggle").click();
+    await page.locator("#general-settings-toggle").click();
+    await page.locator("#game-modes-toggle").click();
   });
 
   test("page loads", async ({ page }) => {

--- a/src/helpers/settings/index.js
+++ b/src/helpers/settings/index.js
@@ -1,1 +1,2 @@
 export * from "./formUtils.js";
+export * from "./sectionToggle.js";

--- a/src/helpers/settings/sectionToggle.js
+++ b/src/helpers/settings/sectionToggle.js
@@ -1,0 +1,35 @@
+/**
+ * Attach handlers to toggle visibility of settings sections.
+ *
+ * @pseudocode
+ * 1. Query all buttons with the `.settings-section-toggle` class.
+ * 2. For each button, locate the associated content element via `aria-controls`.
+ * 3. On `click` or `keydown` (Enter/Space), toggle the hidden state of the content.
+ *    - Update the button's `aria-expanded` attribute accordingly.
+ */
+export function setupSectionToggles() {
+  const buttons = document.querySelectorAll(".settings-section-toggle");
+  buttons.forEach((btn) => {
+    const contentId = btn.getAttribute("aria-controls");
+    const content = document.getElementById(contentId);
+    if (!content) return;
+
+    const toggle = () => {
+      const expanded = btn.getAttribute("aria-expanded") === "true";
+      btn.setAttribute("aria-expanded", String(!expanded));
+      if (expanded) {
+        content.setAttribute("hidden", "");
+      } else {
+        content.removeAttribute("hidden");
+      }
+    };
+
+    btn.addEventListener("click", toggle);
+    btn.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        toggle();
+      }
+    });
+  });
+}

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -16,7 +16,8 @@ import { onDomReady } from "./domReady.js";
 import {
   applyInitialControlValues,
   attachToggleListeners,
-  renderGameModeSwitches
+  renderGameModeSwitches,
+  setupSectionToggles
 } from "./settings/index.js";
 
 /**
@@ -80,6 +81,7 @@ async function initializeSettingsPage() {
     applyDisplayMode(settings.displayMode);
     applyMotionPreference(settings.motionEffects);
     initializeControls(settings, gameModes);
+    setupSectionToggles();
   } catch (error) {
     console.error("Error loading settings page:", error);
     const errorPopup = document.getElementById("settings-error-popup");

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -41,72 +41,128 @@
       <main class="container" role="main">
         <h1 class="settings-header">Settings</h1>
         <form id="settings-form" class="settings-form">
-          <fieldset
-            id="display-settings-container"
-            class="game-mode-toggle-container settings-form"
-          >
-            <legend>Display Settings</legend>
-            <div class="settings-item">
-              <label for="display-mode-select">Display Mode</label>
-              <select id="display-mode-select" aria-label="Display Mode" tabindex="1">
-                <option value="light">Light</option>
-                <option value="dark">Dark</option>
-                <option value="gray">Gray</option>
-              </select>
+          <div class="settings-section">
+            <button
+              class="settings-section-toggle"
+              id="display-settings-toggle"
+              aria-expanded="false"
+              aria-controls="display-settings-content"
+            >
+              Display Settings
+            </button>
+            <div
+              class="settings-section-content"
+              id="display-settings-content"
+              role="region"
+              aria-labelledby="display-settings-toggle"
+              hidden
+            >
+              <fieldset
+                id="display-settings-container"
+                class="game-mode-toggle-container settings-form"
+              >
+                <legend>Display Settings</legend>
+                <div class="settings-item">
+                  <label for="display-mode-select">Display Mode</label>
+                  <select id="display-mode-select" aria-label="Display Mode" tabindex="1">
+                    <option value="light">Light</option>
+                    <option value="dark">Dark</option>
+                    <option value="gray">Gray</option>
+                  </select>
+                </div>
+              </fieldset>
             </div>
-          </fieldset>
-          <fieldset
-            id="general-settings-container"
-            class="game-mode-toggle-container settings-form"
-          >
-            <legend>General Settings</legend>
-            <div class="settings-item">
-              <label for="sound-toggle" class="switch">
-                <input
-                  type="checkbox"
-                  id="sound-toggle"
-                  name="sound"
-                  aria-label="Sound"
-                  tabindex="2"
-                />
-                <div class="slider round"></div>
-                <span>Sound</span>
-              </label>
+          </div>
+
+          <div class="settings-section">
+            <button
+              class="settings-section-toggle"
+              id="general-settings-toggle"
+              aria-expanded="false"
+              aria-controls="general-settings-content"
+            >
+              General Settings
+            </button>
+            <div
+              class="settings-section-content"
+              id="general-settings-content"
+              role="region"
+              aria-labelledby="general-settings-toggle"
+              hidden
+            >
+              <fieldset
+                id="general-settings-container"
+                class="game-mode-toggle-container settings-form"
+              >
+                <legend>General Settings</legend>
+                <div class="settings-item">
+                  <label for="sound-toggle" class="switch">
+                    <input
+                      type="checkbox"
+                      id="sound-toggle"
+                      name="sound"
+                      aria-label="Sound"
+                      tabindex="2"
+                    />
+                    <div class="slider round"></div>
+                    <span>Sound</span>
+                  </label>
+                </div>
+                <div class="settings-item">
+                  <label for="navmap-toggle" class="switch">
+                    <input
+                      type="checkbox"
+                      id="navmap-toggle"
+                      name="navmap"
+                      aria-label="Full Navigation Map"
+                      tabindex="3"
+                    />
+                    <div class="slider round"></div>
+                    <span>Full Navigation Map</span>
+                  </label>
+                </div>
+                <div class="settings-item">
+                  <label for="motion-toggle" class="switch">
+                    <input
+                      type="checkbox"
+                      id="motion-toggle"
+                      name="motion"
+                      aria-label="Motion Effects"
+                      tabindex="4"
+                    />
+                    <div class="slider round"></div>
+                    <span>Motion Effects</span>
+                  </label>
+                </div>
+              </fieldset>
             </div>
-            <div class="settings-item">
-              <label for="navmap-toggle" class="switch">
-                <input
-                  type="checkbox"
-                  id="navmap-toggle"
-                  name="navmap"
-                  aria-label="Full Navigation Map"
-                  tabindex="3"
-                />
-                <div class="slider round"></div>
-                <span>Full Navigation Map</span>
-              </label>
+          </div>
+
+          <div class="settings-section">
+            <button
+              class="settings-section-toggle"
+              id="game-modes-toggle"
+              aria-expanded="false"
+              aria-controls="game-modes-content"
+            >
+              Game Modes
+            </button>
+            <div
+              class="settings-section-content"
+              id="game-modes-content"
+              role="region"
+              aria-labelledby="game-modes-toggle"
+              hidden
+            >
+              <fieldset
+                id="game-mode-toggle-container"
+                class="game-mode-toggle-container settings-form"
+                aria-label="Game Mode Selector"
+              >
+                <legend>Game Modes</legend>
+              </fieldset>
             </div>
-            <div class="settings-item">
-              <label for="motion-toggle" class="switch">
-                <input
-                  type="checkbox"
-                  id="motion-toggle"
-                  name="motion"
-                  aria-label="Motion Effects"
-                  tabindex="4"
-                />
-                <div class="slider round"></div>
-                <span>Motion Effects</span>
-              </label>
-            </div>
-          </fieldset>
-          <fieldset
-            id="game-mode-toggle-container"
-            class="game-mode-toggle-container settings-form"
-            aria-label="Game Mode Selector"
-          >
-            <legend>Game Modes</legend>
-          </fieldset>
+          </div>
           <div class="settings-item">
             <a href="../pages/changeLog.html" id="changelog-link" tabindex="99">View Change Log</a>
           </div>

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -142,3 +142,23 @@
 .slider.round::before {
   border-radius: 50%;
 }
+
+.settings-section {
+  margin-block-end: var(--space-lg);
+}
+
+.settings-section-toggle {
+  width: 100%;
+  text-align: left;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--button-bg);
+  color: var(--button-text-color);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.settings-section-content {
+  padding-block-start: var(--space-sm);
+  transition: height var(--transition-fast);
+}

--- a/tests/helpers/sectionToggle.test.js
+++ b/tests/helpers/sectionToggle.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+
+import { setupSectionToggles } from "../../src/helpers/settings/sectionToggle.js";
+
+describe("setupSectionToggles", () => {
+  it("toggles aria-expanded and hidden on button interaction", () => {
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = `
+      <button class="settings-section-toggle" aria-expanded="false" aria-controls="sec" id="toggle">Toggle</button>
+      <div class="settings-section-content" id="sec" hidden></div>
+    `;
+    document.body.appendChild(wrapper);
+
+    setupSectionToggles();
+    const button = document.getElementById("toggle");
+    const content = document.getElementById("sec");
+
+    button.click();
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(content.hasAttribute("hidden")).toBe(false);
+
+    const event = new KeyboardEvent("keydown", { key: "Enter" });
+    button.dispatchEvent(event);
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(content.hasAttribute("hidden")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- wrap settings fieldsets in collapsible sections
- add new settings section toggle helper and tests
- wire toggle helper into settings page
- style section wrappers and toggles
- adjust Playwright test for new collapsible sections

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot and settings specs)*

------
https://chatgpt.com/codex/tasks/task_e_68801606d4248326a35ef4b8ba5ba021