### PR TITLE
Update search results styles

### DIFF
--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -88,6 +88,7 @@ async function handleSearch(event) {
 
     if (strongMatches.length === 0) {
       const warning = document.createElement("p");
+      warning.classList.add("search-results-message");
       warning.textContent =
         "\u26A0\uFE0F No strong matches found, but here are the closest matches based on similarity.";
       resultsEl.appendChild(warning);
@@ -95,6 +96,7 @@ async function handleSearch(event) {
 
     for (const match of toRender) {
       const li = document.createElement("li");
+      li.classList.add("search-result-item");
       li.innerHTML = `<p>${match.text}</p><p class="small-text">Source: ${match.source} (score: ${match.score.toFixed(2)})</p>`;
       list.appendChild(li);
     }

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -60,3 +60,13 @@
   padding-left: var(--space-md);
   margin-inline-start: var(--space-md);
 }
+
+.search-results-message {
+  font-weight: bold;
+  margin-bottom: var(--space-md);
+}
+
+.search-result-item {
+  margin-bottom: var(--space-md);
+  text-align: justify;
+}


### PR DESCRIPTION
## Summary
- style search results with `.search-results-message` and `.search-result-item`
- apply the new classes in `vectorSearchPage.js`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Screenshot suite – meditation.html, settings.html)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68873fc35b30832692158e8cf8b16dc0