### PR TITLE
Add typewriter effect with settings toggle

### DIFF
--- a/design/productRequirementsDocuments/prdMeditationScreen.md
+++ b/design/productRequirementsDocuments/prdMeditationScreen.md
@@ -154,6 +154,7 @@ Sets the emotional tone. Not a reward, but a rest—balancing the intensity of g
 - Dynamic font scaling for different screen sizes using CSS `clamp()`
 - Skeleton loader animation while quote loads
 - 200ms fade animation when language is toggled
+- Optional typewriter animation for the quote text (default ON, user can disable in Settings)
 
 **Why:**
 
@@ -191,6 +192,7 @@ Provides agency without pressure. Allows the player to re-enter gameplay at thei
 - KG character assets from the core game.
 - Navigation system for entering and exiting the screen.
 - Pseudo-Japanese Text Conversion Function for quote toggle ([prdPseudoJapanese.md](prdPseudoJapanese.md)).
+- Typewriter effect toggle stored in `settings.json` and managed on the Settings screen.
 
 ---
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -43,6 +43,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 | P1       | Full Navigation Map Feature Flag | Enable or disable the full navigation map via feature flag; updates `settings.json` live on change. |
 | P3       | Test Mode Feature Flag | Enables deterministic battles for automated testing. |
 | P1       | Motion Effects Toggle      | Binary toggle updating `settings.json` live on change.                      |
+| P1       | Typewriter Effect Toggle   | Enable or disable quote animation on the meditation screen. |
 | P1       | Display Mode Selector      | Three-option selector applying mode instantly across UI.                    |
 | P2       | Game Modes Toggles         | A list of all defined game modes with binary toggles from `navigationItems.json`. |
 | P3       | Settings Menu Integration  | Ensure settings appear as a game mode in `navigationItems.json`.                  |
@@ -59,6 +60,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - **Sound (binary):** ON/OFF (default: ON)
 - **Full navigation map feature flag (binary):** ON/OFF (default: ON)
 - **Motion effects (binary):** ON/OFF (default: ON)
+- **Typewriter effect (binary):** ON/OFF (default: ON)
 - **Display mode (three options):** Light, Dark, Gray (default: Light)
   - _Gray mode_ provides a grayscale display to reduce visual noise for neurodivergent users.
 - **Game modes list:** Pulled from `gameModes.json` and cross-referenced with `navigationItems.json` to determine order and visibility; each mode has a binary toggle.
@@ -113,9 +115,13 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - AC-3.2 Motion effects on UI start or stop instantly (e.g., animations stop when OFF).
 - AC-3.3 UI toggle reflects the current motion setting accurately on page load.
 
+### Typewriter Effect Toggle
+
+- AC-4.1 Disabling the toggle prevents the quote typewriter animation on the meditation screen.
+- AC-4.2 Setting is stored in `settings.json` within 50ms of change.
 ### Display Mode Selector
 
-- AC-4.1 Selecting a new display mode (light/dark/gray) applies changes instantly across all relevant UI components.
+- AC-5.1 Selecting a new display mode (light/dark/gray) applies changes instantly across all relevant UI components.
 - AC-4.2 Selected mode persists through a page refresh within the same session.
 - AC-4.3 Current display mode is correctly pulled from `settings.json` on page load.
 - AC-4.4 Transition to new display mode completes without visible flickering or rendering artifacts.

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -26,6 +26,7 @@ test.describe("Settings page", () => {
     await verifyPageBasics(page, ["nav-classicBattle", "nav-randomJudoka"]);
     await expect(page.getByLabel(/sound/i)).toBeVisible();
     await expect(page.getByLabel(/motion effects/i)).toBeVisible();
+    await expect(page.getByLabel(/typewriter effect/i)).toBeVisible();
     await expect(page.getByLabel(/display mode/i)).toBeVisible();
   });
 
@@ -42,10 +43,20 @@ test.describe("Settings page", () => {
       .sort((a, b) => a.order - b.order)
       .map((m) => m.name);
 
-    const expectedLabels = ["Display Mode", "Sound", "Motion Effects", ...sortedNames];
+    const expectedLabels = [
+      "Display Mode",
+      "Sound",
+      "Motion Effects",
+      "Typewriter Effect",
+      ...sortedNames
+    ];
 
     await expect(page.locator("#sound-toggle")).toHaveAttribute("aria-label", "Sound");
     await expect(page.locator("#motion-toggle")).toHaveAttribute("aria-label", "Motion Effects");
+    await expect(page.locator("#typewriter-toggle")).toHaveAttribute(
+      "aria-label",
+      "Typewriter Effect"
+    );
 
     await expect(page.locator("#game-mode-toggle-container input[type=checkbox]")).toHaveCount(
       sortedNames.length

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -1,6 +1,7 @@
 {
   "sound": true,
   "motionEffects": true,
+  "typewriterEffect": true,
   "displayMode": "light",
   "gameModes": {},
   "featureFlags": {

--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -21,6 +21,7 @@
  * @throws {Error} If the fetch request fails or the response is not successful.
  */
 import { DATA_DIR } from "./constants.js";
+import { shouldEnableTypewriter, runTypewriterEffect } from "./typewriter.js";
 
 let kgImageLoaded = false;
 let quoteLoaded = false;
@@ -106,6 +107,9 @@ function formatFableStory(story) {
  * 5. Toggle visibility:
  *    - Hide the loader element and remove the `hidden` class from the quote element.
  *
+ * 6. If the typewriter effect setting is enabled:
+ *    - Run the typewriter animation on `#quote-content` and restore the HTML when complete.
+ *
  * @param {Object|null} fable - The fable object containing the title and story, or `null` if no fable is available.
  */
 function displayFable(fable) {
@@ -126,6 +130,10 @@ function displayFable(fable) {
   }
   loaderDiv.classList.add("hidden");
   quoteDiv.classList.remove("hidden");
+  if (shouldEnableTypewriter()) {
+    const contentEl = document.getElementById("quote-content");
+    runTypewriterEffect(contentEl, quoteDiv.querySelector("#quote-content")?.innerHTML || "");
+  }
   const toggleBtn = document.getElementById("language-toggle");
   if (toggleBtn) {
     toggleBtn.classList.remove("hidden");

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -17,10 +17,11 @@ export function applyInitialControlValues(controls, settings) {
   applyInputState(controls.soundToggle, settings.sound);
   applyInputState(controls.motionToggle, settings.motionEffects);
   applyInputState(controls.displaySelect, settings.displayMode);
+  applyInputState(controls.typewriterToggle, settings.typewriterEffect);
 }
 
 export function attachToggleListeners(controls, getCurrentSettings, handleUpdate) {
-  const { soundToggle, motionToggle, displaySelect } = controls;
+  const { soundToggle, motionToggle, displaySelect, typewriterToggle } = controls;
   soundToggle?.addEventListener("change", () => {
     const prev = !soundToggle.checked;
     handleUpdate("sound", soundToggle.checked, () => {
@@ -42,6 +43,12 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
     handleUpdate("displayMode", mode, () => {
       displaySelect.value = previous;
       applyDisplayMode(previous);
+    });
+  });
+  typewriterToggle?.addEventListener("change", () => {
+    const prev = !typewriterToggle.checked;
+    handleUpdate("typewriterEffect", typewriterToggle.checked, () => {
+      typewriterToggle.checked = prev;
     });
   });
 }

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -40,7 +40,8 @@ function initializeControls(settings, gameModes) {
   const controls = {
     soundToggle: document.getElementById("sound-toggle"),
     motionToggle: document.getElementById("motion-toggle"),
-    displaySelect: document.getElementById("display-mode-select")
+    displaySelect: document.getElementById("display-mode-select"),
+    typewriterToggle: document.getElementById("typewriter-toggle")
   };
   const modesContainer = document.getElementById("game-mode-toggle-container");
   const flagsContainer = document.getElementById("feature-flags-container");

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -29,6 +29,7 @@ const SETTINGS_KEY = "settings";
 const DEFAULT_SETTINGS = {
   sound: false,
   motionEffects: true,
+  typewriterEffect: true,
   displayMode: "light",
   gameModes: {},
   featureFlags: {
@@ -146,6 +147,7 @@ export async function updateSetting(key, value) {
  * @typedef {Object} Settings
  * @property {boolean} sound
  * @property {boolean} motionEffects
+ * @property {boolean} typewriterEffect
  * @property {"light"|"dark"|"gray"} displayMode
  * @property {Record<string, boolean>} [gameModes]
  * @property {Record<string, boolean>} [featureFlags]

--- a/src/helpers/typewriter.js
+++ b/src/helpers/typewriter.js
@@ -1,0 +1,41 @@
+/**
+ * Utility for the typewriter effect on quote text.
+ *
+ * @pseudocode
+ * 1. `shouldEnableTypewriter` reads the `settings` item from `localStorage`.
+ *    - If `typewriterEffect` is `false`, return `false`.
+ *    - Otherwise return `true`.
+ * 2. `runTypewriterEffect` types textContent of an element character by
+ *    character at the given speed and restores the final HTML when done.
+ */
+
+export function shouldEnableTypewriter() {
+  try {
+    const raw = localStorage.getItem("settings");
+    if (raw) {
+      const data = JSON.parse(raw);
+      if (data && data.typewriterEffect === false) {
+        return false;
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return true;
+}
+
+export function runTypewriterEffect(element, finalHtml, speed = 20) {
+  if (!element) return;
+  const text = element.textContent;
+  element.textContent = "";
+  let i = 0;
+  (function type() {
+    if (i < text.length) {
+      element.textContent += text.charAt(i);
+      i += 1;
+      setTimeout(type, speed);
+    } else {
+      element.innerHTML = finalHtml;
+    }
+  })();
+}

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -124,6 +124,19 @@
                     <span>Motion Effects</span>
                   </label>
                 </div>
+                <div class="settings-item">
+                  <label for="typewriter-toggle" class="switch">
+                    <input
+                      type="checkbox"
+                      id="typewriter-toggle"
+                      name="typewriter"
+                      aria-label="Typewriter Effect"
+                      tabindex="5"
+                    />
+                    <div class="slider round"></div>
+                    <span>Typewriter Effect</span>
+                  </label>
+                </div>
               </fieldset>
             </div>
           </div>

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -11,6 +11,10 @@
       "type": "boolean",
       "description": "Enable animated motion effects."
     },
+    "typewriterEffect": {
+      "type": "boolean",
+      "description": "Animate meditation quotes with a typewriter effect."
+    },
     "displayMode": {
       "type": "string",
       "enum": ["light", "dark", "gray"],
@@ -27,6 +31,6 @@
       "additionalProperties": { "type": "boolean" }
     }
   },
-  "required": ["sound", "motionEffects", "displayMode"],
+  "required": ["sound", "motionEffects", "typewriterEffect", "displayMode"],
   "additionalProperties": false
 }

--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -91,6 +91,7 @@
   color: var(--color-text-inverted);
   font-size: clamp(18px, 2vw, 24px);
   text-align: justify;
+  white-space: pre-wrap;
   /* align-self: center; */
   /* justify-self: center; */
   padding: 5dvh 5dvw;

--- a/tests/helpers/quoteBuilder.test.js
+++ b/tests/helpers/quoteBuilder.test.js
@@ -20,6 +20,7 @@ describe("displayRandomQuote", () => {
     const liveRegion = document.createElement("div");
     liveRegion.id = "language-announcement";
     document.body.append(quoteDiv, loader, toggle, liveRegion);
+    localStorage.setItem("settings", JSON.stringify({ typewriterEffect: false }));
 
     const storyData = [{ id: 1, story: "B" }];
     const metaData = [{ id: 1, title: "A" }];
@@ -50,6 +51,7 @@ describe("displayRandomQuote", () => {
     const loader = document.createElement("div");
     loader.id = "quote-loader";
     document.body.append(quoteDiv, loader);
+    localStorage.setItem("settings", JSON.stringify({ typewriterEffect: false }));
 
     global.fetch = vi.fn().mockRejectedValue(new Error("fail"));
 
@@ -66,6 +68,7 @@ describe("displayRandomQuote", () => {
     const loader = document.createElement("div");
     loader.id = "quote-loader";
     document.body.append(quoteDiv, loader);
+    localStorage.setItem("settings", JSON.stringify({ typewriterEffect: false }));
 
     // Empty array
     global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: async () => [] }));
@@ -83,6 +86,7 @@ describe("displayRandomQuote", () => {
   });
 
   it("does not throw if DOM elements are missing", async () => {
+    localStorage.setItem("settings", JSON.stringify({ typewriterEffect: false }));
     global.fetch = vi.fn((url) => {
       if (url.includes("aesopsFables.json")) {
         return Promise.resolve({ ok: true, json: async () => [{ id: 1, story: "B" }] });

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -8,6 +8,7 @@ import { hex } from "wcag-contrast";
 const baseSettings = {
   sound: false,
   motionEffects: true,
+  typewriterEffect: true,
   displayMode: "light",
   gameModes: {},
   featureFlags: {

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -4,6 +4,7 @@ import { createSettingsDom } from "../utils/testUtils.js";
 const baseSettings = {
   sound: true,
   motionEffects: true,
+  typewriterEffect: true,
   displayMode: "light",
   gameModes: {},
   featureFlags: {

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -42,6 +42,7 @@ describe("settings utils", () => {
     expect(settings).toEqual({
       sound: false,
       motionEffects: true,
+      typewriterEffect: true,
       displayMode: "light",
       gameModes: {},
       featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
@@ -57,6 +58,7 @@ describe("settings utils", () => {
     const data = {
       sound: false,
       motionEffects: true,
+      typewriterEffect: true,
       displayMode: "dark",
       gameModes: {},
       featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
@@ -85,6 +87,7 @@ describe("settings utils", () => {
     expect(settings).toEqual({
       sound: false,
       motionEffects: true,
+      typewriterEffect: true,
       displayMode: "light",
       gameModes: {},
       featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
@@ -128,6 +131,7 @@ describe("settings utils", () => {
       saveSettings({
         sound: true,
         motionEffects: true,
+        typewriterEffect: true,
         displayMode: "light",
         gameModes: {},
         featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }
@@ -160,6 +164,7 @@ describe("settings utils", () => {
     const data1 = {
       sound: true,
       motionEffects: true,
+      typewriterEffect: true,
       displayMode: "light",
       gameModes: {},
       featureFlags: { battleDebugPanel: false, fullNavigationMap: false, enableTestMode: false }
@@ -167,6 +172,7 @@ describe("settings utils", () => {
     const data2 = {
       sound: false,
       motionEffects: false,
+      typewriterEffect: true,
       displayMode: "dark",
       gameModes: {},
       featureFlags: { battleDebugPanel: false, fullNavigationMap: true, enableTestMode: false }

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -49,6 +49,9 @@ export function createSettingsDom() {
   const motionToggle = document.createElement("input");
   motionToggle.id = "motion-toggle";
   motionToggle.type = "checkbox";
+  const typewriterToggle = document.createElement("input");
+  typewriterToggle.id = "typewriter-toggle";
+  typewriterToggle.type = "checkbox";
   const displayModeSelect = document.createElement("select");
   displayModeSelect.id = "display-mode-select";
   const gameModeToggleContainer = document.createElement("section");
@@ -58,6 +61,7 @@ export function createSettingsDom() {
   fragment.append(
     soundToggle,
     motionToggle,
+    typewriterToggle,
     displayModeSelect,
     gameModeToggleContainer,
     featureFlagsContainer


### PR DESCRIPTION
## Summary
- implement typewriter animation utilities
- run typewriter on meditation quotes when enabled
- add Typewriter Effect toggle in settings UI and JS helpers
- include new property in settings schema and defaults
- update tests and docs for new setting

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688551f0b27483268f7f9fbeded839aa