### PR TITLE
Fix settings test

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -36,12 +36,23 @@ test.describe("Settings page", () => {
   test("controls expose correct labels and follow tab order", async ({ page }) => {
     await page.getByLabel(/Classic Battle/i).waitFor({ state: "attached" });
 
-    const navigationItems = await page.evaluate(async () => {
-      const res = await fetch("/tests/fixtures/navigationItems.json");
-      return res.json();
+    const { navigationItems, gameModes } = await page.evaluate(async () => {
+      const [navRes, modeRes] = await Promise.all([
+        fetch("/tests/fixtures/navigationItems.json"),
+        fetch("/tests/fixtures/gameModes.json")
+      ]);
+      return {
+        navigationItems: await navRes.json(),
+        gameModes: await modeRes.json()
+      };
     });
 
-    const sortedNames = navigationItems
+    const merged = navigationItems.map((nav) => ({
+      ...nav,
+      name: gameModes.find((m) => m.id === nav.gameModeId)?.name || ""
+    }));
+
+    const sortedNames = merged
       .slice()
       .sort((a, b) => a.order - b.order)
       .map((m) => m.name);


### PR DESCRIPTION
## Summary
- fetch gameModes.json in settings e2e test
- merge nav items with their game modes to build labels

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot differences)*

------
https://chatgpt.com/codex/tasks/task_e_688653696f14832694245b819d4b1b9e