### PR TITLE
Add battleDebugPanel flag

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -3,5 +3,8 @@
   "fullNavMap": true,
   "motionEffects": true,
   "displayMode": "light",
-  "gameModes": {}
+  "gameModes": {},
+  "featureFlags": {
+    "battleDebugPanel": false
+  }
 }

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -14,7 +14,8 @@
  *       `handleStatSelection`.
  *    b. Set `window.startRoundOverride` to `startRoundWrapper` so the battle
  *       module uses it for subsequent rounds.
- *    c. Load feature flags and set `data-*` attributes on `#battle-area`.
+ *    c. Load feature flags, set `data-*` attributes on `#battle-area`, and
+ *       toggle the debug panel based on the `battleDebugPanel` flag.
  *    d. Invoke `startRoundWrapper` to begin the match.
  * 5. Execute `setupClassicBattlePage` with `onDomReady`.
  */
@@ -75,14 +76,13 @@ export async function setupClassicBattlePage() {
     battleArea.dataset.randomStat = String(Boolean(settings.featureFlags.randomStatMode));
   }
 
-  const debugToggle = document.getElementById("debug-toggle");
   const debugPanel = document.getElementById("debug-panel");
-  if (debugToggle && debugPanel) {
-    debugToggle.addEventListener("click", () => {
-      const expanded = debugToggle.getAttribute("aria-expanded") === "true";
-      debugToggle.setAttribute("aria-expanded", String(!expanded));
-      debugPanel.classList.toggle("hidden", expanded);
-    });
+  if (debugPanel) {
+    if (settings.featureFlags.battleDebugPanel) {
+      debugPanel.classList.remove("hidden");
+    } else {
+      debugPanel.remove();
+    }
   }
 
   window.startRoundOverride = startRoundWrapper;

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -32,7 +32,7 @@ const DEFAULT_SETTINGS = {
   motionEffects: true,
   displayMode: "light",
   gameModes: {},
-  featureFlags: {}
+  featureFlags: { battleDebugPanel: false }
 };
 export { DEFAULT_SETTINGS };
 

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -84,14 +84,6 @@
             <p id="round-result" aria-live="polite" aria-atomic="true"></p>
             <button id="next-round-button" disabled>Next Round</button>
             <button id="quit-match-button">Quit Match</button>
-            <button
-              id="debug-toggle"
-              class="debug-toggle"
-              aria-controls="debug-panel"
-              aria-expanded="false"
-            >
-              Toggle Debug
-            </button>
             <div id="debug-panel" class="debug-panel hidden">
               <pre id="debug-output" role="status" aria-live="polite"></pre>
             </div>

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -142,7 +142,7 @@ describe("populateNavbar", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: { B: false },
-      featureFlags: {}
+      featureFlags: { battleDebugPanel: false }
     });
     const loadGameModes = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -190,7 +190,7 @@ describe("populateNavbar", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: {}
+      featureFlags: { battleDebugPanel: false }
     });
     const loadGameModes = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -233,7 +233,7 @@ describe("populateNavbar", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: {}
+      featureFlags: { battleDebugPanel: false }
     });
     const loadGameModes = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -11,7 +11,7 @@ const baseSettings = {
   motionEffects: true,
   displayMode: "light",
   gameModes: {},
-  featureFlags: { randomStatMode: false }
+  featureFlags: { randomStatMode: false, battleDebugPanel: false }
 };
 
 describe("randomJudokaPage module", () => {

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -7,7 +7,7 @@ const baseSettings = {
   motionEffects: true,
   displayMode: "light",
   gameModes: {},
-  featureFlags: { randomStatMode: true }
+  featureFlags: { randomStatMode: true, battleDebugPanel: false }
 };
 
 describe("settingsPage module", () => {

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -45,7 +45,7 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: {}
+      featureFlags: { battleDebugPanel: false }
     });
   });
 
@@ -61,7 +61,7 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "dark",
       gameModes: {},
-      featureFlags: {}
+      featureFlags: { battleDebugPanel: false }
     };
     const promise = saveSettings(data);
     await vi.advanceTimersByTimeAsync(110);
@@ -90,7 +90,7 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: {}
+      featureFlags: { battleDebugPanel: false }
     });
     Storage.prototype.getItem = originalGetItem;
   });
@@ -132,7 +132,7 @@ describe("settings utils", () => {
         motionEffects: true,
         displayMode: "light",
         gameModes: {},
-        featureFlags: {}
+        featureFlags: { battleDebugPanel: false }
       })
     ).rejects.toThrow("fail");
     Storage.prototype.setItem = originalSetItem;
@@ -165,7 +165,7 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: {}
+      featureFlags: { battleDebugPanel: false }
     };
     const data2 = {
       sound: false,
@@ -173,7 +173,7 @@ describe("settings utils", () => {
       motionEffects: false,
       displayMode: "dark",
       gameModes: {},
-      featureFlags: {}
+      featureFlags: { battleDebugPanel: false }
     };
     saveSettings(data1);
     saveSettings(data2);


### PR DESCRIPTION
## Summary
- remove debug toggle from Battle Judoka page
- expose battleDebugPanel feature flag in settings defaults and JSON
- show or hide the debug panel based on the flag
- update unit tests to include battleDebugPanel flag

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(one screenshot failure)*

------
https://chatgpt.com/codex/tasks/task_e_6882ad9dfbb883268f44db523b034274