### PR TITLE
Add debug panel with state attributes

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -8,6 +8,8 @@ import {
   handleStatSelection as engineHandleStatSelection,
   quitMatch as engineQuitMatch,
   getScores,
+  getTimerState,
+  isMatchEnded,
   STATS,
   _resetForTest as engineReset
 } from "./battleEngine.js";
@@ -25,6 +27,17 @@ export function getStartRound() {
 let judokaData = null;
 let gokyoLookup = null;
 let computerJudoka = null;
+
+function updateDebugPanel() {
+  const pre = document.getElementById("debug-output");
+  if (!pre) return;
+  const state = {
+    ...getScores(),
+    timer: getTimerState(),
+    matchEnded: isMatchEnded()
+  };
+  pre.textContent = JSON.stringify(state, null, 2);
+}
 
 /**
  * Remove highlight and focus from all stat buttons.
@@ -182,6 +195,7 @@ export async function startRound() {
   const { playerScore, computerScore } = getScores();
   infoBar.updateScore(playerScore, computerScore);
   startTimer();
+  updateDebugPanel();
 }
 
 /**
@@ -209,6 +223,7 @@ export function evaluateRound(stat) {
     const { playerScore, computerScore } = getScores();
     infoBar.updateScore(playerScore, computerScore);
   }
+  updateDebugPanel();
   return result;
 }
 
@@ -238,6 +253,7 @@ export function scheduleNextRound(result) {
 
   btn.addEventListener("click", onClick, { once: true });
   enableNextRoundButton();
+  updateDebugPanel();
 }
 
 /**
@@ -256,6 +272,7 @@ export async function handleStatSelection(stat) {
   const result = evaluateRound(stat);
   resetStatButtons();
   scheduleNextRound(result);
+  updateDebugPanel();
 }
 
 /**
@@ -302,6 +319,7 @@ export function _resetForTest() {
     const { playerScore, computerScore } = getScores();
     infoBar.updateScore(playerScore, computerScore);
   }
+  updateDebugPanel();
 }
 
 export function getComputerJudoka() {

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -84,6 +84,17 @@
             <p id="round-result" aria-live="polite" aria-atomic="true"></p>
             <button id="next-round-button" disabled>Next Round</button>
             <button id="quit-match-button">Quit Match</button>
+            <button
+              id="debug-toggle"
+              class="debug-toggle"
+              aria-controls="debug-panel"
+              aria-expanded="false"
+            >
+              Toggle Debug
+            </button>
+            <div id="debug-panel" class="debug-panel hidden">
+              <pre id="debug-output" role="status" aria-live="polite"></pre>
+            </div>
           </div>
         </section>
       </main>

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -66,3 +66,13 @@
 #next-round-button:disabled {
   opacity: 0.5;
 }
+
+/* Collapsible debug panel */
+.debug-panel {
+  border: 1px dashed #999;
+  padding: 0.5rem;
+  margin-top: 1rem;
+  font-family: monospace;
+  font-size: 0.875rem;
+  overflow-x: auto;
+}


### PR DESCRIPTION
## Summary
- expose classic battle mode and random stat flag via `data-*`
- add collapsible debug panel to `battleJudoka.html`
- update battle page script to load settings and toggle debug panel
- display current scores and timer in new debug panel
- style `.debug-panel`

## Testing
- `npx prettier src/pages/battleJudoka.html src/helpers/classicBattlePage.js src/helpers/classicBattle.js src/styles/battle.css -w`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot tests)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_6882a57c4bb08326a3254a2b412ef798