### PR TITLE
Fix home screen spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,8 @@ signature move band stack directly against each other in Safari and Chrome.
 
 The bottom navbar uses `env(safe-area-inset-bottom)` with a `constant()` fallback to add extra padding and height. This prevents it from overlapping the iOS home indicator and keeps content visible.
 
+The index page adds bottom padding inside `.game-mode-grid` so the last row of tiles stays clear of the navigation bar on tablets. The `.home-screen` fallback now subtracts the header and footer heights when using standard `vh` units.
+
 Layout containers should include a `vh` fallback declared before the `dvh` rule so browsers without dynamic viewport support still size elements correctly. The settings screen previously had its first controls hidden behind the header; wrapping the page in this `.home-screen` container resolves the issue. The page now starts with an `<h1>` heading and two `<fieldset>` sections labeled **General Settings** and **Game Modes**. Legends within `.settings-form` are styled as `<h2>`, and the form now includes padding. The classic battle page also uses this wrapper so the judoka cards appear fully below the header.
 
 ## Changelog

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -12,7 +12,7 @@ body {
 .home-screen {
   display: grid;
   grid-template-rows: auto 1fr auto;
-  min-height: 100vh;
+  min-height: calc(100vh - var(--header-height) - var(--footer-height));
   min-height: calc(100dvh - var(--header-height) - var(--footer-height));
   padding-top: var(--header-height);
   padding-bottom: calc(var(--footer-height) + env(safe-area-inset-bottom));
@@ -87,10 +87,11 @@ body {
   grid-template-rows: repeat(2, 1fr);
   gap: var(--space-lg);
   padding: var(--space-large) var(--space-xl);
+  padding-bottom: var(--space-large);
   flex: 1 1 auto;
-  margin-bottom: var(--space-large);
-  height: calc(100vh - var(--header-height) - var(--footer-height));
-  height: calc(100dvh - var(--header-height) - var(--footer-height));
+  min-height: calc(100vh - var(--header-height) - var(--footer-height));
+  min-height: calc(100dvh - var(--header-height) - var(--footer-height));
+  box-sizing: border-box;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- keep bottom tiles clear of the navigation bar
- document the layout adjustment in the README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6880e9ffb6448326ba331f5988db83b3