### PR TITLE
Remove HTML from card inspector panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ The Settings page (`src/pages/settings.html`) groups all player preferences, inc
 Battle pages include a collapsible debug panel. Enable the **Battle Debug Panel** feature flag in **Settings** to reveal real-time match state in a `<pre>` element. The panel is keyboard accessible and hidden by default so normal gameplay remains unaffected.
 Toggle the **Full Navigation Map** flag to display a map overlay with links to all pages for easier orientation during testing.
 Enable the **Test Mode** flag for deterministic card draws and stat results. A "Test Mode Active" banner appears on battle pages.
-Enable the **Card Inspector** flag to add a collapsible panel on each card containing its raw JSON and markup. Opening the panel sets `data-inspector="true"` on the card for automated checks.
+Enable the **Card Inspector** flag to add a collapsible panel on each card containing its raw JSON. Opening the panel sets `data-inspector="true"` on the card for automated checks.
 
 Game mode data now falls back to a bundled JSON import if the network request fails, so navigation works offline.
 Corrupted settings are detected and automatically reset to defaults, ensuring the Settings page always remains usable.

--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -172,11 +172,8 @@ function createInspectorPanel(container, judoka, sections) {
   jsonPre.textContent = JSON.stringify(judoka, null, 2);
   panel.appendChild(jsonPre);
 
-  for (const el of Object.values(sections)) {
-    const pre = document.createElement("pre");
-    pre.textContent = el.outerHTML;
-    panel.appendChild(pre);
-  }
+  // Only show the card's JSON data. The markup preview was removed to
+  // keep the inspector output concise.
 
   panel.addEventListener("toggle", () => {
     if (panel.open) {


### PR DESCRIPTION
## Summary
- trim card inspector output to only show JSON data
- clarify README that card inspector shows JSON only

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68855b9ba4dc8326b89f50691e3bd5ef