### PR TITLE
Implement display mode radio switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 
 ## Display Modes
 
-Light, dark and gray themes are supported. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode selector applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running.
+Light, dark and gray themes are supported. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode switch applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running.
 
 ## Settings & Feature Flags
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -44,7 +44,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 | P3       | Test Mode Feature Flag | Enables deterministic battles for automated testing. |
 | P1       | Motion Effects Toggle      | Binary toggle updating `settings.json` live on change.                      |
 | P1       | Typewriter Effect Toggle   | Enable or disable quote animation on the meditation screen. |
-| P1       | Display Mode Selector      | Three-option selector applying mode instantly across UI.                    |
+| P1       | Display Mode Switch        | Three-option switch applying mode instantly across UI.                    |
 | P2       | Game Modes Toggles         | A list of all defined game modes with binary toggles from `navigationItems.json`. |
 | P3       | Settings Menu Integration  | Ensure settings appear as a game mode in `navigationItems.json`.                  |
 | P3       | Change Log Link           | Link to `changeLog.html` for viewing recent judoka updates.                 |
@@ -119,7 +119,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 
 - AC-4.1 Disabling the toggle prevents the quote typewriter animation on the meditation screen.
 - AC-4.2 Setting is stored in `settings.json` within 50ms of change.
-### Display Mode Selector
+### Display Mode Switch
 
 - AC-5.1 Selecting a new display mode (light/dark/gray) applies changes instantly across all relevant UI components.
 - AC-4.2 Selected mode persists through a page refresh within the same session.

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -32,7 +32,7 @@ test.describe("Settings page", () => {
     await expect(page.getByText(/sound/i)).toBeVisible();
     await expect(page.getByText(/motion effects/i)).toBeVisible();
     await expect(page.getByText(/typewriter effect/i)).toBeVisible();
-    await expect(page.getByLabel(/display mode/i)).toBeVisible();
+    await expect(page.getByRole("radiogroup", { name: /display mode/i })).toBeVisible();
   });
 
   test("controls expose correct labels and follow tab order", async ({ page }) => {
@@ -48,7 +48,9 @@ test.describe("Settings page", () => {
       .filter(Boolean);
 
     const expectedLabels = [
-      "Display Mode",
+      "Light",
+      "Dark",
+      "Gray",
       "Sound",
       "Motion Effects",
       "Typewriter Effect",
@@ -70,7 +72,7 @@ test.describe("Settings page", () => {
       await expect(page.getByLabel(name, { exact: true })).toHaveAttribute("aria-label", name);
     }
 
-    await page.focus("#display-mode-select");
+    await page.focus("#display-mode-light");
 
     const activeLabels = [];
     for (let i = 0; i < expectedLabels.length; i++) {

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -16,12 +16,16 @@ function applyInputState(element, value) {
 export function applyInitialControlValues(controls, settings) {
   applyInputState(controls.soundToggle, settings.sound);
   applyInputState(controls.motionToggle, settings.motionEffects);
-  applyInputState(controls.displaySelect, settings.displayMode);
+  if (controls.displayRadios) {
+    controls.displayRadios.forEach((radio) => {
+      radio.checked = radio.value === settings.displayMode;
+    });
+  }
   applyInputState(controls.typewriterToggle, settings.typewriterEffect);
 }
 
 export function attachToggleListeners(controls, getCurrentSettings, handleUpdate) {
-  const { soundToggle, motionToggle, displaySelect, typewriterToggle } = controls;
+  const { soundToggle, motionToggle, displayRadios, typewriterToggle } = controls;
   soundToggle?.addEventListener("change", () => {
     const prev = !soundToggle.checked;
     handleUpdate("sound", soundToggle.checked, () => {
@@ -36,15 +40,21 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
       applyMotionPreference(prev);
     });
   });
-  displaySelect?.addEventListener("change", () => {
-    const previous = getCurrentSettings().displayMode;
-    const mode = displaySelect.value;
-    applyDisplayMode(mode);
-    handleUpdate("displayMode", mode, () => {
-      displaySelect.value = previous;
-      applyDisplayMode(previous);
+  if (displayRadios) {
+    displayRadios.forEach((radio) => {
+      radio.addEventListener("change", () => {
+        if (!radio.checked) return;
+        const previous = getCurrentSettings().displayMode;
+        const mode = radio.value;
+        applyDisplayMode(mode);
+        handleUpdate("displayMode", mode, () => {
+          const prevRadio = Array.from(displayRadios).find((r) => r.value === previous);
+          if (prevRadio) prevRadio.checked = true;
+          applyDisplayMode(previous);
+        });
+      });
     });
-  });
+  }
   typewriterToggle?.addEventListener("change", () => {
     const prev = !typewriterToggle.checked;
     handleUpdate("typewriterEffect", typewriterToggle.checked, () => {

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -40,7 +40,7 @@ function initializeControls(settings, gameModes) {
   const controls = {
     soundToggle: document.getElementById("sound-toggle"),
     motionToggle: document.getElementById("motion-toggle"),
-    displaySelect: document.getElementById("display-mode-select"),
+    displayRadios: document.querySelectorAll('input[name="display-mode"]'),
     typewriterToggle: document.getElementById("typewriter-toggle")
   };
   const modesContainer = document.getElementById("game-mode-toggle-container");

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -63,13 +63,35 @@
             class="game-mode-toggle-container settings-form"
           >
             <legend>Display Settings</legend>
-            <div class="settings-item">
-              <!-- <label for="display-mode-select">Display Mode</label> -->
-              <select id="display-mode-select" aria-label="Display Mode" tabindex="1">
-                <option value="light">Light</option>
-                <option value="dark">Dark</option>
-                <option value="gray">Gray</option>
-              </select>
+            <div
+              class="settings-item display-mode-group"
+              role="radiogroup"
+              aria-label="Display Mode"
+            >
+              <input
+                type="radio"
+                id="display-mode-light"
+                name="display-mode"
+                value="light"
+                tabindex="1"
+              />
+              <label for="display-mode-light">Light</label>
+              <input
+                type="radio"
+                id="display-mode-dark"
+                name="display-mode"
+                value="dark"
+                tabindex="1"
+              />
+              <label for="display-mode-dark">Dark</label>
+              <input
+                type="radio"
+                id="display-mode-gray"
+                name="display-mode"
+                value="gray"
+                tabindex="1"
+              />
+              <label for="display-mode-gray">Gray</label>
             </div>
           </fieldset>
           <!-- </div>

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -171,3 +171,10 @@
   padding-block-start: var(--space-sm);
   transition: height var(--transition-fast);
 }
+
+/* Display mode radio group */
+.display-mode-group {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -52,8 +52,21 @@ export function createSettingsDom() {
   const typewriterToggle = document.createElement("input");
   typewriterToggle.id = "typewriter-toggle";
   typewriterToggle.type = "checkbox";
-  const displayModeSelect = document.createElement("select");
-  displayModeSelect.id = "display-mode-select";
+  const displayLight = document.createElement("input");
+  displayLight.id = "display-mode-light";
+  displayLight.type = "radio";
+  displayLight.name = "display-mode";
+  displayLight.value = "light";
+  const displayDark = document.createElement("input");
+  displayDark.id = "display-mode-dark";
+  displayDark.type = "radio";
+  displayDark.name = "display-mode";
+  displayDark.value = "dark";
+  const displayGray = document.createElement("input");
+  displayGray.id = "display-mode-gray";
+  displayGray.type = "radio";
+  displayGray.name = "display-mode";
+  displayGray.value = "gray";
   const gameModeToggleContainer = document.createElement("section");
   gameModeToggleContainer.id = "game-mode-toggle-container";
   const featureFlagsContainer = document.createElement("section");
@@ -63,7 +76,9 @@ export function createSettingsDom() {
     soundToggle,
     motionToggle,
     typewriterToggle,
-    displayModeSelect,
+    displayLight,
+    displayDark,
+    displayGray,
     gameModeToggleContainer,
     featureFlagsContainer
   );


### PR DESCRIPTION
## Summary
- replace display mode dropdown with radio switch on settings page
- update settings form utilities for radio inputs
- style display mode switch
- adjust test DOM helpers and Playwright specs
- document display mode switch in README and PRD

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6886a4054404832694599542d7a94970