### PR TITLE
Document pseudocode helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ npx vitest run               # run unit tests
 npx playwright test          # run Playwright UI tests
 ```
 
+Confirm that any new or modified functions include JSDoc with an `@pseudocode` block so documentation stays complete.
+
 Playwright tests clear `localStorage` at startup. If a manual run fails unexpectedly, clear it in your browser and ensure http://localhost:5000 is served (start it with `npm start`).
 
 **For UI-related changes** (styles, components, layouts, visual elements), also run:

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ is ready so hover and focus listeners are attached.
 </script>
 ```
 
-The repository specifies commenting standards in design/codeStandards. JSDoc comments and @pseudocode blocks must remain intact, as shown in documentation excerpts.
+The repository specifies commenting standards in design/codeStandards. JSDoc comments and @pseudocode blocks must remain intact. When adding or modifying functions, include a matching @pseudocode section describing the logic.
 
 ## Features
 

--- a/src/helpers/battle/score.js
+++ b/src/helpers/battle/score.js
@@ -1,5 +1,17 @@
 import { STATS } from "../battleEngine.js";
 
+/**
+ * Retrieve a numeric stat value from a battle score container.
+ *
+ * @pseudocode
+ * 1. Determine the stat's position in `STATS` and add one for the CSS selector.
+ * 2. Query `container` for `li.stat:nth-child(index) span`.
+ * 3. Return the parsed integer value, or `0` if no span is found.
+ *
+ * @param {HTMLElement} container - Element containing stat list items.
+ * @param {string} stat - Stat name as defined in `STATS`.
+ * @returns {number} Parsed stat value or `0` when missing.
+ */
 function getStatValue(container, stat) {
   const index = STATS.indexOf(stat) + 1;
   const span = container.querySelector(`li.stat:nth-child(${index}) span`);

--- a/src/helpers/cardSections.js
+++ b/src/helpers/cardSections.js
@@ -2,6 +2,19 @@ import { generateCardPortrait, generateCardSignatureMove } from "./cardRender.js
 import { createStatsPanel } from "../components/StatsPanel.js";
 import { createNoDataContainer } from "./cardTopBar.js";
 
+/**
+ * Build the portrait section for a judoka card.
+ *
+ * @pseudocode
+ * 1. Generate portrait HTML with `generateCardPortrait(judoka)`.
+ * 2. Convert the HTML to a fragment and grab the first element.
+ * 3. Create a `<div>` showing the judoka's weight class and append it.
+ * 4. Return the resulting element.
+ * 5. On failure, log the error and return `createNoDataContainer()`.
+ *
+ * @param {import("./types.js").Judoka} judoka - Judoka data object.
+ * @returns {HTMLElement} Portrait element.
+ */
 export function createPortraitSection(judoka) {
   try {
     const fragment = document.createRange().createContextualFragment(generateCardPortrait(judoka));
@@ -19,6 +32,18 @@ export function createPortraitSection(judoka) {
   }
 }
 
+/**
+ * Build the stats section for a judoka card.
+ *
+ * @pseudocode
+ * 1. Call `createStatsPanel` with the judoka stats and card type.
+ * 2. Return the generated element.
+ * 3. On error, log and return `createNoDataContainer()`.
+ *
+ * @param {import("./types.js").Judoka} judoka - Judoka data object.
+ * @param {string} cardType - Card rarity type.
+ * @returns {HTMLElement} Stats panel element.
+ */
 export function createStatsSection(judoka, cardType) {
   try {
     return createStatsPanel(judoka.stats, { type: cardType });
@@ -28,6 +53,19 @@ export function createStatsSection(judoka, cardType) {
   }
 }
 
+/**
+ * Build the signature move section for a judoka card.
+ *
+ * @pseudocode
+ * 1. Generate signature move HTML via `generateCardSignatureMove`.
+ * 2. Parse the HTML into a fragment and return its first element.
+ * 3. On error, log and return `createNoDataContainer()`.
+ *
+ * @param {import("./types.js").Judoka} judoka - Judoka data object.
+ * @param {Record<number, import("./types.js").GokyoEntry>} gokyoLookup - Move lookup.
+ * @param {string} cardType - Card rarity type.
+ * @returns {HTMLElement} Signature move element.
+ */
 export function createSignatureMoveSection(judoka, gokyoLookup, cardType) {
   try {
     const signatureMoveHTML = generateCardSignatureMove(judoka, gokyoLookup, cardType);

--- a/src/helpers/carousel/accessibility.js
+++ b/src/helpers/carousel/accessibility.js
@@ -1,5 +1,15 @@
 const MIN_TOUCH_TARGET_SIZE = 48;
 
+/**
+ * Ensure a carousel control meets minimum touch target dimensions.
+ *
+ * @pseudocode
+ * 1. Read the computed width and height of `element`.
+ * 2. If either dimension is below `MIN_TOUCH_TARGET_SIZE`, set `minWidth`,
+ *    `minHeight`, and apply padding to enlarge the target.
+ *
+ * @param {HTMLElement} element - Button or element to adjust.
+ */
 function ensureTouchTargetSize(element) {
   const style = window.getComputedStyle(element);
   const width = parseInt(style.width, 10);
@@ -11,6 +21,15 @@ function ensureTouchTargetSize(element) {
   }
 }
 
+/**
+ * Apply basic accessibility adjustments to a carousel wrapper.
+ *
+ * @pseudocode
+ * 1. Select all `.scroll-button` elements and call `ensureTouchTargetSize` on each.
+ * 2. Update card text color to ensure contrast against backgrounds.
+ *
+ * @param {HTMLElement} wrapper - Carousel wrapper element.
+ */
 export function applyAccessibilityImprovements(wrapper) {
   const buttons = wrapper.querySelectorAll(".scroll-button");
   buttons.forEach((button) => ensureTouchTargetSize(button));

--- a/src/helpers/country/codes.js
+++ b/src/helpers/country/codes.js
@@ -4,6 +4,17 @@ import { DATA_DIR } from "../constants.js";
 let countryCodeMappingCache = null;
 const COUNTRY_CACHE_KEY = "countryCodeMappingCache";
 
+/**
+ * Load the mapping of country codes to country names.
+ *
+ * @pseudocode
+ * 1. Return cached data when available, including localStorage cache.
+ * 2. Fetch `countryCodeMapping.json` from `DATA_DIR` when no cache exists.
+ * 3. Validate each entry and log warnings for invalid data.
+ * 4. Store the result in memory and localStorage, then return the mapping.
+ *
+ * @returns {Promise<Array<{country:string,code:string,active:boolean}>>} Mapping data.
+ */
 export async function loadCountryCodeMapping() {
   if (countryCodeMappingCache) {
     return countryCodeMappingCache;
@@ -45,6 +56,18 @@ export async function loadCountryCodeMapping() {
   return data;
 }
 
+/**
+ * Resolve the country name for a two-letter code.
+ *
+ * @pseudocode
+ * 1. Validate that `code` is a two-letter string; return "Vanuatu" when invalid.
+ * 2. Load the mapping via `loadCountryCodeMapping()`.
+ * 3. Find the matching active entry and return its country name.
+ * 4. Default to "Vanuatu" if no match is found.
+ *
+ * @param {string} code - Two-letter country code.
+ * @returns {Promise<string>} Resolved country name or fallback.
+ */
 export async function getCountryNameFromCode(code) {
   if (typeof code !== "string" || !/^[A-Za-z]{2}$/.test(code.trim())) {
     console.warn("Invalid country code format. Expected a 2-letter code.");
@@ -58,6 +81,17 @@ export async function getCountryNameFromCode(code) {
   return match ? match.country : "Vanuatu";
 }
 
+/**
+ * Build the flag image URL for a country code.
+ *
+ * @pseudocode
+ * 1. Validate `countryCode` as a two-letter string; return the Vanuatu flag when invalid.
+ * 2. Load the mapping and verify the code exists and is active.
+ * 3. Return the CDN URL using the lower-cased code or the Vanuatu flag when invalid.
+ *
+ * @param {string} countryCode - Two-letter country code.
+ * @returns {Promise<string>} URL for the flag image.
+ */
 export async function getFlagUrl(countryCode) {
   if (typeof countryCode !== "string" || !/^[A-Za-z]{2}$/.test(countryCode.trim())) {
     console.warn("Invalid or missing country code. Defaulting to Vanuatu flag.");

--- a/src/helpers/country/list.js
+++ b/src/helpers/country/list.js
@@ -3,6 +3,19 @@ import { loadCountryCodeMapping, getFlagUrl } from "./codes.js";
 
 const SCROLL_THRESHOLD_PX = 50;
 
+/**
+ * Populate a scrolling list of active countries with flag buttons.
+ *
+ * @pseudocode
+ * 1. Fetch `judoka.json` to determine which countries appear in the deck.
+ * 2. Load the country code mapping and build a sorted list of active entries.
+ * 3. Render an "All" button followed by batches of country buttons with flags.
+ * 4. Lazy-load additional batches when the container is scrolled near the end.
+ * 5. Log errors if data fails to load or individual flags cannot be retrieved.
+ *
+ * @param {HTMLElement} container - Element where buttons will be appended.
+ * @returns {Promise<void>} Resolves when the list is populated.
+ */
 export async function populateCountryList(container) {
   try {
     const judokaResponse = await fetch(`${DATA_DIR}judoka.json`);
@@ -18,6 +31,7 @@ export async function populateCountryList(container) {
       .map((name) => countryData.find((entry) => entry.country === name && entry.active))
       .filter(Boolean)
       .sort((a, b) => a.country.localeCompare(b.country));
+
     const allButton = document.createElement("button");
     allButton.className = "flag-button slide";
     allButton.value = "all";
@@ -31,6 +45,7 @@ export async function populateCountryList(container) {
     allButton.appendChild(allImg);
     allButton.appendChild(allLabel);
     container.appendChild(allButton);
+
     const scrollContainer = container.parentElement || container;
     const BATCH_SIZE = 50;
     let rendered = 0;
@@ -63,6 +78,7 @@ export async function populateCountryList(container) {
       }
       rendered += batch.length;
     };
+
     await renderBatch();
     if (activeCountries.length > rendered) {
       const handleScroll = async () => {

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -4,6 +4,17 @@ import { applyMotionPreference } from "../motionUtils.js";
 import { updateNavigationItemHidden } from "../gameModeUtils.js";
 import { showSettingsError } from "../showSettingsError.js";
 
+/**
+ * Apply a value to an input or checkbox element.
+ *
+ * @pseudocode
+ * 1. Exit early when `element` is null or undefined.
+ * 2. For checkboxes, set the `checked` property based on `value`.
+ * 3. For other inputs, assign the `value` directly.
+ *
+ * @param {HTMLInputElement|HTMLSelectElement|null} element - Control to update.
+ * @param {*} value - Value to apply.
+ */
 function applyInputState(element, value) {
   if (!element) return;
   if (element.type === "checkbox") {
@@ -13,6 +24,15 @@ function applyInputState(element, value) {
   }
 }
 
+/**
+ * Initialize control states based on a settings object.
+ *
+ * @pseudocode
+ * 1. Call `applyInputState` for each setting-related control.
+ *
+ * @param {Object} controls - Collection of form elements.
+ * @param {import("../settingsUtils.js").Settings} settings - Current settings.
+ */
 export function applyInitialControlValues(controls, settings) {
   applyInputState(controls.soundToggle, settings.sound);
   applyInputState(controls.motionToggle, settings.motionEffects);
@@ -20,6 +40,18 @@ export function applyInitialControlValues(controls, settings) {
   applyInputState(controls.typewriterToggle, settings.typewriterEffect);
 }
 
+/**
+ * Attach change listeners that persist settings updates.
+ *
+ * @pseudocode
+ * 1. Listen for changes on each toggle or select element.
+ * 2. Use `handleUpdate` to persist the new value, reverting if it fails.
+ * 3. Apply side effects like `applyMotionPreference` and `applyDisplayMode`.
+ *
+ * @param {Object} controls - Form controls with DOM references.
+ * @param {Function} getCurrentSettings - Returns the latest settings object.
+ * @param {Function} handleUpdate - Persist function `(key,value,revert)=>void`.
+ */
 export function attachToggleListeners(controls, getCurrentSettings, handleUpdate) {
   const { soundToggle, motionToggle, displaySelect, typewriterToggle } = controls;
   soundToggle?.addEventListener("change", () => {
@@ -53,6 +85,19 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
   });
 }
 
+/**
+ * Render game mode toggle switches within the settings page.
+ *
+ * @pseudocode
+ * 1. Sort `gameModes` by `order` and create a toggle for each.
+ * 2. When toggled, update navigation visibility via `updateNavigationItemHidden`.
+ * 3. Persist the updated `gameModes` setting using `handleUpdate`.
+ *
+ * @param {HTMLElement} container - Target container for switches.
+ * @param {Array} gameModes - List of mode definitions.
+ * @param {Function} getCurrentSettings - Returns the current settings.
+ * @param {Function} handleUpdate - Persist function.
+ */
 export function renderGameModeSwitches(container, gameModes, getCurrentSettings, handleUpdate) {
   if (!container || !Array.isArray(gameModes)) return;
   const sortedModes = [...gameModes].sort((a, b) => a.order - b.order);
@@ -84,6 +129,18 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
   });
 }
 
+/**
+ * Render feature flag toggle switches.
+ *
+ * @pseudocode
+ * 1. For each flag, generate a labelled toggle switch element.
+ * 2. Persist updates via `handleUpdate` when toggled.
+ *
+ * @param {HTMLElement} container - Container for the switches.
+ * @param {Record<string, boolean>} flags - Feature flag defaults.
+ * @param {Function} getCurrentSettings - Returns current settings.
+ * @param {Function} handleUpdate - Persist function.
+ */
 export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, handleUpdate) {
   if (!container || !flags) return;
   Object.keys(flags).forEach((flag) => {
@@ -109,3 +166,5 @@ export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, 
     });
   });
 }
+
+export { applyInputState };


### PR DESCRIPTION
## Summary
- add pseudocode for card section helpers
- document score helper
- document country helper functions
- document carousel accessibility helpers
- document settings form utilities
- mention pseudocode requirement in README and CONTRIBUTING

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6886a4b4b38c83269fdfaf8f5efbf2d5