### PR TITLE
Exclude large quotes dataset from embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ After modifying any PRDs, **any file in `src/data/`**, or docs under
 the updated file alongside your documentation changes so other agents have the
 latest vectors.
 
+The generator skips the large `aesopsFables.json` quote dataset to keep the
+output file under the 3MB limit defined in the PRD.
+
 - Both the generation script and the search page use **mean pooled** embeddings so the query vector matches the stored vectors.
 
 - Results appear below the form with up to five entries that show match score and source.

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -4,7 +4,8 @@
  *
  * @pseudocode
  * 1. Discover markdown and JSON files using glob, excluding any existing
- *    `client_embeddings.json` file.
+ *    `client_embeddings.json` file and the large `aesopsFables.json`
+ *    dataset to keep the output size manageable.
  * 2. Read file contents and slice into overlapping chunks using CHUNK_SIZE and
  *    OVERLAP.
  * 3. Load a transformer model for feature extraction.
@@ -33,7 +34,9 @@ async function getFiles() {
   const guidelineFiles = await glob("design/codeStandards/*.md", { cwd: rootDir });
   const workflowFiles = await glob("design/agentWorkflows/*.md", { cwd: rootDir });
   const jsonFiles = (await glob("src/data/*.json", { cwd: rootDir })).filter(
-    (f) => path.extname(f) === ".json" && path.basename(f) !== "client_embeddings.json"
+    (f) =>
+      path.extname(f) === ".json" &&
+      !["client_embeddings.json", "aesopsFables.json", "aesopsMeta.json"].includes(path.basename(f))
   );
   return [...prdFiles, ...guidelineFiles, ...workflowFiles, ...jsonFiles];
 }


### PR DESCRIPTION
## Summary
- document that aesopsFables.json is skipped when generating embeddings
- filter out aesopsFables.json and aesopsMeta.json in the generator script so the output stays under 3MB

## Testing
- `npx prettier . --check` *(fails: Code style issues found in 2 files)*
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68869e04f780832690b278a679edbb5b