### PR TITLE
Update vector search docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ JU-DO-KON! offers a 99-card deck and one-on-one stat battles in a fully browser-
 
 The project ships with a retrieval-augmented search demo. Run `npm run generate:embeddings` to create the index, then open `src/pages/vectorSearch.html` to try it out. Serve the repository with `npm start` or another local server so the page can fetch markdown files; opening it directly via file protocol will prevent additional context from loading. The generation script at `scripts/generateEmbeddings.js` downloads the quantized `Xenova/all-MiniLM-L6-v2` model the first time it runs—so make sure you have internet access or the download will fail. It allocates an 8 GB heap by default (`--max-old-space-size=8192`); adjust this value if Node still runs out of memory. These embeddings let AI agents query the product requirement docs, tooltip descriptions, and game data. The generated `src/data/client_embeddings.json` is pretty-printed for readability and must be committed for the page to work. **Embeddings must be flat numeric arrays like `[0.12, -0.04, ...]`—objects with `dims` or `data` keys will break the search page.**
 
-Embeddings are generated for each PRD section or JSON record, which allows the search interface to return precise matches instead of entire files.
+Embeddings are generated for each PRD section or JSON record, which allows the search interface to return precise matches instead of entire files. Markdown files are chunked from one heading to the next so each section maintains its context.
 
 After modifying any PRDs, **any file in `src/data/`**, or docs under
 `design/codeStandards` or `design/agentWorkflows`, run
@@ -302,6 +302,7 @@ higher value, for example
 - Both the generation script and the search page use **mean pooled** embeddings so the query vector matches the stored vectors.
 
 - Results appear below the form with up to five entries that show match score and source.
+- Scores of **0.6** or higher are treated as strong matches in the UI; weaker results are hidden unless no strong match is found.
 - Tag filters can be passed to limit results (e.g. only `judoka-data` entries).
 - Each result includes an `id` so agents can fetch more text via `fetchContextById`.
 - The page displays “Embeddings could not be loaded – please check console.” if loading fails, or “No close matches found” when nothing is returned.

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -35,6 +35,8 @@ import { findMatches } from "../../src/helpers/vectorSearch.js";
 const matches = await findMatches(vector, 5, ["prd"]);
 ```
 
+Because embeddings capture semantics, synonyms like "grip fighting" and "kumi-kata" map closely. The demo interface marks scores of 0.6 and above as strong matches and only shows weaker results when no strong hits are returned.
+
 ### QA Agent
 
 ```

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -67,10 +67,12 @@ After editing PRDs, tooltips, game rules, or any markdown under
 regeneration whenever those folders change.
 
 The generator parses JSON arrays and objects into individual snippets so each
-record receives its own embedding. Tooltips, judoka entries, and PRD sections
-are broken down into discrete blocks with unique IDs. This granularity improves
-lookup accuracy because search results map back to a single section or data row
-rather than an entire file.
+record receives its own embedding. For markdown sources, text is chunked from
+one heading to the next heading of the same or higher level so each section is
+semantically coherent. Tooltips, judoka entries, and PRD sections are broken
+down into discrete blocks with unique IDs. This granularity improves lookup
+accuracy because search results map back to a single section or data row rather
+than an entire file.
 
 ---
 
@@ -114,6 +116,7 @@ rather than an entire file.
 - Matches scoring at least `0.6` are considered strong. When the top match is
   more than `0.4` higher than the next best score, only that top result is
   displayed.
+- Lower scoring results appear only when there are no strong matches.
 - Result messages such as "No strong matches found…" should use the `.search-result-empty` CSS class. Each result entry uses `.search-result-item` and is fully justified with spacing between items.
 
 ### UI Mockup


### PR DESCRIPTION
## Summary
- document heading-based vector chunking and UI threshold
- mention synonym matching in vector query examples
- clarify PRD notes on markdown chunking and weak matches

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot /src/pages/meditation.html, screenshot /src/pages/vectorSearch.html, selecting a result loads context)*

------
https://chatgpt.com/codex/tasks/task_e_688788c69ab88326bf0fc1d3b495dd7d