### PR TITLE
Fix bottom spacing on iPad

### DIFF
--- a/design/productRequirementsDocuments/prdHomePageNavigation.md
+++ b/design/productRequirementsDocuments/prdHomePageNavigation.md
@@ -243,6 +243,7 @@ Each tile contains:
   - Single-column layout for mobile view (portrait resolution)
   - Tiles stretch to 100% width with top and bottom padding
   - Tile grid height equals `100dvh` minus the top and bottom bar heights (with a `100vh` fallback) so tiles always fill the viewport
+  - Add a small bottom margin so the tile grid does not touch the navigation bar on tablets
   - Tap targets clearly bounded with shadow or color background
   - Include visible focus outline for keyboard navigation
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -88,6 +88,7 @@ body {
   gap: var(--space-lg);
   padding: var(--space-large) var(--space-xl);
   flex: 1 1 auto;
+  margin-bottom: var(--space-large);
   height: calc(100vh - var(--header-height) - var(--footer-height));
   height: calc(100dvh - var(--header-height) - var(--footer-height));
 }


### PR DESCRIPTION
## Summary
- add margin below game mode tiles so they don't butt against the nav bar
- document the new bottom margin requirement in the home page PRD

## Testing
- `npx prettier . --check` *(fails: 403 Forbidden)*
- `npx eslint .` *(fails: 403 Forbidden)*
- `npx vitest run` *(fails: 403 Forbidden)*
- `npx playwright test` *(fails: 403 Forbidden)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6880d89732808326a10abe1d06c4ac77