### PR TITLE
Add tooltip for signature bar

### DIFF
--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -13,6 +13,7 @@
   "ui.winMessage": "**Victory!**\nYou chose the stronger stat.",
   "ui.lossMessage": "**Defeat!**\nYour opponent had the upper hand.",
   "ui.drawMessage": "_It’s a draw._\nBoth stats were equal!",
+  "ui.signatureBar": "Signature Move Bar (also called the stat band or signature bar) shows the fighter’s special technique.",
 
   "mode.classicBattle": "**Classic Battle Mode** pits you against an opponent.\nFirst to 10 round wins is the champion.",
   "mode.teamBattle": "**Team Battle Mode** uses your entire deck.\nWin more rounds than the opponent team to triumph!",


### PR DESCRIPTION
## Summary
- document signature bar in tooltips

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 3 failed)*
- `npm run generate:embeddings` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6887855867008326a65575c4b8d5aa1b