### PR TITLE
Fix score variable in auto-select test

### DIFF
--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -53,6 +53,7 @@ describe("classicBattle match flow", () => {
     await startRound();
     timerSpy.advanceTimersByTime(31000);
     await vi.runAllTimersAsync();
+    const score = document.querySelector("header #score-display").textContent;
     const msg = document.querySelector("header #round-message").textContent;
     expect(score).toBe("You: 1\nComputer: 0");
     expect(msg).toMatch(/win the round/i);


### PR DESCRIPTION
## Summary
- fix undefined `score` variable in `matchFlow` test

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden to download package)*
- `npx playwright test` *(fails: 403 Forbidden to download package)*

------
https://chatgpt.com/codex/tasks/task_e_6882738e33408326a4cddb63c8690d83