### PR TITLE
Improve vector search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,9 +305,10 @@ higher value, for example
 
 - Both the generation script and the search page use **mean pooled** embeddings so the query vector matches the stored vectors.
 
-- Results appear below the form with up to five entries that show match score and source.
+- Results appear below the form with up to five entries that show match score, source, and tags. Each entry also displays a short `qaContext` snippet when available.
 - Search results are displayed in a responsive table with alternating row colors for readability.
-- The Match column takes up more space than Source and Score so the text is easier to read.
+- The Match column takes up more space than Source, Tags, and Score so the text is easier to read.
+- The Tags column lists the categories provided in `client_embeddings.json`.
 - The Source column wraps file paths at `/` characters so long locations stack vertically.
 - Embeddings load when the page initializes so the first search doesn't wait for network fetches.
 - Scores of **0.6** or higher are treated as strong matches in the UI; weaker results are hidden unless no strong match is found.

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -114,9 +114,9 @@ than an entire file.
 - Tap/click targets should be at least 44px height for accessibility.
 - Lookup responses must render within 200ms; show loading spinner if delayed.
 - Display an error message when embeddings or the model fail to load.
-- Show up to five matches with score and source information.
+- Show up to five matches with score, source, and tags information. Each entry displays its optional `qaContext` snippet beneath the match text.
 - Search results appear in a responsive table with alternating row colors for readability.
-- The Match column is wider than Source and Score, which are sized smaller to save space.
+- The Match column is wider than Source, Tags, and Score, which are sized smaller to save space.
 - Paths in the Source column break onto new lines at each `/` so long file names remain legible.
 - Embeddings load automatically when the page initializes so the first search runs immediately.
 - Matches scoring at least `0.6` are considered strong. When the top match is

--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -113,6 +113,16 @@ export function formatSourcePath(source) {
 }
 
 /**
+ * Format tag arrays for display.
+ *
+ * @param {string[]} tags - Tag names.
+ * @returns {string} Comma separated tag string.
+ */
+export function formatTags(tags) {
+  return Array.isArray(tags) ? tags.join(", ") : "";
+}
+
+/**
  * Handle the vector search form submission.
  *
  * @pseudocode
@@ -182,7 +192,15 @@ async function handleSearch(event) {
 
       const textCell = document.createElement("td");
       textCell.classList.add("match-text");
-      textCell.textContent = match.text;
+      const snippet = document.createElement("div");
+      snippet.textContent = match.text;
+      textCell.appendChild(snippet);
+      if (match.qaContext) {
+        const qa = document.createElement("div");
+        qa.classList.add("qa-context", "small-text");
+        qa.textContent = match.qaContext;
+        textCell.appendChild(qa);
+      }
       const context = document.createElement("div");
       context.classList.add("result-context", "small-text");
       context.setAttribute("aria-live", "polite");
@@ -191,10 +209,13 @@ async function handleSearch(event) {
       const sourceCell = document.createElement("td");
       sourceCell.appendChild(formatSourcePath(match.source));
 
+      const tagsCell = document.createElement("td");
+      tagsCell.textContent = formatTags(match.tags);
+
       const scoreCell = document.createElement("td");
       scoreCell.textContent = match.score.toFixed(2);
 
-      row.append(textCell, sourceCell, scoreCell);
+      row.append(textCell, sourceCell, tagsCell, scoreCell);
       row.addEventListener("click", () => loadResultContext(row));
       row.addEventListener("keydown", (e) => {
         if (e.key === "Enter" || e.key === " ") {

--- a/src/pages/vectorSearch.html
+++ b/src/pages/vectorSearch.html
@@ -48,6 +48,7 @@
             <tr>
               <th>Match</th>
               <th>Source</th>
+              <th>Tags</th>
               <th>Score</th>
             </tr>
           </thead>

--- a/src/styles/vectorSearch.css
+++ b/src/styles/vectorSearch.css
@@ -1,6 +1,6 @@
 #vector-results-table {
   display: grid;
-  grid-template-columns: 2fr 0.75fr 0.15fr;
+  grid-template-columns: 2fr 0.75fr 0.75fr 0.15fr;
   width: 100%;
   padding: var(--space-lg);
   gap: var(--space-med);
@@ -26,4 +26,8 @@
 
 #vector-results-table tbody tr:nth-child(even) {
   background-color: #f2f2f2;
+}
+
+.qa-context {
+  color: var(--color-text-secondary);
 }


### PR DESCRIPTION
## Summary
- show embedding tags and `qaContext` in search results
- document new result columns in PRD and README

## Testing
- `npx prettier src/helpers/vectorSearchPage.js src/pages/vectorSearch.html src/styles/vectorSearch.css README.md design/productRequirementsDocuments/prdVectorDatabaseRAG.md --check`
- `npx eslint src/helpers/vectorSearchPage.js` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6887af5b47b48326b7c2b60deabc2eb1