### PR TITLE
Update navigation data structure

### DIFF
--- a/src/data/gameModes.json
+++ b/src/data/gameModes.json
@@ -4,7 +4,6 @@
     "name": "Classic Battle",
     "japaneseName": "試合 (バトルモード)",
     "description": "A standard one-on-one battle mode where players compete to win.",
-    "isHidden": false,
     "rules": {
       "rounds": 25,
       "teamSize": 25,
@@ -17,7 +16,6 @@
     "name": "Team Battle Selection",
     "japaneseName": "団体戦選択",
     "description": "Choose between Male, Female, or Mixed Team Battle modes.",
-    "isHidden": true,
     "rules": {
       "options": ["teamBattleMale", "teamBattleFemale", "teamBattleMixed"]
     }
@@ -27,7 +25,6 @@
     "name": "Manage Judoka",
     "japaneseName": "柔道家編集モード",
     "description": "Choose to update or create a judoka.",
-    "isHidden": true,
     "rules": {
       "options": ["createJudoka", "updateJudoka"]
     }
@@ -37,7 +34,6 @@
     "name": "Team Battle (Male)",
     "japaneseName": "男子団体戦",
     "description": "A team-based mode where male players compete in groups.",
-    "isHidden": true,
     "rules": {
       "base": "teamBattle",
       "gender": "male"
@@ -48,7 +44,6 @@
     "name": "Team Battle (Female)",
     "japaneseName": "女子団体戦",
     "description": "A team-based mode where female players compete in groups.",
-    "isHidden": true,
     "rules": {
       "base": "teamBattle",
       "gender": "female"
@@ -59,7 +54,6 @@
     "name": "Team Battle (Mixed)",
     "japaneseName": "混合団体戦",
     "description": "A team-based mode where male and female players compete together in groups.",
-    "isHidden": true,
     "rules": {
       "rounds": 6,
       "teamSize": 6,
@@ -72,7 +66,6 @@
     "name": "Browse Judoka",
     "japaneseName": "柔道家を閲覧",
     "description": "Explore the available judoka and their stats.",
-    "isHidden": false,
     "rules": {
       "note": "Rules will be defined in the future."
     }
@@ -82,7 +75,6 @@
     "name": "Create A Judoka",
     "japaneseName": "柔道家を作成",
     "description": "Create a new judoka by entering their details and stats.",
-    "isHidden": true,
     "rules": {
       "note": "Rules will be defined in the future."
     }
@@ -92,7 +84,6 @@
     "name": "Update Judoka",
     "japaneseName": "柔道家を更新",
     "description": "Edit the details of an existing judoka.",
-    "isHidden": true,
     "rules": {
       "note": "Rules will be defined in the future."
     }
@@ -102,7 +93,6 @@
     "name": "Team Battle Ruleset",
     "japaneseName": "団体戦ルールセット",
     "description": "Defining the common ruleset for Team Battles.",
-    "isHidden": true,
     "rules": {
       "rounds": 5,
       "teamSize": 5,
@@ -114,7 +104,6 @@
     "name": "Meditation",
     "japaneseName": "メディテーション",
     "description": "Take a moment to pause, breathe, and reflect.",
-    "isHidden": false,
     "rules": {
       "note": "Rules will be defined in the future."
     }
@@ -124,7 +113,6 @@
     "name": "View Judoka",
     "japaneseName": "ランダム柔道家",
     "description": "Displays a random judoka from the available list.",
-    "isHidden": false,
     "rules": {
       "note": "Rules will be defined in the future."
     }
@@ -134,7 +122,6 @@
     "name": "Settings",
     "japaneseName": "設定",
     "description": "Change game settings.",
-    "isHidden": false,
     "rules": {
       "note": "Rules will be defined in the future."
     }

--- a/src/data/navigationItems.json
+++ b/src/data/navigationItems.json
@@ -1,123 +1,86 @@
 [
-    {
-      "id": "classicBattle",
-      "name": "Classic Battle",
-      "japaneseName": "試合 (バトルモード)",
-      "description": "A standard one-on-one battle mode where players compete to win.",
-      "category": "mainMenu",
-      "order": 20,
-      "url": "battleJudoka.html",
-      "isHidden": false
-    },
-    {
-      "id": "teamBattleSelection",
-      "name": "Team Battle Selection",
-      "japaneseName": "団体戦選択",
-      "description": "Choose between Male, Female, or Mixed Team Battle modes.",
-      "category": "subMenu",
-      "order": 30,
-      "url": "teamBattleSelection.html",
-      "isHidden": true
-    },
-    {
-      "id": "manageJudokaSelection",
-      "name": "Manage Judoka",
-      "japaneseName": "柔道家編集モード",
-      "description": "Choose to update or create a judoka.",
-      "category": "subMenu",
-      "order": 40,
-      "url": "judokaUpdateSelection.html",
-      "isHidden": true
-    },
-    {
-      "id": "teamBattleMale",
-      "name": "Team Battle (Male)",
-      "japaneseName": "男子団体戦",
-      "description": "A team-based mode where male players compete in groups.",
-      "category": "teamBattle",
-      "order": 50,
-      "url": "teamBattleMale.html",
-      "isHidden": true
-    },
-    {
-      "id": "teamBattleFemale",
-      "name": "Team Battle (Female)",
-      "japaneseName": "女子団体戦",
-      "description": "A team-based mode where female players compete in groups.",
-      "category": "teamBattle",
-      "order": 60,
-      "url": "teamBattleFemale.html",
-      "isHidden": true
-    },
-    {
-      "id": "teamBattleMixed",
-      "name": "Team Battle (Mixed)",
-      "japaneseName": "混合団体戦",
-      "description": "A team-based mode where male and female players compete together in groups.",
-      "category": "teamBattle",
-      "order": 70,
-      "url": "teamBattleMixed.html",
-      "isHidden": true
-    },
-    {
-      "id": "browseJudoka",
-      "name": "Browse Judoka",
-      "japaneseName": "柔道家を閲覧",
-      "description": "Explore the available judoka and their stats.",
-      "category": "mainMenu",
-      "order": 80,
-      "url": "browseJudoka.html",
-      "isHidden": false
-    },
-    {
-      "id": "createJudoka",
-      "name": "Create A Judoka",
-      "japaneseName": "柔道家を作成",
-      "description": "Create a new judoka by entering their details and stats.",
-      "category": "manageJudoka",
-      "order": 90,
-      "url": "createJudoka.html",
-      "isHidden": true
-    },
-    {
-      "id": "updateJudoka",
-      "name": "Update Judoka",
-      "japaneseName": "柔道家を更新",
-      "description": "Edit the details of an existing judoka.",
-      "category": "mainMenu",
-      "order": 30,
-      "url": "updateJudoka.html",
-      "isHidden": true
-    },
-    {
-      "id": "meditation",
-      "name": "Meditation",
-      "japaneseName": "メディテーション",
-      "description": "Take a moment to pause, breathe, and reflect.",
-      "category": "mainMenu",
-      "order": 85,
-      "url": "meditation.html",
-      "isHidden": false
-    },
-    {
-      "id": "randomJudoka",
-      "name": "View Judoka",
-      "japaneseName": "ランダム柔道家",
-      "description": "Displays a random judoka from the available list.",
-      "category": "mainMenu",
-      "order": 40,
-      "url": "randomJudoka.html",
-      "isHidden": false
-    },
-    {
-      "id": "settingsMenu",
-      "name": "Settings",
-      "japaneseName": "設定",
-      "description": "Change game settings.",
-      "category": "mainMenu",
-      "order": 90,
-      "url": "settings.html",
-      "isHidden": false
-    }
-  ]
-  
+  {
+    "id": "classicBattle",
+    "url": "battleJudoka.html",
+    "category": "mainMenu",
+    "order": 20,
+    "isHidden": false
+  },
+  {
+    "id": "teamBattleSelection",
+    "url": "teamBattleSelection.html",
+    "category": "subMenu",
+    "order": 30,
+    "isHidden": true
+  },
+  {
+    "id": "manageJudokaSelection",
+    "url": "judokaUpdateSelection.html",
+    "category": "subMenu",
+    "order": 40,
+    "isHidden": true
+  },
+  {
+    "id": "teamBattleMale",
+    "url": "teamBattleMale.html",
+    "category": "teamBattle",
+    "order": 50,
+    "isHidden": true
+  },
+  {
+    "id": "teamBattleFemale",
+    "url": "teamBattleFemale.html",
+    "category": "teamBattle",
+    "order": 60,
+    "isHidden": true
+  },
+  {
+    "id": "teamBattleMixed",
+    "url": "teamBattleMixed.html",
+    "category": "teamBattle",
+    "order": 70,
+    "isHidden": true
+  },
+  {
+    "id": "browseJudoka",
+    "url": "browseJudoka.html",
+    "category": "mainMenu",
+    "order": 80,
+    "isHidden": false
+  },
+  {
+    "id": "createJudoka",
+    "url": "createJudoka.html",
+    "category": "manageJudoka",
+    "order": 90,
+    "isHidden": true
+  },
+  {
+    "id": "updateJudoka",
+    "url": "updateJudoka.html",
+    "category": "mainMenu",
+    "order": 30,
+    "isHidden": true
+  },
+  {
+    "id": "meditation",
+    "url": "meditation.html",
+    "category": "mainMenu",
+    "order": 85,
+    "isHidden": false
+  },
+  {
+    "id": "randomJudoka",
+    "url": "randomJudoka.html",
+    "category": "mainMenu",
+    "order": 40,
+    "isHidden": false
+  },
+  {
+    "id": "settingsMenu",
+    "url": "settings.html",
+    "category": "mainMenu",
+    "order": 90,
+    "isHidden": false
+  }
+]

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -1,7 +1,7 @@
 import { createToggleSwitch } from "../../components/ToggleSwitch.js";
 import { applyDisplayMode } from "../displayMode.js";
 import { applyMotionPreference } from "../motionUtils.js";
-import { updateGameModeHidden } from "../gameModeUtils.js";
+import { updateNavigationItemHidden } from "../gameModeUtils.js";
 import { showSettingsError } from "../showSettingsError.js";
 
 function applyInputState(element, value) {
@@ -68,7 +68,7 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
       handleUpdate("gameModes", updated, () => {
         input.checked = prev;
       });
-      updateGameModeHidden(mode.id, !input.checked).catch((err) => {
+      updateNavigationItemHidden(mode.id, !input.checked).catch((err) => {
         console.error("Failed to update navigation item", err);
         input.checked = prev;
         showSettingsError();

--- a/src/schemas/gameModes.schema.json
+++ b/src/schemas/gameModes.schema.json
@@ -65,7 +65,7 @@
         "additionalProperties": false
       }
     },
-    "required": ["id", "name", "description", "isHidden", "rules"],
+    "required": ["id", "name", "description", "rules"],
     "additionalProperties": false
   }
 }

--- a/src/schemas/navigationItems.schema.json
+++ b/src/schemas/navigationItems.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/navigationItems.schema.json",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Identifier referencing a game mode"
+      },
+      "url": {
+        "type": "string",
+        "description": "Relative page URL for navigation"
+      },
+      "category": {
+        "type": "string",
+        "description": "Grouping used for menus"
+      },
+      "order": {
+        "type": "integer",
+        "description": "Display order within its category"
+      },
+      "isHidden": {
+        "type": "boolean",
+        "description": "Controls visibility in navigation"
+      }
+    },
+    "required": ["id", "url", "category", "order", "isHidden"],
+    "additionalProperties": false
+  }
+}

--- a/tests/data/schemaValidation.test.js
+++ b/tests/data/schemaValidation.test.js
@@ -12,6 +12,7 @@ const schemaDir = path.resolve(__dirname, "../../src/schemas");
 const pairs = [
   ["countryCodeMapping.json", "countryCodeMapping.schema.json"],
   ["gameModes.json", "gameModes.schema.json"],
+  ["navigationItems.json", "navigationItems.schema.json"],
   ["gokyo.json", "gokyo.schema.json"],
   ["judoka.json", "judoka.schema.json"],
   ["weightCategories.json", "weightCategories.schema.json"],

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -166,7 +166,7 @@ describe("populateNavbar", () => {
   it("falls back to default items when fetch fails", async () => {
     const navBar = setupDom();
     stubLogoQuery();
-    localStorage.removeItem("gameModes");
+    localStorage.removeItem("navigationItems");
     const loadNavigationItems = vi.fn().mockRejectedValue(new Error("fail"));
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
       loadNavigationItems,
@@ -190,7 +190,7 @@ describe("populateNavbar", () => {
     const data = [
       { id: "X", name: "X", url: "x.html", category: "mainMenu", order: 1, isHidden: false }
     ];
-    localStorage.setItem("gameModes", JSON.stringify(data));
+    localStorage.setItem("navigationItems", JSON.stringify(data));
     const loadSettings = vi.fn().mockResolvedValue({
       sound: true,
       motionEffects: true,

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -23,7 +23,7 @@ describe("settingsPage module", () => {
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
     const loadNavigationItems = vi.fn().mockResolvedValue([]);
-    const updateGameModeHidden = vi.fn();
+    const updateNavigationItemHidden = vi.fn();
     const applyDisplayMode = vi.fn();
     const applyMotionPreference = vi.fn();
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
@@ -33,7 +33,7 @@ describe("settingsPage module", () => {
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
       loadNavigationItems,
       loadGameModes: loadNavigationItems,
-      updateGameModeHidden
+      updateNavigationItemHidden
     }));
     vi.doMock("../../src/helpers/displayMode.js", () => ({
       applyDisplayMode
@@ -62,7 +62,7 @@ describe("settingsPage module", () => {
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
     const loadNavigationItems = vi.fn().mockResolvedValue(gameModes);
-    const updateGameModeHidden = vi.fn();
+    const updateNavigationItemHidden = vi.fn();
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
@@ -70,7 +70,7 @@ describe("settingsPage module", () => {
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
       loadNavigationItems,
       loadGameModes: loadNavigationItems,
-      updateGameModeHidden
+      updateNavigationItemHidden
     }));
 
     await import("../../src/helpers/settingsPage.js");
@@ -97,7 +97,7 @@ describe("settingsPage module", () => {
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
     const loadNavigationItems = vi.fn().mockResolvedValue(gameModes);
-    const updateGameModeHidden = vi.fn();
+    const updateNavigationItemHidden = vi.fn();
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
@@ -105,7 +105,7 @@ describe("settingsPage module", () => {
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
       loadNavigationItems,
       loadGameModes: loadNavigationItems,
-      updateGameModeHidden
+      updateNavigationItemHidden
     }));
 
     await import("../../src/helpers/settingsPage.js");
@@ -122,7 +122,9 @@ describe("settingsPage module", () => {
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
     const loadNavigationItems = vi.fn().mockResolvedValue(gameModes);
-    const updateGameModeHidden = vi.fn().mockResolvedValue([{ ...gameModes[0], isHidden: true }]);
+    const updateNavigationItemHidden = vi
+      .fn()
+      .mockResolvedValue([{ ...gameModes[0], isHidden: true }]);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
@@ -130,7 +132,7 @@ describe("settingsPage module", () => {
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
       loadNavigationItems,
       loadGameModes: loadNavigationItems,
-      updateGameModeHidden
+      updateNavigationItemHidden
     }));
 
     await import("../../src/helpers/settingsPage.js");
@@ -141,7 +143,7 @@ describe("settingsPage module", () => {
     input.checked = false;
     input.dispatchEvent(new Event("change"));
 
-    expect(updateGameModeHidden).toHaveBeenCalledWith("classic", true);
+    expect(updateNavigationItemHidden).toHaveBeenCalledWith("classic", true);
   });
 
   it("renders feature flag switches", async () => {
@@ -156,7 +158,7 @@ describe("settingsPage module", () => {
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
       loadNavigationItems,
       loadGameModes: loadNavigationItems,
-      updateGameModeHidden: vi.fn()
+      updateNavigationItemHidden: vi.fn()
     }));
 
     await import("../../src/helpers/settingsPage.js");
@@ -188,7 +190,7 @@ describe("settingsPage module", () => {
     vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
       loadNavigationItems,
       loadGameModes: loadNavigationItems,
-      updateGameModeHidden: vi.fn()
+      updateNavigationItemHidden: vi.fn()
     }));
 
     await import("../../src/helpers/settingsPage.js");


### PR DESCRIPTION
## Summary
- prune duplicated fields from `navigationItems.json`
- move hidden flag management to new `navigationItems.schema.json`
- update game mode schema and loader utilities
- merge navigation items with game mode metadata
- adjust helpers and tests for new loading functions

## Testing
- `npx prettier . --write`
- `npx eslint src/helpers/gameModeUtils.js`
- `npx vitest run`
- `npx playwright test` *(fails: schema is invalid, cannot fetch)*

------
https://chatgpt.com/codex/tasks/task_e_688503aa12ac8326b05e0b08611e490f