### PR TITLE
Update references to CPU opponent

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -16,7 +16,7 @@ The round message, timer, and score now sit directly inside the page header rath
 
 ## Goals
 
-1. **Display match score (player vs CPU)** on the **right side of the top bar**, updated at the **end of each round**, within **800ms** of score finalization.
+1. **Display match score (player vs opponent)** on the **right side of the top bar**, updated at the **end of each round**, within **800ms** of score finalization.
 2. **Display round-specific messaging** on the **left side of the top bar**, depending on match state:
    - If a round ends: show **win/loss/result** message for **2 seconds**.
    - If awaiting action: show **selection prompt** until a decision is made.
@@ -31,7 +31,7 @@ The round message, timer, and score now sit directly inside the page header rath
 
 | Priority | Feature                | Description                                                   |
 |----------|------------------------|---------------------------------------------------------------|
-| **P1**   | Match Score Display    | Real-time, fast update of player vs CPU score per round       |
+| **P1**   | Match Score Display    | Real-time, fast update of player vs opponent score per round       |
 | **P1**   | Round Status Messaging | Show clear win/loss messages post-round                       |
 | **P1**   | Stat Selection Timer   | Display 30s countdown for stat selection; auto-select if expired; timer pauses/resumes on tab inactivity (see Classic Battle PRD) |
 | **P2**   | Countdown Timer        | Display countdown to next round with fallback for server sync |
@@ -67,8 +67,8 @@ The round message, timer, and score now sit directly inside the page header rath
 ## Design and UX Considerations
 
 - **Layout**
-  - Right side: score display (`Player: X – CPU: Y`)
-  - Two-line score format appears on narrow screens (`Player: X` line break `CPU: Y`)
+  - Right side: score display (`Player: X – Opponent: Y`)
+  - Two-line score format appears on narrow screens (`Player: X` line break `Opponent: Y`)
   - Left side: rotating status messages (e.g., "You won!", "Next round in: 3s", "Select your move", **"Time left: 29s"**)
 - **Visuals**
   - Font size: min 16sp, bold for win/loss messages.
@@ -87,7 +87,7 @@ The round message, timer, and score now sit directly inside the page header rath
 
 | LEFT SIDE (Round Messages)            |                          RIGHT SIDE (Score) |
 |--------------------------------------|---------------------------------------------|
-|  "You won!"  (bold green, 16sp)      |           Player: 2  –  CPU: 1               |
+|  "You won!"  (bold green, 16sp)      |           Player: 2  –  Opponent: 1               |
 |  "Select your move" (neutral grey)   |                                             |
 |  "Next round in: 3s" (neutral grey) |                                             |
 |  **"Time left: 29s" (neutral grey)** |                                             |
@@ -102,7 +102,7 @@ The round message, timer, and score now sit directly inside the page header rath
 
 | "You won!"                   |
 |                             |
-| Player: 2  –  CPU: 1         |
+| Player: 2  –  Opponent: 1         |
 
 ---
 

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -75,7 +75,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 | Priority | Feature                 | Description                                                                                             |
 | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------- |
-| **P1**   | Random Card Draw        | Draw one random card per player each round; the computer card must differ from the player's.            |
+| **P1**   | Random Card Draw        | Draw one random card per player each round; the opponent card must differ from the player's.            |
 | **P1**   | Stat Selection Timer    | Player selects stat within 30 seconds; otherwise, random stat is chosen. Default timer is fixed at 30s. Timer is displayed in the Info Bar and pauses/resumes on tab inactivity. |
 | **P1**   | Scoring                 | Increase score by one for each round win.                                                               |
 | **P1**   | Match End Condition     | End match on 10 points or after 25 rounds.                                                              |
@@ -88,7 +88,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Behavior on tie rounds: round ends with a message explaining the tie and an option to start the next round.
 - Match start conditions: both players begin with a score of zero; player goes first by drawing their card.
 - Players have 30 seconds to select a stat; if no selection is made, the system randomly selects a stat from the drawn card. **The timer and prompt are displayed in the Info Bar.**
-- The computer's card must always differ from the player's card for each round.
+- The opponent's card must always differ from the player's card for each round.
 - **Default:** 30-second timer is fixed (not adjustable by the player at launch), but can be reviewed for future difficulty settings.
 
 ---
@@ -105,7 +105,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 ## Acceptance Criteria
 
 - Cards are revealed in the correct sequence each round.
-- The CPU card displays a placeholder ("Mystery Judoka") until the player selects a stat ([prdMysteryCard.md](prdMysteryCard.md)).
+- The opponent card displays a placeholder ("Mystery Judoka") until the player selects a stat ([prdMysteryCard.md](prdMysteryCard.md)).
 - Player can select a stat within 30 seconds; if not, the system auto-selects a random stat automatically. **Timer and prompt are surfaced in the Info Bar.**
 - After selection, the correct comparison is made, and the score updates based on round outcome.
 - If the selected stats are equal, a tie message displays and the round ends.
@@ -130,11 +130,11 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 ## Design and UX Considerations
 
-- Use consistent color coding for player (blue) vs computer (red) as shown in attached mockups.
+- Use consistent color coding for player (blue) vs opponent (red) as shown in attached mockups.
 - Display clear, large call-to-action text for "Choose an attribute to challenge!" to guide new players.
 - Provide a quit confirmation when the player clicks the logo in the header to return to the Home screen.
 - Match screens should follow the style and layouts demonstrated in shared mockups:
-  - Player and computer cards side-by-side.
+  - Player and opponent cards side-by-side.
   - Central score prominently displayed.
   - Tie or win/loss messages placed centrally.
   - Clear "Next Round" button with distinct state (enabled/disabled).

--- a/design/productRequirementsDocuments/prdGameModes.md
+++ b/design/productRequirementsDocuments/prdGameModes.md
@@ -69,7 +69,7 @@ Improving session variety directly supports retention and encourages more person
 
 | Priority | Feature           | Description                                    |
 | -------- | ----------------- | ---------------------------------------------- |
-| P1       | Classic Battle    | 1v1 battle vs CPU, stat-based combat to 10 pts |
+| P1       | Classic Battle    | 1v1 battle vs opponent, stat-based combat to 10 pts |
 | P1       | Team Battle Modes | Gender-specific team-based battles             |
 | P1       | Judoka Creation   | Interface for new character creation           |
 | P2       | Judoka Update     | Edit existing characters and save changes      |
@@ -85,7 +85,7 @@ Improving session variety directly supports retention and encourages more person
 
 **Japanese**: 試合 (バトルモード)  
 **URL**: `battleJudoka.html`  
-A 1v1 stat-based match against a CPU opponent using a deck of 25 random judoka cards. First to 10 points wins. [Read full PRD](prdClassicBattle.md)
+A 1v1 stat-based match against an AI opponent using a deck of 25 random judoka cards. First to 10 points wins. [Read full PRD](prdClassicBattle.md)
 
 #### Goals
 

--- a/design/productRequirementsDocuments/prdMysteryCard.md
+++ b/design/productRequirementsDocuments/prdMysteryCard.md
@@ -4,15 +4,15 @@
 
 ## TL;DR
 
-The **Mystery Judoka Card** is a placeholder card used in *every round against the computer*. It temporarily hides the opponent’s real card until the player selects a stat, ensuring fair gameplay and preventing stat-based cheating. The card uses a silhouette portrait, obscured stats (`"?"`), and the name “Mystery Judoka”, providing a consistent and thematic experience during the stat selection phase.
+The **Mystery Judoka Card** is a placeholder card used in *every round against the opponent*. It temporarily hides the opponent’s real card until the player selects a stat, ensuring fair gameplay and preventing stat-based cheating. The card uses a silhouette portrait, obscured stats (`"?"`), and the name “Mystery Judoka”, providing a consistent and thematic experience during the stat selection phase.
 
 ---
 
 ## Problem Statement
 
-Currently, the computer’s card is visible before the player chooses a stat. This unintentionally encourages players to base their choice on the opponent’s values — compromising fairness and removing tension from the match. The **Mystery Judoka Card** acts as a stat-obscuring placeholder that maintains surprise and integrity in each round.
+Currently, the opponent’s card is visible before the player chooses a stat. This unintentionally encourages players to base their choice on the opponent’s values — compromising fairness and removing tension from the match. The **Mystery Judoka Card** acts as a stat-obscuring placeholder that maintains surprise and integrity in each round.
 
-> Sota faces off against the CPU. A card appears with a dark silhouette and mysterious stats. He hovers between Power and Kumi-kata. With a deep breath, he picks Power. The card flips — revealing the opponent: a legendary -100kg champion with immense strength. Too late to change. That moment of tension? That’s the thrill we’re aiming for.
+> Sota faces off against an opponent. A card appears with a dark silhouette and mysterious stats. He hovers between Power and Kumi-kata. With a deep breath, he picks Power. The card flips — revealing the opponent: a legendary -100kg champion with immense strength. Too late to change. That moment of tension? That’s the thrill we’re aiming for.
 
 ---
 
@@ -22,7 +22,7 @@ Currently, the computer’s card is visible before the player chooses a stat. Th
 - Introduce momentary suspense in each round to heighten emotional investment.
 - Preserve visual consistency using an existing card (`judokaId=1`) with special styling.
 - Ensure the opponent card reveal animation completes within **400ms**.
-- Guarantee **100% concealment** of all CPU stats during player stat selection.  
+- Guarantee **100% concealment** of all opponent stats during player stat selection.
   - **Note:** The signature move does not need to be obscured and should be displayed as "?" on the Mystery Judoka card.
 
 ---
@@ -37,7 +37,7 @@ Currently, the computer’s card is visible before the player chooses a stat. Th
 
 ## Acceptance Criteria
 
-- **Given** a round starts in any battle mode against the CPU,  
+- **Given** a round starts in any battle mode against an opponent,
   **When** the opponent card is shown,  
   **Then** the “Mystery Judoka” card (`judokaId=1`) is displayed with silhouette image and question marks in all stat fields.
 - **Given** the player selects a stat,  
@@ -66,7 +66,7 @@ Currently, the computer’s card is visible before the player chooses a stat. Th
 - **Portrait Path:** `src/assets/judokaPortraits/judokaPortrait-1.png` (already present).
 - **Stat Display:** Override real stat values with `"?"` at render time via `renderJudokaCard()`. (Note: Stat concealment and animation are handled in the UI layer, not in the battle engine.)
 - **Name Display:** Use value from `judoka.json` (`"Mystery Judoka"`) for visual consistency.
-- **Reveal Timing:** Animate swap to real CPU card after player stat choice within **400ms** using `ease-out` transition.
+- **Reveal Timing:** Animate swap to real opponent card after player stat choice within **400ms** using `ease-out` transition.
 - **Game Logic:** Opponent card is drawn from remaining deck *before* stat selection but only displayed *after* player choice.
 
 ---
@@ -107,7 +107,7 @@ Currently, the computer’s card is visible before the player chooses a stat. Th
 
 | Priority | Feature                      | Description                                                                 |
 |:--------:|:----------------------------|:---------------------------------------------------------------------------|
-| **P1**   | Placeholder Mystery Card     | Show `judokaId=1` card with silhouette and "?" stats at start of each CPU round. Signature move is also shown as "?" |
+| **P1**   | Placeholder Mystery Card     | Show `judokaId=1` card with silhouette and "?" stats at start of each opponent round. Signature move is also shown as "?" |
 | **P1**   | Stat Redaction on Render     | Replace all visible stat values with "?" regardless of real values. Signature move is always shown as "?" |
 | **P1**   | Card Swap on Stat Selection  | Reveal opponent card via animated swap within **400ms**, no layout shift   |
 | **P2**   | Consistent Styling           | Apply proper rarity border, portrait container, and stat layout             |
@@ -126,7 +126,7 @@ Currently, the computer’s card is visible before the player chooses a stat. Th
 
 ## Integration Notes
 
-- The **Mystery Judoka card** is never shown in non-CPU modes.
+- The **Mystery Judoka card** is never shown in non-opponent modes.
 - Use the existing `renderJudokaCard()` helper with a `useObscuredStats` flag to substitute "?" values at render time.
 - Maintain card aspect ratio and layout as defined in the core Judoka Cards PRD — do **not** introduce custom card layouts for the mystery variant.
 
@@ -135,7 +135,7 @@ Currently, the computer’s card is visible before the player chooses a stat. Th
 ## Tasks
 
 - [x] **1.0 Mystery Card Rendering**
-  - [x] 1.1 Show `judokaId=1` as placeholder at start of CPU round
+  - [x] 1.1 Show `judokaId=1` as placeholder at start of opponent round
   - [x] 1.2 Hide real stats and show `"?"` for all attributes and move
   - [ ] 1.3 Apply correct rarity, flag, and weight class styles
 - [ ] **2.0 Reveal Logic**

--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -100,16 +100,16 @@ export function startCountdown(seconds, onFinish) {
  * Display the current match score.
  *
  * @pseudocode
- * 1. Format the score string with player and computer values separated by a
+ * 1. Format the score string with player and opponent values separated by a
  *    line break.
  * 2. Insert the HTML into the score element when present.
  *
  * @param {number} playerScore - Player's score.
- * @param {number} computerScore - Computer's score.
+ * @param {number} computerScore - Opponent's score.
  * @returns {void}
  */
 export function updateScore(playerScore, computerScore) {
   if (scoreEl) {
-    scoreEl.innerHTML = `You: ${playerScore}<br>\nComputer: ${computerScore}`;
+    scoreEl.innerHTML = `You: ${playerScore}<br>\nOpponent: ${computerScore}`;
   }
 }

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -14,7 +14,7 @@
   "ui.lossMessage": "**Defeat!**\nYour opponent had the upper hand.",
   "ui.drawMessage": "_It’s a draw._\nBoth stats were equal!",
 
-  "mode.classicBattle": "**Classic Battle Mode** pits you against the CPU.\nFirst to 10 round wins is the champion.",
+  "mode.classicBattle": "**Classic Battle Mode** pits you against an opponent.\nFirst to 10 round wins is the champion.",
   "mode.teamBattle": "**Team Battle Mode** uses your entire deck.\nWin more rounds than the opponent team to triumph!",
   "mode.meditation": "**Meditation Mode** lets you reflect and compare cards.\nNo battles, just peaceful analysis.",
   "mode.randomJudoka": "**Random Judoka** picks a random card for quick inspiration.",

--- a/src/helpers/battleEngine.js
+++ b/src/helpers/battleEngine.js
@@ -37,7 +37,7 @@ function endMatchIfNeeded() {
       return "You win the match!";
     }
     if (playerScore < computerScore) {
-      return "Computer wins the match!";
+      return "Opponent wins the match!";
     }
     return "Match ends in a tie!";
   }
@@ -132,7 +132,7 @@ export function handleStatSelection(playerVal, computerVal) {
     message = "You win the round!";
   } else if (playerVal < computerVal) {
     computerScore += 1;
-    message = "Computer wins the round!";
+    message = "Opponent wins the round!";
   } else {
     message = "Tie – no score!";
   }

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -39,7 +39,7 @@
           </a>
         </div>
         <div class="info-right" id="info-bar-right">
-          <p id="score-display" aria-live="off" aria-atomic="true">You: 0 Computer: 0</p>
+          <p id="score-display" aria-live="off" aria-atomic="true">You: 0 Opponent: 0</p>
         </div>
       </header>
 

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -30,7 +30,7 @@ describe("InfoBar component", () => {
     expect(document.getElementById("round-message").textContent).toBe("Hello");
 
     updateScore(1, 2);
-    expect(document.getElementById("score-display").textContent).toBe("You: 1\nComputer: 2");
+    expect(document.getElementById("score-display").textContent).toBe("You: 1\nOpponent: 2");
 
     startCountdown(2);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 2s");
@@ -48,7 +48,7 @@ describe("InfoBar component", () => {
     showMessage("Hi");
     expect(document.getElementById("round-message").textContent).toBe("Hi");
     updateScore(2, 3);
-    expect(document.getElementById("score-display").textContent).toBe("You: 2\nComputer: 3");
+    expect(document.getElementById("score-display").textContent).toBe("You: 2\nOpponent: 3");
     startCountdown(1);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
     vi.advanceTimersByTime(1000);

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -56,7 +56,7 @@ describe("classicBattle match flow", () => {
     await vi.runAllTimersAsync();
     const score = document.querySelector("header #score-display").textContent;
     const msg = document.querySelector("header #round-message").textContent;
-    expect(score).toBe("You: 1\nComputer: 0");
+    expect(score).toBe("You: 1\nOpponent: 0");
     expect(msg).toMatch(/win the round/i);
   });
 
@@ -82,7 +82,7 @@ describe("classicBattle match flow", () => {
       await handleStatSelection("power");
     }
     expect(document.querySelector("header #score-display").textContent).toBe(
-      "You: 10\nComputer: 0"
+      "You: 10\nOpponent: 0"
     );
     expect(document.querySelector("header #round-message").textContent).toMatch(/win the match/i);
 
@@ -93,7 +93,7 @@ describe("classicBattle match flow", () => {
     await handleStatSelection("power");
 
     expect(document.querySelector("header #score-display").textContent).toBe(
-      "You: 10\nComputer: 0"
+      "You: 10\nOpponent: 0"
     );
   });
 

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -99,7 +99,7 @@ describe("classicBattle stat selection", () => {
     _resetForTest();
     await handleStatSelection("power");
     expect(document.querySelector("header #round-message").textContent).toMatch(/Tie/);
-    expect(document.querySelector("header #score-display").textContent).toBe("You: 0\nComputer: 0");
+    expect(document.querySelector("header #score-display").textContent).toBe("You: 0\nOpponent: 0");
   });
 
   it("evaluateRound updates the score", async () => {
@@ -111,6 +111,6 @@ describe("classicBattle stat selection", () => {
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     const result = evaluateRound("power");
     expect(result.message).toMatch(/win/);
-    expect(document.querySelector("header #score-display").textContent).toBe("You: 1\nComputer: 0");
+    expect(document.querySelector("header #score-display").textContent).toBe("You: 1\nOpponent: 0");
   });
 });

--- a/tests/helpers/setupBattleInfoBar.test.js
+++ b/tests/helpers/setupBattleInfoBar.test.js
@@ -27,7 +27,7 @@ describe("setupBattleInfoBar", () => {
     expect(document.getElementById("round-message").textContent).toBe("Hi");
 
     mod.updateScore(1, 2);
-    expect(document.getElementById("score-display").textContent).toBe("You: 1\nComputer: 2");
+    expect(document.getElementById("score-display").textContent).toBe("You: 1\nOpponent: 2");
 
     mod.startCountdown(1);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
@@ -54,7 +54,7 @@ describe("setupBattleInfoBar", () => {
     mod.showMessage("Hello");
     expect(document.getElementById("round-message").textContent).toBe("Hello");
     mod.updateScore(3, 4);
-    expect(document.getElementById("score-display").textContent).toBe("You: 3\nComputer: 4");
+    expect(document.getElementById("score-display").textContent).toBe("You: 3\nOpponent: 4");
     vi.useFakeTimers();
     mod.startCountdown(1);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");


### PR DESCRIPTION
## Summary
- rename Computer references to Opponent throughout UI and docs
- adjust unit tests to match new terminology

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6883d95c1a2883268c246900c13ffc22