### PR TITLE
Add Full Navigation Map flag docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Light, dark and gray themes are supported. See [prdSettingsMenu.md](design/produ
 The Settings page (`src/pages/settings.html`) groups all player preferences, including experimental **feature flags**. Toggle a flag to enable an optional feature without modifying code. Flag values persist across pages and apply immediately. Implementation guidelines live in [settingsPageDesignGuidelines.md](design/codeStandards/settingsPageDesignGuidelines.md#feature-flags--agent-observability).
 
 Battle pages include a collapsible debug panel. Enable the **Battle Debug Panel** feature flag in **Settings** to reveal real-time match state in a `<pre>` element. The panel is keyboard accessible and hidden by default so normal gameplay remains unaffected.
+Toggle the **Full Navigation Map** flag to display a map overlay with links to all pages for easier orientation during testing.
 
 ## Browser Compatibility
 

--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -175,9 +175,10 @@ To support AI-assisted testing, variant gameplay modes, and scalable development
 
 - **ID and Naming Convention**  
   Use predictable `id` and `name` values:  
-  - ID format: `feature-<kebab-case-feature-name>`  
-  - Name format: camelCase  
+  - ID format: `feature-<kebab-case-feature-name>`
+  - Name format: camelCase
   - Example: `id="feature-random-stat-mode" name="randomStatMode"`
+  - Common example flags include `Battle Debug Panel` and `Full Navigation Map`
 
 - **ARIA and Accessibility**  
   - Provide `aria-label` for each feature flag  


### PR DESCRIPTION
## Summary
- document feature flag examples in the settings page guidelines
- reference the new **Full Navigation Map** flag in the README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch in settings page)*

------
https://chatgpt.com/codex/tasks/task_e_6883c33541b483269f0fb44bbf111ae8