### PR TITLE
Improve battle button layout

### DIFF
--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -312,6 +312,7 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 ### 8.8 Battle Layout
 
 - In Classic Battle screens, player and opponent cards align horizontally. They only stack vertically on very narrow screens (<480 px). Stat controls sit below the card row.
+- Stat selection buttons should use a grid layout with equal widths and small gaps so players choose solely based on card stats.
 
 ---
 

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -43,8 +43,6 @@ function onStatSelect(stat) {
 export function setupClassicBattlePage() {
   const statButtons = document.querySelectorAll("#stat-buttons button");
   statButtons.forEach((btn) => {
-    btn.style.minWidth = "44px";
-    btn.style.minHeight = "44px";
     btn.addEventListener("click", () => {
       if (!btn.disabled) {
         enableStatButtons(false);

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -59,22 +59,10 @@
               aria-label="Select a stat to battle"
               class="responsive-stat-buttons"
             >
-              <button
-                data-stat="power"
-                type="button"
-                tabindex="0"
-                aria-label="Select Power"
-                style="min-width: 44px; min-height: 44px"
-              >
+              <button data-stat="power" type="button" tabindex="0" aria-label="Select Power">
                 Power
               </button>
-              <button
-                data-stat="speed"
-                type="button"
-                tabindex="0"
-                aria-label="Select Speed"
-                style="min-width: 44px; min-height: 44px"
-              >
+              <button data-stat="speed" type="button" tabindex="0" aria-label="Select Speed">
                 Speed
               </button>
               <button
@@ -82,26 +70,13 @@
                 type="button"
                 tabindex="0"
                 aria-label="Select Technique"
-                style="min-width: 44px; min-height: 44px"
               >
                 Technique
               </button>
-              <button
-                data-stat="kumikata"
-                type="button"
-                tabindex="0"
-                aria-label="Select Kumi-kata"
-                style="min-width: 44px; min-height: 44px"
-              >
+              <button data-stat="kumikata" type="button" tabindex="0" aria-label="Select Kumi-kata">
                 Kumi-kata
               </button>
-              <button
-                data-stat="newaza"
-                type="button"
-                tabindex="0"
-                aria-label="Select Ne-waza"
-                style="min-width: 44px; min-height: 44px"
-              >
+              <button data-stat="newaza" type="button" tabindex="0" aria-label="Select Ne-waza">
                 Ne-waza
               </button>
             </div>

--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -30,10 +30,19 @@ button:active {
 
 #stat-buttons button {
   -webkit-tap-highlight-color: transparent;
+  width: 100%;
+  min-width: var(--touch-target-size, 44px);
+  min-height: var(--touch-target-size, 44px);
 }
 
 #stat-buttons button.selected {
   background-color: var(--button-active-bg);
+}
+
+.responsive-stat-buttons {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: var(--space-sm);
 }
 
 button:focus,


### PR DESCRIPTION
## Summary
- style battle stat buttons with responsive grid
- drop inline stat button styles
- remove JS minWidth and minHeight overrides
- document stat button grid layout

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6880dcdb96b4832693a808a7c104386f