### PR TITLE
Refactor carousel helpers

### DIFF
--- a/src/helpers/carousel/cards.js
+++ b/src/helpers/carousel/cards.js
@@ -1,0 +1,47 @@
+import { generateJudokaCard } from "../cardBuilder.js";
+import { getFallbackJudoka } from "../judokaUtils.js";
+import { getMissingJudokaFields, hasRequiredJudokaFields } from "../judokaValidation.js";
+
+/**
+ * Generate judoka cards and append them to the container.
+ *
+ * @pseudocode
+ * 1. For each judoka:
+ *    a. Validate required fields and log errors for missing data.
+ *    b. Generate a card or fall back to a default judoka.
+ *    c. Apply accessibility attributes and append to the container.
+ *
+ * @param {HTMLElement} container - Carousel container element.
+ * @param {Judoka[]} judokaList - Array of judoka objects.
+ * @param {Object} gokyoLookup - Lookup object for gokyo data.
+ * @returns {Promise<void>} Resolves when all cards are appended.
+ */
+export async function appendCards(container, judokaList, gokyoLookup) {
+  for (const judoka of judokaList) {
+    let entry = judoka;
+    if (!hasRequiredJudokaFields(judoka)) {
+      console.error("Invalid judoka object:", judoka);
+      const missing = getMissingJudokaFields(judoka).join(", ");
+      console.error(`Missing fields: ${missing}`);
+      entry = await getFallbackJudoka();
+    }
+    let card = await generateJudokaCard(entry, gokyoLookup, container);
+    if (!card) {
+      console.warn("Failed to generate card for judoka:", entry);
+      const fallback = await getFallbackJudoka();
+      card = await generateJudokaCard(fallback, gokyoLookup, container);
+    }
+    if (card) {
+      const img = card.querySelector("img");
+      if (img) {
+        img.onerror = () => {
+          img.src = "./assets/cardBacks/cardBack-2.png";
+        };
+      }
+      card.tabIndex = 0;
+      card.setAttribute("role", "listitem");
+      card.setAttribute("aria-label", card.getAttribute("data-judoka-name") || "Judoka card");
+      container.appendChild(card);
+    }
+  }
+}

--- a/src/helpers/carousel/focus.js
+++ b/src/helpers/carousel/focus.js
@@ -1,0 +1,64 @@
+/**
+ * Add focus, keyboard and hover handlers for carousel cards.
+ *
+ * @pseudocode
+ * 1. Highlight the card nearest the carousel center when focus changes.
+ * 2. Move focus with arrow keys and keep the center card enlarged.
+ * 3. Update focus styles on mouse hover for desktop users.
+ *
+ * @param {HTMLElement} container - Carousel container element.
+ */
+export function setupFocusHandlers(container) {
+  function updateCardFocusStyles() {
+    const cards = Array.from(container.querySelectorAll(".judoka-card"));
+    cards.forEach((card) => {
+      card.classList.remove("focused-card");
+      card.style.transform = "";
+    });
+    const containerRect = container.getBoundingClientRect();
+    let minDist = Infinity;
+    let centerCard = null;
+    cards.forEach((card) => {
+      const rect = card.getBoundingClientRect();
+      const cardCenter = rect.left + rect.width / 2;
+      const dist = Math.abs(cardCenter - (containerRect.left + containerRect.width / 2));
+      if (dist < minDist) {
+        minDist = dist;
+        centerCard = card;
+      }
+    });
+    if (centerCard) {
+      centerCard.classList.add("focused-card");
+      centerCard.style.transform = "scale(1.1)";
+      centerCard.focus({ preventScroll: true });
+    }
+  }
+
+  container.addEventListener("keydown", (e) => {
+    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+      const cards = Array.from(container.querySelectorAll(".judoka-card"));
+      const current = document.activeElement;
+      let idx = cards.indexOf(current);
+      if (idx === -1) idx = 0;
+      if (e.key === "ArrowRight" && idx < cards.length - 1) {
+        cards[idx + 1].focus();
+      } else if (e.key === "ArrowLeft" && idx > 0) {
+        cards[idx - 1].focus();
+      }
+      setTimeout(updateCardFocusStyles, 0);
+    }
+  });
+  container.addEventListener("focusin", updateCardFocusStyles);
+  container.addEventListener("focusout", updateCardFocusStyles);
+
+  container.addEventListener("mouseover", (e) => {
+    if (e.target.classList.contains("judoka-card")) {
+      updateCardFocusStyles();
+    }
+  });
+  container.addEventListener("mouseout", (e) => {
+    if (e.target.classList.contains("judoka-card")) {
+      updateCardFocusStyles();
+    }
+  });
+}

--- a/src/helpers/carousel/index.js
+++ b/src/helpers/carousel/index.js
@@ -1,3 +1,6 @@
 export * from "./scroll.js";
 export * from "./navigation.js";
 export * from "./accessibility.js";
+export * from "./responsive.js";
+export * from "./cards.js";
+export * from "./focus.js";

--- a/src/helpers/carousel/responsive.js
+++ b/src/helpers/carousel/responsive.js
@@ -1,0 +1,30 @@
+/**
+ * Setup responsive card sizing and scroll snap behavior.
+ *
+ * @pseudocode
+ * 1. Define a function to calculate card width based on window width.
+ * 2. Apply the calculated width and scroll snap alignment to each card.
+ * 3. Attach a ResizeObserver and window resize listener to update widths.
+ *
+ * @param {HTMLElement} container - Carousel container with judoka cards.
+ */
+export function setupResponsiveSizing(container) {
+  function setCardWidths() {
+    const width = window.innerWidth;
+    let cardsInView = 3;
+    if (width < 600) cardsInView = 1.5;
+    else if (width < 900) cardsInView = 2.5;
+    else if (width < 1200) cardsInView = 3.5;
+    else cardsInView = 5;
+    const cardWidth = `clamp(200px, ${Math.floor(100 / cardsInView)}vw, 260px)`;
+    container.querySelectorAll(".judoka-card").forEach((card) => {
+      card.style.setProperty("--card-width", cardWidth);
+      card.style.scrollSnapAlign = "center";
+    });
+  }
+
+  const resizeObs = new ResizeObserver(setCardWidths);
+  resizeObs.observe(container);
+  window.addEventListener("resize", setCardWidths);
+  setCardWidths();
+}


### PR DESCRIPTION
## Summary
- add responsive, card creation, and focus helper modules
- delegate carouselBuilder to new helpers

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch for settings page)*

------
https://chatgpt.com/codex/tasks/task_e_688484372e0883269dfe6740a1f47c76