### PR TITLE
Use quantized MiniLM model

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ JU-DO-KON! offers a 99-card deck and one-on-one stat battles in a fully browser-
 
 ### Vector Search (RAG)
 
-The project ships with a retrieval-augmented search demo. Run `npm run generate:embeddings` to create the index, then open `src/pages/vectorSearch.html` to try it out. The generation script at `scripts/generateEmbeddings.js` downloads the `Xenova/all-MiniLM-L6-v2` model the first time it runs—so it fails offline unless the weights have been cached. These embeddings let AI agents query the product requirement docs, tooltip descriptions, and game data. The generated `src/data/client_embeddings.json` is pretty-printed for readability and must be committed for the page to work. **Embeddings must be flat numeric arrays like `[0.12, -0.04, ...]`—objects with `dims` or `data` keys will break the search page.**
+The project ships with a retrieval-augmented search demo. Run `npm run generate:embeddings` to create the index, then open `src/pages/vectorSearch.html` to try it out. The generation script at `scripts/generateEmbeddings.js` downloads the quantized `Xenova/all-MiniLM-L6-v2` model the first time it runs—so it fails offline unless the weights have been cached. These embeddings let AI agents query the product requirement docs, tooltip descriptions, and game data. The generated `src/data/client_embeddings.json` is pretty-printed for readability and must be committed for the page to work. **Embeddings must be flat numeric arrays like `[0.12, -0.04, ...]`—objects with `dims` or `data` keys will break the search page.**
 
 Embeddings are generated for each PRD section or JSON record, which allows the search interface to return precise matches instead of entire files.
 
@@ -294,6 +294,9 @@ latest vectors.
 
 The generator skips the large `aesopsFables.json` quote dataset to keep the
 output file under the 3MB limit defined in the PRD.
+
+If Node runs out of memory while generating embeddings, increase the heap limit
+by running `node --max-old-space-size=8192 scripts/generateEmbeddings.js`.
 
 - Both the generation script and the search page use **mean pooled** embeddings so the query vector matches the stored vectors.
 

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -60,7 +60,9 @@ Query: "navbar button transition duration"
 Run `npm run generate:embeddings` whenever you update any PRD, files in
 `src/data/`, or markdown under `design/codeStandards` or
 `design/agentWorkflows`. The script (`scripts/generateEmbeddings.js`) fetches the
-`Xenova/all-MiniLM-L6-v2` model on first run, so it requires internet access
-unless the model is cached. This rebuilds `client_embeddings.json`, now
+**quantized** `Xenova/all-MiniLM-L6-v2` model on first run, so it requires
+internet access unless the model is cached. If the process runs out of memory,
+increase Node's heap limit (for example `node --max-old-space-size=8192
+scripts/generateEmbeddings.js`). This rebuilds `client_embeddings.json`, now
 pretty-printed for easier diffing, so agents search the latest content. Commit
 the regenerated JSON file along with your changes.

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -62,7 +62,7 @@ Ultimately, these issues increase the risk of bugs reaching players, slow down t
 After editing PRDs, tooltips, game rules, or any markdown under
 `design/codeStandards` or `design/agentWorkflows`, run
 `npm run generate:embeddings` from the repository root. The script at
-`scripts/generateEmbeddings.js` downloads the `Xenova/all-MiniLM-L6-v2` model the first time it runs, so the command will fail without internet access. Cache the model locally or run it in an environment with a connection. Commit the updated `client_embeddings.json`—now pretty-printed for readability—so other agents work with the latest vectors. A GitHub Actions workflow could automate this
+`scripts/generateEmbeddings.js` downloads the **quantized** `Xenova/all-MiniLM-L6-v2` model the first time it runs, so the command will fail without internet access. Cache the model locally or run it in an environment with a connection. Commit the updated `client_embeddings.json`—now pretty-printed for readability—so other agents work with the latest vectors. If you hit out-of-memory errors during generation, rerun the command with a higher heap limit (e.g. `node --max-old-space-size=8192 scripts/generateEmbeddings.js`). A GitHub Actions workflow could automate this
 regeneration whenever those folders change.
 
 The generator parses JSON arrays and objects into individual snippets so each

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -5,7 +5,8 @@
  * @pseudocode
  * 1. Use glob to gather markdown and JSON sources, skipping existing
  *    `client_embeddings.json` and large datasets.
- * 2. Load the transformer model for feature extraction.
+ * 2. Load the quantized transformer model for feature extraction to reduce
+ *    memory usage.
  * 3. For each file:
  *    - If markdown, split the text on blank lines or heading markers.
  *      * Combine segments into chunks under CHUNK_SIZE with OVERLAP between
@@ -92,8 +93,14 @@ async function getFiles() {
   return [...prdFiles, ...guidelineFiles, ...workflowFiles, ...jsonFiles];
 }
 
+/**
+ * Load the MiniLM feature extractor in quantized form.
+ *
+ * @returns {Promise<any>} Initialized pipeline instance.
+ */
 async function loadModel() {
-  return pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2");
+  // Reduce memory footprint by loading the quantized model
+  return pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", { quantized: true });
 }
 
 function determineTags(relativePath, isJson) {

--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -14,7 +14,8 @@ const SIMILARITY_THRESHOLD = 0.6;
  * @pseudocode
  * 1. Return the cached `extractor` when available.
  * 2. Dynamically import the Transformers.js `pipeline` helper.
- * 3. Instantiate a feature-extraction pipeline with the MiniLM model and store it.
+ * 3. Instantiate a quantized feature-extraction pipeline with the MiniLM model
+ *    and store it.
  *    - On failure, log the error, reset `extractor` to `null`, and rethrow.
  * 4. Return the initialized `extractor`.
  *
@@ -26,7 +27,9 @@ async function getExtractor() {
       const { pipeline } = await import(
         "https://cdn.jsdelivr.net/npm/@xenova/transformers@2.6.0/dist/transformers.min.js"
       );
-      extractor = await pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2");
+      extractor = await pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", {
+        quantized: true
+      });
     } catch (error) {
       console.error("Model failed to load", error);
       extractor = null;


### PR DESCRIPTION
## Summary
- load quantized MiniLM weights in embedding generator and search page
- document new model load behavior and heap-limit guidance

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: E403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: E403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68876a437a208326a98a5a07245c9387