### PR TITLE
Make logo scale per header

### DIFF
--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -203,6 +203,7 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 
 - Fixed, screen reader accessible
 - Logo left, menu right
+- Logo scales with header height so larger screens display a bigger emblem
 
 #### Map Navigation (Game Mode Locations)
 
@@ -350,6 +351,7 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 | --transition-fast     | all 150ms ease             | UI animations                             |
 | --color-slider-dot    | #BBB                       | Carousel indicator default                |
 | --color-slider-active | #717171                    | Active/hover indicator                    |
+| --logo-max-height     | min(8dvh, 44px)            | Max height for logo images                |
 
 ---
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -44,6 +44,7 @@
   }
   /* Touch target and breakpoints */
   --touch-target-size: 48px;
+  --logo-max-height: min(8dvh, 44px);
   --breakpoint-lg: 1024px;
 
   /* Updated border radius */

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -6,6 +6,10 @@
   padding: 1vh 1.5rem;
 }
 
+.battle-header {
+  --logo-max-height: min(12dvh, 64px);
+}
+
 .battle-header .info-left {
   grid-column: 1;
   align-items: flex-start;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -95,7 +95,7 @@ body {
 
 .logo {
   height: 100%;
-  max-height: min(8dvh, 44px);
+  max-height: var(--logo-max-height);
   width: auto;
   border-radius: 10%;
   margin-top: 0;


### PR DESCRIPTION
## Summary
- add `--logo-max-height` CSS token and use it for `.logo`
- enlarge battle screen logo with custom token value
- clarify top bar guidelines with responsive logo note

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden)*
- `npx playwright test` *(fails: 403 Forbidden)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6883a19257d8832696cc14ee3eda9500