### PR TITLE
Add settings reset feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Enable the **Card Inspector** flag to add a collapsible panel on each card conta
 
 Game mode data now falls back to a bundled JSON import if the network request fails, so navigation works offline.
 Corrupted settings are detected and automatically reset to defaults, ensuring the Settings page always remains usable.
+Use the **Restore Defaults** button in the Links section to quickly reset all settings to their original values.
 
 ## Browser Compatibility
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -67,6 +67,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - **Change Log:** Link opens `changeLog.html` with the latest 20 judoka updates.
 - **PRD Viewer:** Link opens `prdViewer.html` for browsing product documents.
 - **Mockup Viewer:** Link opens `mockupViewer.html` for viewing design mockups.
+- **Restore Defaults:** Button clears stored settings and reapplies defaults.
 
 ---
 

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -6,7 +6,7 @@
  * 2. Apply the stored display mode and motion preference.
  * 3. Initialize the page controls and event listeners.
  */
-import { loadSettings, updateSetting } from "./settingsUtils.js";
+import { loadSettings, updateSetting, resetSettings } from "./settingsUtils.js";
 import { loadNavigationItems } from "./gameModeUtils.js";
 import { showSettingsError } from "./showSettingsError.js";
 import { applyDisplayMode } from "./displayMode.js";
@@ -46,6 +46,7 @@ function initializeControls(settings, gameModes) {
   const modesContainer = document.getElementById("game-mode-toggle-container");
   const flagsContainer = document.getElementById("feature-flags-container");
   const errorPopup = document.getElementById("settings-error-popup");
+  const resetButton = document.getElementById("reset-settings-button");
 
   const getCurrentSettings = () => currentSettings;
 
@@ -72,6 +73,10 @@ function initializeControls(settings, gameModes) {
       });
   }
 
+  function clearToggles(container) {
+    container.querySelectorAll(".settings-item").forEach((el) => el.remove());
+  }
+
   applyInitialControlValues(controls, currentSettings);
   attachToggleListeners(controls, getCurrentSettings, handleUpdate);
   renderGameModeSwitches(modesContainer, gameModes, getCurrentSettings, handleUpdate);
@@ -81,6 +86,22 @@ function initializeControls(settings, gameModes) {
     getCurrentSettings,
     handleUpdate
   );
+
+  resetButton?.addEventListener("click", () => {
+    currentSettings = resetSettings();
+    applyInitialControlValues(controls, currentSettings);
+    applyDisplayMode(currentSettings.displayMode);
+    applyMotionPreference(currentSettings.motionEffects);
+    clearToggles(modesContainer);
+    renderGameModeSwitches(modesContainer, gameModes, getCurrentSettings, handleUpdate);
+    clearToggles(flagsContainer);
+    renderFeatureFlagSwitches(
+      flagsContainer,
+      currentSettings.featureFlags,
+      getCurrentSettings,
+      handleUpdate
+    );
+  });
 }
 
 async function initializeSettingsPage() {

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -146,6 +146,28 @@ export async function updateSetting(key, value) {
 }
 
 /**
+ * Reset all settings to their default values.
+ *
+ * @pseudocode
+ * 1. Overwrite the `SETTINGS_KEY` entry in `localStorage` with `DEFAULT_SETTINGS`.
+ * 2. Ignore errors if `localStorage` is unavailable or write fails.
+ * 3. Return a new copy of `DEFAULT_SETTINGS`.
+ *
+ * @returns {Settings} The default settings object.
+ */
+export function resetSettings() {
+  try {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(SETTINGS_KEY, JSON.stringify(DEFAULT_SETTINGS));
+    }
+  } catch (err) {
+    // For PRD: error popup handled in UI
+    console.error("Failed to reset settings", err);
+  }
+  return { ...DEFAULT_SETTINGS };
+}
+
+/**
  * @typedef {Object} Settings
  * @property {boolean} sound
  * @property {boolean} motionEffects

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -193,6 +193,11 @@
                 >Vector Search for RAG</a
               >
             </div>
+            <div class="settings-item">
+              <button type="button" id="reset-settings-button" tabindex="103">
+                Restore Defaults
+              </button>
+            </div>
           </fieldset>
         </form>
         <div

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -218,4 +218,12 @@ describe("settings utils", () => {
     await vi.advanceTimersByTimeAsync(110);
     expect(JSON.parse(localStorage.getItem("settings"))).toEqual(data2);
   });
+
+  it("resets settings to defaults", async () => {
+    localStorage.setItem("settings", JSON.stringify({ sound: true }));
+    const { resetSettings } = await import("../../src/helpers/settingsUtils.js");
+    const result = resetSettings();
+    expect(result).toEqual(DEFAULT_SETTINGS);
+    expect(JSON.parse(localStorage.getItem("settings"))).toEqual(DEFAULT_SETTINGS);
+  });
 });

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -59,13 +59,16 @@ export function createSettingsDom() {
   const featureFlagsContainer = document.createElement("section");
   featureFlagsContainer.id = "feature-flags-container";
   featureFlagsContainer.className = "game-mode-toggle-container settings-form";
+  const resetButton = document.createElement("button");
+  resetButton.id = "reset-settings-button";
   fragment.append(
     soundToggle,
     motionToggle,
     typewriterToggle,
     displayModeSelect,
     gameModeToggleContainer,
-    featureFlagsContainer
+    featureFlagsContainer,
+    resetButton
   );
   return fragment;
 }


### PR DESCRIPTION
## Summary
- implement `resetSettings` helper and wire to settings page
- add Restore Defaults button in settings.html
- enable button in JS and tests
- update tests for new function and DOM
- document button in README and PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot differences)*
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6886a1ccfea08326823016ee96255560