### PR TITLE
Update pseudocode with 3MB limit

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -20,7 +20,7 @@
  *      labels such as "judoka-data" or "tooltip".
  * 6. Stream each output object directly to `client_embeddings.json` using
  *    `fs.createWriteStream`.
- *    - Track bytes written and abort if the total exceeds MAX_OUTPUT_SIZE.
+ *    - Track bytes written and abort if the total exceeds MAX_OUTPUT_SIZE (3 MB).
  * 7. After writing the file, record the total count, average vector length,
  *    and output size in `client_embeddings.meta.json`.
  */


### PR DESCRIPTION
## Summary
- clarify the 3MB size limit when streaming embeddings

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: vectorSearch fetches context around an id)*
- `npx playwright test` *(fails: meditation screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68878d242b0c832690faa77905cdcba4