### PR TITLE
Fix corrupted settings handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Battle pages include a collapsible debug panel. Enable the **Battle Debug Panel*
 Toggle the **Full Navigation Map** flag to display a map overlay with links to all pages for easier orientation during testing.
 
 Game mode data now falls back to a bundled JSON import if the network request fails, so navigation works offline.
+Corrupted settings are detected and automatically reset to defaults, ensuring the Settings page always remains usable.
 
 ## Browser Compatibility
 

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -53,22 +53,23 @@ const SAVE_DELAY_MS = 100;
  * @returns {Promise<Settings>} Resolved settings object.
  */
 export async function loadSettings() {
+  await getSettingsSchema();
+  if (typeof localStorage === "undefined") {
+    throw new Error("localStorage unavailable");
+  }
+  const raw = localStorage.getItem(SETTINGS_KEY);
+  if (!raw) {
+    return { ...DEFAULT_SETTINGS };
+  }
   try {
-    await getSettingsSchema();
-    if (typeof localStorage === "undefined") {
-      throw new Error("localStorage unavailable");
-    }
-    const raw = localStorage.getItem(SETTINGS_KEY);
-    if (!raw) {
-      return { ...DEFAULT_SETTINGS };
-    }
     const parsed = JSON.parse(raw);
     const merged = { ...DEFAULT_SETTINGS, ...parsed };
     await validateWithSchema(merged, await getSettingsSchema());
     return merged;
   } catch (error) {
-    // For PRD: show error popup in UI, not here
-    throw error;
+    console.warn("Invalid stored settings, resetting to defaults", error);
+    localStorage.removeItem(SETTINGS_KEY);
+    return { ...DEFAULT_SETTINGS };
   }
 }
 

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -106,12 +106,14 @@ describe("settings utils", () => {
   });
 
   /**
-   * Should reject if settings JSON is invalid.
+   * Should reset to defaults if settings JSON is invalid.
    */
-  it("rejects when parsing fails", async () => {
+  it("recovers from invalid stored JSON", async () => {
     localStorage.setItem("settings", "{bad json}");
     const { loadSettings } = await import("../../src/helpers/settingsUtils.js");
-    await expect(loadSettings()).rejects.toBeInstanceOf(Error);
+    const settings = await loadSettings();
+    expect(settings).toEqual(DEFAULT_SETTINGS);
+    expect(localStorage.getItem("settings")).toBeNull();
   });
 
   /**


### PR DESCRIPTION
## Summary
- handle invalid settings by resetting to defaults
- adjust settings utils tests
- mention reset behavior in README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6883d2893db48326b1da8b055c9b7b07