### PR TITLE
Fix vector search data coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,11 @@ JU-DO-KON! offers a 99-card deck and one-on-one stat battles in a fully browser-
 
 The project ships with a retrieval-augmented search demo. Run `npm run generate:embeddings` to create the index, then open `src/pages/vectorSearch.html` to try it out. The generation script at `scripts/generateEmbeddings.js` downloads the `Xenova/all-MiniLM-L6-v2` model the first time it runs—so it fails offline unless the weights have been cached. These embeddings let AI agents query the product requirement docs, tooltip descriptions, and game data. The generated `src/data/client_embeddings.json` is pretty-printed for readability and must be committed for the page to work. **Embeddings must be flat numeric arrays like `[0.12, -0.04, ...]`—objects with `dims` or `data` keys will break the search page.**
 
-After modifying any PRDs **or any file in `src/data/`**, run `npm run generate:embeddings` again to rebuild `client_embeddings.json`. Commit the updated file alongside your documentation changes so other agents have the latest vectors.
+After modifying any PRDs, **any file in `src/data/`**, or docs under
+`design/codeStandards` or `design/agentWorkflows`, run
+`npm run generate:embeddings` again to rebuild `client_embeddings.json`. Commit
+the updated file alongside your documentation changes so other agents have the
+latest vectors.
 
 - Both the generation script and the search page use **mean pooled** embeddings so the query vector matches the stored vectors.
 

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -49,4 +49,10 @@ Query: "navbar button transition duration"
 
 ## Updating Embeddings
 
-Run `npm run generate:embeddings` whenever you update any PRD **or any file under `src/data/`**. The script (`scripts/generateEmbeddings.js`) fetches the `Xenova/all-MiniLM-L6-v2` model on first run, so it requires internet access unless the model is cached. This rebuilds `client_embeddings.json`, now pretty-printed for easier diffing, so agents search the latest content. Commit the regenerated JSON file along with your changes.
+Run `npm run generate:embeddings` whenever you update any PRD, files in
+`src/data/`, or markdown under `design/codeStandards` or
+`design/agentWorkflows`. The script (`scripts/generateEmbeddings.js`) fetches the
+`Xenova/all-MiniLM-L6-v2` model on first run, so it requires internet access
+unless the model is cached. This rebuilds `client_embeddings.json`, now
+pretty-printed for easier diffing, so agents search the latest content. Commit
+the regenerated JSON file along with your changes.

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -59,7 +59,11 @@ Ultimately, these issues increase the risk of bugs reaching players, slow down t
 
 ### Embedding Refresh Pipeline
 
-After editing PRDs, tooltips, or game rules, run `npm run generate:embeddings` from the repository root. The script at `scripts/generateEmbeddings.js` downloads the `Xenova/all-MiniLM-L6-v2` model the first time it runs, so the command will fail without internet access. Cache the model locally or run it in an environment with a connection. Commit the updated `client_embeddings.json`—now pretty-printed for readability—so other agents work with the latest vectors. A GitHub Actions workflow could automate this regeneration whenever those folders change.
+After editing PRDs, tooltips, game rules, or any markdown under
+`design/codeStandards` or `design/agentWorkflows`, run
+`npm run generate:embeddings` from the repository root. The script at
+`scripts/generateEmbeddings.js` downloads the `Xenova/all-MiniLM-L6-v2` model the first time it runs, so the command will fail without internet access. Cache the model locally or run it in an environment with a connection. Commit the updated `client_embeddings.json`—now pretty-printed for readability—so other agents work with the latest vectors. A GitHub Actions workflow could automate this
+regeneration whenever those folders change.
 
 ---
 

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -23,11 +23,15 @@ const MAX_TEXT_LENGTH = 1000;
 const MAX_OUTPUT_SIZE = 3 * 1024 * 1024;
 
 async function getFiles() {
-  const mdFiles = await glob("design/productRequirementsDocuments/*.md", { cwd: rootDir });
+  const prdFiles = await glob("design/productRequirementsDocuments/*.md", {
+    cwd: rootDir
+  });
+  const guidelineFiles = await glob("design/codeStandards/*.md", { cwd: rootDir });
+  const workflowFiles = await glob("design/agentWorkflows/*.md", { cwd: rootDir });
   const jsonFiles = (await glob("src/data/*.json", { cwd: rootDir })).filter(
     (f) => path.extname(f) === ".json"
   );
-  return [...mdFiles, ...jsonFiles];
+  return [...prdFiles, ...guidelineFiles, ...workflowFiles, ...jsonFiles];
 }
 
 async function loadModel() {


### PR DESCRIPTION
## Summary
- include code standards and agent docs when generating embeddings
- mention the new docs in vector search instructions
- document additional directories in Vector Database PRD

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: npm ERR 403 Forbidden)*
- `npx playwright test` *(fails: npm ERR 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68850c5839d883269d2192f8efaab1c6