### PR TITLE
Fix randomJudoka layout on iPad

### DIFF
--- a/design/productRequirementsDocuments/prdRandomJudoka.md
+++ b/design/productRequirementsDocuments/prdRandomJudoka.md
@@ -138,7 +138,7 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 - **Mobile (<600px):** card fills ~70% of viewport; draw button spans nearly full width
 - **Tablet/Desktop (>600px):** card ~40% of viewport; centered draw button with spacing
 - **Landscape Support:** components reposition vertically or side-by-side
-- Card container uses `min-height: 50vh` to keep the Draw button visible on small screens
+- Card container uses `min-height: 50dvh` to keep the Draw button visible on small screens
 - The Draw button and its toggles must remain fully visible within the viewport even with the fixed footer navigation present
 
 #### Audio Feedback (Optional Enhancement)

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -77,7 +77,8 @@ svg {
   justify-content: center;
   align-items: center;
   padding: var(--space-lg) var(--space-lg) 0; /* 24px bottom gap handled by button */
-  min-height: 50vh;
+  min-height: 50vh; /* fallback */
+  min-height: 50dvh;
 }
 
 .judoka-card {


### PR DESCRIPTION
## Summary
- tweak `.card-container` min-height to use `dvh`
- update PRD with dvh height mention

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6880dcca18788326bf3469f1c7893398