### PR TITLE
Update style radii to use tokens

### DIFF
--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -33,6 +33,7 @@ button:active {
   width: 100%;
   min-width: var(--touch-target-size, 44px);
   min-height: var(--touch-target-size, 44px);
+  border-radius: var(--radius-pill);
 }
 
 #stat-buttons button.selected {

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -254,7 +254,7 @@ svg {
   height: auto;
   aspect-ratio: 3/2;
   max-width: 60px;
-  border-radius: min(4px, 1vw);
+  border-radius: min(var(--radius-sm), 1vw);
   border: 1px solid var(--color-tertiary);
 }
 .card-portrait {
@@ -466,7 +466,7 @@ svg {
 
 .card-carousel::-webkit-scrollbar-thumb {
   background-color: var(--color-surface);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .card-carousel::-webkit-scrollbar-track {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -121,7 +121,7 @@ body {
 .homeHelperContainer img {
   max-width: 50vw;
   height: auto;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
 }
 .card-preview {
   margin-top: var(--space-md);

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -29,7 +29,7 @@
 
 .filter-bar button {
   padding: 0.3rem 0.3rem;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: var(--button-bg);
   color: var(--button-text-color);
   border: none;
@@ -187,7 +187,7 @@
 
 .flag-button.selected {
   border: 2px solid var(--color-primary);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
 }
 
 .clear-filter-button {
@@ -196,7 +196,7 @@
   background: var(--button-bg);
   color: var(--button-text-color);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   display: block;
 }
 
@@ -206,7 +206,7 @@
   background: var(--button-bg);
   color: var(--button-text-color);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- use `var(--radius-md)` tokens for navbar buttons
- apply tokenized radii in layout helpers and card UI
- give `#stat-buttons` buttons a pill radius

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688222226ca08326b0c6e733a64faf78