### PR TITLE
Improve vector search tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ output file under the 3MB limit defined in the PRD.
 - Both the generation script and the search page use **mean pooled** embeddings so the query vector matches the stored vectors.
 
 - Results appear below the form with up to five entries that show match score and source.
+- Tag filters can be passed to limit results (e.g. only `judoka-data` entries).
 - The page displays “Embeddings could not be loaded – please check console.” if loading fails, or “No close matches found” when nothing is returned.
 - Users can submit the form by pressing **Enter** in the search box.
 - The transformer library is loaded from jsDelivr on first use, so network connectivity is required for that initial download.

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -12,7 +12,7 @@ Embeddings are stored in `client_embeddings.json` as an array of objects. Each e
   "text": "Classic Battle is Ju-Do-Kon!'s introductory mode...",
   "embedding": [0.12, -0.04, 0.33, ...],
   "source": "PRD",
-  "tags": ["battle", "overview"],
+  "tags": ["design-doc", "battle", "overview"],
   "version": 1
 }
 ```
@@ -21,7 +21,9 @@ Embeddings are stored in `client_embeddings.json` as an array of objects. Each e
 - **text** – snippet used to generate the embedding
 - **embedding** – numeric vector (typically ≤384 dimensions)
 - **source** – origin of the text (PRD, tooltip, etc.)
-- **tags** – optional categories for filtering results
+- **tags** – optional categories for filtering results. Entries include a broad
+  label such as `prd` or `data` along with specific tags like `judoka-data` or
+  `design-doc`.
 - **version** – embedding file version
 
 ## Prompt Examples
@@ -31,6 +33,12 @@ Embeddings are stored in `client_embeddings.json` as an array of objects. Each e
 ```
 You are a QA assistant. Search the vector store for requirements on the Settings page. Use the top result titles in your test plan.
 Query: "settings feature flags order"
+```
+
+To narrow results, pass tag filters to your search call:
+
+```
+findMatches(queryVector, 5, ["judoka-data"]);
 ```
 
 ### Card Generation Agent

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -53,7 +53,7 @@ Ultimately, these issues increase the risk of bugs reaching players, slow down t
 | P1 | Client-Side Embedding Store | Save all text entries and their embeddings in a `client_embeddings.json` file for browser use |
 | P1 | Cosine Similarity Function | Implement JavaScript logic to compare a query vector to all indexed entries and return top N matches |
 | P1 | Static Query Interface | Provide an in-browser demo or utility for querying the embedding file (e.g. using a sample prompt vector) |
-| P2 | Vector Metadata Fields | Store source metadata with each embedding (e.g. “source: PRD Tooltip System”, “type: stat-description”) |
+| P2 | Vector Metadata Fields | Store source metadata with each embedding (e.g. “source: PRD Tooltip System”, “type: stat-description”). Include granular tags like `judoka-data`, `tooltip`, `design-doc`, or `agent-workflow` for filtering. |
 | P2 | Agent Integration Example | Provide a sample script or markdown prompt to demonstrate how AI agents can use the vector store |
 | P3 | Embedding Refresh Pipeline | Optionally support rebuilding the embedding index when PRDs or tooltip files are updated (manual or script-based trigger) |
 
@@ -75,6 +75,7 @@ regeneration whenever those folders change.
 - [x] At least 30 unique content entries from across the PRDs/tooltips are indexed in the demo build
 - [x] Each returned result includes both the match score and a reference to the original source
 - [x] Agent prompt templates are provided with guidance on embedding format and retrieval usage
+- [x] Search function accepts optional tag filters so agents can restrict matches to specific categories
 - [x] The system handles malformed or missing embeddings gracefully (e.g. logs a warning or returns empty result)
 - [x] The `client_embeddings.json` file stays under the 3MB threshold to ensure quick page load and GitHub Pages compatibility
 

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -14,6 +14,8 @@
  *      * When the root is an object, embed each key/value pair.
  * 4. Encode each chunk or entry using mean pooling and round the values.
  * 5. Build output objects with id, text, embedding, source, tags, and version.
+ *    - Tags include both a broad category ("prd" or "data") and more specific
+ *      labels such as "judoka-data" or "tooltip".
  * 6. Verify the output size is under MAX_OUTPUT_SIZE and write it to disk.
  */
 import { readFile, writeFile } from "node:fs/promises";
@@ -49,6 +51,23 @@ async function loadModel() {
   return pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2");
 }
 
+function determineTags(relativePath, isJson) {
+  const tags = [isJson ? "data" : "prd"];
+  if (isJson) {
+    const file = path.basename(relativePath);
+    if (file === "judoka.json") tags.push("judoka-data");
+    else if (file === "tooltips.json") tags.push("tooltip");
+    else tags.push("game-data");
+  } else if (relativePath.startsWith("design/productRequirementsDocuments")) {
+    tags.push("design-doc");
+  } else if (relativePath.startsWith("design/codeStandards")) {
+    tags.push("design-guideline");
+  } else if (relativePath.startsWith("design/agentWorkflows")) {
+    tags.push("agent-workflow");
+  }
+  return tags;
+}
+
 async function generate() {
   const files = await getFiles();
   const extractor = await loadModel();
@@ -59,7 +78,7 @@ async function generate() {
     const text = await readFile(fullPath, "utf8");
     const base = path.basename(relativePath);
     const isJson = relativePath.endsWith(".json");
-    const tags = [isJson ? "data" : "prd"];
+    const tags = determineTags(relativePath, isJson);
 
     if (isJson) {
       const json = JSON.parse(text);

--- a/tests/helpers/vectorSearch.test.js
+++ b/tests/helpers/vectorSearch.test.js
@@ -8,8 +8,8 @@ afterEach(() => {
 });
 
 const sample = [
-  { id: "a", text: "A", embedding: [1, 0], source: "doc1" },
-  { id: "b", text: "B", embedding: [0, 1], source: "doc2" }
+  { id: "a", text: "A", embedding: [1, 0], source: "doc1", tags: ["foo"] },
+  { id: "b", text: "B", embedding: [0, 1], source: "doc2", tags: ["bar"] }
 ];
 
 describe("vectorSearch", () => {
@@ -45,6 +45,16 @@ describe("vectorSearch", () => {
     expect(res.length).toBe(1);
     expect(res[0].id).toBe("a");
     expect(res[0].score).toBeCloseTo(1);
+  });
+
+  it("filters by tags", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => sample });
+    vi.resetModules();
+    const { findMatches } = await import("../../src/helpers/vectorSearch.js");
+    const res = await findMatches([1, 0], 1, ["foo"]);
+    expect(res[0].id).toBe("a");
+    const other = await findMatches([1, 0], 1, ["bar"]);
+    expect(other[0].id).toBe("b");
   });
 
   it("returns empty array for dimension mismatch", async () => {


### PR DESCRIPTION
## Summary
- add optional tags argument to `findMatches`
- add more granular tags in embedding generator
- show tag filtering usage in docs
- adjust README for tag-filtering capability
- test vector search tag filtering

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6887441da7d0832696afd275064c52e5