### PR TITLE
Improve test cleanup for global state

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Some helpers such as `classicBattle.js` keep match state between rounds. The
 `_resetForTest()` function resets this internal state. Invoke it at the start of
 any unit test that depends on the initial score or timer conditions.
 
+All Vitest suites load `tests/setup.js`, which resets the DOM and restores
+global mocks after each test. This cleanup now clears `localStorage` and
+reinstates `window.matchMedia` so stubs never leak between tests.
+
 ### Troubleshooting Playwright Tests
 
 A `Test timeout ... waiting for locator('#general-settings-toggle')` error usually means the Settings page failed to load or the server was unreachable. Verify that:

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,6 +1,8 @@
 import { expect, afterEach } from "vitest";
 import { resetDom } from "./utils/testUtils.js";
 
+const originalMatchMedia = global.matchMedia;
+
 expect.extend({
   toHaveAttribute(element, attribute, expected) {
     const isElem = element && typeof element.getAttribute === "function";
@@ -26,5 +28,6 @@ expect.extend({
 });
 
 afterEach(() => {
+  global.matchMedia = originalMatchMedia;
   resetDom();
 });

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -92,6 +92,9 @@ export function resetDom() {
   if (typeof document !== "undefined" && document.body) {
     document.body.innerHTML = "";
   }
+  if (typeof localStorage !== "undefined") {
+    localStorage.clear();
+  }
   vi.restoreAllMocks();
   vi.useRealTimers();
   vi.resetModules();


### PR DESCRIPTION
## Summary
- restore `window.matchMedia` after each test
- clear `localStorage` in `resetDom`
- document test cleanup in README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden when fetching vitest)*
- `npx playwright test` *(fails: 403 Forbidden when fetching playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6887b295c6cc83269f4b3da1a35ca321