### PR TITLE
Refactor nav selectors in Playwright

### DIFF
--- a/playwright/battleJudoka.spec.js
+++ b/playwright/battleJudoka.spec.js
@@ -1,5 +1,9 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+import {
+  verifyPageBasics,
+  NAV_RANDOM_JUDOKA,
+  NAV_CLASSIC_BATTLE
+} from "./fixtures/navigationChecks.js";
 
 test.describe("Battle Judoka page", () => {
   test.beforeEach(async ({ page }) => {
@@ -7,14 +11,14 @@ test.describe("Battle Judoka page", () => {
   });
 
   test("page loads and nav visible", async ({ page }) => {
-    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
+    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 
   test("navigation links work", async ({ page }) => {
-    await page.getByTestId("nav-randomJudoka").click();
+    await page.getByTestId(NAV_RANDOM_JUDOKA).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
     await page.goBack({ waitUntil: "load" });
-    await page.getByTestId("nav-classicBattle").click();
+    await page.getByTestId(NAV_CLASSIC_BATTLE).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 });

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+import { verifyPageBasics, NAV_CLASSIC_BATTLE } from "./fixtures/navigationChecks.js";
 
 async function setCarouselWidth(page, width) {
   await page.evaluate((w) => {
@@ -25,11 +25,11 @@ test.describe("Browse Judoka screen", () => {
       "aria-label",
       /country filter/i
     );
-    await verifyPageBasics(page, ["nav-classicBattle"]);
+    await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
   });
 
   test("battle link navigates", async ({ page }) => {
-    await page.getByTestId("nav-classicBattle").click();
+    await page.getByTestId(NAV_CLASSIC_BATTLE).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 

--- a/playwright/changelog.spec.js
+++ b/playwright/changelog.spec.js
@@ -1,5 +1,9 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+import {
+  verifyPageBasics,
+  NAV_RANDOM_JUDOKA,
+  NAV_CLASSIC_BATTLE
+} from "./fixtures/navigationChecks.js";
 
 test.describe("Change log page", () => {
   test.beforeEach(async ({ page }) => {
@@ -7,7 +11,7 @@ test.describe("Change log page", () => {
   });
 
   test("header and footer visible", async ({ page }) => {
-    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
+    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 
   test("captures screenshot", async ({ page }) => {

--- a/playwright/createJudoka.spec.js
+++ b/playwright/createJudoka.spec.js
@@ -1,5 +1,9 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+import {
+  verifyPageBasics,
+  NAV_RANDOM_JUDOKA,
+  NAV_CLASSIC_BATTLE
+} from "./fixtures/navigationChecks.js";
 
 test.describe("Create Judoka page", () => {
   test.beforeEach(async ({ page }) => {
@@ -7,14 +11,14 @@ test.describe("Create Judoka page", () => {
   });
 
   test("page loads and nav visible", async ({ page }) => {
-    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
+    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 
   test("navigation links work", async ({ page }) => {
-    await page.getByTestId("nav-randomJudoka").click();
+    await page.getByTestId(NAV_RANDOM_JUDOKA).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
     await page.goBack({ waitUntil: "load" });
-    await page.getByTestId("nav-classicBattle").click();
+    await page.getByTestId(NAV_CLASSIC_BATTLE).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 });

--- a/playwright/fixtures/navigationChecks.js
+++ b/playwright/fixtures/navigationChecks.js
@@ -1,5 +1,9 @@
 import { expect } from "@playwright/test";
 
+export const NAV_RANDOM_JUDOKA = "nav-12";
+export const NAV_CLASSIC_BATTLE = "nav-1";
+export const NAV_UPDATE_JUDOKA = "nav-9";
+
 /**
  * Verify common page elements like title, navigation bar and logo.
  *

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -1,5 +1,9 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+import {
+  verifyPageBasics,
+  NAV_RANDOM_JUDOKA,
+  NAV_CLASSIC_BATTLE
+} from "./fixtures/navigationChecks.js";
 
 test.describe("Homepage", () => {
   test.beforeEach(async ({ page }) => {
@@ -7,7 +11,7 @@ test.describe("Homepage", () => {
   });
 
   test("page loads", async ({ page }) => {
-    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
+    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 
   test("logo has alt text", async ({ page }) => {
@@ -17,7 +21,7 @@ test.describe("Homepage", () => {
 
   test("navigation links visible", async ({ page }) => {
     await page.waitForSelector("footer .bottom-navbar a");
-    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
+    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 
   test("footer navigation links present", async ({ page }) => {
@@ -26,7 +30,7 @@ test.describe("Homepage", () => {
   });
 
   test("view judoka link navigates", async ({ page }) => {
-    await page.getByTestId("nav-randomJudoka").click();
+    await page.getByTestId(NAV_RANDOM_JUDOKA).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
   });
 

--- a/playwright/meditation-screen.spec.js
+++ b/playwright/meditation-screen.spec.js
@@ -1,5 +1,9 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+import {
+  verifyPageBasics,
+  NAV_RANDOM_JUDOKA,
+  NAV_CLASSIC_BATTLE
+} from "./fixtures/navigationChecks.js";
 
 test.describe("Meditation screen", () => {
   test.beforeEach(async ({ page }) => {
@@ -7,7 +11,7 @@ test.describe("Meditation screen", () => {
   });
 
   test("page basics", async ({ page }) => {
-    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
+    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 
   test("elements are visible", async ({ page }) => {

--- a/playwright/prd-reader.spec.js
+++ b/playwright/prd-reader.spec.js
@@ -1,5 +1,9 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+import {
+  verifyPageBasics,
+  NAV_RANDOM_JUDOKA,
+  NAV_CLASSIC_BATTLE
+} from "./fixtures/navigationChecks.js";
 
 test.describe("PRD Reader page", () => {
   test.beforeEach(async ({ page }) => {
@@ -7,7 +11,7 @@ test.describe("PRD Reader page", () => {
   });
 
   test("page basics", async ({ page }) => {
-    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
+    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 
   test("forward and back navigation", async ({ page }) => {

--- a/playwright/pseudo-japanese-toggle.spec.js
+++ b/playwright/pseudo-japanese-toggle.spec.js
@@ -1,7 +1,11 @@
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { test, expect } from "./fixtures/commonSetup.js";
-import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+import {
+  verifyPageBasics,
+  NAV_RANDOM_JUDOKA,
+  NAV_CLASSIC_BATTLE
+} from "./fixtures/navigationChecks.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const STORY_FIXTURE = path.resolve(__dirname, "../tests/fixtures/aesopsFables.json");
@@ -23,7 +27,7 @@ test.describe("Pseudo-Japanese toggle", () => {
   });
 
   test("page basics", async ({ page }) => {
-    await verifyPageBasics(page, ["nav-randomJudoka", "nav-classicBattle"]);
+    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 
   test("toggle updates quote text", async ({ page }) => {

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+import { verifyPageBasics, NAV_CLASSIC_BATTLE } from "./fixtures/navigationChecks.js";
 
 test.describe("View Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
@@ -9,11 +9,11 @@ test.describe("View Judoka screen", () => {
   test("essential elements visible", async ({ page }) => {
     await page.getByTestId("draw-button").waitFor();
     await expect(page.getByTestId("draw-button")).toBeVisible();
-    await verifyPageBasics(page, ["nav-classicBattle"]);
+    await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
   });
 
   test("battle link navigates", async ({ page }) => {
-    const battleLink = page.getByTestId("nav-classicBattle");
+    const battleLink = page.getByTestId(NAV_CLASSIC_BATTLE);
     await battleLink.waitFor();
     await battleLink.click();
     await expect(page).toHaveURL(/battleJudoka\.html/);

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -1,5 +1,9 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+import {
+  verifyPageBasics,
+  NAV_CLASSIC_BATTLE,
+  NAV_RANDOM_JUDOKA
+} from "./fixtures/navigationChecks.js";
 
 test.describe("Settings page", () => {
   test.beforeEach(async ({ page }) => {
@@ -14,7 +18,7 @@ test.describe("Settings page", () => {
   });
 
   test("page loads", async ({ page }) => {
-    await verifyPageBasics(page, ["nav-classicBattle", "nav-randomJudoka"]);
+    await verifyPageBasics(page, [NAV_CLASSIC_BATTLE, NAV_RANDOM_JUDOKA]);
   });
 
   test("mode toggle visible", async ({ page }) => {
@@ -23,7 +27,7 @@ test.describe("Settings page", () => {
   });
 
   test("essential elements visible", async ({ page }) => {
-    await verifyPageBasics(page, ["nav-classicBattle", "nav-randomJudoka"]);
+    await verifyPageBasics(page, [NAV_CLASSIC_BATTLE, NAV_RANDOM_JUDOKA]);
     await expect(page.getByLabel(/sound/i)).toBeVisible();
     await expect(page.getByLabel(/motion effects/i)).toBeVisible();
     await expect(page.getByLabel(/display mode/i)).toBeVisible();

--- a/playwright/updateJudoka.spec.js
+++ b/playwright/updateJudoka.spec.js
@@ -1,5 +1,10 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { verifyPageBasics } from "./fixtures/navigationChecks.js";
+import {
+  verifyPageBasics,
+  NAV_RANDOM_JUDOKA,
+  NAV_UPDATE_JUDOKA,
+  NAV_CLASSIC_BATTLE
+} from "./fixtures/navigationChecks.js";
 
 test.describe("Update Judoka page", () => {
   test.beforeEach(async ({ page }) => {
@@ -10,20 +15,20 @@ test.describe("Update Judoka page", () => {
   });
 
   test("page loads", async ({ page }) => {
-    await verifyPageBasics(page, ["nav-randomJudoka", "nav-updateJudoka", "nav-classicBattle"]);
+    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_UPDATE_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 
   test("navigation links work", async ({ page }) => {
-    await page.getByTestId("nav-randomJudoka").click();
+    await page.getByTestId(NAV_RANDOM_JUDOKA).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
     // Wait for bottom navigation links to populate
-    await page.getByTestId("nav-updateJudoka").waitFor();
+    await page.getByTestId(NAV_UPDATE_JUDOKA).waitFor();
     await page.goBack({ waitUntil: "load" });
 
-    await page.getByTestId("nav-updateJudoka").click();
+    await page.getByTestId(NAV_UPDATE_JUDOKA).click();
     await expect(page).toHaveURL(/updateJudoka\.html/);
 
-    const battleLink = page.getByTestId("nav-classicBattle");
+    const battleLink = page.getByTestId(NAV_CLASSIC_BATTLE);
     await battleLink.waitFor();
     await expect(battleLink).toHaveCount(1);
   });

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -58,23 +58,23 @@
               aria-labelledby="display-settings-toggle"
               hidden
             > -->
-              <fieldset
-                id="display-settings-container"
-                class="game-mode-toggle-container settings-form"
-              >
-                <legend>Display Settings</legend>
-                <div class="settings-item">
-                  <!-- <label for="display-mode-select">Display Mode</label> -->
-                  <select id="display-mode-select" aria-label="Display Mode" tabindex="1">
-                    <option value="light">Light</option>
-                    <option value="dark">Dark</option>
-                    <option value="gray">Gray</option>
-                  </select>
-                </div>
-              </fieldset>
-            <!-- </div>
+          <fieldset
+            id="display-settings-container"
+            class="game-mode-toggle-container settings-form"
+          >
+            <legend>Display Settings</legend>
+            <div class="settings-item">
+              <!-- <label for="display-mode-select">Display Mode</label> -->
+              <select id="display-mode-select" aria-label="Display Mode" tabindex="1">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="gray">Gray</option>
+              </select>
+            </div>
+          </fieldset>
+          <!-- </div>
           </div> -->
-          <br>
+          <br />
 
           <div class="settings-section">
             <button

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -128,7 +128,7 @@ body {
   border: 2px solid var(--color-tertiary);
   border-radius: var(--radius-md);
   text-align: center;
-    /* border: 2px solid red; */
+  /* border: 2px solid red; */
 }
 
 .homeHelperContainer img {
@@ -147,7 +147,7 @@ body {
   gap: var(--space-lg);
   flex: 1 1 auto;
   list-style-type: none;
-    /* border: 2px solid red; */
+  /* border: 2px solid red; */
 }
 #gameArea {
   display: flex;
@@ -155,7 +155,7 @@ body {
   align-items: center;
   padding: var(--space-large);
   backdrop-filter: blur(10px);
-    /* border: 2px solid red; */
+  /* border: 2px solid red; */
 }
 .country-flag-slider {
   background-color: var(--color-tertiary);


### PR DESCRIPTION
## Summary
- export navigation ID constants
- use navigation constants in all Playwright specs
- run Prettier on HTML/CSS files to satisfy formatting checks

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 17 failed, 50 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68855119940c83268e62c986c68ca051