### PR TITLE
Fix flaky classicBattle auto-select test

### DIFF
--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -48,6 +48,7 @@ describe("classicBattle match flow", () => {
   });
 
   it("auto-selects a stat when timer expires", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
     const { startRound, _resetForTest } = await import("../../../src/helpers/classicBattle.js");
     _resetForTest();
     await startRound();


### PR DESCRIPTION
## Summary
- mock `Math.random` in the `auto-selects a stat` test to consistently choose the Power stat

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run tests/helpers/classicBattle/matchFlow.test.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688296a5d31483268e83d54776218069