### PR TITLE
Add vector search demo page

### DIFF
--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -1,0 +1,49 @@
+import { onDomReady } from "./domReady.js";
+import { findMatches } from "./vectorSearch.js";
+import { pipeline } from "@xenova/transformers";
+
+let extractor;
+
+async function getExtractor() {
+  if (!extractor) {
+    extractor = await pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2");
+  }
+  return extractor;
+}
+
+async function handleSearch(event) {
+  event.preventDefault();
+  const input = document.getElementById("vector-search-input");
+  const resultsEl = document.getElementById("search-results");
+  const query = input.value.trim();
+  resultsEl.textContent = "";
+  if (!query) return;
+  resultsEl.textContent = "Searching...";
+  try {
+    const model = await getExtractor();
+    const vector = (await model(query))[0];
+    const matches = await findMatches(Array.from(vector), 3);
+    resultsEl.textContent = "";
+    if (matches.length === 0) {
+      resultsEl.textContent = "No close matches found — refine your query.";
+      return;
+    }
+    const list = document.createElement("ol");
+    for (const match of matches) {
+      const li = document.createElement("li");
+      li.innerHTML = `<p>${match.text}</p><p class="small-text">Source: ${match.source} (score: ${match.score.toFixed(2)})</p>`;
+      list.appendChild(li);
+    }
+    resultsEl.appendChild(list);
+  } catch (err) {
+    console.error("Search failed", err);
+    resultsEl.textContent = "An error occurred while searching.";
+  }
+}
+
+function init() {
+  const form = document.getElementById("vector-search-form");
+  form?.addEventListener("submit", handleSearch);
+}
+
+onDomReady(init);

--- a/src/pages/vectorSearch.html
+++ b/src/pages/vectorSearch.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="keywords" content="judo, vector search" />
+    <meta name="author" content="Marc Scheimann" />
+    <meta name="description" content="JU-DO-KON! vector search demo" />
+    <meta property="og:title" content="JU-DO-KON!" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://cyanautomation.github.io/judokon/" />
+    <meta property="og:description" content="JU-DO-KON! vector search demo" />
+    <meta name="theme-color" content="#ffffff" />
+    <title>Ju-Do-Kon! Vector Search</title>
+    <link rel="stylesheet" href="../styles/fonts.css" />
+    <link rel="stylesheet" href="../styles/base.css" />
+    <link rel="stylesheet" href="../styles/layout.css" />
+    <link rel="stylesheet" href="../styles/components.css" />
+    <link rel="stylesheet" href="../styles/utilities.css" />
+    <link rel="icon" type="image/png" href="../assets/images/favicon.ico" />
+  </head>
+  <body>
+    <div class="home-screen">
+      <header class="header">
+        <div class="header-spacer left"></div>
+        <div class="logo-container">
+          <a href="../../index.html">
+            <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
+          </a>
+        </div>
+        <div class="header-spacer right"></div>
+      </header>
+
+      <main class="container long-form" role="main">
+        <h1>Vector Search</h1>
+        <form id="vector-search-form" role="search" class="search-form">
+          <label for="vector-search-input" class="visually-hidden">Search</label>
+          <input id="vector-search-input" type="search" placeholder="Enter query" required />
+          <button id="vector-search-btn" type="submit">Search</button>
+        </form>
+        <section
+          id="search-results"
+          role="region"
+          aria-live="polite"
+          aria-label="Search results"
+        ></section>
+      </main>
+
+      <footer>
+        <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
+      </footer>
+      <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+      <script type="module" src="../helpers/setupDisplaySettings.js"></script>
+      <script type="module" src="../helpers/vectorSearchPage.js"></script>
+      <script type="module" src="../helpers/setupSvgFallback.js"></script>
+      <noscript>
+        <p class="noscript-warning">
+          JU-DO-KON! requires JavaScript to run. Please enable JavaScript to search.
+        </p>
+      </noscript>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Vector Search page with search form and results section
- implement `vectorSearchPage` helper to encode queries and find matches

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6883d2b9628c8326bd926c796766ccd2