### PR TITLE
Document vector search improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ higher value, for example
 - Each result includes an `id` so agents can fetch more text via `fetchContextById`.
 - The page displays “Embeddings could not be loaded – please check console.” if loading fails, or “No close matches found” when nothing is returned.
 - Users can submit the form by pressing **Enter** in the search box.
+- The search page provides a tag filter dropdown so you can limit results to PRDs, tooltips, or character data.
+- Agent scripts can import `findMatches` from `src/helpers/vectorSearch.js` to query embeddings programmatically.
 - The transformer library is loaded from jsDelivr on first use, so network connectivity is required for that initial download.
 
 ## About JU-DO-KON!

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -27,6 +27,12 @@ Embeddings are stored in `client_embeddings.json` as an array of objects. Each e
 - **version** – embedding file version
 
 ## Prompt Examples
+Agent scripts can import `findMatches` from `src/helpers/vectorSearch.js` to query the embeddings programmatically.
+
+```javascript
+import { findMatches } from "../../src/helpers/vectorSearch.js";
+const matches = await findMatches(vector, 5, ["prd"]);
+```
 
 ### QA Agent
 

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -53,7 +53,7 @@ Ultimately, these issues increase the risk of bugs reaching players, slow down t
 | P1 | Client-Side Embedding Store | Save all text entries and their embeddings in a `client_embeddings.json` file for browser use |
 | P1 | Cosine Similarity Function | Implement JavaScript logic to compare a query vector to all indexed entries and return top N matches |
 | P1 | Static Query Interface | Provide an in-browser demo or utility for querying the embedding file (e.g. using a sample prompt vector) |
-| P2 | Vector Metadata Fields | Store source metadata with each embedding (e.g. “source: PRD Tooltip System”, “type: stat-description”). Include granular tags like `judoka-data`, `tooltip`, `design-doc`, or `agent-workflow` for filtering. |
+| P2 | Vector Metadata Fields | Store source metadata with each embedding (e.g. “source: PRD Tooltip System”, “type: stat-description”). Include granular tags like `judoka-data`, `tooltip`, `design-doc`, or `agent-workflow` for filtering. Tag each entry by its source ("prd","tooltip","data") and by topic such as "judoka","rules","ui" to enable fine-grained queries. |
 | P2 | Agent Integration Example | Provide a sample script or markdown prompt to demonstrate how AI agents can use the vector store |
 | P2 | Source Context Retrieval | Provide helpers so agents can fetch adjacent chunks or the full document using an entry id |
 | P3 | Embedding Refresh Pipeline | Optionally support rebuilding the embedding index when PRDs or tooltip files are updated (manual or script-based trigger) |
@@ -170,8 +170,11 @@ No user settings or toggles are included. This is appropriate since the feature 
   - [ ] 4.1 Design and implement offline query UI
   - [ ] 4.2 Add keyboard accessibility and result display
   - [ ] 4.3 Provide example queries with results
+    - [ ] 4.4 Add tag filter controls so users or agents can restrict results by source or topic
 
 - [ ] 5.0 Agent Integration and Demos
   - [ ] 5.1 Create markdown prompt templates
   - [ ] 5.2 Provide usage examples with test agents
   - [ ] 5.3 Log agent response coverage and latency
+
+  - [ ] 5.4 Expose a simple API or utility function for programmatic search access


### PR DESCRIPTION
## Summary
- clarify metadata tagging requirements in vector search PRD
- show how agent scripts can import `findMatches`
- note tag filter dropdown and API helper in README

## Testing
- `npx prettier . --check` *(fails: `npx` not found)*
- `npx eslint .` *(fails: `npx` not found)*
- `npx vitest run` *(fails: `npx` not found)*
- `npx playwright test` *(fails: `npx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688781878d308326b9873411cd200381