### PR TITLE
Improve tooltip docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,18 @@ and instructions on updating schemas when data changes.
 ## Tooltip Helper
 
 Add lightweight help text anywhere by tagging elements with
-`data-tooltip-id`. The `initTooltips()` helper reads messages from
-`src/data/tooltips.json` and displays them on hover or focus.
+`data-tooltip-id`. Tooltip text lives in `src/data/tooltips.json`.
+Each page's initialization script must call `initTooltips()` once the DOM
+is ready so hover and focus listeners are attached.
+
+```html
+<button data-tooltip-id="draw-button">Draw</button>
+<script type="module">
+  import { onDomReady } from "../helpers/domReady.js";
+  import { initTooltips } from "../helpers/tooltip.js";
+  onDomReady(() => initTooltips());
+</script>
+```
 
 The repository specifies commenting standards in design/codeStandards. JSDoc comments and @pseudocode blocks must remain intact, as shown in documentation excerpts.
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -76,6 +76,16 @@ Structured gameplay data lives in `src/data`. Matching JSON Schemas in `src/sche
 `src/helpers/tooltip.js` displays contextual help when elements with
 `data-tooltip-id` gain hover or focus. The helper loads text from
 `src/data/tooltips.json` and positions a small popup near the target.
+Initialize it after the DOM is ready so tooltip listeners are attached.
+
+```html
+<span data-tooltip-id="draw-help">Draw a card</span>
+<script type="module">
+  import { onDomReady } from "../helpers/domReady.js";
+  import { initTooltips } from "../helpers/tooltip.js";
+  onDomReady(() => initTooltips());
+</script>
+```
 
 ## tests
 


### PR DESCRIPTION
## Summary
- clarify tooltip helper usage in README
- add example initialization and attribute usage in architecture docs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6883b2a69dc88326ad30821395dcfa13