### PR TITLE
Enhance tooltip support across UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,12 @@
       </header>
 
       <main class="game-mode-grid">
-        <a href="./src/pages/battleJudoka.html" class="card" aria-label="Start classic battle mode">
+        <a
+          href="./src/pages/battleJudoka.html"
+          class="card"
+          aria-label="Start classic battle mode"
+          data-tooltip-id="mode.classicBattle"
+        >
           <div class="tile-content">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -54,7 +59,12 @@
             <h2>Classic Battle</h2>
           </div>
         </a>
-        <a href="./src/pages/randomJudoka.html" class="card" aria-label="View a random judoka">
+        <a
+          href="./src/pages/randomJudoka.html"
+          class="card"
+          aria-label="View a random judoka"
+          data-tooltip-id="mode.randomJudoka"
+        >
           <div class="tile-content">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -70,7 +80,12 @@
             <h2>Random Judoka</h2>
           </div>
         </a>
-        <a href="./src/pages/meditation.html" class="card" aria-label="Open meditation screen">
+        <a
+          href="./src/pages/meditation.html"
+          class="card"
+          aria-label="Open meditation screen"
+          data-tooltip-id="mode.meditation"
+        >
           <div class="tile-content">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -86,7 +101,12 @@
             <h2>Meditation</h2>
           </div>
         </a>
-        <a href="./src/pages/browseJudoka.html" class="card" aria-label="Browse Judoka">
+        <a
+          href="./src/pages/browseJudoka.html"
+          class="card"
+          aria-label="Browse Judoka"
+          data-tooltip-id="mode.browseJudoka"
+        >
           <div class="tile-content">
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -5,6 +5,9 @@
   "stat.technique": "**Technique** measures mastery of judo throws and transitions.\nHigh values indicate sharp, precise execution.",
   "stat.balance": "**Balance** affects a judoka's stability when attacking or defending.\nHigher values reduce the chance of being thrown.",
 
+  "ui.countryFilter": "Toggle the country filter panel to pick flags and narrow the roster.",
+  "ui.clearFilter": "Clear the current country filter and show all judoka.",
+
   "ui.selectStat": "Choose a stat below.\nThe higher value wins the round!",
   "ui.cardOfTheDay": "**Card of the Day** shows a featured judoka.\nCheck back tomorrow for a new pick!",
   "ui.winMessage": "**Victory!**\nYou chose the stronger stat.",
@@ -13,5 +16,7 @@
 
   "mode.classicBattle": "**Classic Battle Mode** pits you against the CPU.\nFirst to 10 round wins is the champion.",
   "mode.teamBattle": "**Team Battle Mode** uses your entire deck.\nWin more rounds than the opponent team to triumph!",
-  "mode.meditation": "**Meditation Mode** lets you reflect and compare cards.\nNo battles, just peaceful analysis."
+  "mode.meditation": "**Meditation Mode** lets you reflect and compare cards.\nNo battles, just peaceful analysis.",
+  "mode.randomJudoka": "**Random Judoka** picks a random card for quick inspiration.",
+  "mode.browseJudoka": "**Browse Judoka** opens the full roster in a carousel."
 }

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -59,10 +59,22 @@
               aria-label="Select a stat to battle"
               class="responsive-stat-buttons"
             >
-              <button data-stat="power" type="button" tabindex="0" aria-label="Select Power">
+              <button
+                data-stat="power"
+                type="button"
+                tabindex="0"
+                aria-label="Select Power"
+                data-tooltip-id="stat.power"
+              >
                 Power
               </button>
-              <button data-stat="speed" type="button" tabindex="0" aria-label="Select Speed">
+              <button
+                data-stat="speed"
+                type="button"
+                tabindex="0"
+                aria-label="Select Speed"
+                data-tooltip-id="stat.speed"
+              >
                 Speed
               </button>
               <button
@@ -70,13 +82,26 @@
                 type="button"
                 tabindex="0"
                 aria-label="Select Technique"
+                data-tooltip-id="stat.technique"
               >
                 Technique
               </button>
-              <button data-stat="kumikata" type="button" tabindex="0" aria-label="Select Kumi-kata">
+              <button
+                data-stat="kumikata"
+                type="button"
+                tabindex="0"
+                aria-label="Select Kumi-kata"
+                data-tooltip-id="stat.kumikata"
+              >
                 Kumi-kata
               </button>
-              <button data-stat="newaza" type="button" tabindex="0" aria-label="Select Ne-waza">
+              <button
+                data-stat="newaza"
+                type="button"
+                tabindex="0"
+                aria-label="Select Ne-waza"
+                data-tooltip-id="stat.newaza"
+              >
                 Ne-waza
               </button>
             </div>

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -47,7 +47,7 @@
             aria-controls="country-panel"
             aria-expanded="false"
             aria-label="Country Filter"
-            title="Country Filter"
+            data-tooltip-id="ui.countryFilter"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -75,7 +75,7 @@
           data-testid="clear-filter"
           class="clear-filter-button"
           aria-label="Clear filter"
-          title="Clear filter"
+          data-tooltip-id="ui.clearFilter"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- wire up tooltip ids for filtering controls in Browse Judoka
- add tooltip ids to stat buttons in battle mode
- connect home page mode buttons with tooltip data
- document new tooltip content for filters and modes

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot regression)*
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6883a86cf288832684895b2d28cfae1c