### PR TITLE
Fix embedding generator by reducing output size

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -35,8 +35,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
 
 // Larger chunks reduce the total embedding count and help keep the
-// final JSON under the 3MB limit.
-const CHUNK_SIZE = 1500;
+// final JSON under the 3MB limit. Bump slightly to shrink output.
+const CHUNK_SIZE = 2000;
 const OVERLAP = 100;
 const MAX_OUTPUT_SIZE = 3 * 1024 * 1024;
 

--- a/src/helpers/vectorSearch.js
+++ b/src/helpers/vectorSearch.js
@@ -98,7 +98,7 @@ export async function findMatches(queryVector, topN = 5, tags = []) {
     .slice(0, topN);
 }
 
-const CHUNK_SIZE = 1500;
+const CHUNK_SIZE = 2000;
 const OVERLAP = 100;
 
 function chunkMarkdown(text) {


### PR DESCRIPTION
## Summary
- increase `CHUNK_SIZE` in `generateEmbeddings.js` and in the helper used by
  `vectorSearch.js`

This reduces the number of generated embedding chunks so
`client_embeddings.json` stays under the 3 MB limit described in
`prdVectorDatabaseRAG.md`.

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6887891db0cc83268a416c239bf5e88a