### PR TITLE
Update changelog table layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Layout containers should include a `vh` fallback declared before the `dvh` rule 
 
 ## Changelog
 
-The game includes an in-app change log that lists the 20 most recently updated judoka. The page loads data from `judoka.json` and is populated by `changeLogPage.js`. Open the **Settings** screen and choose **View Change Log** to visit `src/pages/changeLog.html`.
+The game includes an in-app change log that lists the 20 most recently updated judoka. The page loads data from `judoka.json` and is populated by `changeLogPage.js`. The log table now uses a responsive CSS grid with padded cells. Columns appear in the following order: **ID**, **Portrait**, **Name**, **Code**, and **Date**. Open the **Settings** screen and choose **View Change Log** to visit `src/pages/changeLog.html`.
 
 ## Future Plans
 

--- a/src/helpers/changeLogPage.js
+++ b/src/helpers/changeLogPage.js
@@ -32,10 +32,6 @@ function createRow(judoka) {
   idCell.textContent = String(judoka.id);
   row.appendChild(idCell);
 
-  const codeCell = document.createElement("td");
-  codeCell.textContent = judoka.cardCode || "";
-  row.appendChild(codeCell);
-
   const portraitCell = document.createElement("td");
   const img = document.createElement("img");
   img.width = 48;
@@ -48,13 +44,17 @@ function createRow(judoka) {
   portraitCell.appendChild(img);
   row.appendChild(portraitCell);
 
-  const dateCell = document.createElement("td");
-  dateCell.textContent = formatDate(judoka.lastUpdated);
-  row.appendChild(dateCell);
-
   const nameCell = document.createElement("td");
   nameCell.textContent = `${judoka.firstname} ${judoka.surname}`;
   row.appendChild(nameCell);
+
+  const codeCell = document.createElement("td");
+  codeCell.textContent = judoka.cardCode || "";
+  row.appendChild(codeCell);
+
+  const dateCell = document.createElement("td");
+  dateCell.textContent = formatDate(judoka.lastUpdated);
+  row.appendChild(dateCell);
 
   return row;
 }

--- a/src/pages/changeLog.html
+++ b/src/pages/changeLog.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="../styles/base.css" />
     <link rel="stylesheet" href="../styles/layout.css" />
     <link rel="stylesheet" href="../styles/components.css" />
+    <link rel="stylesheet" href="../styles/changeLog.css" />
     <link rel="stylesheet" href="../styles/utilities.css" />
     <link rel="icon" type="image/png" href="../assets/images/favicon.ico" />
   </head>
@@ -47,10 +48,10 @@
           <thead>
             <tr>
               <th>ID</th>
-              <th>Code</th>
               <th>Portrait</th>
-              <th>Date</th>
               <th>Name</th>
+              <th>Code</th>
+              <th>Date</th>
             </tr>
           </thead>
           <tbody></tbody>

--- a/src/styles/changeLog.css
+++ b/src/styles/changeLog.css
@@ -1,0 +1,27 @@
+#changelog-table {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  width: 100%;
+  padding: var(--space-lg);
+  gap: var(--space-sm);
+  box-sizing: border-box;
+}
+
+#changelog-table thead,
+#changelog-table tbody,
+#changelog-table tr {
+  display: contents;
+}
+
+#changelog-table th,
+#changelog-table td {
+  padding: var(--space-xs) var(--space-sm);
+  text-align: left;
+  border-bottom: 1px solid var(--color-secondary);
+}
+
+#changelog-table img {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- tweak the Change Log page table to use ID/Portrait/Name/Code/Date order
- add new `changeLog.css` for grid-style table with padding
- document the grid-based Change Log layout in README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6880efa094c8832683fcc0879e0c892f