### PR TITLE
Fix Playwright label query

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ A `Test timeout ... waiting for locator('#general-settings-toggle')` error usual
 - Port **5000** is free; the tests start `scripts/playwrightServer.js` automatically.
 - Visiting `http://localhost:5000/src/pages/settings.html` shows the toggles (`#display-settings-toggle`, `#general-settings-toggle`, `#game-modes-toggle`).
 - Running tests with `PWDEBUG=1` helps inspect the page when a timeout occurs.
+- `strict mode violation: getByLabel('text') resolved to multiple elements`
+  indicates the locator is too generic. Use `getByLabel(text, { exact: true })`
+  or a more specific `getByRole` query so only one element matches.
 
 ## Project Structure
 

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -63,7 +63,7 @@ test.describe("Settings page", () => {
     );
 
     for (const name of sortedNames) {
-      await expect(page.getByLabel(name)).toHaveAttribute("aria-label", name);
+      await expect(page.getByLabel(name, { exact: true })).toHaveAttribute("aria-label", name);
     }
 
     await page.focus("#display-mode-select");


### PR DESCRIPTION
## Summary
- ensure settings toggles match by exact label
- document Playwright strict mode locator errors

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6880a9ec5bd08326802925e68edbb5df