### PR TITLE
Add context loader for vector search results

### DIFF
--- a/playwright/vector-search.spec.js
+++ b/playwright/vector-search.spec.js
@@ -1,0 +1,32 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+
+/**
+ * Vector search demo tests.
+ */
+test.describe("Vector search page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/client_embeddings.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/client_embeddings_vector.json" })
+    );
+    await page.route("**/transformers.min.js", (route) =>
+      route.fulfill({
+        contentType: "application/javascript",
+        body: "export async function pipeline(){return async()=>({data:[1,0]});}"
+      })
+    );
+    await page.route("**/design/productRequirementsDocuments/docA.md", (route) =>
+      route.fulfill({ path: "tests/fixtures/docA.md" })
+    );
+    await page.goto("/src/pages/vectorSearch.html");
+  });
+
+  test("selecting a result loads context", async ({ page }) => {
+    await page.getByRole("textbox").fill("query");
+    await page.getByRole("button", { name: /search/i }).click();
+    const item = page.locator(".search-result-item").first();
+    await item.waitFor();
+    await item.click();
+    const context = item.locator(".result-context");
+    await expect(context).toContainText("context A1");
+  });
+});

--- a/src/pages/vectorSearch.html
+++ b/src/pages/vectorSearch.html
@@ -38,6 +38,7 @@
           <input id="vector-search-input" type="search" placeholder="Enter query" required />
           <button id="vector-search-btn" type="submit">Search</button>
         </form>
+        <p class="small-text" id="context-note">Click a result to load more context.</p>
         <div id="search-spinner" class="loading-spinner" aria-hidden="true"></div>
         <section
           id="search-results"

--- a/tests/fixtures/client_embeddings_vector.json
+++ b/tests/fixtures/client_embeddings_vector.json
@@ -1,0 +1,4 @@
+[
+  { "id": "docA.md-chunk-1", "text": "Alpha text", "embedding": [1, 0], "source": "docA.md" },
+  { "id": "docB.md-chunk-1", "text": "Beta text", "embedding": [0, 1], "source": "docB.md" }
+]

--- a/tests/fixtures/docA.md
+++ b/tests/fixtures/docA.md
@@ -1,0 +1,5 @@
+# DocA
+
+This is context A1.
+
+This is context A2.


### PR DESCRIPTION
## Summary
- load additional context chunks on click in vectorSearchPage
- mention context loading instructions on Vector Search page
- add Playwright test covering context loading
- include fixtures for search test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run --reporter dot`
- `npx playwright test --reporter=list`

------
https://chatgpt.com/codex/tasks/task_e_688776d17b748326bab32415f20277c2