### PR TITLE
Fix vector search query pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ The project ships with a retrieval-augmented search demo. Run `npm run generate:
 
 After modifying any PRDs **or any file in `src/data/`**, run `npm run generate:embeddings` again to rebuild `client_embeddings.json`. Commit the updated file alongside your documentation changes so other agents have the latest vectors.
 
+- Both the generation script and the search page use **mean pooled** embeddings so the query vector matches the stored vectors.
+
 - Results appear below the form with up to five entries that show match score and source.
 - The page displays “Embeddings could not be loaded – please check console.” if loading fails, or “No close matches found” when nothing is returned.
 - Users can submit the form by pressing **Enter** in the search box.

--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -42,7 +42,7 @@ async function getExtractor() {
  * 2. Read and trim the query from the input element; clear previous results.
  *    - Exit early if the query is empty.
  * 3. Show the spinner and a searching message.
- * 4. Obtain the extractor and generate the query vector.
+ * 4. Obtain the extractor and generate the query vector using mean pooling.
  * 5. Use `findMatches` to fetch the top results for the vector.
  * 6. Hide the spinner and handle empty or missing embeddings cases.
  * 7. Build an ordered list of matches and append it to the results element.
@@ -61,7 +61,7 @@ async function handleSearch(event) {
   resultsEl.textContent = "Searching...";
   try {
     const model = await getExtractor();
-    const vector = (await model(query))[0];
+    const vector = await model(query, { pooling: "mean" });
     const matches = await findMatches(Array.from(vector), 5);
     resultsEl.textContent = "";
     spinner.style.display = "none";


### PR DESCRIPTION
## Summary
- pool query embeddings to match stored vectors
- mention pooling requirement in README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68850a38d2a083269313b86f35336537