### PR TITLE
Update vector embedding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,10 @@ latest vectors.
 The generator skips the large `aesopsFables.json` quote dataset to keep the
 output file under the 3MB limit defined in the PRD.
 
+If the output would exceed that limit, `scripts/generateEmbeddings.js` aborts
+with `"Output exceeds 3MB"`. Increase the `CHUNK_SIZE` constant or exclude
+large files to reduce the result size before rerunning the script.
+
 If generation still fails because of memory limits, rerun the script with a
 higher value, for example
 `node --max-old-space-size=16384 scripts/generateEmbeddings.js`.

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -80,3 +80,7 @@ increase Node's heap limit (for example `node --max-old-space-size=8192
 scripts/generateEmbeddings.js`). This rebuilds `client_embeddings.json`, now
 pretty-printed for easier diffing, so agents search the latest content. Commit
 the regenerated JSON file along with your changes.
+
+If the result would be larger than 3MB, the generator exits with
+`"Output exceeds 3MB"`. Increase the `CHUNK_SIZE` constant or omit large files to
+reduce the output size before running the script again.


### PR DESCRIPTION
## Summary
- clarify 3MB limit behavior in README
- explain how to reduce output size in vector query docs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run --reporter=verbose` *(fails: Test Files 1 failed | 61 passed (62))*
- `npx playwright test` *(fails: 1 failed, 65 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68878d1d96ac8326b29e1627a01e7ae0