### PR TITLE
Add timer auto-select feedback

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -169,9 +169,9 @@ Implementation for score, message, and countdown/stat selection timer updates is
 
 - [x] 2.0 Implement Round Info Messages
   - [x] 2.1 Display win/loss messages for 2 seconds
-  - [x] 2.2 Start countdown timer after message disappears
-  - [ ] 2.3 Display selection prompt when input is needed
-  - [ ] 2.4 Display stat selection timer and auto-select if expired (see Classic Battle PRD)
+- [x] 2.2 Start countdown timer after message disappears
+  - [x] 2.3 Display selection prompt when input is needed
+  - [x] 2.4 Display stat selection timer and auto-select if expired (see Classic Battle PRD)
 
 - [ ] 3.0 Handle Responsive Layout
   - [ ] 3.1 Detect screen width <375px and switch to stacked layout

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -162,8 +162,8 @@ _Resolved in [Future Considerations](#future-considerations):_ AI difficulty wil
 ## Tasks
 
 - [x] 1.0 Implement Classic Battle Match Flow
-  - [x] 1.1 Create round loop: random card draw, stat selection, comparison
-  - [ ] 1.2 Implement 30-second stat selection timer with auto-selection fallback (displayed in Info Bar)
+- [x] 1.1 Create round loop: random card draw, stat selection, comparison
+  - [x] 1.2 Implement 30-second stat selection timer with auto-selection fallback (displayed in Info Bar)
   - [x] 1.3 Handle scoring updates on win, loss, and tie
   - [ ] 1.4 End match after 10 points or 25 rounds
 - [ ] 2.0 Add Early Quit Functionality

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -102,6 +102,7 @@ function startTimer() {
     },
     () => {
       const randomStat = STATS[Math.floor(Math.random() * STATS.length)];
+      infoBar.showMessage(`Time's up! Auto-selecting ${randomStat}`);
       handleStatSelection(randomStat);
     }
   );

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -54,7 +54,9 @@ describe("classicBattle match flow", () => {
     timerSpy.advanceTimersByTime(800);
     await vi.runAllTimersAsync();
     const score = document.querySelector("header #score-display").textContent;
+    const msg = document.querySelector("header #round-message").textContent;
     expect(score).not.toBe("You: 0\nComputer: 0");
+    expect(msg).toMatch(/Auto-selecting/i);
   });
 
   it("quits match after confirmation", async () => {


### PR DESCRIPTION
## Summary
- display auto-select message when the 30s timer expires
- verify auto-select message in match flow test
- mark timer tasks complete in Classic Battle and Info Bar PRDs

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68824bdfb8d883269f5100374f0e2362