### PR TITLE
Improve vector search page layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ higher value, for example
 
 - Results appear below the form with up to five entries that show match score and source.
 - Search results are displayed in a responsive table with alternating row colors for readability.
+- The Match column takes up more space than Source and Score so the text is easier to read.
+- Embeddings load when the page initializes so the first search doesn't wait for network fetches.
 - Scores of **0.6** or higher are treated as strong matches in the UI; weaker results are hidden unless no strong match is found.
 - Tag filters can be passed to limit results (e.g. only `judoka-data` entries).
 - Each result includes an `id` so agents can fetch more text via `fetchContextById`.

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -114,6 +114,8 @@ than an entire file.
 - Display an error message when embeddings or the model fail to load.
 - Show up to five matches with score and source information.
 - Search results appear in a responsive table with alternating row colors for readability.
+- The Match column is wider than Source and Score, which are sized smaller to save space.
+- Embeddings load automatically when the page initializes so the first search runs immediately.
 - Matches scoring at least `0.6` are considered strong. When the top match is
   more than `0.4` higher than the next best score, only that top result is
   displayed.

--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -1,5 +1,5 @@
 import { onDomReady } from "./domReady.js";
-import { findMatches, fetchContextById } from "./vectorSearch.js";
+import { findMatches, fetchContextById, loadEmbeddings } from "./vectorSearch.js";
 // Load Transformers.js dynamically from jsDelivr when first used
 // This avoids bundling the large library with the rest of the code.
 
@@ -204,6 +204,8 @@ async function handleSearch(event) {
 function init() {
   spinner = document.getElementById("search-spinner");
   if (spinner) spinner.style.display = "none";
+  // Preload embeddings on page load so search runs instantly
+  loadEmbeddings();
   const form = document.getElementById("vector-search-form");
   form?.addEventListener("submit", handleSearch);
   form?.addEventListener("keydown", (e) => {

--- a/src/pages/vectorSearch.html
+++ b/src/pages/vectorSearch.html
@@ -32,7 +32,7 @@
         <div class="header-spacer right"></div>
       </header>
 
-      <main class="container long-form" role="main">
+      <main class="container" role="main">
         <h1>Vector Search</h1>
         <form id="vector-search-form" role="search" class="search-form">
           <label for="vector-search-input" class="visually-hidden">Search</label>

--- a/src/styles/vectorSearch.css
+++ b/src/styles/vectorSearch.css
@@ -1,29 +1,29 @@
 #vector-results-table {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    width: 100%;
-    padding: var(--space-lg);
-    gap: var(--space-med);
-    box-sizing: border-box;
-  }
-  
-  #vector-results-table thead,
-  #vector-results-table tbody,
-  #vector-results-table tr {
-    display: contents;
-  }
-  
-  #vector-results-table th,
-  #vector-results-table td {
-    padding: var(--space-xs) var(--space-sm);
-    text-align: left;
-    border-bottom: 1px solid var(--color-secondary);
-  }
-  
-  #vector-results-table tbody tr:nth-child(odd) {
-    background-color: #ffffff;
-  }
-  
-  #vector-results-table tbody tr:nth-child(even) {
-    background-color: #f2f2f2;
-  }
+  display: grid;
+  grid-template-columns: 2fr 0.75fr 0.5fr;
+  width: 100%;
+  padding: var(--space-lg);
+  gap: var(--space-med);
+  box-sizing: border-box;
+}
+
+#vector-results-table thead,
+#vector-results-table tbody,
+#vector-results-table tr {
+  display: contents;
+}
+
+#vector-results-table th,
+#vector-results-table td {
+  padding: var(--space-xs) var(--space-sm);
+  text-align: left;
+  border-bottom: 1px solid var(--color-secondary);
+}
+
+#vector-results-table tbody tr:nth-child(odd) {
+  background-color: #ffffff;
+}
+
+#vector-results-table tbody tr:nth-child(even) {
+  background-color: #f2f2f2;
+}


### PR DESCRIPTION
## Summary
- widen the Match column in Vector Search results
- shrink Source and Score columns
- table spans full screen width by default
- preload embeddings when the Vector Search page loads
- document updated layout and preload behavior

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688799500dc88326aa5d61a7c1aa4312