### PR TITLE
Fix mockup viewer layout

### DIFF
--- a/src/styles/mockupViewer.css
+++ b/src/styles/mockupViewer.css
@@ -122,4 +122,5 @@ body {
 
 .center-content {
   justify-items: center;
+  grid-template-columns: 1fr;
 }


### PR DESCRIPTION
## Summary
- center mockup grid and force single column

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6882a30f47a083269a7470607c7ce388