### PR TITLE
Add hover/focus styles for settings toggle button

### DIFF
--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -158,6 +158,15 @@
   cursor: pointer;
 }
 
+.settings-section-toggle:hover {
+  background: var(--button-hover-bg);
+}
+
+.settings-section-toggle:focus-visible {
+  outline: 2px solid var(--button-hover-bg);
+  outline-offset: 2px;
+}
+
 .settings-section-content {
   padding-block-start: var(--space-sm);
   transition: height var(--transition-fast);


### PR DESCRIPTION
## Summary
- update settings.css with :hover and :focus-visible for `.settings-section-toggle`
- keep other states unchanged

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68820709e73483269891d3df2f1112b7