### PR TITLE
Increase embedding file limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,10 +293,10 @@ the updated file alongside your documentation changes so other agents have the
 latest vectors.
 
 The generator skips the large `aesopsFables.json` quote dataset to keep the
-output file under the 3MB limit defined in the PRD.
+output file under the 3.6MB limit defined in the PRD.
 
 If the output would exceed that limit, `scripts/generateEmbeddings.js` aborts
-with `"Output exceeds 3MB"`. Increase the `CHUNK_SIZE` constant or exclude
+with `"Output exceeds 3.6MB"`. Increase the `CHUNK_SIZE` constant or exclude
 large files to reduce the result size before rerunning the script.
 
 If generation still fails because of memory limits, rerun the script with a

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -81,6 +81,6 @@ scripts/generateEmbeddings.js`). This rebuilds `client_embeddings.json`, now
 pretty-printed for easier diffing, so agents search the latest content. Commit
 the regenerated JSON file along with your changes.
 
-If the result would be larger than 3MB, the generator exits with
-`"Output exceeds 3MB"`. Increase the `CHUNK_SIZE` constant or omit large files to
+If the result would be larger than 3.6MB, the generator exits with
+`"Output exceeds 3.6MB"`. Increase the `CHUNK_SIZE` constant or omit large files to
 reduce the output size before running the script again.

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -32,7 +32,7 @@ Ultimately, these issues increase the risk of bugs reaching players, slow down t
 | Response accuracy | ≥90% agent-retrieved responses align with top 3 relevant matches |
 | Search latency | ≤200ms average similarity lookup on mid-tier desktop browsers (e.g., 2022 MacBook Air M1 or Windows laptop with 8GB RAM) |
 | Coverage | ≥90% of PRDs/tooltips indexed within the system |
-| File size | <3MB total JSON size to ensure fast client-side loading |
+| File size | <3.6MB total JSON size to ensure fast client-side loading |
 
 ---
 
@@ -87,7 +87,7 @@ than an entire file.
 - [x] Agents can request adjacent chunks or the full document by passing the result `id` to `fetchContextById`
 - [x] Search function accepts optional tag filters so agents can restrict matches to specific categories
 - [x] The system handles malformed or missing embeddings gracefully (e.g. logs a warning or returns empty result)
-- [x] The `client_embeddings.json` file stays under the 3MB threshold to ensure quick page load and GitHub Pages compatibility
+- [x] The `client_embeddings.json` file stays under the 3.6MB threshold to ensure quick page load and GitHub Pages compatibility
 
 ---
 
@@ -164,7 +164,7 @@ No user settings or toggles are included. This is appropriate since the feature 
 
 - [ ] 2.0 Implement Client-Side Embedding Store
   - [ ] 2.1 Structure JSON with `id`, `text`, `embedding`, `source`, `tags`
-  - [ ] 2.2 Ensure total file size stays below the 3MB threshold
+  - [ ] 2.2 Ensure total file size stays below the 3.6MB threshold
   - [ ] 2.3 Validate JSON loading in-browser
 
 - [ ] 3.0 Develop Similarity Search Function

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -20,7 +20,7 @@
  *      labels such as "judoka-data" or "tooltip".
  * 6. Stream each output object directly to `client_embeddings.json` using
  *    `fs.createWriteStream`.
- *    - Track bytes written and abort if the total exceeds MAX_OUTPUT_SIZE (3 MB).
+ *    - Track bytes written and abort if the total exceeds MAX_OUTPUT_SIZE (3.6 MB).
  * 7. After writing the file, record the total count, average vector length,
  *    and output size in `client_embeddings.meta.json`.
  */
@@ -35,10 +35,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
 
 // Larger chunks reduce the total embedding count and help keep the
-// final JSON under the 3MB limit. Bump slightly to shrink output.
+// final JSON under the 3.6MB limit. Bump slightly to shrink output.
 const CHUNK_SIZE = 2000;
 const OVERLAP = 100;
-const MAX_OUTPUT_SIZE = 3 * 1024 * 1024;
+const MAX_OUTPUT_SIZE = 3.6 * 1024 * 1024;
 
 function chunkMarkdown(text) {
   const lines = text.split(/\r?\n/);
@@ -143,7 +143,7 @@ async function generate() {
     const size = Buffer.byteLength(chunk + "\n]", "utf8");
     if (bytesWritten + size > MAX_OUTPUT_SIZE) {
       writer.end();
-      throw new Error("Output exceeds 3MB");
+      throw new Error("Output exceeds 3.6MB");
     }
     writer.write(chunk);
     bytesWritten += Buffer.byteLength(chunk, "utf8");
@@ -207,7 +207,7 @@ async function generate() {
   const endStr = "\n]\n";
   if (bytesWritten + Buffer.byteLength(endStr, "utf8") > MAX_OUTPUT_SIZE) {
     writer.end();
-    throw new Error("Output exceeds 3MB");
+    throw new Error("Output exceeds 3.6MB");
   }
   writer.end(endStr);
   await new Promise((resolve) => writer.on("finish", resolve));

--- a/src/styles/vectorSearch.css
+++ b/src/styles/vectorSearch.css
@@ -1,29 +1,29 @@
 #vector-results-table {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    width: 100%;
-    padding: var(--space-lg);
-    gap: var(--space-med);
-    box-sizing: border-box;
-  }
-  
-  #vector-results-table thead,
-  #vector-results-table tbody,
-  #vector-results-table tr {
-    display: contents;
-  }
-  
-  #vector-results-table th,
-  #vector-results-table td {
-    padding: var(--space-xs) var(--space-sm);
-    text-align: left;
-    border-bottom: 1px solid var(--color-secondary);
-  }
-  
-  #vector-results-table tbody tr:nth-child(odd) {
-    background-color: #ffffff;
-  }
-  
-  #vector-results-table tbody tr:nth-child(even) {
-    background-color: #f2f2f2;
-  }
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  width: 100%;
+  padding: var(--space-lg);
+  gap: var(--space-med);
+  box-sizing: border-box;
+}
+
+#vector-results-table thead,
+#vector-results-table tbody,
+#vector-results-table tr {
+  display: contents;
+}
+
+#vector-results-table th,
+#vector-results-table td {
+  padding: var(--space-xs) var(--space-sm);
+  text-align: left;
+  border-bottom: 1px solid var(--color-secondary);
+}
+
+#vector-results-table tbody tr:nth-child(odd) {
+  background-color: #ffffff;
+}
+
+#vector-results-table tbody tr:nth-child(even) {
+  background-color: #f2f2f2;
+}


### PR DESCRIPTION
## Summary
- allow embedding generation up to 3.6MB
- document new 3.6MB limit
- run Prettier on vectorSearch.css to satisfy checks

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6887983ad0b08326a7c81d2559f157d8