### PR TITLE
Add zebra striping for changelog rows

### DIFF
--- a/src/styles/changeLog.css
+++ b/src/styles/changeLog.css
@@ -26,3 +26,11 @@
   height: 48px;
   object-fit: cover;
 }
+
+#changelog-table tbody tr:nth-child(odd) {
+  background-color: var(--color-surface);
+}
+
+#changelog-table tbody tr:nth-child(even) {
+  background-color: var(--color-tertiary);
+}


### PR DESCRIPTION
## Summary
- update changelog styles so rows alternate background colors

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6883bfbf83c88326837baeecf612c758