### PR TITLE
Add source context retrieval notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ higher value, for example
 
 - Results appear below the form with up to five entries that show match score and source.
 - Tag filters can be passed to limit results (e.g. only `judoka-data` entries).
+- Each result includes an `id` so agents can fetch more text via `fetchContextById`.
 - The page displays “Embeddings could not be loaded – please check console.” if loading fails, or “No close matches found” when nothing is returned.
 - Users can submit the form by pressing **Enter** in the search box.
 - The transformer library is loaded from jsDelivr on first use, so network connectivity is required for that initial download.

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -41,6 +41,11 @@ To narrow results, pass tag filters to your search call:
 findMatches(queryVector, 5, ["judoka-data"]);
 ```
 
+```
+const results = await findMatches(queryVector, 5);
+const context = await fetchContextById(results[0].id);
+```
+
 ### Card Generation Agent
 
 ```

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -55,6 +55,7 @@ Ultimately, these issues increase the risk of bugs reaching players, slow down t
 | P1 | Static Query Interface | Provide an in-browser demo or utility for querying the embedding file (e.g. using a sample prompt vector) |
 | P2 | Vector Metadata Fields | Store source metadata with each embedding (e.g. “source: PRD Tooltip System”, “type: stat-description”). Include granular tags like `judoka-data`, `tooltip`, `design-doc`, or `agent-workflow` for filtering. |
 | P2 | Agent Integration Example | Provide a sample script or markdown prompt to demonstrate how AI agents can use the vector store |
+| P2 | Source Context Retrieval | Provide helpers so agents can fetch adjacent chunks or the full document using an entry id |
 | P3 | Embedding Refresh Pipeline | Optionally support rebuilding the embedding index when PRDs or tooltip files are updated (manual or script-based trigger) |
 
 ### Embedding Refresh Pipeline
@@ -81,6 +82,7 @@ rather than an entire file.
 - [x] At least 30 unique content entries from across the PRDs/tooltips are indexed in the demo build
 - [x] Each returned result includes both the match score and a reference to the original source
 - [x] Agent prompt templates are provided with guidance on embedding format and retrieval usage
+- [x] Agents can request adjacent chunks or the full document by passing the result `id` to `fetchContextById`
 - [x] Search function accepts optional tag filters so agents can restrict matches to specific categories
 - [x] The system handles malformed or missing embeddings gracefully (e.g. logs a warning or returns empty result)
 - [x] The `client_embeddings.json` file stays under the 3MB threshold to ensure quick page load and GitHub Pages compatibility


### PR DESCRIPTION
## Summary
- note how to fetch extra context using `fetchContextById`
- clarify PRD requirements to support context lookup
- mention ID field in README so agents can fetch full documents

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 2 interrupted, 62 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68877eba60888326be20d966c361a271