### PR TITLE
Fix inspector panel stubs

### DIFF
--- a/tests/helpers/renderJudokaCard.test.js
+++ b/tests/helpers/renderJudokaCard.test.js
@@ -13,7 +13,18 @@ vi.mock("../../src/helpers/cardBuilder.js", () => ({
     }
     return el;
   },
-  createInspectorPanel: () => document.createElement("details")
+  createInspectorPanel: (container) => {
+    const panel = document.createElement("details");
+    panel.className = "debug-panel";
+    panel.addEventListener("toggle", () => {
+      if (panel.open) {
+        container.dataset.inspector = "true";
+      } else {
+        container.removeAttribute("data-inspector");
+      }
+    });
+    return panel;
+  }
 }));
 vi.mock("../../src/helpers/lazyPortrait.js", () => ({
   setupLazyPortraits: (...args) => setupLazyPortraitsMock(...args)


### PR DESCRIPTION
## Summary
- improve the mocked `createInspectorPanel` in `renderJudokaCard` tests to mimic
  event behaviour

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68855aa5f8348326bc5890350f3597ef