### PR TITLE
Remove card enlargement on battle screen

### DIFF
--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -94,3 +94,8 @@
   font-weight: bold;
   margin-top: var(--space-sm);
 }
+/* Disable hover enlargement for battle screen */
+#battle-area .judoka-card:hover,
+#battle-area .judoka-card:focus-visible {
+  transform: none;
+}


### PR DESCRIPTION
## Summary
- remove hover scale transform from battle area cards

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: cannot find module '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6885553d2bc08326bc513d0f987dc7d1