### PR TITLE
Update changelog grid layout

### DIFF
--- a/design/productRequirementsDocuments/prdChangeLog.md
+++ b/design/productRequirementsDocuments/prdChangeLog.md
@@ -62,6 +62,7 @@ Players and developers currently lack a simple, in-game method to see which Judo
 
 - Table rows appear instantly (no animation) to prioritize performance.
 - Portrait thumbnails are 48×48 px with rounded corners.
+- ID column width matches the 48 px portrait column because IDs never exceed three digits.
 - All cells have a minimum 44px touch target.
 - Responsive layout: two-column stacking below 600px width; portraits align left, text stacks right.
 - Row height: min 56px; all touchable areas ≥44px.

--- a/src/styles/changeLog.css
+++ b/src/styles/changeLog.css
@@ -1,6 +1,7 @@
 #changelog-table {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  /* IDs never exceed three digits; portraits are 48×48 px */
+  grid-template-columns: var(--touch-target-size) var(--touch-target-size) 1fr 1fr 1fr;
   width: 100%;
   padding: var(--space-lg);
   gap: var(--space-sm);


### PR DESCRIPTION
## Summary
- tweak change log grid layout using --touch-target-size
- explain ID column width in the PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: changeLog page screenshot diff)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6882a2fddb608326b2df8feeabf66db7