### PR TITLE
Fix update page tests

### DIFF
--- a/playwright/updateJudoka.spec.js
+++ b/playwright/updateJudoka.spec.js
@@ -2,7 +2,6 @@ import { test, expect } from "./fixtures/commonSetup.js";
 import {
   verifyPageBasics,
   NAV_RANDOM_JUDOKA,
-  NAV_UPDATE_JUDOKA,
   NAV_CLASSIC_BATTLE
 } from "./fixtures/navigationChecks.js";
 
@@ -15,21 +14,17 @@ test.describe("Update Judoka page", () => {
   });
 
   test("page loads", async ({ page }) => {
-    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_UPDATE_JUDOKA, NAV_CLASSIC_BATTLE]);
+    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 
   test("navigation links work", async ({ page }) => {
     await page.getByTestId(NAV_RANDOM_JUDOKA).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
-    // Wait for bottom navigation links to populate
-    await page.getByTestId(NAV_UPDATE_JUDOKA).waitFor();
     await page.goBack({ waitUntil: "load" });
-
-    await page.getByTestId(NAV_UPDATE_JUDOKA).click();
-    await expect(page).toHaveURL(/updateJudoka\.html/);
 
     const battleLink = page.getByTestId(NAV_CLASSIC_BATTLE);
     await battleLink.waitFor();
-    await expect(battleLink).toHaveCount(1);
+    await battleLink.click();
+    await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 });


### PR DESCRIPTION
## Summary
- handle update judoka navigation as hidden

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6885f0d229b48326bd90dbb8dd230ad2