### PR TITLE
Improve vector search relevance

### DIFF
--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -40,6 +40,8 @@ const matches = await findMatches(vector, 5, ["prd"]);
 ```
 
 Because embeddings capture semantics, synonyms like "grip fighting" and "kumi-kata" map closely. The demo interface marks scores of 0.6 and above as strong matches and only shows weaker results when no strong hits are returned.
+Exact keyword matches earn a small 0.1 score bonus before ranking, so quoting a
+term can bump the most literal result to the top.
 
 ### QA Agent
 

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -122,6 +122,8 @@ than an entire file.
 - Matches scoring at least `0.6` are considered strong. When the top match is
   more than `0.4` higher than the next best score, only that top result is
   displayed.
+- Scores are normalized to the 0–1 range. Exact term matches (case-insensitive)
+  receive a small `+0.1` bonus before sorting to promote literal keyword hits.
 - Lower scoring results appear only when there are no strong matches.
 - Result messages such as "No strong matches found…" should use the `.search-result-empty` CSS class. Each result entry uses `.search-result-item` and is fully justified with spacing between items.
 

--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -159,7 +159,7 @@ async function handleSearch(event) {
     const model = await getExtractor();
     const result = await model(query, { pooling: "mean" });
     const vector = Array.from(result.data ?? result);
-    const matches = await findMatches(vector, 5);
+    const matches = await findMatches(vector, 5, [], query);
     if (messageEl) messageEl.textContent = "";
     spinner.style.display = "none";
     if (matches === null) {

--- a/tests/helpers/vectorSearch.test.js
+++ b/tests/helpers/vectorSearch.test.js
@@ -57,6 +57,14 @@ describe("vectorSearch", () => {
     expect(other[0].id).toBe("b");
   });
 
+  it("boosts results containing exact query terms", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => sample });
+    vi.resetModules();
+    const { findMatches } = await import("../../src/helpers/vectorSearch.js");
+    const res = await findMatches([1, 1], 2, [], "B");
+    expect(res[0].id).toBe("b");
+  });
+
   it("returns empty array for dimension mismatch", async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => sample });
     vi.resetModules();


### PR DESCRIPTION
## Summary
- boost exact term matches with a new bonus in `findMatches`
- normalize similarity scores before ranking
- pass query text to the search helper
- document score bonus and normalization in PRD and agent workflow docs
- test new ranking logic

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: meditation screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6887e73b78908326a90fb5719c652ff2