### PR TITLE
Fix flaky meditation screenshot

### DIFF
--- a/playwright/meditation-screen.spec.js
+++ b/playwright/meditation-screen.spec.js
@@ -7,6 +7,9 @@ import {
 
 test.describe("Meditation screen", () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() =>
+      localStorage.setItem("settings", JSON.stringify({ typewriterEffect: false }))
+    );
     await page.goto("/src/pages/meditation.html");
   });
 

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -35,6 +35,7 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
       });
       await page.addInitScript(() => {
         Math.random = () => 0.42;
+        localStorage.setItem("settings", JSON.stringify({ typewriterEffect: false }));
       });
       await page.goto(url, { waitUntil: "domcontentloaded" });
       await expect(page).toHaveScreenshot(name, { fullPage: true });


### PR DESCRIPTION
## Summary
- disable typewriter effect in meditation screen tests
- disable typewriter effect in screenshot suite for consistent diffs

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6887bcab1bbc8326aa2eadbda17e11e7