### PR TITLE
Add battleDebugPanel flag tests

### DIFF
--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -156,8 +156,44 @@ describe("settingsPage module", () => {
     await vi.runAllTimersAsync();
 
     const container = document.getElementById("feature-flags-container");
-    const input = container.querySelector("#feature-random-stat-mode");
-    expect(input).toBeTruthy();
-    expect(input.checked).toBe(true);
+    const randomInput = container.querySelector("#feature-random-stat-mode");
+    const debugInput = container.querySelector("#feature-battle-debug-panel");
+    expect(randomInput).toBeTruthy();
+    expect(debugInput).toBeTruthy();
+    expect(randomInput.checked).toBe(true);
+    expect(debugInput.checked).toBe(false);
+  });
+
+  it("updates feature flag when toggled", async () => {
+    vi.useFakeTimers();
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updatedSettings = {
+      ...baseSettings,
+      featureFlags: { ...baseSettings.featureFlags, battleDebugPanel: true }
+    };
+    const updateSetting = vi.fn().mockResolvedValue(updatedSettings);
+    const loadGameModes = vi.fn().mockResolvedValue([]);
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadGameModes,
+      updateGameModeHidden: vi.fn()
+    }));
+
+    await import("../../src/helpers/settingsPage.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const container = document.getElementById("feature-flags-container");
+    const debugInput = container.querySelector("#feature-battle-debug-panel");
+    debugInput.checked = true;
+    debugInput.dispatchEvent(new Event("change"));
+
+    expect(updateSetting).toHaveBeenCalledWith("featureFlags", {
+      randomStatMode: true,
+      battleDebugPanel: true
+    });
   });
 });


### PR DESCRIPTION
## Summary
- verify feature flag switch rendering includes `battleDebugPanel`
- ensure updating the debug panel flag triggers a save

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch in `settings.html`)*

------
https://chatgpt.com/codex/tasks/task_e_6882b031c5a08326ad585df97ead0571