### PR TITLE
Fix inspector dataset initialization

### DIFF
--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -178,13 +178,16 @@ function createInspectorPanel(container, judoka, sections) {
     panel.appendChild(pre);
   }
 
-  panel.addEventListener("toggle", () => {
+  function updateDataset() {
     if (panel.open) {
       container.dataset.inspector = "true";
     } else {
       container.removeAttribute("data-inspector");
     }
-  });
+  }
+
+  panel.addEventListener("toggle", updateDataset);
+  updateDataset();
 
   return panel;
 }


### PR DESCRIPTION
## Summary
- ensure debug panel updates `data-inspector` consistently

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68855c1c9af083269e3f8d34168cee0b