### PR TITLE
Enhance battle info bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ The repository specifies commenting standards in design/codeStandards. JSDoc com
 - Layout keeps the Random Judoka draw button within the viewport even with the fixed footer navigation
 - Country picker panel appears below the fixed header for unobstructed viewing
 - Scroll buttons disable when the carousel reaches either end
-- Header bar displays real-time round results, countdown timer and score
+- The battle **Info Bar** in the header shows round results, a countdown to the next round, and your current score
 - Mockup viewer page with next/back controls for design screenshots (includes a Home link)
 - Settings page includes a **Links** section with shortcuts to the Change Log, PRD reader, and Mockup viewer
 - Contextual tooltips explain stats and buttons on hover or focus

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -21,6 +21,9 @@
 .battle-header #next-round-timer,
 .battle-header #score-display {
   margin: 0;
+  font-size: clamp(20px, 4vw, 32px);
+  font-weight: bold;
+  color: var(--color-secondary);
 }
 
 @media (max-width: 374px) {


### PR DESCRIPTION
## Summary
- restyle round info, timer and score text with a consistent font clamp
- document the Info Bar in the Features list

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68824ead55e48326a0c64d85a34ef2cc