### PR TITLE
Fix settings toggle button types

### DIFF
--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -124,7 +124,7 @@ To improve organization and reduce visual clutter, each major settings area (e.g
 
 ```html
 <div class="settings-section">
-  <button class="settings-section-toggle" aria-expanded="false" aria-controls="general-settings-content" id="general-settings-toggle">
+  <button type="button" class="settings-section-toggle" aria-expanded="false" aria-controls="general-settings-content" id="general-settings-toggle">
     General Settings
   </button>
   <div class="settings-section-content" id="general-settings-content" role="region" aria-labelledby="general-settings-toggle" hidden>
@@ -135,6 +135,7 @@ To improve organization and reduce visual clutter, each major settings area (e.g
 
 - Repeat for each section (e.g., Game Modes).
 - The toggle button must be keyboard-focusable and operable (Enter/Space).
+- Toggle buttons must use `type="button"` to avoid submitting the form.
 - Use `aria-expanded`, `aria-controls`, and `aria-labelledby` for accessibility.
 - The content div should be hidden by default (`hidden` attribute or `display: none;`).
 

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -43,6 +43,7 @@
         <form id="settings-form" class="settings-form">
           <div class="settings-section">
             <button
+              type="button"
               class="settings-section-toggle"
               id="display-settings-toggle"
               aria-expanded="false"
@@ -76,6 +77,7 @@
 
           <div class="settings-section">
             <button
+              type="button"
               class="settings-section-toggle"
               id="general-settings-toggle"
               aria-expanded="false"
@@ -140,6 +142,7 @@
 
           <div class="settings-section">
             <button
+              type="button"
               class="settings-section-toggle"
               id="game-modes-toggle"
               aria-expanded="false"


### PR DESCRIPTION
## Summary
- prevent settings collapsible buttons from submitting the form
- mention `type="button"` usage in settings page guidelines

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot and accessibility tests)*

------
https://chatgpt.com/codex/tasks/task_e_6880a2359d808326b85d9041cf57da5c