### PR TITLE
Fix game random card test

### DIFF
--- a/tests/helpers/gameRandom.test.js
+++ b/tests/helpers/gameRandom.test.js
@@ -32,6 +32,13 @@ describe("game.js", () => {
     document.dispatchEvent(new Event("DOMContentLoaded"));
     showRandom.dispatchEvent(new Event("click"));
 
-    expect(generateRandomCard).toHaveBeenCalledWith(null, null, gameArea, true);
+    expect(generateRandomCard).toHaveBeenCalledWith(
+      null,
+      null,
+      gameArea,
+      true,
+      undefined,
+      { enableInspector: false }
+    );
   });
 });


### PR DESCRIPTION
## Summary
- adjust `gameRandom.test.js` to expect updated arguments for `generateRandomCard`

## Testing
- `npx prettier . --check` *(fails: 403 Forbidden)*
- `npx eslint .` *(fails: 403 Forbidden)*
- `npx vitest run` *(fails: 403 Forbidden)*
- `npx playwright test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6885572a0c7083268c885fcd06f25716