### PR TITLE
QA: document viewport requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ The repository specifies commenting standards in design/codeStandards. JSDoc com
 - Draw button on the Random Judoka screen provides its accessible name via
   `aria-label="Draw a random judoka card"` so screen readers announce the same
   label even if the visible text changes
+- Layout keeps the Random Judoka draw button within the viewport even with the fixed footer navigation
 - Country picker panel appears below the fixed header for unobstructed viewing
 - Scroll buttons disable when the carousel reaches either end
 - Header bar displays real-time round results, countdown timer and score

--- a/design/productRequirementsDocuments/prdRandomJudoka.md
+++ b/design/productRequirementsDocuments/prdRandomJudoka.md
@@ -139,6 +139,7 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 - **Tablet/Desktop (>600px):** card ~40% of viewport; centered draw button with spacing
 - **Landscape Support:** components reposition vertically or side-by-side
 - Card container uses `min-height: 50vh` to keep the Draw button visible on small screens
+- The Draw button and its toggles must remain fully visible within the viewport even with the fixed footer navigation present
 
 #### Audio Feedback (Optional Enhancement)
 


### PR DESCRIPTION
## Summary
- document viewport visibility for Random Judoka draw button

## Testing
- `npx prettier . --check` *(fails: 403 Forbidden)*
- `npx eslint .` *(fails: 403 Forbidden)*
- `npx vitest run` *(fails: 403 Forbidden)*
- `npx playwright test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6880a9d728ec8326aece60e34833ec52