### PR TITLE
Increase chunk size to reduce embeddings output

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -23,7 +23,9 @@ import { pipeline } from "@xenova/transformers";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
 
-const CHUNK_SIZE = 1000;
+// Larger chunks reduce the total embedding count and help keep the
+// final JSON under the 3MB limit.
+const CHUNK_SIZE = 1500;
 const OVERLAP = 200;
 const MAX_OUTPUT_SIZE = 3 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary
- keep embeddings under the 3MB limit by using larger chunks

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden when downloading vitest)*
- `npx playwright test` *(fails: 403 Forbidden when downloading playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6886a0e8dbc48326ac6064b86e1748ca