### PR TITLE
Adjust vector chunk size to 1500

### DIFF
--- a/src/helpers/vectorSearch.js
+++ b/src/helpers/vectorSearch.js
@@ -98,7 +98,7 @@ export async function findMatches(queryVector, topN = 5, tags = []) {
     .slice(0, topN);
 }
 
-const CHUNK_SIZE = 2000;
+const CHUNK_SIZE = 1500;
 const OVERLAP = 100;
 
 function chunkMarkdown(text) {


### PR DESCRIPTION
## Summary
- reduce `CHUNK_SIZE` in `vectorSearch` to 1500

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Screenshot suite › screenshot /src/pages/meditation.html)*

------
https://chatgpt.com/codex/tasks/task_e_68878c28f3808326bdd8925c197d441e