### PR TITLE
Add changelog page

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Layout containers should include a `vh` fallback declared before the `dvh` rule 
 
 ## Changelog
 
-The game includes an in-app change log that lists the 20 most recently updated judoka. Open the **Settings** screen and choose **View Change Log** to visit `src/pages/changeLog.html`.
+The game includes an in-app change log that lists the 20 most recently updated judoka. The page loads data from `judoka.json` and is populated by `changeLogPage.js`. Open the **Settings** screen and choose **View Change Log** to visit `src/pages/changeLog.html`.
 
 ## Future Plans
 

--- a/playwright/changelog.spec.js
+++ b/playwright/changelog.spec.js
@@ -1,0 +1,16 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+
+test.describe("Change log page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/src/pages/changeLog.html");
+  });
+
+  test("header and footer visible", async ({ page }) => {
+    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
+  });
+
+  test("captures screenshot", async ({ page }) => {
+    await expect(page).toHaveScreenshot("changeLog.png", { fullPage: true });
+  });
+});

--- a/src/helpers/changeLogPage.js
+++ b/src/helpers/changeLogPage.js
@@ -1,0 +1,84 @@
+import { fetchJson } from "./dataUtils.js";
+import { DATA_DIR } from "./constants.js";
+import { escapeHTML, formatDate } from "./utils.js";
+import { onDomReady } from "./domReady.js";
+
+/**
+ * Sort judoka entries by lastUpdated descending, then by full name ascending.
+ *
+ * @pseudocode
+ * 1. Clone the array to avoid mutating the input.
+ * 2. Sort by `lastUpdated` in descending order.
+ * 3. When dates are equal, sort by full name ascending.
+ *
+ * @param {Judoka[]} entries - Array of judoka objects.
+ * @returns {Judoka[]} Sorted array of judoka objects.
+ */
+export function sortJudoka(entries) {
+  return [...entries].sort((a, b) => {
+    const dateA = new Date(a.lastUpdated).getTime();
+    const dateB = new Date(b.lastUpdated).getTime();
+    if (dateA !== dateB) return dateB - dateA;
+    const nameA = `${a.firstname} ${a.surname}`.toLowerCase();
+    const nameB = `${b.firstname} ${b.surname}`.toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
+}
+
+function createRow(judoka) {
+  const row = document.createElement("tr");
+
+  const idCell = document.createElement("td");
+  idCell.textContent = String(judoka.id);
+  row.appendChild(idCell);
+
+  const codeCell = document.createElement("td");
+  codeCell.textContent = judoka.cardCode || "";
+  row.appendChild(codeCell);
+
+  const portraitCell = document.createElement("td");
+  const img = document.createElement("img");
+  img.width = 48;
+  img.height = 48;
+  img.src = `../assets/judokaPortraits/judokaPortrait-${judoka.id}.png`;
+  img.alt = `Portrait of ${escapeHTML(`${judoka.firstname} ${judoka.surname}`)}`;
+  img.onerror = () => {
+    img.src = "../assets/judokaPortraits/judokaPortrait-0.png";
+  };
+  portraitCell.appendChild(img);
+  row.appendChild(portraitCell);
+
+  const dateCell = document.createElement("td");
+  dateCell.textContent = formatDate(judoka.lastUpdated);
+  row.appendChild(dateCell);
+
+  const nameCell = document.createElement("td");
+  nameCell.textContent = `${judoka.firstname} ${judoka.surname}`;
+  row.appendChild(nameCell);
+
+  return row;
+}
+
+export async function setupChangeLogPage() {
+  const table = document.getElementById("changelog-table");
+  const tbody = table?.querySelector("tbody");
+  const loading = document.getElementById("loading-container");
+  if (!table || !tbody) return;
+
+  try {
+    const data = await fetchJson(`${DATA_DIR}judoka.json`);
+    if (Array.isArray(data) && data.length) {
+      const rows = sortJudoka(data).slice(0, 20).map(createRow);
+      rows.forEach((r) => tbody.appendChild(r));
+    } else {
+      table.insertAdjacentHTML("afterend", "<p>No Judoka data found</p>");
+    }
+  } catch (err) {
+    console.error("Failed to load judoka:", err);
+    table.insertAdjacentHTML("afterend", "<p>No Judoka data found</p>");
+  } finally {
+    if (loading) loading.remove();
+  }
+}
+
+onDomReady(setupChangeLogPage);

--- a/src/pages/changeLog.html
+++ b/src/pages/changeLog.html
@@ -1,3 +1,74 @@
-<body>
-  tbc
-</body>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="keywords" content="judo, card game, web game" />
+    <meta name="author" content="Marc Scheimann" />
+    <meta
+      name="description"
+      content="JU-DO-KON! A web-based judo-themed card battle game featuring elite judoka."
+    />
+    <meta property="og:title" content="JU-DO-KON!" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://cyanautomation.github.io/judokon/" />
+    <meta
+      property="og:description"
+      content="JU-DO-KON! A web-based judo-themed card battle game featuring elite judoka."
+    />
+    <meta name="theme-color" content="#ffffff" />
+    <title>Ju-Do-Kon! Change Log</title>
+    <link rel="stylesheet" href="../styles/fonts.css" />
+    <link rel="stylesheet" href="../styles/base.css" />
+    <link rel="stylesheet" href="../styles/layout.css" />
+    <link rel="stylesheet" href="../styles/components.css" />
+    <link rel="stylesheet" href="../styles/utilities.css" />
+    <link rel="icon" type="image/png" href="../assets/images/favicon.ico" />
+  </head>
+
+  <body>
+    <div class="home-screen">
+      <header class="header">
+        <div class="character-slot left"></div>
+        <div class="logo-container">
+          <a href="../../index.html" data-testid="home-link">
+            <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
+          </a>
+        </div>
+        <div class="character-slot right"></div>
+      </header>
+
+      <main class="container" role="main">
+        <h1>Recent Judoka Updates</h1>
+        <div id="loading-container">
+          <div class="loading-spinner"></div>
+        </div>
+        <table id="changelog-table" aria-label="Judoka update log">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Code</th>
+              <th>Portrait</th>
+              <th>Date</th>
+              <th>Name</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </main>
+
+      <footer>
+        <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
+      </footer>
+      <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+      <script type="module" src="../helpers/setupDisplaySettings.js"></script>
+      <script type="module" src="../helpers/changeLogPage.js"></script>
+      <script type="module" src="../helpers/setupSvgFallback.js"></script>
+      <noscript>
+        <p class="noscript-warning">
+          JU-DO-KON! requires JavaScript to run. Please enable JavaScript to play.
+        </p>
+      </noscript>
+    </div>
+  </body>
+</html>

--- a/tests/helpers/changeLogPage.test.js
+++ b/tests/helpers/changeLogPage.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+
+const sample = [
+  {
+    id: 2,
+    firstname: "Alpha",
+    surname: "Zulu",
+    cardCode: "A",
+    lastUpdated: "2025-04-02T10:00:00Z"
+  },
+  {
+    id: 1,
+    firstname: "Beta",
+    surname: "Alpha",
+    cardCode: "B",
+    lastUpdated: "2025-04-03T10:00:00Z"
+  },
+  {
+    id: 3,
+    firstname: "Charlie",
+    surname: "Bravo",
+    cardCode: "C",
+    lastUpdated: "2025-04-03T10:00:00Z"
+  }
+];
+
+describe("changeLogPage", () => {
+  it("sorts by lastUpdated then name", async () => {
+    const { sortJudoka } = await import("../../src/helpers/changeLogPage.js");
+    const sorted = sortJudoka(sample);
+    expect(sorted[0].id).toBe(1);
+    expect(sorted[1].id).toBe(3);
+    expect(sorted[2].id).toBe(2);
+  });
+
+  it("falls back to placeholder portrait", async () => {
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue([sample[0]])
+    }));
+    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+
+    const { setupChangeLogPage } = await import("../../src/helpers/changeLogPage.js");
+
+    document.body.innerHTML = `
+      <div id="loading-container"></div>
+      <table id="changelog-table"><tbody></tbody></table>`;
+
+    await setupChangeLogPage();
+
+    const img = document.querySelector("img");
+    img.dispatchEvent(new Event("error"));
+    expect(img.src).toMatch(/judokaPortrait-0\.png$/);
+  });
+});


### PR DESCRIPTION
## Summary
- implement changelog page layout and helper script
- document changelog loading in README
- add unit tests for changelog helper
- cover changelog in Playwright tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test --update-snapshots`
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6880dcf6186083269561089aa67c1fc4