### PR TITLE
Rename character-slot placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ Global rules should not be repeated across files.
 
 All pages include a fixed header and persistent bottom navigation bar. The body
 has top and bottom padding to ensure content scrolls under these elements.
+Each header uses two `.header-spacer` elements flanking the logo so it stays
+centered in the layout grid.
 
 The `.animate-card` class in `buttons.css` (imported via `components.css`)
 reveals new cards with a short fade and upward slide. A

--- a/index.html
+++ b/index.html
@@ -30,11 +30,11 @@
   <body>
     <div class="home-screen">
       <header class="header">
-        <div class="character-slot left"></div>
+        <div class="header-spacer left"></div>
         <div class="logo-container">
           <img src="./src/assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </div>
-        <div class="character-slot right"></div>
+        <div class="header-spacer right"></div>
       </header>
 
       <main class="game-mode-grid">

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -30,13 +30,13 @@
   <body>
     <div class="kodokan-screen">
       <header class="header">
-        <div class="character-slot left"></div>
+        <div class="header-spacer left"></div>
         <div class="logo-container">
           <a href="../../index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
-        <div class="character-slot right"></div>
+        <div class="header-spacer right"></div>
       </header>
 
       <main class="kodokan-grid" role="main">

--- a/src/pages/changeLog.html
+++ b/src/pages/changeLog.html
@@ -30,13 +30,13 @@
   <body>
     <div class="home-screen">
       <header class="header">
-        <div class="character-slot left"></div>
+        <div class="header-spacer left"></div>
         <div class="logo-container">
           <a href="../../index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
-        <div class="character-slot right"></div>
+        <div class="header-spacer right"></div>
       </header>
 
       <main class="container" role="main">

--- a/src/pages/createJudoka.html
+++ b/src/pages/createJudoka.html
@@ -28,13 +28,13 @@
 
   <body>
     <header class="header">
-      <div class="character-slot left"></div>
+      <div class="header-spacer left"></div>
       <div class="logo-container">
         <a href="../../index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>
-      <div class="character-slot right"></div>
+      <div class="header-spacer right"></div>
     </header>
 
     <main class="container" role="main">

--- a/src/pages/meditation.html
+++ b/src/pages/meditation.html
@@ -18,13 +18,13 @@
   <body>
     <div class="home-screen">
       <header class="header">
-        <div class="character-slot left"></div>
+        <div class="header-spacer left"></div>
         <div class="logo-container">
           <a href="../../index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
-        <div class="character-slot right"></div>
+        <div class="header-spacer right"></div>
       </header>
 
       <main class="container meditation-screen" role="main">

--- a/src/pages/mockupViewer.html
+++ b/src/pages/mockupViewer.html
@@ -23,13 +23,13 @@
   <body>
     <div class="home-screen">
       <header class="header">
-        <div class="character-slot left"></div>
+        <div class="header-spacer left"></div>
         <div class="logo-container">
           <a href="../../index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
-        <div class="character-slot right"></div>
+        <div class="header-spacer right"></div>
       </header>
       <main class="kodokan-grid center-content" role="main">
         <div class="slideshow-container">

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -29,13 +29,13 @@
   <body>
     <div class="home-screen">
       <header class="header">
-        <div class="character-slot left"></div>
+        <div class="header-spacer left"></div>
         <div class="logo-container">
           <a href="../../index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
-        <div class="character-slot right"></div>
+        <div class="header-spacer right"></div>
       </header>
 
       <div class="card-section">

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -29,13 +29,13 @@
   <body>
     <div class="home-screen">
       <header class="header">
-        <div class="character-slot left"></div>
+        <div class="header-spacer left"></div>
         <div class="logo-container">
           <a href="../../index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
-        <div class="character-slot right"></div>
+        <div class="header-spacer right"></div>
       </header>
 
       <main class="container" role="main">

--- a/src/pages/updateJudoka.html
+++ b/src/pages/updateJudoka.html
@@ -28,13 +28,13 @@
 
   <body>
     <header class="header">
-      <div class="character-slot left"></div>
+      <div class="header-spacer left"></div>
       <div class="logo-container">
         <a href="../../index.html" data-testid="home-link">
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>
-      <div class="character-slot right"></div>
+      <div class="header-spacer right"></div>
     </header>
 
     <main class="container" role="main">

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -80,7 +80,7 @@ body {
   min-height: var(--header-height);
 }
 
-.character-slot {
+.header-spacer {
   height: 20px;
   opacity: 0.5;
 }


### PR DESCRIPTION
## Summary
- rename `.character-slot` to `.header-spacer`
- update references across HTML
- document header spacer in README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6883a1f04e4c832687615ba3af120fda