### PR TITLE
Update test for pseudo-Japanese toggle

### DIFF
--- a/playwright/pseudo-japanese-toggle.spec.js
+++ b/playwright/pseudo-japanese-toggle.spec.js
@@ -22,6 +22,9 @@ test.describe("Pseudo-Japanese toggle", () => {
     await page.route("**/src/data/aesopsMeta.json", (route) =>
       route.fulfill({ path: META_FIXTURE })
     );
+    await page.addInitScript(() =>
+      localStorage.setItem("settings", JSON.stringify({ typewriterEffect: false }))
+    );
     await page.goto("/src/pages/meditation.html");
     await page.waitForSelector("#quote .quote-content");
   });


### PR DESCRIPTION
## Summary
- disable the typewriter effect in pseudo-japanese-toggle test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 12 failed, 1 interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6885f25321c083268ab602616912f373