### PR TITLE
Fix Playwright tests for settings page

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -11,7 +11,7 @@ test.describe("Settings page", () => {
       route.fulfill({ path: "tests/fixtures/navigationItems.json" })
     );
     await page.goto("/src/pages/settings.html", { waitUntil: "domcontentloaded" });
-    await page.getByLabel(/Classic Battle/i).waitFor();
+    await page.getByLabel(/Classic Battle/i).waitFor({ state: "attached" });
     await page.locator("#display-settings-toggle").click();
     await page.locator("#general-settings-toggle").click();
     await page.locator("#game-modes-toggle").click();
@@ -22,20 +22,20 @@ test.describe("Settings page", () => {
   });
 
   test("mode toggle visible", async ({ page }) => {
-    await page.getByLabel(/Classic Battle/i).waitFor();
-    await expect(page.getByLabel(/Classic Battle/i)).toBeVisible();
+    await page.getByLabel(/Classic Battle/i).waitFor({ state: "attached" });
+    await expect(page.getByText(/Classic Battle/i)).toBeVisible();
   });
 
   test("essential elements visible", async ({ page }) => {
     await verifyPageBasics(page, [NAV_CLASSIC_BATTLE, NAV_RANDOM_JUDOKA]);
-    await expect(page.getByLabel(/sound/i)).toBeVisible();
-    await expect(page.getByLabel(/motion effects/i)).toBeVisible();
-    await expect(page.getByLabel(/typewriter effect/i)).toBeVisible();
+    await expect(page.getByText(/sound/i)).toBeVisible();
+    await expect(page.getByText(/motion effects/i)).toBeVisible();
+    await expect(page.getByText(/typewriter effect/i)).toBeVisible();
     await expect(page.getByLabel(/display mode/i)).toBeVisible();
   });
 
   test("controls expose correct labels and follow tab order", async ({ page }) => {
-    await page.getByLabel(/Classic Battle/i).waitFor();
+    await page.getByLabel(/Classic Battle/i).waitFor({ state: "attached" });
 
     const navigationItems = await page.evaluate(async () => {
       const res = await fetch("/tests/fixtures/navigationItems.json");


### PR DESCRIPTION
## Summary
- update selectors in `settings.spec.js` so tests wait for hidden inputs using `{ state: "attached" }`
- verify visibility on label text instead of hidden checkboxes

## Testing
- `npx prettier playwright/settings.spec.js --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688633d59f888326bb3a3e7c5c15a2a4