### PR TITLE
Move feature docs from README into PRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,26 +260,7 @@ The repository specifies commenting standards in design/codeStandards. JSDoc com
 
 ## Features
 
-- 99-card deck featuring elite judoka (slowly building up to this)
-- One-on-one stat battles
-- Designed for kids and judo fans alike
-- Playable directly in the browser
-- Loading indicator for better user experience
-- Modularized JavaScript for better maintainability
-- Slide-in country picker, opened via a panel icon with an arrow, for filtering judoka by flag with accessible
-  `aria-label` descriptions
-- Draw button on the Random Judoka screen provides its accessible name via
-  `aria-label="Draw a random judoka card"` so screen readers announce the same
-  label even if the visible text changes. The Playwright suite verifies that
-  this aria-label stays "Draw a random judoka card" regardless of the button's
-  visible text.
-- Layout keeps the Random Judoka draw button within the viewport even with the fixed footer navigation
-- Country picker panel appears below the fixed header for unobstructed viewing
-- Scroll buttons disable when the carousel reaches either end
-- Header bar displays real-time round results, countdown timer and score
-- Mockup viewer page with next/back controls for design screenshots (includes a Home link)
-- Settings page includes a **Links** section with shortcuts to the Change Log, PRD reader, and Mockup viewer
-- Contextual tooltips explain stats and buttons on hover or focus
+JU-DO-KON! offers a 99-card deck and one-on-one stat battles in a fully browser-based format. The UI supports accessible components, modular JavaScript helpers, and a country picker for filtering cards. See the Product Requirements Documents in `design/productRequirementsDocuments` for details.
 
 ## About JU-DO-KON!
 
@@ -295,31 +276,7 @@ This project is built with HTML, CSS, and JavaScript, and hosted on GitHub Pages
 
 ## 🎮 How to Play JUDOKON!
 
-**JUDOKON!** is a fast-paced, Top Trumps-style card game featuring real-life elite judoka. You play against the computer in a battle of stats — first to 10 wins takes the match!
-
-### 🥋 The Rules:
-
-1. **You vs. Computer**
-   - Each match starts with both players receiving **25 random cards** from a 99-card deck.
-
-2. **Start the Battle**
-   - In each round, you and the computer each draw your top card.
-
-3. **Choose Your Stat**
-   - You select one of the stats on your card (e.g. Power, Speed, Technique, etc.)
-
-4. **Compare Stats**
-   - The chosen stat is compared with the computer’s card.
-   - **Highest value wins the round**.
-   - If both stats are equal, it’s a **draw** — no one scores.
-
-5. **Scoring**
-   - Each round win gives you **1 point**.
-   - The cards used in that round are **discarded** (not reused).
-
-6. **Winning the Match**
-   - First player to reach **10 points** wins!
-   - If **neither player reaches 10 points after 25 rounds**, the match ends in a **draw**.
+See [prdClassicBattle.md](design/productRequirementsDocuments/prdClassicBattle.md) for a step‑by‑step overview of match flow and scoring.
 
 ## Live Demo
 
@@ -345,14 +302,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 
 ## Display Modes
 
-JU-DO-KON! supports **light**, **dark**, and **gray** themes. The
-`applyDisplayMode` helper sets a `data-theme` attribute on the `<body>` element
-so CSS in `src/styles/base.css` can override variables for each mode. Define a
-new theme by adding a `[data-theme="my-theme"]` block with your custom
-variables and call `applyDisplayMode("my-theme")` to activate it.
-
-If you modify theme colors, run `npm run check:contrast` while the development
-server is running to verify adequate color contrast.
+Light, dark and gray themes are supported. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode selector applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running.
 
 ## Browser Compatibility
 
@@ -403,9 +353,7 @@ Layout containers should include a `vh` fallback declared before the `dvh` rule 
 
 ## Changelog
 
-The game includes an in-app change log that lists the 20 most recently updated judoka. The page loads data from `judoka.json` and is populated by `changeLogPage.js`. Open the **Settings** screen and use the **Links** section to visit `src/pages/changeLog.html`, the PRD reader, or the design mockup viewer. The log table now uses a responsive CSS grid with padded cells. Columns appear in the following order: **ID**, **Portrait**, **Name**, **Code**, and **Date**. Open the **Settings** screen and choose **View Change Log** to visit `src/pages/changeLog.html`.
-- Documented navigation highlight for the current page using secondary blue and `aria-current="page"`.
-- Clarified button radius: use `--radius-md` or `--radius-pill`; avoid hardcoded values.
+See [prdChangeLog.md](design/productRequirementsDocuments/prdChangeLog.md) for requirements around the in-app change log that lists the twenty most recently updated judoka.
 
 
 ## Future Plans

--- a/design/productRequirementsDocuments/prdCardCarousel.md
+++ b/design/productRequirementsDocuments/prdCardCarousel.md
@@ -62,6 +62,7 @@ Failure to provide an efficient browsing experience may impact core gameplay —
 
 - Carousel loads within 1 second for up to 150 cards.
 - User can scroll left/right via on-screen buttons.
+- Scroll buttons disable when the carousel reaches either end so players cannot scroll past the available cards.
 - User can see an indicator (scroll markers) showing current position.
 - Hovering over a card enlarges it by 10%, verified via bounding box.
 - Carousel is responsive, adapting to both portrait and landscape orientations.

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -50,6 +50,17 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 ---
 
+## Gameplay Basics
+
+- The standard deck contains **99 unique cards**.
+- Each match begins with both sides receiving **25 random cards**.
+- At the start of each round, both players draw their top card.
+- The player selects one stat (Power, Speed, Technique, etc.).
+- The higher value wins the round and scores **1 point**; used cards are discarded.
+- The match ends when a player reaches **10 points** or after **25 rounds** (draw).
+
+---
+
 ## Technical Considerations
 
 - Classic Battle logic must reuse shared random card draw module (`generateRandomCard`).

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -111,6 +111,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - AC-4.2 Selected mode persists through a page refresh within the same session.
 - AC-4.3 Current display mode is correctly pulled from `settings.json` on page load.
 - AC-4.4 Transition to new display mode completes without visible flickering or rendering artifacts.
+- Implementation uses the `applyDisplayMode` helper which sets a `data-theme` attribute on `<body>` so `base.css` variables can switch values per theme.
 
 ### Game Modes Toggles
 
@@ -175,6 +176,7 @@ This pattern keeps the settings page organized and accessible, especially as mor
 - Player can open **Change Log** to view recent judoka updates.
 - Player can open **PRD Viewer** to read product requirement documents.
 - Player can open **Mockup Viewer** to browse design mockups.
+- The mockup viewer provides Next/Back controls for cycling through images and includes a Home link back to the main menu.
 
 ---
 


### PR DESCRIPTION
## Summary
- shorten README feature list and link to PRDs
- point to PRDs for gameplay rules, display modes and changelog
- document scroll button disable behaviour in `prdCardCarousel`
- add gameplay basics to `prdClassicBattle`
- expand display mode and mockup viewer details in `prdSettingsMenu`

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden for vitest)*
- `npx playwright test` *(fails: 403 Forbidden for playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6882511a87a883268837322ed981e31d