### PR TITLE
Update Playwright test instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ npx vitest run               # run unit tests
 npx playwright test          # run Playwright UI tests
 ```
 
+Playwright tests clear `localStorage` at startup. If a manual run fails unexpectedly, clear it in your browser and ensure http://localhost:5000 is served (start it with `npm start`).
+
 **For UI-related changes** (styles, components, layouts, visual elements), also run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ A `Test timeout ... waiting for locator('#general-settings-toggle')` error usual
 - Visiting `http://localhost:5000/src/pages/settings.html` shows the toggles (`#display-settings-toggle`, `#general-settings-toggle`, `#game-modes-toggle`).
 - Running tests with `PWDEBUG=1` helps inspect the page when a timeout occurs.
 
+Playwright tests clear `localStorage` at startup. If a manual run fails unexpectedly, clear `localStorage` in your browser before retrying. A static server must be reachable at http://localhost:5000 (typically via `npm start`).
+
+
 ## Project Structure
 
 The repository follows a simple layout. GitHub Pages requires `index.html` to live at the project root.


### PR DESCRIPTION
## Summary
- mention localStorage reset for Playwright tests
- call out local static server requirement

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: settings.spec.js etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6880a6e43ae8832693363714e2b5959e