### PR TITLE
Improve markdown chunking

### DIFF
--- a/src/pages/vectorSearch.html
+++ b/src/pages/vectorSearch.html
@@ -38,7 +38,9 @@
           <input id="vector-search-input" type="search" placeholder="Enter query" required />
           <button id="vector-search-btn" type="submit">Search</button>
         </form>
-        <p class="small-text" id="context-note">Click a result to load more context when available.</p>
+        <p class="small-text" id="context-note">
+          Click a result to load more context when available.
+        </p>
         <div id="search-spinner" class="loading-spinner" aria-hidden="true"></div>
         <section
           id="search-results"

--- a/tests/helpers/vectorSearch.test.js
+++ b/tests/helpers/vectorSearch.test.js
@@ -84,9 +84,16 @@ describe("vectorSearch", () => {
     const result = await fetchContextById("doc.md-chunk-3", 1);
     expect(global.fetch).toHaveBeenCalled();
     expect(result).toHaveLength(3);
-    expect(result[0].length).toBe(300);
+    expect(result[0].length).toBe(1500);
     expect(result[1].length).toBe(1500);
-    expect(result[2].length).toBe(300);
+    expect(result[2].length).toBe(604);
+  });
+
+  it("chunks markdown by heading", async () => {
+    const md = "## A\nText A\n### B\nText B\n## C\nText C";
+    const { chunkMarkdown } = await import("../../src/helpers/vectorSearch.js");
+    const chunks = chunkMarkdown(md);
+    expect(chunks).toEqual(["## A\nText A\n### B\nText B", "### B\nText B", "## C\nText C"]);
   });
 
   it("returns empty array for invalid id", async () => {


### PR DESCRIPTION
## Summary
- refine markdown section handling
- export chunkMarkdown for reuse
- update vectorSearch helpers and unit tests
- format vector search HTML

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diff on meditation.html and vectorSearch.html, vector-search page timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688783348f688326ab28793f4d5df5ba