### PR TITLE
Fix mockup viewer nav alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
     `mockupViewer.html`, a simple carousel for browsing the image files
     under `design/mockups/`. It displays the filename overlay, centers
     each image, and scales it to fit the viewport. The page now
-    centers all of its content for a consistent layout.
+    centers all of its content for a consistent layout. The Prev and
+    Next buttons are anchored to the left and right edges so they never
+    cover the content.
   - `data/`
   - `schemas/`
     JSON Schema definitions used to validate the data files.

--- a/src/styles/mockupViewer.css
+++ b/src/styles/mockupViewer.css
@@ -58,6 +58,10 @@ body {
   user-select: none;
 }
 
+.prev {
+  left: 0;
+}
+
 .next {
   right: 0;
   border-radius: 3px 0 0 3px;


### PR DESCRIPTION
## Summary
- adjust mockup viewer buttons to stick to the edges
- document nav button position in README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6881113d55608326af850ea8f3d284b5