### PR TITLE
Fix renderJudokaCard inspector tests

### DIFF
--- a/tests/helpers/renderJudokaCard.test.js
+++ b/tests/helpers/renderJudokaCard.test.js
@@ -4,8 +4,8 @@ let generateMock;
 let setupLazyPortraitsMock;
 
 vi.mock("../../src/helpers/cardBuilder.js", () => ({
-  generateJudokaCardHTML: (j, g, opts) => {
-    const el = generateMock(j, g, opts);
+  generateJudokaCardHTML: async (j, g, opts) => {
+    const el = await generateMock(j, g, opts);
     if (opts?.enableInspector) {
       const panel = document.createElement("details");
       panel.className = "debug-panel";


### PR DESCRIPTION
## Summary
- adjust mocked `generateJudokaCardHTML` to await async test helpers

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68855916451c8326bf8531bda3ca1817