### PR TITLE
Initialize tooltips after pages render

### DIFF
--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -5,6 +5,7 @@ import { fetchJson } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
 import { createButton } from "../components/Button.js";
 import { onDomReady } from "./domReady.js";
+import { initTooltips } from "./tooltip.js";
 
 function handleKeyboardNavigation(event, container, buttonClass) {
   const buttons = Array.from(container.querySelectorAll(`button.${buttonClass}`));
@@ -103,7 +104,7 @@ export function setupCountryFilter(
  * 4. Attach event listeners for filtering and panel controls.
  * 5. Handle errors by showing a retry button when loading fails.
  */
-export function setupBrowseJudokaPage() {
+export async function setupBrowseJudokaPage() {
   const carouselContainer = document.getElementById("carousel-container");
   const countryListContainer = document.getElementById("country-list");
   const toggleBtn = document.getElementById("country-toggle");
@@ -209,7 +210,8 @@ export function setupBrowseJudokaPage() {
     );
   }
 
-  init();
+  await init();
+  initTooltips();
 }
 
 onDomReady(setupBrowseJudokaPage);

--- a/src/helpers/changeLogPage.js
+++ b/src/helpers/changeLogPage.js
@@ -2,6 +2,7 @@ import { fetchJson } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
 import { escapeHTML, formatDate } from "./utils.js";
 import { onDomReady } from "./domReady.js";
+import { initTooltips } from "./tooltip.js";
 
 /**
  * Sort judoka entries by lastUpdated descending, then by full name ascending.
@@ -79,6 +80,8 @@ export async function setupChangeLogPage() {
   } finally {
     if (loading) loading.remove();
   }
+
+  initTooltips();
 }
 
 onDomReady(setupChangeLogPage);

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -23,6 +23,7 @@ import { startRound as classicStartRound, handleStatSelection } from "./classicB
 import { onDomReady } from "./domReady.js";
 import { waitForComputerCard } from "./battleJudokaPage.js";
 import { loadSettings } from "./settingsUtils.js";
+import { initTooltips } from "./tooltip.js";
 
 function enableStatButtons(enable = true) {
   document.querySelectorAll("#stat-buttons button").forEach((btn) => {
@@ -87,6 +88,7 @@ export async function setupClassicBattlePage() {
 
   window.startRoundOverride = startRoundWrapper;
   startRoundWrapper();
+  initTooltips();
 }
 
 onDomReady(setupClassicBattlePage);

--- a/src/helpers/meditationPage.js
+++ b/src/helpers/meditationPage.js
@@ -10,10 +10,12 @@
  */
 import { setupLanguageToggle } from "./pseudoJapanese.js";
 import { onDomReady } from "./domReady.js";
+import { initTooltips } from "./tooltip.js";
 
 export function setupMeditationPage() {
   const quoteEl = document.getElementById("quote");
   setupLanguageToggle(quoteEl);
+  initTooltips();
 }
 
 onDomReady(setupMeditationPage);

--- a/src/helpers/mockupViewerPage.js
+++ b/src/helpers/mockupViewerPage.js
@@ -1,5 +1,6 @@
 import { setupButtonEffects } from "./buttonEffects.js";
 import { onDomReady } from "./domReady.js";
+import { initTooltips } from "./tooltip.js";
 
 /**
  * Initialize the mockup image carousel.
@@ -83,6 +84,7 @@ export function setupMockupViewerPage() {
 
   showImage(0);
   setupButtonEffects();
+  initTooltips();
 }
 
 onDomReady(setupMockupViewerPage);

--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -1,5 +1,6 @@
 import { onDomReady } from "./domReady.js";
 import { marked } from "../vendor/marked.esm.js";
+import { initTooltips } from "./tooltip.js";
 
 /**
  * Initialize the Product Requirements Document reader page.
@@ -102,6 +103,7 @@ export async function setupPrdReaderPage(docsMap, markedLib) {
   });
 
   render();
+  initTooltips();
 }
 
 if (!window.SKIP_PRD_AUTO_INIT) {

--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -22,6 +22,7 @@ import { createToggleSwitch } from "../components/ToggleSwitch.js";
 import { loadSettings, updateSetting } from "./settingsUtils.js";
 import { applyMotionPreference } from "./motionUtils.js";
 import { onDomReady } from "./domReady.js";
+import { initTooltips } from "./tooltip.js";
 
 const DRAW_ICON =
   '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#1f1f1f"><path d="m600-200-56-57 143-143H300q-75 0-127.5-52.5T120-580q0-75 52.5-127.5T300-760h20v80h-20q-42 0-71 29t-29 71q0 42 29 71t71 29h387L544-624l56-56 240 240-240 240Z"/></svg>';
@@ -164,6 +165,7 @@ export async function setupRandomJudokaPage() {
     drawButton.disabled = true;
     drawButton.setAttribute("aria-disabled", "true");
   }
+  initTooltips();
 }
 
 onDomReady(setupRandomJudokaPage);

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -12,6 +12,7 @@ import { showSettingsError } from "./showSettingsError.js";
 import { applyDisplayMode } from "./displayMode.js";
 import { applyMotionPreference } from "./motionUtils.js";
 import { onDomReady } from "./domReady.js";
+import { initTooltips } from "./tooltip.js";
 
 import {
   applyInitialControlValues,
@@ -90,6 +91,7 @@ async function initializeSettingsPage() {
     applyMotionPreference(settings.motionEffects);
     initializeControls(settings, gameModes);
     setupSectionToggles();
+    initTooltips();
   } catch (error) {
     console.error("Error loading settings page:", error);
     const errorPopup = document.getElementById("settings-error-popup");


### PR DESCRIPTION
## Summary
- initialize tooltips on page setup across modules

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6883ad00a870832682cd7fa09caca44a