### PR TITLE
Update embeddings generation to chunk files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ design/productRequirementsDocuments/*.md
 design/codeStandards/*.md
 README.md
 src/data/navigationItems.json
+src/data/client_embeddings.json


### PR DESCRIPTION
## Summary
- chunk embedding source files into overlapping segments
- ignore generated embeddings file in Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68866009d9c48326b0cd6f00fbd9e0c8