### PR TITLE
Load transformers dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ After modifying any PRDs **or any file in `src/data/`**, run `npm run generate:e
 - Results appear below the form with up to five entries that show match score and source.
 - The page displays “Embeddings could not be loaded – please check console.” if loading fails, or “No close matches found” when nothing is returned.
 - Users can submit the form by pressing **Enter** in the search box.
+- The transformer library is loaded from jsDelivr on first use, so network connectivity is required for that initial download.
 
 ## About JU-DO-KON!
 

--- a/playwright/vector-search.spec.js
+++ b/playwright/vector-search.spec.js
@@ -4,7 +4,7 @@ import fs from "fs";
 const patchedScript = fs
   .readFileSync("src/helpers/vectorSearchPage.js", "utf8")
   .replace(
-    'import { pipeline } from "@xenova/transformers";',
+    'const { pipeline } = await import("https://cdn.jsdelivr.net/npm/@xenova/transformers@2.6.0/dist/transformers.min.js");',
     "const pipeline = async () => async () => [[1,0]];"
   );
 

--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -1,6 +1,7 @@
 import { onDomReady } from "./domReady.js";
 import { findMatches } from "./vectorSearch.js";
-import { pipeline } from "@xenova/transformers";
+// Load Transformers.js dynamically from jsDelivr when first used
+// This avoids bundling the large library with the rest of the code.
 
 let extractor;
 let spinner;
@@ -8,6 +9,9 @@ let spinner;
 async function getExtractor() {
   if (!extractor) {
     try {
+      const { pipeline } = await import(
+        "https://cdn.jsdelivr.net/npm/@xenova/transformers@2.6.0/dist/transformers.min.js"
+      );
       extractor = await pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2");
     } catch (error) {
       console.error("Model failed to load", error);


### PR DESCRIPTION
## Summary
- lazy-load Transformers.js from jsDelivr in `vectorSearchPage.js`
- update Playwright mock to replace new dynamic import
- document CDN requirement for Vector Search page

## Testing
- `npx prettier . --check`
- `npm run lint`
- `npx vitest run`
- `npx playwright test` *(fails: several UI tests and screenshots)*

------
https://chatgpt.com/codex/tasks/task_e_688502fcaad88326a337483ce64b251a