### PR TITLE
Document vector embed generation requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ JU-DO-KON! offers a 99-card deck and one-on-one stat battles in a fully browser-
 
 ### Vector Search (RAG)
 
-The project ships with a retrieval-augmented search demo. Run `npm run generate:embeddings` to create the index, then open `src/pages/vectorSearch.html` to try it out. These embeddings let AI agents query the product requirement docs, tooltip descriptions, and game data. The generated `src/data/client_embeddings.json` must be committed for the page to work.
+The project ships with a retrieval-augmented search demo. Run `npm run generate:embeddings` to create the index, then open `src/pages/vectorSearch.html` to try it out. The generation script at `scripts/generateEmbeddings.js` downloads the `Xenova/all-MiniLM-L6-v2` model the first time it runs—so it fails offline unless the weights have been cached. These embeddings let AI agents query the product requirement docs, tooltip descriptions, and game data. The generated `src/data/client_embeddings.json` must be committed for the page to work.
 
 After modifying any PRDs, tooltip text, or game rule files, run `npm run generate:embeddings` again to rebuild `client_embeddings.json`. Commit the updated file alongside your documentation changes so other agents have the latest vectors.
 

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -49,4 +49,4 @@ Query: "navbar button transition duration"
 
 ## Updating Embeddings
 
-Run `npm run generate:embeddings` whenever you update documentation or data files. This rebuilds `client_embeddings.json` so agents search the latest content. Commit the regenerated JSON file along with your changes.
+Run `npm run generate:embeddings` whenever you update documentation or data files. The script (`scripts/generateEmbeddings.js`) fetches the `Xenova/all-MiniLM-L6-v2` model on first run, so it requires internet access unless the model is cached. This rebuilds `client_embeddings.json` so agents search the latest content. Commit the regenerated JSON file along with your changes.

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -59,7 +59,7 @@ Ultimately, these issues increase the risk of bugs reaching players, slow down t
 
 ### Embedding Refresh Pipeline
 
-After editing PRDs, tooltips, or game rules, run `npm run generate:embeddings` from the repository root. Commit the updated `client_embeddings.json` so other agents work with the latest vectors. A GitHub Actions workflow could automate this regeneration whenever those folders change.
+After editing PRDs, tooltips, or game rules, run `npm run generate:embeddings` from the repository root. The script at `scripts/generateEmbeddings.js` downloads the `Xenova/all-MiniLM-L6-v2` model the first time it runs, so the command will fail without internet access. Cache the model locally or run it in an environment with a connection. Commit the updated `client_embeddings.json` so other agents work with the latest vectors. A GitHub Actions workflow could automate this regeneration whenever those folders change.
 
 ---
 


### PR DESCRIPTION
## Summary
- add notes in the PRD that the embedding generator downloads the model on first run
- document the same advice in the agent workflow guide
- warn about the network requirement in README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6883ee22056c83269029dd62f32113fa