### PR TITLE
Document draw button aria-label

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,9 @@ The repository specifies commenting standards in design/codeStandards. JSDoc com
 - Modularized JavaScript for better maintainability
 - Slide-in country picker, opened via a panel icon with an arrow, for filtering judoka by flag with accessible
   `aria-label` descriptions
+- Draw button on the Random Judoka screen provides its accessible name via
+  `aria-label="Draw a random judoka card"` so screen readers announce the same
+  label even if the visible text changes
 - Country picker panel appears below the fixed header for unobstructed viewing
 - Scroll buttons disable when the carousel reaches either end
 - Header bar displays real-time round results, countdown timer and score

--- a/design/productRequirementsDocuments/prdDrawRandomCard.md
+++ b/design/productRequirementsDocuments/prdDrawRandomCard.md
@@ -91,6 +91,8 @@ Motion** enabled, ensuring the card appears instantly without movement.
 - **Accessibility**:
   - Respect system Reduced Motion settings — disable animations if active.
   - Default: Animations ON, but respect system/user preferences.
+  - Provide an `aria-label` on the Draw button so the accessible name stays
+    "Draw a random judoka card" even when the visible text is updated.
 
 ---
 

--- a/design/productRequirementsDocuments/prdRandomJudoka.md
+++ b/design/productRequirementsDocuments/prdRandomJudoka.md
@@ -130,6 +130,8 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 - Tap targets ≥44px × 44px (64px recommended for kid-friendly design). See [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness)
 - Text must meet WCAG 2.1 AA 4.5:1 contrast ratio (verify with automated tools)
 - All buttons and states require clear text labels
+- The Draw button uses `aria-label="Draw a random judoka card"` so screen readers
+  announce a consistent name even if the visible text changes
 
 #### Responsiveness
 


### PR DESCRIPTION
## Summary
- note `aria-label` usage for the Random Judoka draw button
- document consistent accessible name in the PRD documents

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68809e07181083268892d85af3f61d9a