### PR TITLE
Update embedding generator

### DIFF
--- a/.github/workflows/updateEmbeddings.yml
+++ b/.github/workflows/updateEmbeddings.yml
@@ -95,4 +95,3 @@ jobs:
             backend
             vector
           assignees: ${{ github.actor }}
-          

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -66,7 +66,7 @@ async function generate() {
       output.push({
         id: `${base}-chunk-${index + 1}`,
         text: chunkText,
-        embedding: Array.from(result.data),
+        embedding: Array.from(result.data ?? result),
         source: `${relativePath} [chunk ${index + 1}]`,
         tags,
         version: 1


### PR DESCRIPTION
## Summary
- allow vector result to fall back when `.data` is missing
- keep workflow formatting tidy

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 3 failing tests)*
- `npx playwright test` *(fails: 1 failing test)*
- `npm run generate:embeddings` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6886a4762360832686afee8cc6fbb246