### PR TITLE
Add Playwright test for vector search page

### DIFF
--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -15,7 +15,8 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
     { url: "/src/pages/randomJudoka.html", name: "randomJudoka.png" },
     { url: "/src/pages/meditation.html", name: "meditation.png" },
     { url: "/src/pages/updateJudoka.html", name: "updateJudoka.png" },
-    { url: "/src/pages/settings.html", name: "settings.png" }
+    { url: "/src/pages/settings.html", name: "settings.png" },
+    { url: "/src/pages/vectorSearch.html", name: "vectorSearch.png" }
   ];
 
   for (const { url, name } of pages) {

--- a/playwright/vector-search.spec.js
+++ b/playwright/vector-search.spec.js
@@ -1,0 +1,53 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+import fs from "fs";
+
+const patchedScript = fs
+  .readFileSync("src/helpers/vectorSearchPage.js", "utf8")
+  .replace(
+    'import { pipeline } from "@xenova/transformers";',
+    "const pipeline = async () => async () => [[1,0]];"
+  );
+
+test.describe("Vector search page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/src/helpers/vectorSearchPage.js", (route) =>
+      route.fulfill({ contentType: "application/javascript", body: patchedScript })
+    );
+    await page.route("**/src/data/client_embeddings.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/client_embeddings.json" })
+    );
+    await page.goto("/src/pages/vectorSearch.html");
+  });
+
+  test("pressing Enter triggers search and shows results", async ({ page }) => {
+    await page.evaluate(() => {
+      window.formSubmitted = false;
+      document
+        .getElementById("vector-search-form")
+        .addEventListener("submit", () => (window.formSubmitted = true));
+    });
+    const input = page.locator("#vector-search-input");
+    await input.fill("apple");
+    await input.press("Enter");
+    await page.waitForFunction(() => window.formSubmitted === true);
+
+    const items = page.locator("#search-results li");
+    await expect(items).toHaveCount(3);
+    for (let i = 0; i < 3; i++) {
+      await expect(items.nth(i)).toContainText(/Source:/);
+      await expect(items.nth(i)).toContainText(/score:/i);
+    }
+  });
+
+  test("shows message when embeddings fail to load", async ({ page }) => {
+    await page.unroute("**/src/data/client_embeddings.json");
+    await page.route("**/src/data/client_embeddings.json", (route) =>
+      route.fulfill({ status: 404, body: "Not Found" })
+    );
+    const input = page.locator("#vector-search-input");
+    await input.fill("apple");
+    await page.click("#vector-search-btn");
+    const results = page.locator("#search-results");
+    await expect(results).toContainText("Embeddings could not be loaded");
+  });
+});

--- a/tests/fixtures/client_embeddings.json
+++ b/tests/fixtures/client_embeddings.json
@@ -1,0 +1,5 @@
+[
+  { "id": "a", "text": "Apple", "embedding": [1, 0], "source": "doc1" },
+  { "id": "b", "text": "Banana", "embedding": [0.9, 0.1], "source": "doc2" },
+  { "id": "c", "text": "Carrot", "embedding": [0, 1], "source": "doc3" }
+]


### PR DESCRIPTION
## Summary
- create vector search Playwright tests
- capture vectorSearch page in screenshot suite
- add small client_embeddings fixture

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_68840d62cd608326b6e09f1d3454e72f