### PR TITLE
Improve vector search UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ JU-DO-KON! offers a 99-card deck and one-on-one stat battles in a fully browser-
 
 ### Vector Search (RAG)
 
-The project ships with a retrieval-augmented search demo. Run `npm run generate:embeddings` to create the index, then open `vectorSearch.html` to try it out. These embeddings let AI agents query the product requirement docs, tooltip descriptions, and game data.
+The project ships with a retrieval-augmented search demo. Run `npm run generate:embeddings` to create the index, then open `vectorSearch.html` to try it out. The page shows a spinner while the MiniLM model loads and lists up to five matches with their score and source. If the embeddings fail to load, an error message appears in the results area. These embeddings let AI agents query the product requirement docs, tooltip descriptions, and game data.
 
 After modifying any PRDs, tooltip text, or game rule files, run `npm run generate:embeddings` again to rebuild `client_embeddings.json`. Commit the updated file alongside your documentation changes so other agents have the latest vectors.
 

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -66,7 +66,7 @@ After editing PRDs, tooltips, or game rules, run `npm run generate:embeddings` f
 ## Acceptance Criteria
 
 - [x] `client_embeddings.json` contains ≥5 fields per entry: `id`, `text`, `embedding`, `source`, and optional `tags`
-- [x] Vector similarity function returns top 3 matches in ≤200ms on a mid-tier device (e.g. 2022 MacBook Air M1)
+- [x] Vector similarity function returns top 5 matches in ≤200ms on a mid-tier device (e.g. 2022 MacBook Air M1)
 - [x] Search works offline in a local browser with no server backend
 - [x] At least 30 unique content entries from across the PRDs/tooltips are indexed in the demo build
 - [x] Each returned result includes both the match score and a reference to the original source
@@ -95,6 +95,8 @@ After editing PRDs, tooltips, or game rules, run `npm run generate:embeddings` f
 - UI must support keyboard navigation and screen readers.
 - Tap/click targets should be at least 44px height for accessibility.
 - Lookup responses must render within 200ms; show loading spinner if delayed.
+- Display an error message when embeddings or the model fail to load.
+- Show up to five matches with score and source information.
 
 ### UI Mockup
 
@@ -146,7 +148,7 @@ No user settings or toggles are included. This is appropriate since the feature 
 
 - [ ] 3.0 Develop Similarity Search Function
   - [ ] 3.1 Implement cosine similarity in JS
-  - [ ] 3.2 Return top 3 matches within 200ms
+  - [ ] 3.2 Return top 5 matches within 200ms
   - [ ] 3.3 Include score and source reference in response
 
 - [ ] 4.0 Create Static Query Interface

--- a/src/pages/vectorSearch.html
+++ b/src/pages/vectorSearch.html
@@ -38,6 +38,7 @@
           <input id="vector-search-input" type="search" placeholder="Enter query" required />
           <button id="vector-search-btn" type="submit">Search</button>
         </form>
+        <div id="search-spinner" class="loading-spinner" aria-hidden="true"></div>
         <section
           id="search-results"
           role="region"

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -51,3 +51,12 @@
 .reduce-motion .draw-card-btn {
   transition: none !important;
 }
+
+#search-results {
+  margin-top: var(--space-lg);
+}
+
+#search-results ol {
+  padding-left: var(--space-md);
+  margin-inline-start: var(--space-md);
+}

--- a/tests/helpers/vectorSearch.test.js
+++ b/tests/helpers/vectorSearch.test.js
@@ -23,6 +23,14 @@ describe("vectorSearch", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
+  it("returns null when loading fails", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("fail"));
+    vi.resetModules();
+    const { loadEmbeddings } = await import("../../src/helpers/vectorSearch.js");
+    const result = await loadEmbeddings();
+    expect(result).toBeNull();
+  });
+
   it("computes cosine similarity", async () => {
     const { cosineSimilarity } = await import("../../src/helpers/vectorSearch.js");
     expect(cosineSimilarity([1, 0], [1, 0])).toBeCloseTo(1);
@@ -31,6 +39,7 @@ describe("vectorSearch", () => {
 
   it("finds top matches", async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => sample });
+    vi.resetModules();
     const { findMatches } = await import("../../src/helpers/vectorSearch.js");
     const res = await findMatches([1, 0], 1);
     expect(res.length).toBe(1);
@@ -40,8 +49,17 @@ describe("vectorSearch", () => {
 
   it("returns empty array for dimension mismatch", async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => sample });
+    vi.resetModules();
     const { findMatches } = await import("../../src/helpers/vectorSearch.js");
     const res = await findMatches([1, 0, 0], 1);
     expect(res).toEqual([]);
+  });
+
+  it("returns null when embeddings fail to load", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("fail"));
+    vi.resetModules();
+    const { findMatches } = await import("../../src/helpers/vectorSearch.js");
+    const res = await findMatches([1, 0], 1);
+    expect(res).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- show spinner and feedback when the MiniLM model or embeddings fail
- list up to five matches with score and source
- keep keyboard support for the search form
- document new behaviour
- update vector search tests

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6883e4e76d3c8326a3d8b940016055d7