### PR TITLE
Fix infinite loop in embedding generator

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -73,7 +73,11 @@ function chunkMarkdown(text) {
       overlapLen += segments[k].length + 2;
       k -= 1;
     }
-    i = Math.max(k + 1, j - 1);
+    let nextIndex = Math.max(k + 1, j - 1);
+    if (nextIndex <= i) {
+      nextIndex = j;
+    }
+    i = nextIndex;
   }
 
   return chunks;


### PR DESCRIPTION
## Summary
- avoid non-advancing pointer in `chunkMarkdown`

## Testing
- `node --max-old-space-size=8192 scripts/generateEmbeddings.js` *(fails: Cannot find package 'glob')*


------
https://chatgpt.com/codex/tasks/task_e_68876fe82fac8326bb1c94d25a1b501b