### PR TITLE
Update debug panel docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Light, dark and gray themes are supported. See [prdSettingsMenu.md](design/produ
 
 The Settings page (`src/pages/settings.html`) groups all player preferences, including experimental **feature flags**. Toggle a flag to enable an optional feature without modifying code. Flag values persist across pages and apply immediately. Implementation guidelines live in [settingsPageDesignGuidelines.md](design/codeStandards/settingsPageDesignGuidelines.md#feature-flags--agent-observability).
 
-Battle pages include a collapsible debug panel. Activate the "Toggle Debug" button to reveal real-time match state in a `<pre>` element. The button is keyboard accessible and the panel is hidden by default so normal gameplay remains unaffected.
+Battle pages include a collapsible debug panel. Enable the **Battle Debug Panel** feature flag in **Settings** to reveal real-time match state in a `<pre>` element. The panel is keyboard accessible and hidden by default so normal gameplay remains unaffected.
 
 ## Browser Compatibility
 

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -67,6 +67,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Card reveal and result animations should use hardware-accelerated CSS for smooth performance on low-end devices (**≥60 fps**).
 - **Stat selection timer (30s) must be displayed in the Info Bar; if timer expires, a random stat is auto-selected. Timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see prdBattleInfoBar.md).**
 - Backend must send real-time stat updates via WebSocket or polling for smooth live updates (**<200 ms latency**).
+- The debug panel is available when the `battleDebugPanel` feature flag is enabled.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace Toggle Debug button reference in README
- clarify debug panel feature flag in Classic Battle PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot /src/pages/settings.html)*

------
https://chatgpt.com/codex/tasks/task_e_6882b02b21d08326a8b5e6fa04ae72b2