### PR TITLE
Update tests for feature flag changes

### DIFF
--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -147,7 +147,8 @@ describe("populateNavbar", () => {
         battleDebugPanel: false,
         fullNavigationMap: true,
         enableTestMode: false,
-        enableCardInspector: false
+        enableCardInspector: false,
+        enableLowConfidenceResults: false
       }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
@@ -205,7 +206,8 @@ describe("populateNavbar", () => {
         battleDebugPanel: false,
         fullNavigationMap: true,
         enableTestMode: false,
-        enableCardInspector: false
+        enableCardInspector: false,
+        enableLowConfidenceResults: false
       }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
@@ -255,7 +257,8 @@ describe("populateNavbar", () => {
         battleDebugPanel: false,
         fullNavigationMap: true,
         enableTestMode: false,
-        enableCardInspector: false
+        enableCardInspector: false,
+        enableLowConfidenceResults: false
       }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -16,7 +16,8 @@ const baseSettings = {
     battleDebugPanel: false,
     fullNavigationMap: true,
     enableTestMode: false,
-    enableCardInspector: false
+    enableCardInspector: false,
+    enableLowConfidenceResults: false
   }
 };
 

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -12,7 +12,8 @@ const baseSettings = {
     battleDebugPanel: false,
     fullNavigationMap: true,
     enableTestMode: false,
-    enableCardInspector: false
+    enableCardInspector: false,
+    enableLowConfidenceResults: false
   }
 };
 
@@ -209,7 +210,8 @@ describe("settingsPage module", () => {
       battleDebugPanel: true,
       fullNavigationMap: true,
       enableTestMode: false,
-      enableCardInspector: false
+      enableCardInspector: false,
+      enableLowConfidenceResults: false
     });
   });
 });


### PR DESCRIPTION
## Summary
- extend feature flag objects in unit tests to include `enableLowConfidenceResults`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: connect ENETUNREACH)*
- `npx playwright test` *(fails: could not download Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_688665c8e3d0832684306e52e042663d