### PR TITLE
Fix carousel width variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,8 @@ Safari 18.5 positions `.signature-move-container` text at the bottom edge unless
 Safari 18.5 sometimes shrinks judoka cards, causing text overlap. The width rule now uses `clamp(200px, 60vw, 260px)` so cards occupy about 60% of the viewport on mobile. This applies to both the random card view and the browse carousel.
 Safari 18.5 may keep a stat button highlighted between rounds. The rule `#stat-buttons button { -webkit-tap-highlight-color: transparent; }` works with the reset logic to force a reflow and blur the element so the red overlay disappears.
 
+- The carousel sets the `--card-width` CSS variable via JavaScript so each card maintains consistent sizing across browsers and devices.
+
 Chrome may show a small gap below the stats panel when the combined height of
 card sections is less than 100%. Ensure `.card-top-bar`, `.card-portrait`,
 `.card-stats`, and `.signature-move-container` together fill the card height to

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -200,8 +200,7 @@ export async function buildCardCarousel(judokaList, gokyoData) {
     else cardsInView = 5;
     const cardWidth = `clamp(200px, ${Math.floor(100 / cardsInView)}vw, 260px)`;
     container.querySelectorAll(".judoka-card").forEach((card) => {
-      card.style.minWidth = cardWidth;
-      card.style.maxWidth = "260px";
+      card.style.setProperty("--card-width", cardWidth);
       card.style.scrollSnapAlign = "center";
     });
   }


### PR DESCRIPTION
## Summary
- compute card width once in carousel JS and set `--card-width` on every card
- note in README that JS sets the card width variable for consistent sizing

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot and signatureMove visual diffs)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68812525698c8326a0986d640bc75fb6