### PR TITLE
Add feature flag controls

### DIFF
--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -83,3 +83,29 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
     });
   });
 }
+
+export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, handleUpdate) {
+  if (!container || !flags) return;
+  Object.keys(flags).forEach((flag) => {
+    const kebab = flag.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+    const label = flag.replace(/([A-Z])/g, " $1").replace(/^./, (c) => c.toUpperCase());
+    const wrapper = createToggleSwitch(label, {
+      id: `feature-${kebab}`,
+      name: flag,
+      checked: Boolean(getCurrentSettings().featureFlags[flag]),
+      ariaLabel: label
+    });
+    container.appendChild(wrapper);
+    const input = wrapper.querySelector("input");
+    input.addEventListener("change", () => {
+      const prev = !input.checked;
+      const updated = {
+        ...getCurrentSettings().featureFlags,
+        [flag]: input.checked
+      };
+      handleUpdate("featureFlags", updated, () => {
+        input.checked = prev;
+      });
+    });
+  });
+}

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -17,6 +17,7 @@ import {
   applyInitialControlValues,
   attachToggleListeners,
   renderGameModeSwitches,
+  renderFeatureFlagSwitches,
   setupSectionToggles
 } from "./settings/index.js";
 
@@ -42,6 +43,7 @@ function initializeControls(settings, gameModes) {
     displaySelect: document.getElementById("display-mode-select")
   };
   const modesContainer = document.getElementById("game-mode-toggle-container");
+  const flagsContainer = document.getElementById("feature-flags-container");
   const errorPopup = document.getElementById("settings-error-popup");
 
   const getCurrentSettings = () => currentSettings;
@@ -72,6 +74,12 @@ function initializeControls(settings, gameModes) {
   applyInitialControlValues(controls, currentSettings);
   attachToggleListeners(controls, getCurrentSettings, handleUpdate);
   renderGameModeSwitches(modesContainer, gameModes, getCurrentSettings, handleUpdate);
+  renderFeatureFlagSwitches(
+    flagsContainer,
+    currentSettings.featureFlags,
+    getCurrentSettings,
+    handleUpdate
+  );
 }
 
 async function initializeSettingsPage() {

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -31,7 +31,8 @@ const DEFAULT_SETTINGS = {
   fullNavMap: true,
   motionEffects: true,
   displayMode: "light",
-  gameModes: {}
+  gameModes: {},
+  featureFlags: {}
 };
 export { DEFAULT_SETTINGS };
 
@@ -144,4 +145,5 @@ export async function updateSetting(key, value) {
  * @property {boolean} motionEffects
  * @property {"light"|"dark"|"gray"} displayMode
  * @property {Record<string, boolean>} [gameModes]
+ * @property {Record<string, boolean>} [featureFlags]
  */

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -166,6 +166,9 @@
               </fieldset>
             </div>
           </div>
+          <fieldset id="feature-flags-container" class="settings-form">
+            <legend>Feature Flags</legend>
+          </fieldset>
           <fieldset id="links-container" class="settings-form">
             <legend>Links</legend>
             <div class="settings-item">

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -24,6 +24,11 @@
       "type": "object",
       "description": "Per-mode enable/disable flags.",
       "additionalProperties": { "type": "boolean" }
+    },
+    "featureFlags": {
+      "type": "object",
+      "description": "Experimental feature toggles.",
+      "additionalProperties": { "type": "boolean" }
     }
   },
   "required": ["sound", "fullNavMap", "motionEffects", "displayMode"],

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -141,7 +141,8 @@ describe("populateNavbar", () => {
       fullNavMap: true,
       motionEffects: true,
       displayMode: "light",
-      gameModes: { B: false }
+      gameModes: { B: false },
+      featureFlags: {}
     });
     const loadGameModes = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -188,7 +189,8 @@ describe("populateNavbar", () => {
       fullNavMap: true,
       motionEffects: true,
       displayMode: "light",
-      gameModes: {}
+      gameModes: {},
+      featureFlags: {}
     });
     const loadGameModes = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -230,7 +232,8 @@ describe("populateNavbar", () => {
       fullNavMap: true,
       motionEffects: true,
       displayMode: "light",
-      gameModes: {}
+      gameModes: {},
+      featureFlags: {}
     });
     const loadGameModes = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -10,7 +10,8 @@ const baseSettings = {
   fullNavMap: true,
   motionEffects: true,
   displayMode: "light",
-  gameModes: {}
+  gameModes: {},
+  featureFlags: { randomStatMode: false }
 };
 
 describe("randomJudokaPage module", () => {

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -6,7 +6,8 @@ const baseSettings = {
   fullNavMap: true,
   motionEffects: true,
   displayMode: "light",
-  gameModes: {}
+  gameModes: {},
+  featureFlags: { randomStatMode: true }
 };
 
 describe("settingsPage module", () => {
@@ -134,5 +135,29 @@ describe("settingsPage module", () => {
     input.dispatchEvent(new Event("change"));
 
     expect(updateGameModeHidden).toHaveBeenCalledWith("classic", true);
+  });
+
+  it("renders feature flag switches", async () => {
+    vi.useFakeTimers();
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updateSetting = vi.fn().mockResolvedValue(baseSettings);
+    const loadGameModes = vi.fn().mockResolvedValue([]);
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadGameModes,
+      updateGameModeHidden: vi.fn()
+    }));
+
+    await import("../../src/helpers/settingsPage.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const container = document.getElementById("feature-flags-container");
+    const input = container.querySelector("#feature-random-stat-mode");
+    expect(input).toBeTruthy();
+    expect(input.checked).toBe(true);
   });
 });

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -44,7 +44,8 @@ describe("settings utils", () => {
       fullNavMap: true,
       motionEffects: true,
       displayMode: "light",
-      gameModes: {}
+      gameModes: {},
+      featureFlags: {}
     });
   });
 
@@ -59,7 +60,8 @@ describe("settings utils", () => {
       fullNavMap: true,
       motionEffects: true,
       displayMode: "dark",
-      gameModes: {}
+      gameModes: {},
+      featureFlags: {}
     };
     const promise = saveSettings(data);
     await vi.advanceTimersByTimeAsync(110);
@@ -87,7 +89,8 @@ describe("settings utils", () => {
       fullNavMap: true,
       motionEffects: true,
       displayMode: "light",
-      gameModes: {}
+      gameModes: {},
+      featureFlags: {}
     });
     Storage.prototype.getItem = originalGetItem;
   });
@@ -128,7 +131,8 @@ describe("settings utils", () => {
         fullNavMap: true,
         motionEffects: true,
         displayMode: "light",
-        gameModes: {}
+        gameModes: {},
+        featureFlags: {}
       })
     ).rejects.toThrow("fail");
     Storage.prototype.setItem = originalSetItem;
@@ -160,14 +164,16 @@ describe("settings utils", () => {
       fullNavMap: false,
       motionEffects: true,
       displayMode: "light",
-      gameModes: {}
+      gameModes: {},
+      featureFlags: {}
     };
     const data2 = {
       sound: false,
       fullNavMap: true,
       motionEffects: false,
       displayMode: "dark",
-      gameModes: {}
+      gameModes: {},
+      featureFlags: {}
     };
     saveSettings(data1);
     saveSettings(data2);

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -56,12 +56,15 @@ export function createSettingsDom() {
   displayModeSelect.id = "display-mode-select";
   const gameModeToggleContainer = document.createElement("section");
   gameModeToggleContainer.id = "game-mode-toggle-container";
+  const featureFlagsContainer = document.createElement("section");
+  featureFlagsContainer.id = "feature-flags-container";
   fragment.append(
     soundToggle,
     navmapToggle,
     motionToggle,
     displayModeSelect,
-    gameModeToggleContainer
+    gameModeToggleContainer,
+    featureFlagsContainer
   );
   return fragment;
 }


### PR DESCRIPTION
## Summary
- support `featureFlags` in settings schema and utilities
- render feature flags on the Settings page
- add Feature Flags section to settings UI
- update tests for new feature flags

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diff for settings page)*

------
https://chatgpt.com/codex/tasks/task_e_6882a0a375388326bea829f66a295c4e