### PR TITLE
Fix embedding generation format

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -54,10 +54,11 @@ async function generate() {
     const tags = [relativePath.endsWith(".json") ? "data" : "prd"];
     for (let start = 0, index = 0; start < text.length; start += CHUNK_SIZE - OVERLAP, index++) {
       const chunkText = text.slice(start, start + CHUNK_SIZE);
+      const result = await extractor(chunkText, { pooling: "mean" });
       output.push({
         id: `${base}-chunk-${index + 1}`,
         text: chunkText,
-        embedding: Array.from(await extractor(chunkText, { pooling: "mean" })),
+        embedding: Array.from(result.data),
         source: `${relativePath} [chunk ${index + 1}]`,
         tags,
         version: 1


### PR DESCRIPTION
## Summary
- ensure embeddings are stored as flat numeric arrays

## Testing
- `npx prettier . --check` *(fails: Code style issues found)*
- `npx eslint scripts/generateEmbeddings.js` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68866a2d3bac8326b3675e2e221b9592