### PR TITLE
Fix settings toggle test

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ A `Test timeout ... waiting for locator('#general-settings-toggle')` error usual
 
 - **Node 18+** is installed.
 - Port **5000** is free; the tests start `scripts/playwrightServer.js` automatically.
-- Visiting `http://localhost:5000/src/pages/settings.html` shows the toggles (`#display-settings-toggle`, `#general-settings-toggle`, `#game-modes-toggle`).
+- Visiting `http://localhost:5000/src/pages/settings.html` shows the Display Settings section followed by the toggles (`#general-settings-toggle`, `#game-modes-toggle`).
 - Running tests with `PWDEBUG=1` helps inspect the page when a timeout occurs.
 - `strict mode violation: getByLabel('text') resolved to multiple elements`
   indicates the locator is too generic. Use `getByLabel(text, { exact: true })`

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -12,7 +12,6 @@ test.describe("Settings page", () => {
     );
     await page.goto("/src/pages/settings.html", { waitUntil: "domcontentloaded" });
     await page.getByLabel(/Classic Battle/i).waitFor({ state: "attached" });
-    await page.locator("#display-settings-toggle").click();
     await page.locator("#general-settings-toggle").click();
     await page.locator("#game-modes-toggle").click();
   });


### PR DESCRIPTION
## Summary
- adjust `settings.spec.js` to skip the missing Display Settings toggle
- clarify the Troubleshooting instructions in the README

## Testing
- `npx prettier . --check` *(fails: 403 Forbidden)*
- `npx eslint .` *(fails: 403 Forbidden)*
- `npx vitest run` *(fails: 403 Forbidden)*
- `npx playwright test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68863ba221cc8326870ae1a606f93dd2