### PR TITLE
Update PRDs and standards for game mode data

### DIFF
--- a/design/codeStandards/codePseudocodeStandards.md
+++ b/design/codeStandards/codePseudocodeStandards.md
@@ -32,24 +32,18 @@ Clear pseudocode descriptions are essential for explaining the underlying logic 
 
 ```javascript
 /**
- * Populates the bottom navigation bar with game modes from a JSON file.
+ * Populates the bottom navigation bar with game modes from JSON files.
  *
  * @pseudocode
- * 1. Fetch the JSON file containing game modes ("navigationItems.json").
- *    - If the fetch fails, log an error and display an error message.
- *
- * 2. Parse the JSON response to retrieve game modes.
- *    - Handle parsing errors gracefully.
- *
- * 3. Filter game modes to include only visible, main menu items.
- *
- * 4. Sort game modes by the specified order.
- *
- * 5. Generate HTML list items for each mode.
- *
- * 6. Update the navigation bar with the generated HTML.
- *
- * 7. Handle any errors during the process gracefully.
+ * 1. Load mode definitions using `loadGameModes()` (reads `gameModes.json`).
+ * 2. Fetch `navigationItems.json` for display order and visibility flags.
+ *    - If either fetch fails, log an error and show a fallback message.
+ * 3. Merge navigation items with mode data by matching the `id` field.
+ * 4. Filter out items where `isHidden` is true and keep only main menu entries.
+ * 5. Sort the remaining items by their `order` value.
+ * 6. Generate HTML list items for each merged object.
+ * 7. Update the navigation bar with the generated HTML.
+ * 8. Handle any errors during the process gracefully.
  */
 function populateNavigationBar() { ... }
 ```

--- a/design/dataSchemas/README.md
+++ b/design/dataSchemas/README.md
@@ -10,7 +10,7 @@ Run `npm run validate:data` to check all schema and data pairs at once. The comm
 npx ajv validate -s src/schemas/judoka.schema.json -d src/data/judoka.json
 ```
 
-Run the command for every pair of schema and data file (e.g. `gameModes`, `weightCategories`). The CLI reports any mismatches so they can be fixed before runtime.
+Run the command for every pair of schema and data file (e.g. `gameModes`, `weightCategories`). The CLI reports any mismatches so they can be fixed before runtime. A new schema, `navigationItems.schema.json`, validates the structure of `navigationItems.json` which drives navigation order and visibility.
 
 ## Updating Schemas
 

--- a/design/productRequirementsDocuments/prdHomePageNavigation.md
+++ b/design/productRequirementsDocuments/prdHomePageNavigation.md
@@ -19,6 +19,8 @@ The purpose of this menu is to allow players to access the core game modes quick
 
 A fast, accessible, and thematic navigation experience is crucial to ensure new players feel confident and engaged from their first visit.
 
+The list of available modes is defined in `gameModes.json`. `navigationItems.json` references each mode by `id` to control which tiles appear on the home page and in what order.
+
 ---
 
 ## Goals
@@ -199,6 +201,8 @@ Each tile contains:
 
 ## Dependencies / Integrations
 
+- `gameModes.json` lists all game modes.
+- `navigationItems.json` references those modes by `id` and sets tile order and visibility.
 - Uses global CSS tokens (`--button-bg`, `--radius-md`, etc.) defined in `src/styles/base.css`.
 
 ---

--- a/design/productRequirementsDocuments/prdNavigationBar.md
+++ b/design/productRequirementsDocuments/prdNavigationBar.md
@@ -56,7 +56,7 @@ The **JU-DO-KON!** game features multiple game modes and screens. Players need e
 
 ## How It Works
 
-The bottom navigation bar appears consistently across all game screens, dynamically loading active game modes from `navigationItems.json`.
+The bottom navigation bar appears consistently across all game screens, dynamically loading active game modes from `navigationItems.json`. Each item references an entry in `gameModes.json` via its `id` so mode names and descriptions remain consistent.
 
 ### Standard Mode (Default View)
 
@@ -87,7 +87,8 @@ The bottom navigation bar appears consistently across all game screens, dynamica
 
 ### Dependencies / Integrations
 
-- `navigationItems.json` data file for mode list.
+- `gameModes.json` defines the available modes.
+- `navigationItems.json` references those modes by `id` and controls navigation order and visibility.
 - CSS variables `--color-secondary` and `--button-text-color` for styling.
 - Existing footer layout modules.
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -61,7 +61,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - **Motion effects (binary):** ON/OFF (default: ON)
 - **Display mode (three options):** Light, Dark, Gray (default: Light)
   - _Gray mode_ provides a grayscale display to reduce visual noise for neurodivergent users.
-- **Game modes list:** A list populated from `navigationItems.json`, showing all modes defined there, with binary toggles per mode.
+- **Game modes list:** Pulled from `gameModes.json` and cross-referenced with `navigationItems.json` to determine order and visibility; each mode has a binary toggle.
 - **Change Log:** Link opens `changeLog.html` with the latest 20 judoka updates.
 - **PRD Viewer:** Link opens `prdViewer.html` for browsing product documents.
 - **Mockup Viewer:** Link opens `mockupViewer.html` for viewing design mockups.
@@ -79,7 +79,8 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 
 ## Data & Persistence
 
-- The Settings page **must pull current states** from data sources (`settings.json` and `navigationItems.json`) on load.
+- The Settings page **must pull current states** from data sources (`settings.json`, `gameModes.json`, and `navigationItems.json`) on load.
+- `gameModes.json` defines all available modes, while `navigationItems.json` references each by `id` to control order and hidden status.
 - Changes should trigger **immediate data writes** without requiring a “Save Changes” button.
 - All live updates must persist across page refreshes within the same session.
 - If `navigationItems.json` fails to load, the game modes section should **disable gracefully** and show an error message.


### PR DESCRIPTION
## Summary
- clarify gameModes.json vs navigationItems.json usage in PRDs
- note new navigationItems schema
- update pseudocode example to load game modes

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot and navigation tests)*

------
https://chatgpt.com/codex/tasks/task_e_68850a3edaf08326868364d982fbc7cf