### PR TITLE
Fix tab order for display mode radios

### DIFF
--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -81,7 +81,7 @@
                 id="display-mode-dark"
                 name="display-mode"
                 value="dark"
-                tabindex="1"
+                tabindex="2"
               />
               <label for="display-mode-dark">Dark</label>
               <input
@@ -89,7 +89,7 @@
                 id="display-mode-gray"
                 name="display-mode"
                 value="gray"
-                tabindex="1"
+                tabindex="3"
               />
               <label for="display-mode-gray">Gray</label>
             </div>
@@ -127,7 +127,7 @@
                       id="sound-toggle"
                       name="sound"
                       aria-label="Sound"
-                      tabindex="2"
+                      tabindex="4"
                     />
                     <div class="slider round"></div>
                     <span>Sound</span>
@@ -140,7 +140,7 @@
                       id="motion-toggle"
                       name="motion"
                       aria-label="Motion Effects"
-                      tabindex="4"
+                      tabindex="5"
                     />
                     <div class="slider round"></div>
                     <span>Motion Effects</span>
@@ -153,7 +153,7 @@
                       id="typewriter-toggle"
                       name="typewriter"
                       aria-label="Typewriter Effect"
-                      tabindex="5"
+                      tabindex="6"
                     />
                     <div class="slider round"></div>
                     <span>Typewriter Effect</span>


### PR DESCRIPTION
## Summary
- keep display mode radios in sequential tab order

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688722823e308326a9315ef62e19e515