### PR TITLE
Fix viewport check in Playwright test

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ the other Playwright tests:
 SKIP_SCREENSHOTS=true npm run test:screenshot
 ```
 
+When using `page.evaluate` to query elements, always wait for the element to
+exist (e.g., `await page.getByTestId("draw-button").waitFor()`). Otherwise
+the evaluation may run before the DOM is ready and throw a `Cannot read
+properties of null` error.
+
 ## Project Structure
 
 The repository follows a simple layout. GitHub Pages requires `index.html` to live at the project root.

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -72,8 +72,10 @@ test.describe("View Judoka screen", () => {
   });
 
   test("draw button remains within viewport", async ({ page }) => {
-    const { bottom, innerHeight } = await page.evaluate(() => {
-      const rect = document.querySelector('[data-testid="draw-button"]').getBoundingClientRect();
+    const btn = page.getByTestId("draw-button");
+    await btn.waitFor();
+    const { bottom, innerHeight } = await btn.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
       return { bottom: rect.bottom, innerHeight: window.innerHeight };
     });
     expect(bottom).toBeLessThanOrEqual(innerHeight);


### PR DESCRIPTION
## Summary
- wait for draw button before measuring viewport
- document Playwright evaluate caveat

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden to fetch vitest)*
- `npx playwright test` *(fails: 403 Forbidden to fetch playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68809e1ea990832689934583d23c8742