### PR TITLE
Update navigation and button design docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,9 @@ Layout containers should include a `vh` fallback declared before the `dvh` rule 
 ## Changelog
 
 The game includes an in-app change log that lists the 20 most recently updated judoka. The page loads data from `judoka.json` and is populated by `changeLogPage.js`. Open the **Settings** screen and use the **Links** section to visit `src/pages/changeLog.html`, the PRD reader, or the design mockup viewer. The log table now uses a responsive CSS grid with padded cells. Columns appear in the following order: **ID**, **Portrait**, **Name**, **Code**, and **Date**. Open the **Settings** screen and choose **View Change Log** to visit `src/pages/changeLog.html`.
+- Documented navigation highlight for the current page using secondary blue and `aria-current="page"`.
+- Clarified button radius: use `--radius-md` or `--radius-pill`; avoid hardcoded values.
+
 
 ## Future Plans
 

--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -218,6 +218,7 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 - Icon + label pairs
 - Inline icons use Material Symbols SVGs with `viewBox="0 -960 960 960"`.
 - Clear active/focus state
+- The current page link uses a secondary blue background and `aria-current="page"`
 - Do not truncate labels
 
 ### 8.3 Judoka Cards
@@ -305,6 +306,7 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 - Primary style uses `var(--button-bg)`, `var(--button-hover-bg)`, `var(--button-active-bg)`, and `var(--button-text-color)`
 - `.secondary-button` variation with lighter background and border
 - Minimum height 44-48 px; keep `--radius-pill`
+- All buttons must use either `--radius-md` or `--radius-pill`; avoid hardcoded values like `4px`
 - Hover/active states scale slightly and use drop shadows
 - Ripple feedback via `setupButtonEffects()`
 - `:focus-visible` outline or underline for keyboard users


### PR DESCRIPTION
## Summary
- clarify active link styling and aria-current attribute in UI design guide
- require radius tokens for button styles
- document these updates in README changelog

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(1 failing screenshot test)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68822890349c8326bf4cc7158599a2db