### PR TITLE
Update Playwright fixture to clear localStorage

### DIFF
--- a/playwright/fixtures/commonSetup.js
+++ b/playwright/fixtures/commonSetup.js
@@ -4,7 +4,8 @@
  * @pseudocode
  * 1. Import base test and expect from Playwright.
  * 2. Import registerCommonRoutes helper.
- * 3. Extend the base test's page fixture to register routes before each test.
+ * 3. Extend the base test's page fixture to register routes and clear
+ *    localStorage before each test.
  * 4. Export the extended test and expect.
  */
 import { test as base, expect } from "@playwright/test";
@@ -14,6 +15,7 @@ export const test = base.extend({
   /** @type {import('@playwright/test').Page} */
   page: async ({ page }, use) => {
     await registerCommonRoutes(page);
+    await page.addInitScript(() => localStorage.clear());
     await use(page);
   }
 });


### PR DESCRIPTION
## Summary
- clear localStorage before each Playwright test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 9 failed, 53 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6880a21c15f48326b96ee5a3375ba3ad