### PR TITLE
Fix mockup viewer centering

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,10 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
     `src/helpers` (for example `randomJudokaPage.js`) that wires up its
     interactive behavior. The directory also contains
     `mockupViewer.html`, a simple carousel for browsing the image files
-    under `design/mockups/`. It displays the filename overlay, centers
-    each image, and scales it to fit the viewport. The page now
-    centers all of its content for a consistent layout. The Prev and
-    Next buttons are anchored to the left and right edges so they never
-    cover the content.
+    under `design/mockups/`. It displays the filename overlay and now
+    scales wide images to fit within the viewport while keeping every
+    mockup centered on screen. The Prev and Next buttons are anchored
+    to the left and right edges so they never cover the content.
   - `data/`
   - `schemas/`
     JSON Schema definitions used to validate the data files.

--- a/design/productRequirementsDocuments/prdMockupViewer.md
+++ b/design/productRequirementsDocuments/prdMockupViewer.md
@@ -76,10 +76,12 @@ Designers and developers previously relied on scattered folder structures to fin
 
 ## Wireframe Sketch (Suggested Additions)  
 
-**Layout Elements (Desktop View):**  
-- Image centered with filename below.  
-- Next and Previous buttons on either side of the image.  
-- Close button top-right corner.  
+**Layout Elements (Desktop View):**
+- Image centered with filename below.
+- Images must scale to fit the viewport so wide mockups remain fully
+  visible without horizontal scrolling.
+- Next and Previous buttons on either side of the image.
+- Close button top-right corner.
 
 **Layout Behavior:**  
 - On mobile: buttons stack vertically below image, filename wraps if needed.  

--- a/src/styles/mockupViewer.css
+++ b/src/styles/mockupViewer.css
@@ -15,9 +15,9 @@ body {
 }
 
 .slideshow-container {
-  max-width: 100vh;
+  max-width: 100vw;
+  width: 100%;
   position: relative;
-  /* margin: auto; */
   margin: 0 auto;
 }
 
@@ -25,6 +25,7 @@ body {
   display: block;
   margin: 0 auto;
   max-height: calc(100dvh - var(--header-height) - var(--footer-height));
+  max-width: 100%;
   width: auto;
   object-fit: contain;
   height: auto;


### PR DESCRIPTION
## Summary
- ensure mockup images always fit within the viewport
- document scaling behaviour in the Mockup Viewer PRD
- clarify README notes about the viewer layout

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6882a9c35d148326ba4a7fc4a1381780