### PR TITLE
Fix selector in settings tests

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -11,7 +11,7 @@ test.describe("Settings page", () => {
       route.fulfill({ path: "tests/fixtures/navigationItems.json" })
     );
     await page.goto("/src/pages/settings.html", { waitUntil: "domcontentloaded" });
-    await page.waitForSelector("#mode-classicBattle", { state: "attached" });
+    await page.getByLabel(/Classic Battle/i).waitFor();
     await page.locator("#display-settings-toggle").click();
     await page.locator("#general-settings-toggle").click();
     await page.locator("#game-modes-toggle").click();


### PR DESCRIPTION
## Summary
- wait for 'Classic Battle' label in settings tests instead of outdated selector

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6885f0b5a5a48326b07bd1e6620d3176