### PR TITLE
Fix classic battle auto-select test

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ exist (e.g., `await page.getByTestId("draw-button").waitFor()`). Otherwise
 the evaluation may run before the DOM is ready and throw a `Cannot read
 properties of null` error.
 
+### Unit Test Helpers
+
+Some helpers such as `classicBattle.js` keep match state between rounds. The
+`_resetForTest()` function resets this internal state. Invoke it at the start of
+any unit test that depends on the initial score or timer conditions.
+
 ### Troubleshooting Playwright Tests
 
 A `Test timeout ... waiting for locator('#general-settings-toggle')` error usually means the Settings page failed to load or the server was unreachable. Verify that:

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -48,15 +48,15 @@ describe("classicBattle match flow", () => {
   });
 
   it("auto-selects a stat when timer expires", async () => {
-    const { startRound } = await import("../../../src/helpers/classicBattle.js");
+    const { startRound, _resetForTest } = await import("../../../src/helpers/classicBattle.js");
+    _resetForTest();
     await startRound();
     timerSpy.advanceTimersByTime(31000);
-    timerSpy.advanceTimersByTime(800);
     await vi.runAllTimersAsync();
     const score = document.querySelector("header #score-display").textContent;
     const msg = document.querySelector("header #round-message").textContent;
-    expect(score).not.toBe("You: 0\nComputer: 0");
-    expect(msg).toMatch(/Auto-selecting/i);
+    expect(score).toBe("You: 1\nComputer: 0");
+    expect(msg).toMatch(/win the round/i);
   });
 
   it("quits match after confirmation", async () => {


### PR DESCRIPTION
## Summary
- reset battle state before testing auto-select logic
- expect round win message after auto-select
- document `_resetForTest` in README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688266823e9c832699da745fb78730ca