### PR TITLE
Refactor navigation menu helpers

### DIFF
--- a/src/helpers/navigation/navData.js
+++ b/src/helpers/navigation/navData.js
@@ -1,0 +1,47 @@
+import { debugLog } from "../debug.js";
+import { loadSettings } from "../settingsUtils.js";
+import { loadGameModes } from "../gameModeUtils.js";
+
+/**
+ * Validates game modes data to ensure all required properties are present.
+ *
+ * @pseudocode
+ * 1. Filter out items missing `name` or `url` properties.
+ * 2. Return the filtered array.
+ *
+ * @param {Array} gameModes - The list of game modes to validate.
+ * @returns {Array} Validated game modes.
+ */
+export function validateGameModes(gameModes) {
+  const validatedModes = gameModes.filter((mode) => mode.name && mode.url);
+  debugLog("Validated modes:", validatedModes); // Debug validated modes
+  return validatedModes;
+}
+
+/**
+ * Load and validate active main menu game modes.
+ *
+ * @pseudocode
+ * 1. Fetch all game modes using `loadGameModes()`.
+ * 2. Retrieve user settings via `loadSettings()`.
+ * 3. Filter the modes to include only visible main menu items not disabled in settings.
+ * 4. Sort the filtered modes by their `order` property.
+ * 5. Validate the resulting array with `validateGameModes()`.
+ * 6. Return the validated array.
+ *
+ * @returns {Promise<Array>} Resolved array of active game modes.
+ */
+export async function loadMenuModes() {
+  const data = await loadGameModes();
+  const settings = await loadSettings();
+  return validateGameModes(
+    data
+      .filter(
+        (mode) =>
+          mode.category === "mainMenu" &&
+          mode.isHidden === false &&
+          settings.gameModes[mode.id] !== false
+      )
+      .sort((a, b) => a.order - b.order)
+  );
+}

--- a/src/helpers/navigation/navMenu.js
+++ b/src/helpers/navigation/navMenu.js
@@ -1,0 +1,105 @@
+import { validateGameModes } from "./navData.js";
+
+/**
+ * Base path for navigation links derived from the current module location.
+ */
+export const BASE_PATH = (() => {
+  const url = new URL("../../pages/", import.meta.url);
+  return url.href.endsWith("/") ? url : new URL(url.href + "/");
+})();
+
+/**
+ * Clears existing content in the bottom navigation bar.
+ *
+ * @pseudocode
+ * 1. Select the `.bottom-navbar` element.
+ * 2. Exit early if the element is not found.
+ * 3. Remove all child elements to prevent duplication.
+ */
+export function clearBottomNavbar() {
+  const navBar = document.querySelector(".bottom-navbar");
+  if (!navBar) return; // Guard: do nothing if navbar is missing
+  navBar.innerHTML = ""; // Clear all existing content
+}
+
+/**
+ * Toggles the expanded map view for landscape mode.
+ *
+ * @pseudocode
+ * 1. Check if the device is in landscape orientation.
+ * 2. Select the `.bottom-navbar` element and exit early if not found.
+ * 3. Create a map view with clickable tiles for game modes.
+ * 4. Add a slide-up animation when the logo is clicked.
+ * 5. Hide the map view when the logo is clicked again.
+ *
+ * @param {Array} gameModes - The list of game modes to display.
+ */
+export function toggleExpandedMapView(gameModes) {
+  const navBar = document.querySelector(".bottom-navbar");
+  if (!navBar) return; // Guard: do nothing if navbar is missing
+  clearBottomNavbar(); // Clear existing content
+
+  const validModes = validateGameModes(gameModes);
+
+  const mapView = document.createElement("div");
+  mapView.className = "expanded-map-view";
+
+  mapView.innerHTML = validModes
+    .map(
+      (mode) =>
+        `<div class="map-tile">
+          <img src="${mode.image}" alt="${mode.name}" loading="lazy">
+          <a href="${BASE_PATH}${mode.url}" aria-label="${mode.name}">${mode.name}</a>
+        </div>`
+    )
+    .join("");
+
+  navBar.appendChild(mapView);
+
+  const logo = document.querySelector(".bottom-navbar .logo");
+  logo.addEventListener("click", () => {
+    mapView.classList.toggle("visible");
+    mapView.style.animation = mapView.classList.contains("visible")
+      ? "slide-up 500ms ease-in-out"
+      : "slide-down 500ms ease-in-out";
+  });
+}
+
+/**
+ * Toggles the vertical text menu for portrait mode.
+ *
+ * @pseudocode
+ * 1. Check if the device is in portrait orientation.
+ * 2. Create a vertical menu with game modes as list items.
+ * 3. Add a slide-down animation when the logo is clicked.
+ * 4. Hide the menu when the logo is clicked again.
+ *
+ * @param {Array} gameModes - The list of game modes to display.
+ */
+export function togglePortraitTextMenu(gameModes) {
+  const navBar = document.querySelector(".bottom-navbar");
+  if (!navBar) return; // Guard: do nothing if navbar is missing
+  clearBottomNavbar(); // Clear existing content
+
+  const validModes = validateGameModes(gameModes);
+
+  const textMenu = document.createElement("ul");
+  textMenu.className = "portrait-text-menu";
+
+  textMenu.innerHTML = validModes
+    .map(
+      (mode) =>
+        `<li><a href="${BASE_PATH}${mode.url}" aria-label="${mode.name}">${mode.name}</a></li>`
+    )
+    .join("");
+
+  navBar.appendChild(textMenu);
+
+  const logo = document.querySelector(".bottom-navbar .logo");
+  logo.addEventListener("click", () => {
+    textMenu.classList.toggle("visible");
+    textMenu.style.animation = textMenu.classList.contains("visible")
+      ? "slide-down 500ms ease-in-out"
+      : "slide-up 500ms ease-in-out";
+  });
+}

--- a/src/helpers/navigationBar.js
+++ b/src/helpers/navigationBar.js
@@ -1,126 +1,5 @@
-import { debugLog } from "./debug.js";
-import { loadSettings } from "./settingsUtils.js";
-import { loadGameModes } from "./gameModeUtils.js";
-
-/**
- * Base path for navigation links derived from the current module location.
- */
-export const BASE_PATH = (() => {
-  const url = new URL("../pages/", import.meta.url);
-  return url.href.endsWith("/") ? url : new URL(url.href + "/");
-})();
-
-/**
- * Toggles the expanded map view for landscape mode.
- *
- * @pseudocode
- * 1. Check if the device is in landscape orientation.
- * 2. Select the `.bottom-navbar` element and exit early if not found.
- * 3. Create a map view with clickable tiles for game modes.
- * 4. Add a slide-up animation when the logo is clicked.
- * 5. Hide the map view when the logo is clicked again.
- *
- * @param {Array} gameModes - The list of game modes to display.
- */
-export function toggleExpandedMapView(gameModes) {
-  const navBar = document.querySelector(".bottom-navbar");
-  if (!navBar) return; // Guard: do nothing if navbar is missing
-  clearBottomNavbar(); // Clear existing content
-
-  const validModes = validateGameModes(gameModes);
-
-  const mapView = document.createElement("div");
-  mapView.className = "expanded-map-view";
-
-  mapView.innerHTML = validModes
-    .map(
-      (mode) =>
-        `<div class="map-tile">
-          <img src="${mode.image}" alt="${mode.name}" loading="lazy">
-          <a href="${BASE_PATH}${mode.url}" aria-label="${mode.name}">${mode.name}</a>
-        </div>`
-    )
-    .join("");
-
-  navBar.appendChild(mapView);
-
-  const logo = document.querySelector(".bottom-navbar .logo");
-  logo.addEventListener("click", () => {
-    mapView.classList.toggle("visible");
-    mapView.style.animation = mapView.classList.contains("visible")
-      ? "slide-up 500ms ease-in-out"
-      : "slide-down 500ms ease-in-out";
-  });
-}
-
-/**
- * Clears existing content in the bottom navigation bar.
- *
- * @pseudocode
- * 1. Select the `.bottom-navbar` element.
- * 2. Exit early if the element is not found.
- * 3. Remove all child elements to prevent duplication.
- */
-function clearBottomNavbar() {
-  const navBar = document.querySelector(".bottom-navbar");
-  if (!navBar) return; // Guard: do nothing if navbar is missing
-  navBar.innerHTML = ""; // Clear all existing content
-}
-
-/**
- * Toggles the vertical text menu for portrait mode.
- *
- * @pseudocode
- * 1. Check if the device is in portrait orientation.
- * 2. Create a vertical menu with game modes as list items.
- * 3. Add a slide-down animation when the logo is clicked.
- * 4. Hide the menu when the logo is clicked again.
- *
- * @param {Array} gameModes - The list of game modes to display.
- */
-export function togglePortraitTextMenu(gameModes) {
-  const navBar = document.querySelector(".bottom-navbar");
-  if (!navBar) return; // Guard: do nothing if navbar is missing
-  clearBottomNavbar(); // Clear existing content
-
-  const validModes = validateGameModes(gameModes);
-
-  const textMenu = document.createElement("ul");
-  textMenu.className = "portrait-text-menu";
-
-  textMenu.innerHTML = validModes
-    .map(
-      (mode) =>
-        `<li><a href="${BASE_PATH}${mode.url}" aria-label="${mode.name}">${mode.name}</a></li>`
-    )
-    .join("");
-
-  navBar.appendChild(textMenu);
-
-  const logo = document.querySelector(".bottom-navbar .logo");
-  logo.addEventListener("click", () => {
-    textMenu.classList.toggle("visible");
-    textMenu.style.animation = textMenu.classList.contains("visible")
-      ? "slide-down 500ms ease-in-out"
-      : "slide-up 500ms ease-in-out";
-  });
-}
-
-/**
- * Validates game modes data to ensure all required properties are present.
- *
- * @pseudocode
- * 1. Filter out items missing `name`, or `url` properties.
- * 2. Return the filtered array.
- *
- * @param {Array} gameModes - The list of game modes to validate.
- * @returns {Array} Validated game modes.
- */
-function validateGameModes(gameModes) {
-  const validatedModes = gameModes.filter((mode) => mode.name && mode.url);
-  debugLog("Validated modes:", validatedModes); // Debug validated modes
-  return validatedModes;
-}
+import { loadMenuModes } from "./navigation/navData.js";
+import { BASE_PATH, clearBottomNavbar } from "./navigation/navMenu.js";
 
 /**
  * Adds touch feedback animations to navigation links.
@@ -152,37 +31,13 @@ function addTouchFeedback() {
  *
  * @pseudocode
  * 1. Guard: return immediately if `document` is undefined.
- * 2. Attempt to retrieve cached game modes from `localStorage`.
- *    - Parse the JSON string if it exists.
- * 3. When online, fetch `gameModes.json` to refresh the data.
- *    - On success, update `localStorage` with the fetched JSON string.
- *    - On failure or when offline, fall back to the cached data.
- *
- * 4. Parse the JSON to retrieve the game modes data.
- *    - Handle parsing errors gracefully.
- *
- * 5. Select the `.bottom-navbar` element and exit if not found.
- *
- * 6. Load user settings to determine disabled game modes.
- *
- * 7. Filter the game modes:
- *    - Include only modes where `category` is "mainMenu", `isHidden` is `false`,
- *      and the mode is not disabled in settings.
- *
- * 8. Sort the filtered game modes by their `order` property in ascending order.
- *
- * 9. Check if there are any active modes:
- *    - If no modes are available, display "No game modes available" in the navigation bar.
- *
- * 10. Map the sorted game modes to HTML list items (`<li>`):
- *    - Each list item contains a link (`<a>`) to the corresponding game mode's URL.
- * 11. Compare each link's URL with `window.location.pathname` and mark the
- *     matching link with `aria-current="page"` and an `active` class.
- *
- * 12. Update the navigation bar (`.bottom-navbar ul`) with the generated HTML.
- *
- * 13. Handle any errors during the process:
- *    - Log the error to the console and display fallback items in the navigation bar.
+ * 2. Select the `.bottom-navbar` element and exit if not found.
+ * 3. Clear existing content using `clearBottomNavbar()`.
+ * 4. Call `loadMenuModes()` to retrieve active game modes.
+ * 5. If none are returned, display "No game modes available".
+ * 6. Map the modes to list items and mark the current page link as active.
+ * 7. Append the list to the navigation bar and add touch feedback.
+ * 8. On error, log the issue and show fallback items.
  *
  * @returns {Promise<void>} A promise that resolves once the navbar is populated.
  */
@@ -190,24 +45,11 @@ function addTouchFeedback() {
 export async function populateNavbar() {
   if (typeof document === "undefined") return; // Guard for non-DOM environments
   try {
-    const data = await loadGameModes();
-
     const navBar = document.querySelector(".bottom-navbar");
     if (!navBar) return; // Guard: do nothing if navbar is missing
     clearBottomNavbar();
 
-    const settings = await loadSettings();
-
-    const activeModes = validateGameModes(
-      data.filter(
-        (mode) =>
-          mode.category === "mainMenu" &&
-          mode.isHidden === false &&
-          settings.gameModes[mode.id] !== false
-      )
-    ).sort((a, b) => a.order - b.order);
-
-    debugLog("Validated game modes:", activeModes);
+    const activeModes = await loadMenuModes();
 
     if (activeModes.length === 0) {
       navBar.innerHTML = "<ul><li>No game modes available</li></ul>";

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -49,7 +49,9 @@ describe("toggleExpandedMapView", () => {
       { url: "broken.html", image: "img3.png" }
     ];
 
-    const { toggleExpandedMapView, BASE_PATH } = await import("../../src/helpers/navigationBar.js");
+    const { toggleExpandedMapView, BASE_PATH } = await import(
+      "../../src/helpers/navigation/navMenu.js"
+    );
 
     toggleExpandedMapView(modes);
 
@@ -63,7 +65,7 @@ describe("toggleExpandedMapView", () => {
   });
 
   it("does not create tiles if no valid modes", async () => {
-    const { toggleExpandedMapView } = await import("../../src/helpers/navigationBar.js");
+    const { toggleExpandedMapView } = await import("../../src/helpers/navigation/navMenu.js");
     toggleExpandedMapView([]);
     const view = navBar.querySelector(".expanded-map-view");
     expect(view).toBeTruthy();
@@ -72,7 +74,7 @@ describe("toggleExpandedMapView", () => {
 
   it("sets correct ARIA attributes and alt text for images", async () => {
     const modes = [{ name: "Mode1", url: "mode1.html", image: "img1.png" }];
-    const { toggleExpandedMapView } = await import("../../src/helpers/navigationBar.js");
+    const { toggleExpandedMapView } = await import("../../src/helpers/navigation/navMenu.js");
     toggleExpandedMapView(modes);
     const tile = navBar.querySelector(".map-tile");
     const link = tile.querySelector("a");
@@ -97,7 +99,7 @@ describe("togglePortraitTextMenu", () => {
     ];
 
     const { togglePortraitTextMenu, BASE_PATH } = await import(
-      "../../src/helpers/navigationBar.js"
+      "../../src/helpers/navigation/navMenu.js"
     );
 
     togglePortraitTextMenu(modes);
@@ -112,7 +114,7 @@ describe("togglePortraitTextMenu", () => {
   });
 
   it("does not create items if no valid modes", async () => {
-    const { togglePortraitTextMenu } = await import("../../src/helpers/navigationBar.js");
+    const { togglePortraitTextMenu } = await import("../../src/helpers/navigation/navMenu.js");
     togglePortraitTextMenu([]);
     const menu = navBar.querySelector(".portrait-text-menu");
     expect(menu).toBeTruthy();
@@ -121,7 +123,7 @@ describe("togglePortraitTextMenu", () => {
 
   it("sets correct ARIA attributes for links", async () => {
     const modes = [{ name: "Mode1", url: "mode1.html", image: "img1.png" }];
-    const { togglePortraitTextMenu } = await import("../../src/helpers/navigationBar.js");
+    const { togglePortraitTextMenu } = await import("../../src/helpers/navigation/navMenu.js");
     togglePortraitTextMenu(modes);
     const link = navBar.querySelector(".portrait-text-menu li a");
     expect(link).toHaveAttribute("aria-label", "Mode1");


### PR DESCRIPTION
## Summary
- split navigation helpers into navMenu and navData modules
- simplify populateNavbar to use new helpers
- update bottom navigation unit tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(1 failing screenshot test)*

------
https://chatgpt.com/codex/tasks/task_e_688484602a888326a6304a63ee99bff7