### PR TITLE
Convert navigation data IDs to integers

### DIFF
--- a/src/data/gameModes.json
+++ b/src/data/gameModes.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "classicBattle",
+    "id": 1,
     "name": "Classic Battle",
     "japaneseName": "試合 (バトルモード)",
     "description": "A standard one-on-one battle mode where players compete to win.",
@@ -12,7 +12,7 @@
     }
   },
   {
-    "id": "teamBattleSelection",
+    "id": 2,
     "name": "Team Battle Selection",
     "japaneseName": "団体戦選択",
     "description": "Choose between Male, Female, or Mixed Team Battle modes.",
@@ -21,7 +21,7 @@
     }
   },
   {
-    "id": "manageJudokaSelection",
+    "id": 3,
     "name": "Manage Judoka",
     "japaneseName": "柔道家編集モード",
     "description": "Choose to update or create a judoka.",
@@ -30,7 +30,7 @@
     }
   },
   {
-    "id": "teamBattleMale",
+    "id": 4,
     "name": "Team Battle (Male)",
     "japaneseName": "男子団体戦",
     "description": "A team-based mode where male players compete in groups.",
@@ -40,7 +40,7 @@
     }
   },
   {
-    "id": "teamBattleFemale",
+    "id": 5,
     "name": "Team Battle (Female)",
     "japaneseName": "女子団体戦",
     "description": "A team-based mode where female players compete in groups.",
@@ -50,7 +50,7 @@
     }
   },
   {
-    "id": "teamBattleMixed",
+    "id": 6,
     "name": "Team Battle (Mixed)",
     "japaneseName": "混合団体戦",
     "description": "A team-based mode where male and female players compete together in groups.",
@@ -62,7 +62,7 @@
     }
   },
   {
-    "id": "browseJudoka",
+    "id": 7,
     "name": "Browse Judoka",
     "japaneseName": "柔道家を閲覧",
     "description": "Explore the available judoka and their stats.",
@@ -71,7 +71,7 @@
     }
   },
   {
-    "id": "createJudoka",
+    "id": 8,
     "name": "Create A Judoka",
     "japaneseName": "柔道家を作成",
     "description": "Create a new judoka by entering their details and stats.",
@@ -80,7 +80,7 @@
     }
   },
   {
-    "id": "updateJudoka",
+    "id": 9,
     "name": "Update Judoka",
     "japaneseName": "柔道家を更新",
     "description": "Edit the details of an existing judoka.",
@@ -89,7 +89,7 @@
     }
   },
   {
-    "id": "teamBattle",
+    "id": 10,
     "name": "Team Battle Ruleset",
     "japaneseName": "団体戦ルールセット",
     "description": "Defining the common ruleset for Team Battles.",
@@ -100,7 +100,7 @@
     }
   },
   {
-    "id": "meditation",
+    "id": 11,
     "name": "Meditation",
     "japaneseName": "メディテーション",
     "description": "Take a moment to pause, breathe, and reflect.",
@@ -109,7 +109,7 @@
     }
   },
   {
-    "id": "randomJudoka",
+    "id": 12,
     "name": "View Judoka",
     "japaneseName": "ランダム柔道家",
     "description": "Displays a random judoka from the available list.",
@@ -118,7 +118,7 @@
     }
   },
   {
-    "id": "settingsMenu",
+    "id": 13,
     "name": "Settings",
     "japaneseName": "設定",
     "description": "Change game settings.",

--- a/src/data/navigationItems.json
+++ b/src/data/navigationItems.json
@@ -1,86 +1,98 @@
 [
   {
-    "id": "classicBattle",
+    "id": 1,
     "url": "battleJudoka.html",
     "category": "mainMenu",
     "order": 20,
-    "isHidden": false
+    "isHidden": false,
+    "gameModeId": 1
   },
   {
-    "id": "teamBattleSelection",
+    "id": 2,
     "url": "teamBattleSelection.html",
     "category": "subMenu",
     "order": 30,
-    "isHidden": true
+    "isHidden": true,
+    "gameModeId": 2
   },
   {
-    "id": "manageJudokaSelection",
+    "id": 3,
     "url": "judokaUpdateSelection.html",
     "category": "subMenu",
     "order": 40,
-    "isHidden": true
+    "isHidden": true,
+    "gameModeId": 3
   },
   {
-    "id": "teamBattleMale",
+    "id": 4,
     "url": "teamBattleMale.html",
     "category": "teamBattle",
     "order": 50,
-    "isHidden": true
+    "isHidden": true,
+    "gameModeId": 4
   },
   {
-    "id": "teamBattleFemale",
+    "id": 5,
     "url": "teamBattleFemale.html",
     "category": "teamBattle",
     "order": 60,
-    "isHidden": true
+    "isHidden": true,
+    "gameModeId": 5
   },
   {
-    "id": "teamBattleMixed",
+    "id": 6,
     "url": "teamBattleMixed.html",
     "category": "teamBattle",
     "order": 70,
-    "isHidden": true
+    "isHidden": true,
+    "gameModeId": 6
   },
   {
-    "id": "browseJudoka",
+    "id": 7,
     "url": "browseJudoka.html",
     "category": "mainMenu",
     "order": 80,
-    "isHidden": false
+    "isHidden": false,
+    "gameModeId": 7
   },
   {
-    "id": "createJudoka",
+    "id": 8,
     "url": "createJudoka.html",
     "category": "manageJudoka",
     "order": 90,
-    "isHidden": true
+    "isHidden": true,
+    "gameModeId": 8
   },
   {
-    "id": "updateJudoka",
+    "id": 9,
     "url": "updateJudoka.html",
     "category": "mainMenu",
     "order": 30,
-    "isHidden": true
+    "isHidden": true,
+    "gameModeId": 9
   },
   {
-    "id": "meditation",
+    "id": 11,
     "url": "meditation.html",
     "category": "mainMenu",
     "order": 85,
-    "isHidden": false
+    "isHidden": false,
+    "gameModeId": 11
   },
   {
-    "id": "randomJudoka",
+    "id": 12,
     "url": "randomJudoka.html",
     "category": "mainMenu",
     "order": 40,
-    "isHidden": false
+    "isHidden": false,
+    "gameModeId": 12
   },
   {
-    "id": "settingsMenu",
+    "id": 13,
     "url": "settings.html",
     "category": "mainMenu",
     "order": 90,
-    "isHidden": false
+    "isHidden": false,
+    "gameModeId": 13
   }
 ]

--- a/src/schemas/gameModes.schema.json
+++ b/src/schemas/gameModes.schema.json
@@ -6,7 +6,7 @@
     "type": "object",
     "properties": {
       "id": {
-        "type": "string",
+        "type": "integer",
         "description": "Unique identifier for the game mode."
       },
       "name": {

--- a/src/schemas/navigationItems.schema.json
+++ b/src/schemas/navigationItems.schema.json
@@ -6,8 +6,12 @@
     "type": "object",
     "properties": {
       "id": {
-        "type": "string",
-        "description": "Identifier referencing a game mode"
+        "type": "integer",
+        "description": "Unique identifier for the navigation item"
+      },
+      "gameModeId": {
+        "type": "integer",
+        "description": "Reference to an entry in gameModes.json"
       },
       "url": {
         "type": "string",
@@ -26,7 +30,7 @@
         "description": "Controls visibility in navigation"
       }
     },
-    "required": ["id", "url", "category", "order", "isHidden"],
+    "required": ["id", "gameModeId", "url", "category", "order", "isHidden"],
     "additionalProperties": false
   }
 }

--- a/tests/fixtures/gameModes.json
+++ b/tests/fixtures/gameModes.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "classicBattle",
+    "id": 1,
     "name": "Classic Battle",
     "japaneseName": "試合 (バトルモード)",
     "description": "A standard one-on-one battle mode where players compete to win.",
@@ -16,7 +16,7 @@
     }
   },
   {
-    "id": "teamBattleSelection",
+    "id": 2,
     "name": "Team Battle Selection",
     "japaneseName": "団体戦選択",
     "description": "Choose between Male, Female, or Mixed Team Battle modes.",
@@ -29,7 +29,7 @@
     }
   },
   {
-    "id": "manageJudokaSelection",
+    "id": 3,
     "name": "Manage Judoka",
     "japaneseName": "柔道家編集モード",
     "description": "Choose to update or create a judoka.",
@@ -42,7 +42,7 @@
     }
   },
   {
-    "id": "teamBattleMale",
+    "id": 4,
     "name": "Team Battle (Male)",
     "japaneseName": "男子団体戦",
     "description": "A team-based mode where male players compete in groups.",
@@ -56,7 +56,7 @@
     }
   },
   {
-    "id": "teamBattleFemale",
+    "id": 5,
     "name": "Team Battle (Female)",
     "japaneseName": "女子団体戦",
     "description": "A team-based mode where female players compete in groups.",
@@ -70,7 +70,7 @@
     }
   },
   {
-    "id": "teamBattleMixed",
+    "id": 6,
     "name": "Team Battle (Mixed)",
     "japaneseName": "混合団体戦",
     "description": "A team-based mode where male and female players compete together in groups.",
@@ -86,7 +86,7 @@
     }
   },
   {
-    "id": "browseJudoka",
+    "id": 7,
     "name": "Browse Judoka",
     "japaneseName": "柔道家を閲覧",
     "description": "Explore the available judoka and their stats.",
@@ -99,7 +99,7 @@
     }
   },
   {
-    "id": "createJudoka",
+    "id": 8,
     "name": "Create A Judoka",
     "japaneseName": "柔道家を作成",
     "description": "Create a new judoka by entering their details and stats.",
@@ -112,7 +112,7 @@
     }
   },
   {
-    "id": "updateJudoka",
+    "id": 9,
     "name": "Update Judoka",
     "japaneseName": "柔道家を更新",
     "description": "Edit the details of an existing judoka.",
@@ -125,7 +125,7 @@
     }
   },
   {
-    "id": "teamBattle",
+    "id": 10,
     "name": "teamBattle Ruleset",
     "japaneseName": "団体戦ルールセット",
     "description": "Defining the common ruleset for Team Battles.",
@@ -140,7 +140,7 @@
     }
   },
   {
-    "id": "meditation",
+    "id": 11,
     "name": "Meditation",
     "japaneseName": "メディテーション",
     "description": "Take a moment to pause, breathe, and reflect.",
@@ -153,7 +153,7 @@
     }
   },
   {
-    "id": "randomJudoka",
+    "id": 12,
     "name": "View Judoka",
     "japaneseName": "ランダム柔道家",
     "description": "Displays a random judoka from the available list.",
@@ -166,7 +166,7 @@
     }
   },
   {
-    "id": "settingsMenu",
+    "id": 13,
     "name": "Settings",
     "japaneseName": "設定",
     "description": "Change game settings.",

--- a/tests/fixtures/navigationItems.json
+++ b/tests/fixtures/navigationItems.json
@@ -1,181 +1,98 @@
 [
   {
-    "id": "classicBattle",
-    "name": "Classic Battle",
-    "japaneseName": "試合 (バトルモード)",
-    "description": "A standard one-on-one battle mode where players compete to win.",
+    "id": 1,
+    "url": "battleJudoka.html",
     "category": "mainMenu",
     "order": 20,
-    "url": "battleJudoka.html",
     "isHidden": false,
-    "rules": {
-      "rounds": 25,
-      "teamSize": 25,
-      "maxScore": 10,
-      "gender": "any"
-    }
+    "gameModeId": 1
   },
   {
-    "id": "teamBattleSelection",
-    "name": "Team Battle Selection",
-    "japaneseName": "団体戦選択",
-    "description": "Choose between Male, Female, or Mixed Team Battle modes.",
-    "category": "subMenu",
-    "order": 35,
+    "id": 2,
     "url": "teamBattleSelection.html",
+    "category": "subMenu",
+    "order": 30,
     "isHidden": true,
-    "rules": {
-      "options": ["teamBattleMale", "teamBattleFemale", "teamBattleMixed"]
-    }
+    "gameModeId": 2
   },
   {
-    "id": "manageJudokaSelection",
-    "name": "Manage Judoka",
-    "japaneseName": "柔道家編集モード",
-    "description": "Choose to update or create a judoka.",
+    "id": 3,
+    "url": "judokaUpdateSelection.html",
     "category": "subMenu",
     "order": 40,
-    "url": "judokaUpdateSelection.html",
     "isHidden": true,
-    "rules": {
-      "options": ["createJudoka", "updateJudoka"]
-    }
+    "gameModeId": 3
   },
   {
-    "id": "teamBattleMale",
-    "name": "Team Battle (Male)",
-    "japaneseName": "男子団体戦",
-    "description": "A team-based mode where male players compete in groups.",
+    "id": 4,
+    "url": "teamBattleMale.html",
     "category": "teamBattle",
     "order": 50,
-    "url": "teamBattleMale.html",
     "isHidden": true,
-    "rules": {
-      "base": "teamBattle",
-      "gender": "male"
-    }
+    "gameModeId": 4
   },
   {
-    "id": "teamBattleFemale",
-    "name": "Team Battle (Female)",
-    "japaneseName": "女子団体戦",
-    "description": "A team-based mode where female players compete in groups.",
+    "id": 5,
+    "url": "teamBattleFemale.html",
     "category": "teamBattle",
     "order": 60,
-    "url": "teamBattleFemale.html",
     "isHidden": true,
-    "rules": {
-      "base": "teamBattle",
-      "gender": "female"
-    }
+    "gameModeId": 5
   },
   {
-    "id": "teamBattleMixed",
-    "name": "Team Battle (Mixed)",
-    "japaneseName": "混合団体戦",
-    "description": "A team-based mode where male and female players compete together in groups.",
+    "id": 6,
+    "url": "teamBattleMixed.html",
     "category": "teamBattle",
     "order": 70,
-    "url": "teamBattleMixed.html",
-    "isHidden": false,
-    "rules": {
-      "rounds": 6,
-      "teamSize": 6,
-      "maxScore": 6,
-      "gender": "mixed"
-    }
+    "isHidden": true,
+    "gameModeId": 6
   },
   {
-    "id": "browseJudoka",
-    "name": "Browse Judoka",
-    "japaneseName": "柔道家を閲覧",
-    "description": "Explore the available judoka and their stats.",
+    "id": 7,
+    "url": "browseJudoka.html",
     "category": "mainMenu",
     "order": 80,
-    "url": "browseJudoka.html",
     "isHidden": false,
-    "rules": {
-      "note": "Rules will be defined in the future."
-    }
+    "gameModeId": 7
   },
   {
-    "id": "createJudoka",
-    "name": "Create A Judoka",
-    "japaneseName": "柔道家を作成",
-    "description": "Create a new judoka by entering their details and stats.",
-    "category": "judokaUpdate",
-    "order": 90,
+    "id": 8,
     "url": "createJudoka.html",
-    "isHidden": false,
-    "rules": {
-      "note": "Rules will be defined in the future."
-    }
+    "category": "manageJudoka",
+    "order": 90,
+    "isHidden": true,
+    "gameModeId": 8
   },
   {
-    "id": "updateJudoka",
-    "name": "Update Judoka",
-    "japaneseName": "柔道家を更新",
-    "description": "Edit the details of an existing judoka.",
+    "id": 9,
+    "url": "updateJudoka.html",
     "category": "mainMenu",
     "order": 30,
-    "url": "updateJudoka.html",
-    "isHidden": false,
-    "rules": {
-      "note": "Rules will be defined in the future."
-    }
-  },
-  {
-    "id": "teamBattle",
-    "name": "teamBattle Ruleset",
-    "japaneseName": "団体戦ルールセット",
-    "description": "Defining the common ruleset for Team Battles.",
-    "category": "none",
-    "order": 65,
-    "url": "teamBattleRuleset.html",
     "isHidden": true,
-    "rules": {
-      "rounds": 5,
-      "teamSize": 5,
-      "maxScore": 5
-    }
+    "gameModeId": 9
   },
   {
-    "id": "meditation",
-    "name": "Meditation",
-    "japaneseName": "メディテーション",
-    "description": "Take a moment to pause, breathe, and reflect.",
+    "id": 11,
+    "url": "meditation.html",
     "category": "mainMenu",
     "order": 85,
-    "url": "meditation.html",
     "isHidden": false,
-    "rules": {
-      "note": "Rules will be defined in the future."
-    }
+    "gameModeId": 11
   },
   {
-    "id": "randomJudoka",
-    "name": "View Judoka",
-    "japaneseName": "ランダム柔道家",
-    "description": "Displays a random judoka from the available list.",
+    "id": 12,
+    "url": "randomJudoka.html",
     "category": "mainMenu",
     "order": 40,
-    "url": "randomJudoka.html",
     "isHidden": false,
-    "rules": {
-      "note": "Rules will be defined in the future."
-    }
+    "gameModeId": 12
   },
   {
-    "id": "settingsMenu",
-    "name": "Settings",
-    "japaneseName": "設定",
-    "description": "Change game settings.",
+    "id": 13,
+    "url": "settings.html",
     "category": "mainMenu",
     "order": 90,
-    "url": "settings.html",
     "isHidden": false,
-    "rules": {
-      "note": "Rules will be defined in the future."
-    }
+    "gameModeId": 13
   }
 ]

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -135,14 +135,14 @@ describe("populateNavbar", () => {
     const navBar = setupDom();
     stubLogoQuery();
     const data = [
-      { id: "A", name: "A", url: "a.html", category: "mainMenu", order: 2, isHidden: false },
-      { id: "B", name: "B", url: "b.html", category: "mainMenu", order: 1, isHidden: false }
+      { id: 1, name: "A", url: "a.html", category: "mainMenu", order: 2, isHidden: false },
+      { id: 2, name: "B", url: "b.html", category: "mainMenu", order: 1, isHidden: false }
     ];
     const loadSettings = vi.fn().mockResolvedValue({
       sound: true,
       motionEffects: true,
       displayMode: "light",
-      gameModes: { B: false },
+      gameModes: { 2: false },
       featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
@@ -188,7 +188,7 @@ describe("populateNavbar", () => {
     const navBar = setupDom();
     stubLogoQuery();
     const data = [
-      { id: "X", name: "X", url: "x.html", category: "mainMenu", order: 1, isHidden: false }
+      { id: 3, name: "X", url: "x.html", category: "mainMenu", order: 1, isHidden: false }
     ];
     localStorage.setItem("navigationItems", JSON.stringify(data));
     const loadSettings = vi.fn().mockResolvedValue({
@@ -220,7 +220,7 @@ describe("populateNavbar", () => {
     stubLogoQuery();
     const data = [
       {
-        id: "home",
+        id: 1,
         name: "Home",
         url: "home.html",
         category: "mainMenu",
@@ -228,7 +228,7 @@ describe("populateNavbar", () => {
         isHidden: false
       },
       {
-        id: "about",
+        id: 2,
         name: "About",
         url: "about.html",
         category: "mainMenu",

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -56,9 +56,9 @@ describe("settingsPage module", () => {
   it("renders checkboxes for all modes", async () => {
     vi.useFakeTimers();
     const gameModes = [
-      { id: "classic", name: "Classic", category: "mainMenu", order: 10 },
-      { id: "blitz", name: "Blitz", category: "bonus", order: 20 },
-      { id: "dojo", name: "Dojo", category: "mainMenu", order: 30 }
+      { id: 1, name: "Classic", category: "mainMenu", order: 10 },
+      { id: 2, name: "Blitz", category: "bonus", order: 20 },
+      { id: 3, name: "Dojo", category: "mainMenu", order: 30 }
     ];
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
@@ -82,9 +82,9 @@ describe("settingsPage module", () => {
     const checkboxes = container.querySelectorAll("input[type='checkbox']");
     const labels = container.querySelectorAll("label span");
     expect(checkboxes).toHaveLength(3);
-    expect(container.querySelector("#mode-classic")).toBeTruthy();
-    expect(container.querySelector("#mode-dojo")).toBeTruthy();
-    expect(container.querySelector("#mode-blitz")).toBeTruthy();
+    expect(container.querySelector("#mode-1")).toBeTruthy();
+    expect(container.querySelector("#mode-3")).toBeTruthy();
+    expect(container.querySelector("#mode-2")).toBeTruthy();
     expect(labels[0].textContent).toBe("Classic (mainMenu - 10)");
     expect(labels[1].textContent).toBe("Blitz (bonus - 20)");
     expect(labels[2].textContent).toBe("Dojo (mainMenu - 30)");
@@ -92,9 +92,7 @@ describe("settingsPage module", () => {
 
   it("checkbox state reflects isHidden when no setting exists", async () => {
     vi.useFakeTimers();
-    const gameModes = [
-      { id: "team", name: "Team", category: "mainMenu", order: 5, isHidden: true }
-    ];
+    const gameModes = [{ id: 4, name: "Team", category: "mainMenu", order: 5, isHidden: true }];
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
     const loadNavigationItems = vi.fn().mockResolvedValue(gameModes);
@@ -113,13 +111,13 @@ describe("settingsPage module", () => {
     document.dispatchEvent(new Event("DOMContentLoaded"));
     await vi.runAllTimersAsync();
 
-    const input = document.getElementById("mode-team");
+    const input = document.getElementById("mode-4");
     expect(input.checked).toBe(false);
   });
 
   it("updates isHidden when a checkbox is toggled", async () => {
     vi.useFakeTimers();
-    const gameModes = [{ id: "classic", name: "Classic", category: "mainMenu", isHidden: false }];
+    const gameModes = [{ id: 1, name: "Classic", category: "mainMenu", isHidden: false }];
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updateSetting = vi.fn().mockResolvedValue(baseSettings);
     const loadNavigationItems = vi.fn().mockResolvedValue(gameModes);
@@ -140,11 +138,11 @@ describe("settingsPage module", () => {
     document.dispatchEvent(new Event("DOMContentLoaded"));
     await vi.runAllTimersAsync();
 
-    const input = document.getElementById("mode-classic");
+    const input = document.getElementById("mode-1");
     input.checked = false;
     input.dispatchEvent(new Event("change"));
 
-    expect(updateNavigationItemHidden).toHaveBeenCalledWith("classic", true);
+    expect(updateNavigationItemHidden).toHaveBeenCalledWith(1, true);
   });
 
   it("renders feature flag switches", async () => {


### PR DESCRIPTION
## Summary
- use numeric IDs in `gameModes.json` and `navigationItems.json`
- link navigation items to game modes via `gameModeId`
- update JSON schemas for integer IDs
- adjust fixtures and tests for new ID format

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: navigation tests could not run)*

------
https://chatgpt.com/codex/tasks/task_e_68850c340ec883268b0d4020a72c39b9