### PR TITLE
Add card inspector feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ The Settings page (`src/pages/settings.html`) groups all player preferences, inc
 Battle pages include a collapsible debug panel. Enable the **Battle Debug Panel** feature flag in **Settings** to reveal real-time match state in a `<pre>` element. The panel is keyboard accessible and hidden by default so normal gameplay remains unaffected.
 Toggle the **Full Navigation Map** flag to display a map overlay with links to all pages for easier orientation during testing.
 Enable the **Test Mode** flag for deterministic card draws and stat results. A "Test Mode Active" banner appears on battle pages.
+Enable the **Card Inspector** flag to add a collapsible panel on each card containing its raw JSON and markup. Opening the panel sets `data-inspector="true"` on the card for automated checks.
 
 Game mode data now falls back to a bundled JSON import if the network request fails, so navigation works offline.
 Corrupted settings are detected and automatically reset to defaults, ensuring the Settings page always remains usable.

--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -178,7 +178,7 @@ To support AI-assisted testing, variant gameplay modes, and scalable development
   - ID format: `feature-<kebab-case-feature-name>`
   - Name format: camelCase
   - Example: `id="feature-random-stat-mode" name="randomStatMode"`
-  - Common example flags include `Battle Debug Panel` and `Full Navigation Map`
+  - Common example flags include `Battle Debug Panel`, `Full Navigation Map`, and `Card Inspector`
 
 - **ARIA and Accessibility**  
   - Provide `aria-label` for each feature flag  

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -6,6 +6,7 @@
   "featureFlags": {
     "battleDebugPanel": false,
     "fullNavigationMap": true,
-    "enableTestMode": false
+    "enableTestMode": false,
+    "enableCardInspector": false
   }
 }

--- a/src/game.js
+++ b/src/game.js
@@ -114,7 +114,9 @@ export function setupRandomCardButton(button, container) {
     container.innerHTML = "";
 
     const prefersReducedMotion = shouldReduceMotionSync();
-    await generateRandomCard(null, null, container, prefersReducedMotion);
+    await generateRandomCard(null, null, container, prefersReducedMotion, undefined, {
+      enableInspector: false
+    });
   });
 }
 

--- a/src/helpers/cardUtils.js
+++ b/src/helpers/cardUtils.js
@@ -1,4 +1,4 @@
-import { generateJudokaCardHTML } from "./cardBuilder.js";
+import { generateJudokaCardHTML, createInspectorPanel } from "./cardBuilder.js";
 import { debugLog } from "./debug.js";
 import { seededRandom } from "./testModeUtils.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
@@ -126,7 +126,7 @@ export async function renderJudokaCard(
   judoka,
   gokyoLookup,
   container,
-  { animate = false, useObscuredStats = false } = {}
+  { animate = false, useObscuredStats = false, enableInspector = false } = {}
 ) {
   if (!container) return null;
   if (!hasRequiredJudokaFields(judoka)) {
@@ -147,7 +147,9 @@ export async function renderJudokaCard(
       }
     }
 
-    const card = await generateJudokaCardHTML(cardData, gokyoLookup);
+    const card = await generateJudokaCardHTML(cardData, gokyoLookup, {
+      enableInspector
+    });
     if (!card) return null;
     container.innerHTML = "";
     container.appendChild(card);
@@ -163,4 +165,27 @@ export async function renderJudokaCard(
     console.error("Error rendering judoka card:", error);
     return null;
   }
+}
+
+export function toggleInspectorPanels(enable) {
+  document.querySelectorAll(".card-container").forEach((container) => {
+    const existing = container.querySelector(".debug-panel");
+    if (enable) {
+      if (!existing) {
+        const json = container.dataset.cardJson;
+        const card = container.querySelector(".judoka-card");
+        if (!json || !card) return;
+        const panel = createInspectorPanel(container, JSON.parse(json), {
+          topBar: card.querySelector(".card-top-bar"),
+          portrait: card.querySelector(".card-portrait"),
+          stats: card.querySelector(".card-stats"),
+          signature: card.querySelector(".signature-move-container")
+        });
+        container.appendChild(panel);
+      }
+    } else if (existing) {
+      existing.remove();
+      container.removeAttribute("data-inspector");
+    }
+  });
 }

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -131,9 +131,16 @@ export async function startRound() {
   const playerContainer = document.getElementById("player-card");
   const computerContainer = document.getElementById("computer-card");
   let playerJudoka = null;
-  await generateRandomCard(availableJudoka, null, playerContainer, false, (j) => {
-    playerJudoka = j;
-  });
+  await generateRandomCard(
+    availableJudoka,
+    null,
+    playerContainer,
+    false,
+    (j) => {
+      playerJudoka = j;
+    },
+    { enableInspector: false }
+  );
   let compJudoka = getRandomJudoka(availableJudoka);
   if (playerJudoka) {
     // avoid showing the same judoka, but guard against infinite loops
@@ -148,7 +155,8 @@ export async function startRound() {
   const placeholder = judokaData.find((j) => j.id === 1) || compJudoka;
   await renderJudokaCard(placeholder, gokyoLookup, computerContainer, {
     animate: false,
-    useObscuredStats: true
+    useObscuredStats: true,
+    enableInspector: false
   });
   showSelectionPrompt();
   const { playerScore, computerScore } = getScores();

--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -76,7 +76,8 @@ export async function generateRandomCard(
   gokyoData,
   containerEl,
   prefersReducedMotion = false,
-  onSelect
+  onSelect,
+  options = {}
 ) {
   if (!containerEl) return;
 
@@ -104,7 +105,8 @@ export async function generateRandomCard(
       onSelect(selectedJudoka);
     }
     await renderJudokaCard(selectedJudoka, gokyoLookup, containerEl, {
-      animate: !prefersReducedMotion
+      animate: !prefersReducedMotion,
+      enableInspector: options.enableInspector
     });
     // else: do not update DOM if card is null/undefined
   } catch (error) {
@@ -117,7 +119,8 @@ export async function generateRandomCard(
         onSelect(fallbackJudoka);
       }
       await renderJudokaCard(fallbackJudoka, gokyoLookup, containerEl, {
-        animate: !prefersReducedMotion
+        animate: !prefersReducedMotion,
+        enableInspector: options.enableInspector
       });
     } catch (fallbackError) {
       console.error("Error displaying fallback card:", fallbackError);

--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -16,6 +16,7 @@
  */
 import { fetchJson } from "./dataUtils.js";
 import { generateRandomCard } from "./randomCard.js";
+import { toggleInspectorPanels } from "./cardUtils.js";
 import { DATA_DIR } from "./constants.js";
 import { createButton } from "../components/Button.js";
 import { createToggleSwitch } from "../components/ToggleSwitch.js";
@@ -40,6 +41,7 @@ export async function setupRandomJudokaPage() {
   }
 
   applyMotionPreference(settings.motionEffects);
+  toggleInspectorPanels(Boolean(settings.featureFlags?.enableCardInspector));
   const prefersReducedMotion =
     !settings.motionEffects || window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
@@ -93,7 +95,9 @@ export async function setupRandomJudokaPage() {
       cachedJudokaData,
       cachedGokyoData,
       cardContainer,
-      prefersReducedMotion
+      prefersReducedMotion,
+      undefined,
+      { enableInspector: settings.featureFlags.enableCardInspector }
     );
     // Wait for animation to finish (max 500ms), then re-enable button
     setTimeout(
@@ -140,6 +144,15 @@ export async function setupRandomJudokaPage() {
   animationToggle.style.marginTop = "24px";
   soundToggle.style.marginLeft = "16px";
   cardSection.append(animationToggle, soundToggle);
+
+  window.addEventListener("storage", (e) => {
+    if (e.key === "settings" && e.newValue) {
+      try {
+        const s = JSON.parse(e.newValue);
+        toggleInspectorPanels(Boolean(s.featureFlags?.enableCardInspector));
+      } catch {}
+    }
+  });
 
   animationToggle.querySelector("input")?.addEventListener("change", (e) => {
     const value = e.currentTarget.checked;

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -34,7 +34,8 @@ const DEFAULT_SETTINGS = {
   featureFlags: {
     battleDebugPanel: false,
     fullNavigationMap: true,
-    enableTestMode: false
+    enableTestMode: false,
+    enableCardInspector: false
   }
 };
 export { DEFAULT_SETTINGS };

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -85,19 +85,6 @@
 }
 
 /* Collapsible debug panel */
-.debug-panel {
-  background-color: #f9f9f9;
-  border-radius: 10%;
-  padding: 0.8rem;
-  margin-top: 1rem;
-  font-family: monospace;
-  font-size: 1rem;
-  overflow-x: auto;
-  text-align: left;
-  max-width: 300px;
-  margin: 5vh auto;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
-}
 
 .test-mode-banner {
   background-color: var(--color-tertiary);

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -6,3 +6,17 @@
 @import "./modal.css";
 @import "./battle.css";
 @import "./tooltip.css";
+
+.debug-panel {
+  background-color: #f9f9f9;
+  border-radius: 10%;
+  padding: 0.8rem;
+  margin-top: 1rem;
+  font-family: monospace;
+  font-size: 1rem;
+  overflow-x: auto;
+  text-align: left;
+  max-width: 300px;
+  margin: 5vh auto;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
+}

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -143,7 +143,12 @@ describe("populateNavbar", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: { 2: false },
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
+      featureFlags: {
+        battleDebugPanel: false,
+        fullNavigationMap: true,
+        enableTestMode: false,
+        enableCardInspector: false
+      }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -196,7 +201,12 @@ describe("populateNavbar", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
+      featureFlags: {
+        battleDebugPanel: false,
+        fullNavigationMap: true,
+        enableTestMode: false,
+        enableCardInspector: false
+      }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -241,7 +251,12 @@ describe("populateNavbar", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
+      featureFlags: {
+        battleDebugPanel: false,
+        fullNavigationMap: true,
+        enableTestMode: false,
+        enableCardInspector: false
+      }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -33,7 +33,7 @@ describe("classicBattle card selection", () => {
     document.body.append(playerCard, computerCard, header);
     timerSpy = vi.useFakeTimers();
     fetchJsonMock = vi.fn(async () => []);
-    generateRandomCardMock = vi.fn(async (_d, _g, container, _pm, cb) => {
+    generateRandomCardMock = vi.fn(async (_d, _g, container, _pm, cb, _opts) => {
       container.innerHTML = "<ul></ul>";
       if (cb) cb({ id: 1 });
     });
@@ -52,7 +52,7 @@ describe("classicBattle card selection", () => {
       }
       return [];
     });
-    generateRandomCardMock = vi.fn(async (d, g, c, _pm, cb) => {
+    generateRandomCardMock = vi.fn(async (d, g, c, _pm, cb, _opts) => {
       c.innerHTML = "<ul></ul>";
       cb({ id: 1 });
     });
@@ -70,7 +70,7 @@ describe("classicBattle card selection", () => {
       expect.objectContaining({ id: 1 }),
       expect.anything(),
       expect.anything(),
-      { animate: false, useObscuredStats: true }
+      { animate: false, useObscuredStats: true, enableInspector: false }
     );
     expect(getComputerJudoka()).toEqual(expect.objectContaining({ id: 2 }));
   });
@@ -86,7 +86,7 @@ describe("classicBattle card selection", () => {
       }
       return [];
     });
-    generateRandomCardMock = vi.fn(async (d, g, c, _pm, cb) => {
+    generateRandomCardMock = vi.fn(async (d, g, c, _pm, cb, _opts) => {
       c.innerHTML = "<ul></ul>";
       if (cb) cb(d[0]);
     });
@@ -99,7 +99,8 @@ describe("classicBattle card selection", () => {
       null,
       expect.anything(),
       false,
-      expect.any(Function)
+      expect.any(Function),
+      { enableInspector: false }
     );
     expect(getRandomJudokaMock).toHaveBeenCalledWith([
       expect.objectContaining({ id: 2, isHidden: false })

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -10,7 +10,8 @@ const baseSettings = {
     randomStatMode: true,
     battleDebugPanel: false,
     fullNavigationMap: true,
-    enableTestMode: false
+    enableTestMode: false,
+    enableCardInspector: false
   }
 };
 
@@ -205,7 +206,8 @@ describe("settingsPage module", () => {
       randomStatMode: true,
       battleDebugPanel: true,
       fullNavigationMap: true,
-      enableTestMode: false
+      enableTestMode: false,
+      enableCardInspector: false
     });
   });
 });

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -44,7 +44,12 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
+      featureFlags: {
+        battleDebugPanel: false,
+        fullNavigationMap: true,
+        enableTestMode: false,
+        enableCardInspector: false
+      }
     });
   });
 
@@ -59,7 +64,12 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "dark",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
+      featureFlags: {
+        battleDebugPanel: false,
+        fullNavigationMap: true,
+        enableTestMode: false,
+        enableCardInspector: false
+      }
     };
     const promise = saveSettings(data);
     await vi.advanceTimersByTimeAsync(110);
@@ -87,7 +97,12 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
+      featureFlags: {
+        battleDebugPanel: false,
+        fullNavigationMap: true,
+        enableTestMode: false,
+        enableCardInspector: false
+      }
     });
     Storage.prototype.getItem = originalGetItem;
   });
@@ -130,7 +145,12 @@ describe("settings utils", () => {
         motionEffects: true,
         displayMode: "light",
         gameModes: {},
-        featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
+        featureFlags: {
+          battleDebugPanel: false,
+          fullNavigationMap: true,
+          enableTestMode: false,
+          enableCardInspector: false
+        }
       })
     ).rejects.toThrow("fail");
     Storage.prototype.setItem = originalSetItem;
@@ -162,14 +182,24 @@ describe("settings utils", () => {
       motionEffects: true,
       displayMode: "light",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: false, enableTestMode: false }
+      featureFlags: {
+        battleDebugPanel: false,
+        fullNavigationMap: false,
+        enableTestMode: false,
+        enableCardInspector: false
+      }
     };
     const data2 = {
       sound: false,
       motionEffects: false,
       displayMode: "dark",
       gameModes: {},
-      featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
+      featureFlags: {
+        battleDebugPanel: false,
+        fullNavigationMap: true,
+        enableTestMode: false,
+        enableCardInspector: false
+      }
     };
     saveSettings(data1);
     saveSettings(data2);


### PR DESCRIPTION
## Summary
- add `enableCardInspector` setting
- inject inspector panels into cards when flag enabled
- allow toggling inspector panels via storage events
- move `.debug-panel` styles to `components.css`
- document new Card Inspector setting
- update unit tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: fetch errors and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68854ef90ba08326a612a3d48bc13453