### PR TITLE
Fix random judoka layout padding

### DIFF
--- a/design/productRequirementsDocuments/prdRandomJudoka.md
+++ b/design/productRequirementsDocuments/prdRandomJudoka.md
@@ -140,6 +140,7 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 - **Landscape Support:** components reposition vertically or side-by-side
 - Card container uses `min-height: 50dvh` to keep the Draw button visible on small screens
 - The Draw button and its toggles must remain fully visible within the viewport even with the fixed footer navigation present
+- `.card-section` uses `padding-bottom: calc(var(--footer-height) + env(safe-area-inset-bottom))` so buttons stay visible above the footer
 
 #### Audio Feedback (Optional Enhancement)
 

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -116,6 +116,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-bottom: calc(var(--footer-height) + env(safe-area-inset-bottom));
 }
 
 .card-section .draw-card-btn {


### PR DESCRIPTION
## Summary
- add footer-aware padding for `.card-section`
- document padding rule in Random Judoka PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Screenshot suite screenshot /src/pages/randomJudoka.html)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6880eb60cf608326bde4bb2348c30b7c