### PR TITLE
Add enableTestMode feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ The Settings page (`src/pages/settings.html`) groups all player preferences, inc
 
 Battle pages include a collapsible debug panel. Enable the **Battle Debug Panel** feature flag in **Settings** to reveal real-time match state in a `<pre>` element. The panel is keyboard accessible and hidden by default so normal gameplay remains unaffected.
 Toggle the **Full Navigation Map** flag to display a map overlay with links to all pages for easier orientation during testing.
+Enable the **Test Mode** flag for deterministic card draws and stat results. A "Test Mode Active" banner appears on battle pages.
 
 Game mode data now falls back to a bundled JSON import if the network request fails, so navigation works offline.
 Corrupted settings are detected and automatically reset to defaults, ensuring the Settings page always remains usable.

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -41,6 +41,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 | -------- | -------------------------- | --------------------------------------------------------------------------- |
 | P1       | Sound Toggle               | Binary toggle updating `settings.json` live on change.                      |
 | P1       | Full Navigation Map Feature Flag | Enable or disable the full navigation map via feature flag; updates `settings.json` live on change. |
+| P3       | Test Mode Feature Flag | Enables deterministic battles for automated testing. |
 | P1       | Motion Effects Toggle      | Binary toggle updating `settings.json` live on change.                      |
 | P1       | Display Mode Selector      | Three-option selector applying mode instantly across UI.                    |
 | P2       | Game Modes Toggles         | A list of all defined game modes with binary toggles from `navigationItems.json`. |
@@ -98,6 +99,12 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - AC-2.1 Enabling or disabling the flag updates `settings.json` within 50ms.
 - AC-2.2 The toggle correctly reflects the current flag state in the UI.
 - AC-2.3 The navigation map is available only when the flag is enabled.
+
+### Test Mode Feature Flag
+
+- AC-2.4 Enabling the flag displays a "Test Mode Active" banner on battle pages.
+- AC-2.5 Card draws and stat choices become deterministic for repeat tests.
+- AC-2.6 `data-test-mode="true"` appears on the battle area while active.
 
 ### Motion Effects Toggle
 

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -5,6 +5,7 @@
   "gameModes": {},
   "featureFlags": {
     "battleDebugPanel": false,
-    "fullNavigationMap": true
+    "fullNavigationMap": true,
+    "enableTestMode": false
   }
 }

--- a/src/helpers/cardUtils.js
+++ b/src/helpers/cardUtils.js
@@ -1,5 +1,6 @@
 import { generateJudokaCardHTML } from "./cardBuilder.js";
 import { debugLog } from "./debug.js";
+import { seededRandom } from "./testModeUtils.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
 import { setupLazyPortraits } from "./lazyPortrait.js";
 
@@ -39,7 +40,7 @@ export function getRandomJudoka(data) {
     throw new Error("No valid judoka data available to select.");
   }
 
-  const index = Math.floor(Math.random() * validJudoka.length);
+  const index = Math.floor(seededRandom() * validJudoka.length);
   const selectedJudoka = validJudoka[index];
 
   debugLog("Selected judoka:", selectedJudoka);

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -1,5 +1,6 @@
 import { generateRandomCard } from "./randomCard.js";
 import { getRandomJudoka, renderJudokaCard } from "./cardUtils.js";
+import { seededRandom, isTestModeEnabled, getCurrentSeed } from "./testModeUtils.js";
 import { fetchJson } from "./dataUtils.js";
 import { createGokyoLookup } from "./utils.js";
 import { DATA_DIR } from "./constants.js";
@@ -36,6 +37,9 @@ function updateDebugPanel() {
     timer: getTimerState(),
     matchEnded: isMatchEnded()
   };
+  if (isTestModeEnabled()) {
+    state.seed = getCurrentSeed();
+  }
   pre.textContent = JSON.stringify(state, null, 2);
 }
 
@@ -62,7 +66,7 @@ function startTimer() {
       if (timerEl) timerEl.textContent = `Time Left: ${remaining}s`;
     },
     () => {
-      const randomStat = STATS[Math.floor(Math.random() * STATS.length)];
+      const randomStat = STATS[Math.floor(seededRandom() * STATS.length)];
       infoBar.showMessage(`Time's up! Auto-selecting ${randomStat}`);
       handleStatSelection(randomStat);
     }

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -24,6 +24,7 @@ import { onDomReady } from "./domReady.js";
 import { waitForComputerCard } from "./battleJudokaPage.js";
 import { loadSettings } from "./settingsUtils.js";
 import { initTooltips } from "./tooltip.js";
+import { setTestMode } from "./testModeUtils.js";
 
 function enableStatButtons(enable = true) {
   document.querySelectorAll("#stat-buttons button").forEach((btn) => {
@@ -75,6 +76,14 @@ export async function setupClassicBattlePage() {
   if (battleArea) {
     battleArea.dataset.mode = "classic";
     battleArea.dataset.randomStat = String(Boolean(settings.featureFlags.randomStatMode));
+    battleArea.dataset.testMode = String(Boolean(settings.featureFlags.enableTestMode));
+  }
+
+  setTestMode(Boolean(settings.featureFlags.enableTestMode));
+
+  const banner = document.getElementById("test-mode-banner");
+  if (banner) {
+    banner.classList.toggle("hidden", !settings.featureFlags.enableTestMode);
   }
 
   const debugPanel = document.getElementById("debug-panel");

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -31,7 +31,11 @@ const DEFAULT_SETTINGS = {
   motionEffects: true,
   displayMode: "light",
   gameModes: {},
-  featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
+  featureFlags: {
+    battleDebugPanel: false,
+    fullNavigationMap: true,
+    enableTestMode: false
+  }
 };
 export { DEFAULT_SETTINGS };
 

--- a/src/helpers/testModeUtils.js
+++ b/src/helpers/testModeUtils.js
@@ -1,0 +1,29 @@
+/**
+ * Utilities for deterministic Test Mode behaviour.
+ *
+ * @pseudocode
+ * 1. Track whether test mode is active and a numeric seed.
+ * 2. When active, `seededRandom()` returns a predictable pseudo-random number.
+ * 3. Provide helpers to enable/disable test mode and query current state.
+ */
+let active = false;
+let seed = 1;
+
+export function setTestMode(enable, initialSeed = 1) {
+  active = Boolean(enable);
+  seed = initialSeed;
+}
+
+export function isTestModeEnabled() {
+  return active;
+}
+
+export function seededRandom() {
+  if (!active) return Math.random();
+  const x = Math.sin(seed++) * 10000;
+  return x - Math.floor(x);
+}
+
+export function getCurrentSeed() {
+  return seed;
+}

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -43,6 +43,10 @@
         </div>
       </header>
 
+      <div id="test-mode-banner" class="test-mode-banner hidden" aria-live="polite">
+        Test Mode Active
+      </div>
+
       <main class="container" role="main">
         <section id="battle-area">
           <div id="player-card" class="card-slot"></div>

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -98,3 +98,12 @@
   margin: 5vh auto;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
 }
+
+.test-mode-banner {
+  background-color: var(--color-tertiary);
+  color: var(--color-text);
+  text-align: center;
+  padding: var(--space-sm) var(--space-md);
+  font-weight: bold;
+  margin-top: var(--space-sm);
+}

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -143,7 +143,7 @@ describe("populateNavbar", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: { B: false },
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -196,7 +196,7 @@ describe("populateNavbar", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -241,7 +241,7 @@ describe("populateNavbar", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -13,7 +13,8 @@ const baseSettings = {
   featureFlags: {
     randomStatMode: false,
     battleDebugPanel: false,
-    fullNavigationMap: true
+    fullNavigationMap: true,
+    enableTestMode: false
   }
 };
 

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -9,7 +9,8 @@ const baseSettings = {
   featureFlags: {
     randomStatMode: true,
     battleDebugPanel: false,
-    fullNavigationMap: true
+    fullNavigationMap: true,
+    enableTestMode: false
   }
 };
 
@@ -203,7 +204,8 @@ describe("settingsPage module", () => {
     expect(updateSetting).toHaveBeenCalledWith("featureFlags", {
       randomStatMode: true,
       battleDebugPanel: true,
-      fullNavigationMap: true
+      fullNavigationMap: true,
+      enableTestMode: false
     });
   });
 });

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -44,7 +44,7 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
     });
   });
 
@@ -59,7 +59,7 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "dark",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
     };
     const promise = saveSettings(data);
     await vi.advanceTimersByTimeAsync(110);
@@ -87,7 +87,7 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
     });
     Storage.prototype.getItem = originalGetItem;
   });
@@ -130,7 +130,7 @@ describe("settings utils", () => {
         motionEffects: true,
         displayMode: "light",
         gameModes: {},
-        featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
+        featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
       })
     ).rejects.toThrow("fail");
     Storage.prototype.setItem = originalSetItem;
@@ -162,14 +162,14 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: false }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: false, enableTestMode: false }
     };
     const data2 = {
       sound: false,
       motionEffects: false,
       displayMode: "dark",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true }
+      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
     };
     saveSettings(data1);
     saveSettings(data2);


### PR DESCRIPTION
## Summary
- add `enableTestMode` to default settings
- support deterministic battles when flag is enabled
- expose test mode seed in debug output
- show banner and data attribute for test mode
- document the new flag
- update tests for new default

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6885073051c483268748e75b7f825d45