### PR TITLE
Standardize CSS class naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ the footer buttons clear the persistent navigation bar. Users can return to the
 - `utilities.css` – helper classes.
 - Page-specific files such as `carousel.css` and `quote.css`.
 
+Class names follow **kebab-case** (lowercase with dashes) throughout all style sheets. Avoid camelCase names to keep selectors consistent.
+
 Import styles in this order: `base.css` first, then layout and component files, and finally `utilities.css`.
 
 Global rules should not be repeated across files.

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
           </div>
         </a>
       </main>
-      <!-- <div class="homeHelperContainer">
+      <!-- <div class="home-helper-container">
         <img src="./src/assets/actionPortraits/actionPortrait-40.png" />
       </div> -->
       <footer>

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -35,7 +35,7 @@
   /* border: 2px solid red; */
 }
 
-.locationTile {
+.location-tile {
   max-width: 100%;
   max-height: 36vh;
   width: auto;
@@ -46,7 +46,7 @@
   align-items: center;
 }
 
-.locationTileSmall {
+.location-tile-small {
   border-radius: var(--radius-lg);
   display: flex;
   flex: 1 1 auto;
@@ -54,14 +54,14 @@
   /* border: 2px solid red; */
 }
 
-.locationTileSmall img {
+.location-tile-small img {
   max-width: 10vh;
   height: auto;
   aspect-ratio: 1 / 1;
   border-radius: var(--radius-lg);
   flex: 1 1 auto;
 }
-.svgTile {
+.svg-tile {
   aspect-ratio: 1 / 1;
   display: flex;
   justify-content: center;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -123,7 +123,7 @@ body {
     /* border: 2px solid red; */
   }
 }
-.homeHelperContainer {
+.home-helper-container {
   background: var(--color-tertiary);
   border: 2px solid var(--color-tertiary);
   border-radius: var(--radius-md);
@@ -131,7 +131,7 @@ body {
   /* border: 2px solid red; */
 }
 
-.homeHelperContainer img {
+.home-helper-container img {
   max-width: 50vw;
   height: auto;
   border-radius: var(--radius-md);
@@ -141,7 +141,7 @@ body {
   background: var(--color-tertiary);
   border: 1px solid var(--color-secondary);
 }
-.locationTileContainer {
+.location-tile-container {
   padding: var(--space-md);
   display: inline-flex;
   gap: var(--space-lg);


### PR DESCRIPTION
## Summary
- rename camelCase CSS classes in `card.css` and `layout.css`
- update commented example in `index.html`
- document kebab-case rule in README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6887e06e8fec8326a46ed34a5310f28c