### PR TITLE
Add offline fallback for game modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ The Settings page (`src/pages/settings.html`) groups all player preferences, inc
 Battle pages include a collapsible debug panel. Enable the **Battle Debug Panel** feature flag in **Settings** to reveal real-time match state in a `<pre>` element. The panel is keyboard accessible and hidden by default so normal gameplay remains unaffected.
 Toggle the **Full Navigation Map** flag to display a map overlay with links to all pages for easier orientation during testing.
 
+Game mode data now falls back to a bundled JSON import if the network request fails, so navigation works offline.
+
 ## Browser Compatibility
 
 JU-DO-KON! is tested in the latest versions of Chrome, Firefox, Safari, and Edge.


### PR DESCRIPTION
## Summary
- load game modes via dynamic import if the network fetch fails
- mention the new offline fallback in the README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden when installing vitest)*
- `npx playwright test` *(fails: 403 Forbidden when installing playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6883c9db15a88326809101bf5c8b2274