### PR TITLE
Refactor battle UI helpers

### DIFF
--- a/src/helpers/battle/battleUI.js
+++ b/src/helpers/battle/battleUI.js
@@ -1,0 +1,78 @@
+/**
+ * DOM helpers for Classic Battle UI.
+ *
+ * @pseudocode
+ * Export functions:
+ *  - `getStatButtons` -> return NodeList of stat buttons within `#stat-buttons`.
+ *  - `getRoundMessageEl` -> return the element with id `round-message`.
+ *  - `resetStatButtons` -> clear selected state and touch highlight from stat buttons.
+ *  - `showResult` -> display result text and fade it out after a delay.
+ */
+
+/**
+ * Query all stat buttons.
+ *
+ * @returns {NodeListOf<HTMLButtonElement>} Node list of stat buttons.
+ */
+export function getStatButtons() {
+  return document.querySelectorAll("#stat-buttons button");
+}
+
+/**
+ * Get the element used for round messages.
+ *
+ * @returns {HTMLElement|null} The round message element or null.
+ */
+export function getRoundMessageEl() {
+  return document.getElementById("round-message");
+}
+
+/**
+ * Remove highlight and focus from all stat buttons.
+ *
+ * @pseudocode
+ * 1. Loop over buttons returned by `getStatButtons`.
+ * 2. Remove the `selected` class and any inline background color.
+ * 3. Disable the button to clear active/tap highlight.
+ * 4. Force reflow and set `-webkit-tap-highlight-color` to transparent.
+ * 5. In the next animation frame re-enable, clear styles, and blur.
+ */
+export function resetStatButtons() {
+  getStatButtons().forEach((btn) => {
+    btn.classList.remove("selected");
+    btn.style.removeProperty("background-color");
+    btn.disabled = true;
+    void btn.offsetWidth;
+    btn.style.setProperty("-webkit-tap-highlight-color", "transparent");
+    requestAnimationFrame(() => {
+      btn.disabled = false;
+      btn.style.removeProperty("-webkit-tap-highlight-color");
+      btn.style.backgroundColor = "";
+      btn.blur();
+    });
+  });
+}
+
+/**
+ * Display the round result message and fade it out after 2s.
+ *
+ * @pseudocode
+ * 1. Get the round message element using `getRoundMessageEl`.
+ * 2. Exit early if the element is missing.
+ * 3. Add `fade-transition`, set the text content, and ensure it's visible.
+ * 4. If `message` is non-empty, add the `fading` class after 2 seconds.
+ *
+ * @param {string} message - Result text to show.
+ */
+export function showResult(message) {
+  const el = getRoundMessageEl();
+  if (!el) return;
+  el.classList.add("fade-transition");
+  el.textContent = message;
+  el.classList.remove("fading");
+  if (message) {
+    setTimeout(() => {
+      el.classList.add("fading");
+    }, 2000);
+  }
+}

--- a/src/helpers/battle/index.js
+++ b/src/helpers/battle/index.js
@@ -1,1 +1,2 @@
 export * from "./score.js";
+export * from "./battleUI.js";

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -15,7 +15,7 @@ import {
 } from "./battleEngine.js";
 import * as infoBar from "./setupBattleInfoBar.js";
 
-import { getStatValue } from "./battle/index.js";
+import { getStatValue, resetStatButtons, showResult } from "./battle/index.js";
 
 export function getStartRound() {
   if (typeof window !== "undefined" && window.startRoundOverride) {
@@ -37,51 +37,6 @@ function updateDebugPanel() {
     matchEnded: isMatchEnded()
   };
   pre.textContent = JSON.stringify(state, null, 2);
-}
-
-/**
- * Remove highlight and focus from all stat buttons.
- *
- * @pseudocode
- * 1. Select all stat buttons within `#stat-buttons`.
- * 2. For each button:
- *    a. Remove the `selected` class so the button style resets.
- *    b. Clear any inline background color to force a repaint in Safari.
- *    c. Disable the button to break the `:active` highlight.
- *    d. Force a reflow and set `-webkit-tap-highlight-color` to
- *       `transparent` so Safari clears its touch overlay.
- *    e. On the next animation frame, re-enable the button,
- *       remove the temporary style, clear `backgroundColor`,
- *       and call `blur()` so Safari drops the highlight.
- */
-function resetStatButtons() {
-  document.querySelectorAll("#stat-buttons button").forEach((btn) => {
-    btn.classList.remove("selected");
-    btn.style.removeProperty("background-color");
-    btn.disabled = true;
-    // Force reflow so Safari drops the touch highlight
-    void btn.offsetWidth;
-    btn.style.setProperty("-webkit-tap-highlight-color", "transparent");
-    requestAnimationFrame(() => {
-      btn.disabled = false;
-      btn.style.removeProperty("-webkit-tap-highlight-color");
-      btn.style.backgroundColor = "";
-      btn.blur();
-    });
-  });
-}
-
-function showResult(message) {
-  const el = document.getElementById("round-message");
-  if (!el) return;
-  el.classList.add("fade-transition");
-  el.textContent = message;
-  el.classList.remove("fading");
-  if (message) {
-    setTimeout(() => {
-      el.classList.add("fading");
-    }, 2000);
-  }
 }
 
 /**

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  resetStatButtons,
+  showResult,
+  getStatButtons,
+  getRoundMessageEl
+} from "../../src/helpers/battle/battleUI.js";
+
+describe("battleUI helpers", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("resetStatButtons clears selection and re-enables buttons", () => {
+    document.body.innerHTML =
+      '<div id="stat-buttons"><button class="selected" style="background-color:red"></button><button class="selected"></button></div>';
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", (cb) => setTimeout(cb, 0));
+    const buttons = getStatButtons();
+    resetStatButtons();
+    buttons.forEach((btn) => {
+      expect(btn.classList.contains("selected")).toBe(false);
+      expect(btn.disabled).toBe(true);
+    });
+    vi.runAllTimers();
+    buttons.forEach((btn) => {
+      expect(btn.disabled).toBe(false);
+      expect(btn.style.backgroundColor).toBe("");
+    });
+  });
+
+  it("showResult updates text and fades after delay", () => {
+    document.body.innerHTML = '<p id="round-message" class="fading"></p>';
+    vi.useFakeTimers();
+    showResult("You win!");
+    const el = getRoundMessageEl();
+    expect(el.textContent).toBe("You win!");
+    expect(el.classList.contains("fade-transition")).toBe(true);
+    expect(el.classList.contains("fading")).toBe(false);
+    vi.advanceTimersByTime(2000);
+    expect(el.classList.contains("fading")).toBe(true);
+  });
+
+  it("DOM helper functions return elements", () => {
+    document.body.innerHTML =
+      '<div id="stat-buttons"><button></button></div><p id="round-message"></p>';
+    expect(getStatButtons().length).toBe(1);
+    expect(getRoundMessageEl()).toBeInstanceOf(HTMLElement);
+  });
+});


### PR DESCRIPTION
## Summary
- extract battle UI utilities into `battleUI.js`
- use the new helpers inside `classicBattle.js`
- add unit tests for battle UI helpers

Playwright screenshot tests show a diff for `settings.html` but other tests pass.


------
https://chatgpt.com/codex/tasks/task_e_68848444e4ac8326b50d52d1d69a1ef1