### PR TITLE
Add embeddings generation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "npx prettier . --check && npx eslint .",
     "check:contrast": "node scripts/runPa11y.js",
     "prepare": "husky install",
-    "validate:data": "node scripts/validateData.js"
+    "validate:data": "node scripts/validateData.js",
+    "generate:embeddings": "node scripts/generateEmbeddings.js"
   },
   "keywords": [],
   "author": "",
@@ -99,6 +100,7 @@
     "why-is-node-running": "^2.3.0",
     "ws": "^8.18.1",
     "xml-name-validator": "^5.0.0",
-    "xmlchars": "^2.2.0"
+    "xmlchars": "^2.2.0",
+    "@xenova/transformers": "^2.6.0"
   }
 }

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -1,0 +1,66 @@
+/* eslint-env node */
+/**
+ * Generate embeddings for PRD markdown and JSON data files.
+ *
+ * @pseudocode
+ * 1. Discover markdown and JSON files using glob.
+ * 2. Read file contents and truncate long text.
+ * 3. Load a transformer model for feature extraction.
+ * 4. Encode each text block into an embedding vector.
+ * 5. Build output objects with id, text, embedding, source, tags, and version.
+ * 6. Ensure the final JSON output is under 1MB and write to disk.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { glob } from "glob";
+import { pipeline } from "@xenova/transformers";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+
+const MAX_TEXT_LENGTH = 1000;
+
+async function getFiles() {
+  const mdFiles = await glob("design/productRequirementsDocuments/*.md", { cwd: rootDir });
+  const jsonFiles = (await glob("src/data/*.json", { cwd: rootDir })).filter(
+    (f) => path.extname(f) === ".json"
+  );
+  return [...mdFiles, ...jsonFiles];
+}
+
+async function loadModel() {
+  return pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2");
+}
+
+async function generate() {
+  const files = await getFiles();
+  const extractor = await loadModel();
+  const output = [];
+
+  for (const relativePath of files) {
+    const fullPath = path.join(rootDir, relativePath);
+    let text = await readFile(fullPath, "utf8");
+    if (relativePath.endsWith(".json")) {
+      text = JSON.stringify(JSON.parse(text));
+    }
+    text = text.slice(0, MAX_TEXT_LENGTH);
+    const embedding = (await extractor(text))[0];
+    output.push({
+      id: path.basename(relativePath),
+      text,
+      embedding,
+      source: relativePath,
+      tags: [relativePath.endsWith(".json") ? "data" : "prd"],
+      version: 1
+    });
+  }
+
+  const jsonString = JSON.stringify(output);
+  if (Buffer.byteLength(jsonString, "utf8") > 1024 * 1024) {
+    throw new Error("Output exceeds 1MB");
+  }
+  await writeFile(path.join(rootDir, "src/data/client_embeddings.json"), jsonString);
+}
+
+await generate();


### PR DESCRIPTION
## Summary
- create `generateEmbeddings.js` to encode docs and JSON files
- store vectors in `src/data/client_embeddings.json`
- add `generate:embeddings` npm script
- install `@xenova/transformers` dependency

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6883ca82ffcc8326b3cfcd8083e67a9a