### PR TITLE
Add drop-off handling to vector search

### DIFF
--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -111,6 +111,9 @@ rather than an entire file.
 - Lookup responses must render within 200ms; show loading spinner if delayed.
 - Display an error message when embeddings or the model fail to load.
 - Show up to five matches with score and source information.
+- Matches scoring at least `0.6` are considered strong. When the top match is
+  more than `0.4` higher than the next best score, only that top result is
+  displayed.
 - Result messages such as "No strong matches found…" should use the `.search-result-empty` CSS class. Each result entry uses `.search-result-item` and is fully justified with spacing between items.
 
 ### UI Mockup

--- a/tests/helpers/vectorSearchPage.test.js
+++ b/tests/helpers/vectorSearchPage.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Unit tests for selectMatches helper in vectorSearchPage.
+ */
+
+describe("selectMatches", () => {
+  it("returns only the top match when drop off exceeds threshold", async () => {
+    const { selectMatches } = await import("../../src/helpers/vectorSearchPage.js");
+    const strong = [
+      { id: "1", score: 0.95 },
+      { id: "2", score: 0.4 },
+      { id: "3", score: 0.39 }
+    ];
+    const result = selectMatches(strong, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+  });
+
+  it("returns all strong matches when drop off is small", async () => {
+    const { selectMatches } = await import("../../src/helpers/vectorSearchPage.js");
+    const strong = [
+      { id: "1", score: 0.8 },
+      { id: "2", score: 0.7 }
+    ];
+    const result = selectMatches(strong, []);
+    expect(result).toEqual(strong);
+  });
+
+  it("uses weak matches when no strong matches exist", async () => {
+    const { selectMatches } = await import("../../src/helpers/vectorSearchPage.js");
+    const weak = [
+      { id: "a", score: 0.5 },
+      { id: "b", score: 0.4 },
+      { id: "c", score: 0.3 },
+      { id: "d", score: 0.2 }
+    ];
+    const result = selectMatches([], weak);
+    expect(result).toEqual(weak.slice(0, 3));
+  });
+});


### PR DESCRIPTION
## Summary
- add `DROP_OFF_THRESHOLD` constant and helper to limit vector search results
- update pseudocode for new logic
- document similarity thresholds in PRD
- test `selectMatches` helper

## Testing
- `npx prettier src/helpers/vectorSearchPage.js tests/helpers/vectorSearchPage.test.js design/productRequirementsDocuments/prdVectorDatabaseRAG.md --check`
- `npx eslint src/helpers/vectorSearchPage.js tests/helpers/vectorSearchPage.test.js`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diffs in meditation.html and vectorSearch.html, context load timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6887855d630c83269f43eac2a603ffd2