### PR TITLE
Remove unused display modes from expected labels

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -54,8 +54,6 @@ test.describe("Settings page", () => {
 
     const expectedLabels = [
       "Light",
-      "Dark",
-      "Gray",
       "Sound",
       "Motion Effects",
       "Typewriter Effect",


### PR DESCRIPTION
## Summary
- update settings page Playwright test to drop unused "Dark" and "Gray" labels

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch in meditation and settings pages)*

------
https://chatgpt.com/codex/tasks/task_e_68873796a1b08326848257f2f9129eb0