### PR TITLE
Remove navmap toggle

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -25,7 +25,6 @@ test.describe("Settings page", () => {
   test("essential elements visible", async ({ page }) => {
     await verifyPageBasics(page, ["nav-classicBattle", "nav-randomJudoka"]);
     await expect(page.getByLabel(/sound/i)).toBeVisible();
-    await expect(page.getByLabel(/full navigation map/i)).toBeVisible();
     await expect(page.getByLabel(/motion effects/i)).toBeVisible();
     await expect(page.getByLabel(/display mode/i)).toBeVisible();
   });
@@ -43,19 +42,9 @@ test.describe("Settings page", () => {
       .sort((a, b) => a.order - b.order)
       .map((m) => m.name);
 
-    const expectedLabels = [
-      "Display Mode",
-      "Sound",
-      "Full Navigation Map",
-      "Motion Effects",
-      ...sortedNames
-    ];
+    const expectedLabels = ["Display Mode", "Sound", "Motion Effects", ...sortedNames];
 
     await expect(page.locator("#sound-toggle")).toHaveAttribute("aria-label", "Sound");
-    await expect(page.locator("#navmap-toggle")).toHaveAttribute(
-      "aria-label",
-      "Full Navigation Map"
-    );
     await expect(page.locator("#motion-toggle")).toHaveAttribute("aria-label", "Motion Effects");
 
     await expect(page.locator("#game-mode-toggle-container input[type=checkbox]")).toHaveCount(

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -1,10 +1,10 @@
 {
   "sound": true,
-  "fullNavMap": true,
   "motionEffects": true,
   "displayMode": "light",
   "gameModes": {},
   "featureFlags": {
-    "battleDebugPanel": false
+    "battleDebugPanel": false,
+    "fullNavigationMap": true
   }
 }

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -15,23 +15,16 @@ function applyInputState(element, value) {
 
 export function applyInitialControlValues(controls, settings) {
   applyInputState(controls.soundToggle, settings.sound);
-  applyInputState(controls.navToggle, settings.fullNavMap);
   applyInputState(controls.motionToggle, settings.motionEffects);
   applyInputState(controls.displaySelect, settings.displayMode);
 }
 
 export function attachToggleListeners(controls, getCurrentSettings, handleUpdate) {
-  const { soundToggle, navToggle, motionToggle, displaySelect } = controls;
+  const { soundToggle, motionToggle, displaySelect } = controls;
   soundToggle?.addEventListener("change", () => {
     const prev = !soundToggle.checked;
     handleUpdate("sound", soundToggle.checked, () => {
       soundToggle.checked = prev;
-    });
-  });
-  navToggle?.addEventListener("change", () => {
-    const prev = !navToggle.checked;
-    handleUpdate("fullNavMap", navToggle.checked, () => {
-      navToggle.checked = prev;
     });
   });
   motionToggle?.addEventListener("change", () => {

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -39,7 +39,6 @@ function initializeControls(settings, gameModes) {
 
   const controls = {
     soundToggle: document.getElementById("sound-toggle"),
-    navToggle: document.getElementById("navmap-toggle"),
     motionToggle: document.getElementById("motion-toggle"),
     displaySelect: document.getElementById("display-mode-select")
   };

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -28,11 +28,10 @@ async function getSettingsSchema() {
 const SETTINGS_KEY = "settings";
 const DEFAULT_SETTINGS = {
   sound: false,
-  fullNavMap: true,
   motionEffects: true,
   displayMode: "light",
   gameModes: {},
-  featureFlags: { battleDebugPanel: false }
+  featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
 };
 export { DEFAULT_SETTINGS };
 
@@ -141,7 +140,6 @@ export async function updateSetting(key, value) {
 /**
  * @typedef {Object} Settings
  * @property {boolean} sound
- * @property {boolean} fullNavMap
  * @property {boolean} motionEffects
  * @property {"light"|"dark"|"gray"} displayMode
  * @property {Record<string, boolean>} [gameModes]

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -111,19 +111,6 @@
                   </label>
                 </div>
                 <div class="settings-item">
-                  <label for="navmap-toggle" class="switch">
-                    <input
-                      type="checkbox"
-                      id="navmap-toggle"
-                      name="navmap"
-                      aria-label="Full Navigation Map"
-                      tabindex="3"
-                    />
-                    <div class="slider round"></div>
-                    <span>Full Navigation Map</span>
-                  </label>
-                </div>
-                <div class="settings-item">
                   <label for="motion-toggle" class="switch">
                     <input
                       type="checkbox"

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -7,10 +7,6 @@
       "type": "boolean",
       "description": "Enable or disable game sound effects."
     },
-    "fullNavMap": {
-      "type": "boolean",
-      "description": "Show full navigation map when enabled."
-    },
     "motionEffects": {
       "type": "boolean",
       "description": "Enable animated motion effects."
@@ -31,6 +27,6 @@
       "additionalProperties": { "type": "boolean" }
     }
   },
-  "required": ["sound", "fullNavMap", "motionEffects", "displayMode"],
+  "required": ["sound", "motionEffects", "displayMode"],
   "additionalProperties": false
 }

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -138,11 +138,10 @@ describe("populateNavbar", () => {
     ];
     const loadSettings = vi.fn().mockResolvedValue({
       sound: true,
-      fullNavMap: true,
       motionEffects: true,
       displayMode: "light",
       gameModes: { B: false },
-      featureFlags: { battleDebugPanel: false }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
     });
     const loadGameModes = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -186,11 +185,10 @@ describe("populateNavbar", () => {
     localStorage.setItem("gameModes", JSON.stringify(data));
     const loadSettings = vi.fn().mockResolvedValue({
       sound: true,
-      fullNavMap: true,
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
     });
     const loadGameModes = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -229,11 +227,10 @@ describe("populateNavbar", () => {
     ];
     const loadSettings = vi.fn().mockResolvedValue({
       sound: true,
-      fullNavMap: true,
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
     });
     const loadGameModes = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -7,11 +7,14 @@ import { hex } from "wcag-contrast";
 
 const baseSettings = {
   sound: false,
-  fullNavMap: true,
   motionEffects: true,
   displayMode: "light",
   gameModes: {},
-  featureFlags: { randomStatMode: false, battleDebugPanel: false }
+  featureFlags: {
+    randomStatMode: false,
+    battleDebugPanel: false,
+    fullNavigationMap: true
+  }
 };
 
 describe("randomJudokaPage module", () => {

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -3,11 +3,14 @@ import { createSettingsDom } from "../utils/testUtils.js";
 
 const baseSettings = {
   sound: true,
-  fullNavMap: true,
   motionEffects: true,
   displayMode: "light",
   gameModes: {},
-  featureFlags: { randomStatMode: true, battleDebugPanel: false }
+  featureFlags: {
+    randomStatMode: true,
+    battleDebugPanel: false,
+    fullNavigationMap: true
+  }
 };
 
 describe("settingsPage module", () => {
@@ -193,7 +196,8 @@ describe("settingsPage module", () => {
 
     expect(updateSetting).toHaveBeenCalledWith("featureFlags", {
       randomStatMode: true,
-      battleDebugPanel: true
+      battleDebugPanel: true,
+      fullNavigationMap: true
     });
   });
 });

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -41,11 +41,10 @@ describe("settings utils", () => {
     const settings = await loadSettings();
     expect(settings).toEqual({
       sound: false,
-      fullNavMap: true,
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
     });
   });
 
@@ -57,11 +56,10 @@ describe("settings utils", () => {
     const { saveSettings } = await import("../../src/helpers/settingsUtils.js");
     const data = {
       sound: false,
-      fullNavMap: true,
       motionEffects: true,
       displayMode: "dark",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
     };
     const promise = saveSettings(data);
     await vi.advanceTimersByTimeAsync(110);
@@ -86,11 +84,10 @@ describe("settings utils", () => {
     const settings = await loadSettings();
     expect(settings).toEqual({
       sound: false,
-      fullNavMap: true,
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
     });
     Storage.prototype.getItem = originalGetItem;
   });
@@ -128,11 +125,10 @@ describe("settings utils", () => {
     await expect(
       saveSettings({
         sound: true,
-        fullNavMap: true,
         motionEffects: true,
         displayMode: "light",
         gameModes: {},
-        featureFlags: { battleDebugPanel: false }
+        featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
       })
     ).rejects.toThrow("fail");
     Storage.prototype.setItem = originalSetItem;
@@ -161,19 +157,17 @@ describe("settings utils", () => {
     const { saveSettings } = await import("../../src/helpers/settingsUtils.js");
     const data1 = {
       sound: true,
-      fullNavMap: false,
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: false }
     };
     const data2 = {
       sound: false,
-      fullNavMap: true,
       motionEffects: false,
       displayMode: "dark",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
     };
     saveSettings(data1);
     saveSettings(data2);

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -46,9 +46,6 @@ export function createSettingsDom() {
   const soundToggle = document.createElement("input");
   soundToggle.id = "sound-toggle";
   soundToggle.type = "checkbox";
-  const navmapToggle = document.createElement("input");
-  navmapToggle.id = "navmap-toggle";
-  navmapToggle.type = "checkbox";
   const motionToggle = document.createElement("input");
   motionToggle.id = "motion-toggle";
   motionToggle.type = "checkbox";
@@ -60,7 +57,6 @@ export function createSettingsDom() {
   featureFlagsContainer.id = "feature-flags-container";
   fragment.append(
     soundToggle,
-    navmapToggle,
     motionToggle,
     displayModeSelect,
     gameModeToggleContainer,


### PR DESCRIPTION
## Summary
- clean up Settings page markup and helpers
- drop `fullNavMap` from schema, defaults and data
- move existing value to `featureFlags.fullNavigationMap`
- update tests for new feature flag

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6883bf87cd608326aa25b636c5cca2f6