### PR TITLE
Use toHaveAttribute matcher in tests

### DIFF
--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -21,9 +21,9 @@ describe("InfoBar component", () => {
     const msg = header.querySelector("#round-message");
     const timer = header.querySelector("#next-round-timer");
     const score = header.querySelector("#score-display");
-    expect(msg.getAttribute("aria-live")).toBe("polite");
-    expect(timer.getAttribute("aria-live")).toBe("polite");
-    expect(score.getAttribute("aria-live")).toBe("off");
+    expect(msg).toHaveAttribute("aria-live", "polite");
+    expect(timer).toHaveAttribute("aria-live", "polite");
+    expect(score).toHaveAttribute("aria-live", "off");
   });
 
   it("updates message and score", () => {

--- a/tests/components/StatsPanel.test.js
+++ b/tests/components/StatsPanel.test.js
@@ -15,7 +15,7 @@ describe("createStatsPanel", () => {
     expect(items).toHaveLength(5);
     expect(items[0].textContent).toContain("5");
     expect(items[4].textContent).toContain("9");
-    expect(panel.getAttribute("aria-label")).toBe("Judoka Stats");
+    expect(panel).toHaveAttribute("aria-label", "Judoka Stats");
   });
 
   it("applies custom type and class", () => {
@@ -25,7 +25,7 @@ describe("createStatsPanel", () => {
     );
     expect(panel.classList.contains("legendary")).toBe(true);
     expect(panel.classList.contains("extra")).toBe(true);
-    expect(panel.getAttribute("aria-label")).toBe("Player Stats");
+    expect(panel).toHaveAttribute("aria-label", "Player Stats");
   });
 
   it("throws when stats is missing", () => {

--- a/tests/helpers/buttonComponent.test.js
+++ b/tests/helpers/buttonComponent.test.js
@@ -28,6 +28,6 @@ describe("createButton", () => {
     expect(btn.innerHTML).toContain(icon);
     expect(btn.textContent).toBe("Label");
     const svg = btn.querySelector("svg");
-    expect(svg.getAttribute("aria-hidden")).toBe("true");
+    expect(svg).toHaveAttribute("aria-hidden", "true");
   });
 });

--- a/tests/helpers/cardComponent.test.js
+++ b/tests/helpers/cardComponent.test.js
@@ -12,7 +12,7 @@ describe("createCard", () => {
   it("creates an anchor card when href provided", () => {
     const card = createCard("Link", { href: "#" });
     expect(card).toBeInstanceOf(HTMLAnchorElement);
-    expect(card.getAttribute("href")).toBe("#");
+    expect(card).toHaveAttribute("href", "#");
   });
 
   it("applies id, class and click handler", () => {

--- a/tests/helpers/modalComponent.test.js
+++ b/tests/helpers/modalComponent.test.js
@@ -23,12 +23,12 @@ describe("createModal", () => {
 
     open(trigger);
     expect(element.hasAttribute("hidden")).toBe(false);
-    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
     expect(document.activeElement.id).toBe("cancel-btn");
 
     close();
     expect(element.hasAttribute("hidden")).toBe(true);
-    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
     expect(document.activeElement).toBe(trigger);
   });
 
@@ -41,7 +41,7 @@ describe("createModal", () => {
     });
     document.body.appendChild(element);
     const dialog = element.querySelector(".modal");
-    expect(dialog.getAttribute("aria-labelledby")).toBe("modal-title");
-    expect(dialog.getAttribute("aria-describedby")).toBe("modal-desc");
+    expect(dialog).toHaveAttribute("aria-labelledby", "modal-title");
+    expect(dialog).toHaveAttribute("aria-describedby", "modal-desc");
   });
 });

--- a/tests/helpers/populateCountryList.test.js
+++ b/tests/helpers/populateCountryList.test.js
@@ -52,8 +52,8 @@ describe("populateCountryList", () => {
     await populateCountryList(container);
 
     const buttons = container.querySelectorAll("button.flag-button");
-    expect(buttons[0].getAttribute("aria-label")).toBe("Show all countries");
-    expect(buttons[1].getAttribute("aria-label")).toBe("Filter by Japan");
+    expect(buttons[0]).toHaveAttribute("aria-label", "Show all countries");
+    expect(buttons[1]).toHaveAttribute("aria-label", "Filter by Japan");
   });
 
   it("lazy loads additional countries on scroll", async () => {

--- a/tests/helpers/quoteBuilder.test.js
+++ b/tests/helpers/quoteBuilder.test.js
@@ -40,7 +40,7 @@ describe("displayRandomQuote", () => {
     expect(loader.classList.contains("hidden")).toBe(true);
     expect(quoteDiv.innerHTML).toContain("A");
     expect(toggle.classList.contains("hidden")).toBe(false);
-    expect(toggle.getAttribute("aria-live")).toBe("polite");
+    expect(toggle).toHaveAttribute("aria-live", "polite");
     expect(document.activeElement).toBe(toggle);
     expect(liveRegion.textContent).toBe("language toggle available");
   });

--- a/tests/helpers/sectionToggle.test.js
+++ b/tests/helpers/sectionToggle.test.js
@@ -16,12 +16,12 @@ describe("setupSectionToggles", () => {
     const content = document.getElementById("sec");
 
     button.click();
-    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(button).toHaveAttribute("aria-expanded", "true");
     expect(content.hasAttribute("hidden")).toBe(false);
 
     const event = new KeyboardEvent("keydown", { key: "Enter" });
     button.dispatchEvent(event);
-    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(button).toHaveAttribute("aria-expanded", "false");
     expect(content.hasAttribute("hidden")).toBe(true);
   });
 });

--- a/tests/helpers/toggleSwitch.test.js
+++ b/tests/helpers/toggleSwitch.test.js
@@ -20,7 +20,7 @@ describe("createToggleSwitch", () => {
     expect(input?.id).toBe("sound-toggle");
     expect(input?.name).toBe("sound");
     expect(input?.checked).toBe(true);
-    expect(input?.getAttribute("aria-label")).toBe("Sound toggle");
+    expect(input).toHaveAttribute("aria-label", "Sound toggle");
     expect(slider?.classList.contains("round")).toBe(true);
     expect(span?.textContent).toBe("Sound");
   });
@@ -34,6 +34,6 @@ describe("createToggleSwitch", () => {
   it("uses label text as aria-label by default", () => {
     const wrapper = createToggleSwitch("AutoToggle");
     const input = wrapper.querySelector("input[type='checkbox']");
-    expect(input?.getAttribute("aria-label")).toBe("AutoToggle");
+    expect(input).toHaveAttribute("aria-label", "AutoToggle");
   });
 });


### PR DESCRIPTION
## Summary
- clean up DOM attribute assertions in test suite

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6887c7e3061c8326a9b2ec9a578107b2