### PR TITLE
Switch tests to navigationItems fixture

### DIFF
--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -21,8 +21,8 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
 
   for (const { url, name } of pages) {
     test(`screenshot ${url}`, async ({ page }) => {
-      await page.route("**/src/data/gameModes.json", (route) => {
-        route.fulfill({ path: "tests/fixtures/gameModes.json" });
+      await page.route("**/src/data/navigationItems.json", (route) => {
+        route.fulfill({ path: "tests/fixtures/navigationItems.json" });
       });
       await page.route("**/src/data/*.json", (route) => {
         const file = route.request().url().split("/").pop();

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -3,8 +3,8 @@ import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 test.describe("Settings page", () => {
   test.beforeEach(async ({ page }) => {
-    await page.route("**/src/data/gameModes.json", (route) =>
-      route.fulfill({ path: "tests/fixtures/gameModes.json" })
+    await page.route("**/src/data/navigationItems.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/navigationItems.json" })
     );
     await page.goto("/src/pages/settings.html", { waitUntil: "domcontentloaded" });
     await page.waitForSelector("#mode-classicBattle", { state: "attached" });
@@ -32,12 +32,12 @@ test.describe("Settings page", () => {
   test("controls expose correct labels and follow tab order", async ({ page }) => {
     await page.getByLabel(/Classic Battle/i).waitFor();
 
-    const gameModes = await page.evaluate(async () => {
-      const res = await fetch("/tests/fixtures/gameModes.json");
+    const navigationItems = await page.evaluate(async () => {
+      const res = await fetch("/tests/fixtures/navigationItems.json");
       return res.json();
     });
 
-    const sortedNames = gameModes
+    const sortedNames = navigationItems
       .slice()
       .sort((a, b) => a.order - b.order)
       .map((m) => m.name);

--- a/playwright/updateJudoka.spec.js
+++ b/playwright/updateJudoka.spec.js
@@ -3,8 +3,8 @@ import { verifyPageBasics } from "./fixtures/navigationChecks.js";
 
 test.describe("Update Judoka page", () => {
   test.beforeEach(async ({ page }) => {
-    await page.route("**/src/data/gameModes.json", (route) =>
-      route.fulfill({ path: "tests/fixtures/gameModes.json" })
+    await page.route("**/src/data/navigationItems.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/navigationItems.json" })
     );
     await page.goto("/src/pages/updateJudoka.html");
   });

--- a/tests/fixtures/navigationItems.json
+++ b/tests/fixtures/navigationItems.json
@@ -1,0 +1,181 @@
+[
+  {
+    "id": "classicBattle",
+    "name": "Classic Battle",
+    "japaneseName": "試合 (バトルモード)",
+    "description": "A standard one-on-one battle mode where players compete to win.",
+    "category": "mainMenu",
+    "order": 20,
+    "url": "battleJudoka.html",
+    "isHidden": false,
+    "rules": {
+      "rounds": 25,
+      "teamSize": 25,
+      "maxScore": 10,
+      "gender": "any"
+    }
+  },
+  {
+    "id": "teamBattleSelection",
+    "name": "Team Battle Selection",
+    "japaneseName": "団体戦選択",
+    "description": "Choose between Male, Female, or Mixed Team Battle modes.",
+    "category": "subMenu",
+    "order": 35,
+    "url": "teamBattleSelection.html",
+    "isHidden": true,
+    "rules": {
+      "options": ["teamBattleMale", "teamBattleFemale", "teamBattleMixed"]
+    }
+  },
+  {
+    "id": "manageJudokaSelection",
+    "name": "Manage Judoka",
+    "japaneseName": "柔道家編集モード",
+    "description": "Choose to update or create a judoka.",
+    "category": "subMenu",
+    "order": 40,
+    "url": "judokaUpdateSelection.html",
+    "isHidden": true,
+    "rules": {
+      "options": ["createJudoka", "updateJudoka"]
+    }
+  },
+  {
+    "id": "teamBattleMale",
+    "name": "Team Battle (Male)",
+    "japaneseName": "男子団体戦",
+    "description": "A team-based mode where male players compete in groups.",
+    "category": "teamBattle",
+    "order": 50,
+    "url": "teamBattleMale.html",
+    "isHidden": true,
+    "rules": {
+      "base": "teamBattle",
+      "gender": "male"
+    }
+  },
+  {
+    "id": "teamBattleFemale",
+    "name": "Team Battle (Female)",
+    "japaneseName": "女子団体戦",
+    "description": "A team-based mode where female players compete in groups.",
+    "category": "teamBattle",
+    "order": 60,
+    "url": "teamBattleFemale.html",
+    "isHidden": true,
+    "rules": {
+      "base": "teamBattle",
+      "gender": "female"
+    }
+  },
+  {
+    "id": "teamBattleMixed",
+    "name": "Team Battle (Mixed)",
+    "japaneseName": "混合団体戦",
+    "description": "A team-based mode where male and female players compete together in groups.",
+    "category": "teamBattle",
+    "order": 70,
+    "url": "teamBattleMixed.html",
+    "isHidden": false,
+    "rules": {
+      "rounds": 6,
+      "teamSize": 6,
+      "maxScore": 6,
+      "gender": "mixed"
+    }
+  },
+  {
+    "id": "browseJudoka",
+    "name": "Browse Judoka",
+    "japaneseName": "柔道家を閲覧",
+    "description": "Explore the available judoka and their stats.",
+    "category": "mainMenu",
+    "order": 80,
+    "url": "browseJudoka.html",
+    "isHidden": false,
+    "rules": {
+      "note": "Rules will be defined in the future."
+    }
+  },
+  {
+    "id": "createJudoka",
+    "name": "Create A Judoka",
+    "japaneseName": "柔道家を作成",
+    "description": "Create a new judoka by entering their details and stats.",
+    "category": "judokaUpdate",
+    "order": 90,
+    "url": "createJudoka.html",
+    "isHidden": false,
+    "rules": {
+      "note": "Rules will be defined in the future."
+    }
+  },
+  {
+    "id": "updateJudoka",
+    "name": "Update Judoka",
+    "japaneseName": "柔道家を更新",
+    "description": "Edit the details of an existing judoka.",
+    "category": "mainMenu",
+    "order": 30,
+    "url": "updateJudoka.html",
+    "isHidden": false,
+    "rules": {
+      "note": "Rules will be defined in the future."
+    }
+  },
+  {
+    "id": "teamBattle",
+    "name": "teamBattle Ruleset",
+    "japaneseName": "団体戦ルールセット",
+    "description": "Defining the common ruleset for Team Battles.",
+    "category": "none",
+    "order": 65,
+    "url": "teamBattleRuleset.html",
+    "isHidden": true,
+    "rules": {
+      "rounds": 5,
+      "teamSize": 5,
+      "maxScore": 5
+    }
+  },
+  {
+    "id": "meditation",
+    "name": "Meditation",
+    "japaneseName": "メディテーション",
+    "description": "Take a moment to pause, breathe, and reflect.",
+    "category": "mainMenu",
+    "order": 85,
+    "url": "meditation.html",
+    "isHidden": false,
+    "rules": {
+      "note": "Rules will be defined in the future."
+    }
+  },
+  {
+    "id": "randomJudoka",
+    "name": "View Judoka",
+    "japaneseName": "ランダム柔道家",
+    "description": "Displays a random judoka from the available list.",
+    "category": "mainMenu",
+    "order": 40,
+    "url": "randomJudoka.html",
+    "isHidden": false,
+    "rules": {
+      "note": "Rules will be defined in the future."
+    }
+  },
+  {
+    "id": "settingsMenu",
+    "name": "Settings",
+    "japaneseName": "設定",
+    "description": "Change game settings.",
+    "category": "mainMenu",
+    "order": 90,
+    "url": "settings.html",
+    "isHidden": false,
+    "rules": {
+      "note": "Rules will be defined in the future."
+    }
+  }
+]

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -145,11 +145,11 @@ describe("populateNavbar", () => {
       gameModes: { B: false },
       featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
     });
-    const loadGameModes = vi.fn().mockResolvedValue(data);
+    const loadNavigationItems = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
-      loadNavigationItems: loadGameModes,
-      loadGameModes
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems
     }));
 
     const { populateNavbar } = await import("../../src/helpers/navigationBar.js");
@@ -160,17 +160,17 @@ describe("populateNavbar", () => {
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toBe("A");
     expect(loadSettings).toHaveBeenCalled();
-    expect(loadGameModes).toHaveBeenCalled();
+    expect(loadNavigationItems).toHaveBeenCalled();
   });
 
   it("falls back to default items when fetch fails", async () => {
     const navBar = setupDom();
     stubLogoQuery();
     localStorage.removeItem("gameModes");
-    const loadGameModes = vi.fn().mockRejectedValue(new Error("fail"));
+    const loadNavigationItems = vi.fn().mockRejectedValue(new Error("fail"));
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
-      loadNavigationItems: loadGameModes,
-      loadGameModes
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems
     }));
 
     const { populateNavbar } = await import("../../src/helpers/navigationBar.js");
@@ -198,11 +198,11 @@ describe("populateNavbar", () => {
       gameModes: {},
       featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
     });
-    const loadGameModes = vi.fn().mockResolvedValue(data);
+    const loadNavigationItems = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
-      loadNavigationItems: loadGameModes,
-      loadGameModes
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems
     }));
 
     const { populateNavbar } = await import("../../src/helpers/navigationBar.js");
@@ -212,7 +212,7 @@ describe("populateNavbar", () => {
     const items = navBar.querySelectorAll("li");
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toBe("X");
-    expect(loadGameModes).toHaveBeenCalled();
+    expect(loadNavigationItems).toHaveBeenCalled();
   });
 
   it("marks current page link as active", async () => {
@@ -243,11 +243,11 @@ describe("populateNavbar", () => {
       gameModes: {},
       featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
     });
-    const loadGameModes = vi.fn().mockResolvedValue(data);
+    const loadNavigationItems = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
-      loadNavigationItems: loadGameModes,
-      loadGameModes
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems
     }));
 
     window.history.pushState({}, "", "/src/pages/home.html");

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -22,7 +22,7 @@ describe("settingsPage module", () => {
     vi.useFakeTimers();
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
-    const loadGameModes = vi.fn().mockResolvedValue([]);
+    const loadNavigationItems = vi.fn().mockResolvedValue([]);
     const updateGameModeHidden = vi.fn();
     const applyDisplayMode = vi.fn();
     const applyMotionPreference = vi.fn();
@@ -31,8 +31,8 @@ describe("settingsPage module", () => {
       updateSetting
     }));
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
-      loadNavigationItems: loadGameModes,
-      loadGameModes,
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
       updateGameModeHidden
     }));
     vi.doMock("../../src/helpers/displayMode.js", () => ({
@@ -47,7 +47,7 @@ describe("settingsPage module", () => {
     await vi.runAllTimersAsync();
 
     expect(loadSettings).toHaveBeenCalled();
-    expect(loadGameModes).toHaveBeenCalled();
+    expect(loadNavigationItems).toHaveBeenCalled();
     expect(applyDisplayMode).toHaveBeenCalledWith(baseSettings.displayMode);
     expect(applyMotionPreference).toHaveBeenCalledWith(baseSettings.motionEffects);
     vi.useRealTimers();
@@ -61,15 +61,15 @@ describe("settingsPage module", () => {
     ];
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
-    const loadGameModes = vi.fn().mockResolvedValue(gameModes);
+    const loadNavigationItems = vi.fn().mockResolvedValue(gameModes);
     const updateGameModeHidden = vi.fn();
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
     }));
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
-      loadNavigationItems: loadGameModes,
-      loadGameModes,
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
       updateGameModeHidden
     }));
 
@@ -96,15 +96,15 @@ describe("settingsPage module", () => {
     ];
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
-    const loadGameModes = vi.fn().mockResolvedValue(gameModes);
+    const loadNavigationItems = vi.fn().mockResolvedValue(gameModes);
     const updateGameModeHidden = vi.fn();
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
     }));
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
-      loadNavigationItems: loadGameModes,
-      loadGameModes,
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
       updateGameModeHidden
     }));
 
@@ -121,15 +121,15 @@ describe("settingsPage module", () => {
     const gameModes = [{ id: "classic", name: "Classic", category: "mainMenu", isHidden: false }];
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
-    const loadGameModes = vi.fn().mockResolvedValue(gameModes);
+    const loadNavigationItems = vi.fn().mockResolvedValue(gameModes);
     const updateGameModeHidden = vi.fn().mockResolvedValue([{ ...gameModes[0], isHidden: true }]);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
     }));
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
-      loadNavigationItems: loadGameModes,
-      loadGameModes,
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
       updateGameModeHidden
     }));
 
@@ -148,14 +148,14 @@ describe("settingsPage module", () => {
     vi.useFakeTimers();
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
-    const loadGameModes = vi.fn().mockResolvedValue([]);
+    const loadNavigationItems = vi.fn().mockResolvedValue([]);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
     }));
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
-      loadNavigationItems: loadGameModes,
-      loadGameModes,
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
       updateGameModeHidden: vi.fn()
     }));
 
@@ -180,14 +180,14 @@ describe("settingsPage module", () => {
       featureFlags: { ...baseSettings.featureFlags, battleDebugPanel: true }
     };
     const updateSetting = vi.fn().mockResolvedValue(updatedSettings);
-    const loadGameModes = vi.fn().mockResolvedValue([]);
+    const loadNavigationItems = vi.fn().mockResolvedValue([]);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
     }));
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
-      loadNavigationItems: loadGameModes,
-      loadGameModes,
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
       updateGameModeHidden: vi.fn()
     }));
 


### PR DESCRIPTION
## Summary
- add `navigationItems.json` fixture
- intercept `navigationItems.json` in Playwright specs
- update navigation menu unit tests to use `loadNavigationItems` mocks

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_6884cae073c88326aa82eaee9de0b73a