### PR TITLE
Load navigation items in settings page

### DIFF
--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -69,7 +69,7 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
         input.checked = prev;
       });
       updateGameModeHidden(mode.id, !input.checked).catch((err) => {
-        console.error("Failed to update game mode", err);
+        console.error("Failed to update navigation item", err);
         input.checked = prev;
         showSettingsError();
       });

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -2,12 +2,12 @@
  * Set up the Settings page once the document is ready.
  *
  * @pseudocode
- * 1. Load saved settings and available game modes.
+ * 1. Load saved settings and available navigation items.
  * 2. Apply the stored display mode and motion preference.
  * 3. Initialize the page controls and event listeners.
  */
 import { loadSettings, updateSetting } from "./settingsUtils.js";
-import { loadGameModes } from "./gameModeUtils.js";
+import { loadNavigationItems } from "./gameModeUtils.js";
 import { showSettingsError } from "./showSettingsError.js";
 import { applyDisplayMode } from "./displayMode.js";
 import { applyMotionPreference } from "./motionUtils.js";
@@ -85,7 +85,7 @@ function initializeControls(settings, gameModes) {
 async function initializeSettingsPage() {
   try {
     const settings = await loadSettings();
-    const gameModes = await loadGameModes();
+    const gameModes = await loadNavigationItems();
     applyDisplayMode(settings.displayMode);
     applyMotionPreference(settings.motionEffects);
     initializeControls(settings, gameModes);


### PR DESCRIPTION
## Summary
- update Settings page to use `loadNavigationItems`
- tweak settings form error log wording

## Testing
- `npx prettier src/helpers/settingsPage.js src/helpers/settings/formUtils.js --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_6884c8d210e08326833a00ce4fc181ee