### PR TITLE
Update spacing tokens

### DIFF
--- a/src/helpers/carousel/accessibility.js
+++ b/src/helpers/carousel/accessibility.js
@@ -17,7 +17,7 @@ function ensureTouchTargetSize(element) {
   if (width < MIN_TOUCH_TARGET_SIZE || height < MIN_TOUCH_TARGET_SIZE) {
     element.style.minWidth = `${MIN_TOUCH_TARGET_SIZE}px`;
     element.style.minHeight = `${MIN_TOUCH_TARGET_SIZE}px`;
-    element.style.padding = "10px";
+    element.style.padding = "var(--space-sm)";
   }
 }
 

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -23,7 +23,7 @@
 .settings-form fieldset {
   border: none;
   margin: 0;
-  padding: 10px;
+  padding: var(--space-sm);
 }
 
 .settings-form {


### PR DESCRIPTION
## Summary
- use spacing token for settings form fieldset
- replace numeric fallback with spacing token in carousel accessibility helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6887e66cd06083269cb3ad70d9ea56d4