### PR TITLE
Adjust embedding serialization

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -135,10 +135,7 @@ async function generate() {
   bytesWritten += Buffer.byteLength("[", "utf8");
 
   const writeEntry = (obj) => {
-    const serialized = JSON.stringify(obj, null, 2)
-      .split("\n")
-      .map((line) => `  ${line}`)
-      .join("\n");
+    const serialized = JSON.stringify(obj);
     const chunk = (first ? "\n" : ",\n") + serialized;
     const size = Buffer.byteLength(chunk + "\n]", "utf8");
     if (bytesWritten + size > MAX_OUTPUT_SIZE) {


### PR DESCRIPTION
## Summary
- simplify `writeEntry` in embedding generator

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diffs)*
- `npm run generate:embeddings` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68879c7c28a4832683549860c71ae5da