### PR TITLE
Add tooltip id for signature bar

### DIFF
--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -12,7 +12,7 @@
   "ui.winMessage": "**Victory!**\nYou chose the stronger stat.",
   "ui.lossMessage": "**Defeat!**\nYour opponent had the upper hand.",
   "ui.drawMessage": "_It’s a draw._\nBoth stats were equal!",
-  "ui.signatureBar": "Signature Move Bar (also called the stat band or signature bar) shows the fighter’s special technique.",
+  "ui.signatureBar": "The Signature Bar displays this judoka’s special move.",
 
   "mode.classicBattle": "**Classic Battle Mode** pits you against an opponent.\nFirst to 10 round wins is the champion.",
   "mode.teamBattle": "**Team Battle Mode** uses your entire deck.\nWin more rounds than the opponent team to triumph!",

--- a/src/helpers/cardRender.js
+++ b/src/helpers/cardRender.js
@@ -118,6 +118,7 @@ export function generateCardStats(card, cardType = "common") {
  *
  * 4. Construct the signature move HTML:
  *    - Create a `<div>` element with the class `signature-move-container` and the card type as an additional class.
+ *    - Add a `data-tooltip-id="ui.signatureBar"` attribute for tooltip support.
  *    - Add `<span>` elements for the label ("Signature Move:") and the escaped technique name.
  *    - Ensure the band is at least 44px tall for touch accessibility (see PRD: touch target size).
  *
@@ -164,7 +165,7 @@ export function generateCardSignatureMove(judoka, gokyoLookup, cardType = "commo
   const cardClass = cardType.toLowerCase();
 
   return `
-    <div class="signature-move-container ${cardClass}">
+    <div class="signature-move-container ${cardClass}" data-tooltip-id="ui.signatureBar">
       <span class="signature-move-label">Signature Move:</span>
       <span class="signature-move-value">${techniqueName}</span>
     </div>

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -62,6 +62,7 @@
               role="group"
               aria-label="Select a stat to battle"
               class="responsive-stat-buttons"
+              data-tooltip-id="ui.selectStat"
             >
               <button
                 data-stat="power"

--- a/tests/card/judokaCardSignatureMove.test.js
+++ b/tests/card/judokaCardSignatureMove.test.js
@@ -23,5 +23,6 @@ describe("signature move placement", () => {
     const card = container.querySelector(".judoka-card");
     const direct = card.querySelector(":scope > .signature-move-container");
     expect(direct).toBeInstanceOf(HTMLElement);
+    expect(direct.dataset.tooltipId).toBe("ui.signatureBar");
   });
 });

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -13,7 +13,7 @@ describe("battleUI helpers", () => {
 
   it("resetStatButtons clears selection and re-enables buttons", () => {
     document.body.innerHTML =
-      '<div id="stat-buttons"><button class="selected" style="background-color:red"></button><button class="selected"></button></div>';
+      '<div id="stat-buttons" data-tooltip-id="ui.selectStat"><button class="selected" style="background-color:red"></button><button class="selected"></button></div>';
     vi.useFakeTimers();
     vi.stubGlobal("requestAnimationFrame", (cb) => setTimeout(cb, 0));
     const buttons = getStatButtons();
@@ -43,7 +43,7 @@ describe("battleUI helpers", () => {
 
   it("DOM helper functions return elements", () => {
     document.body.innerHTML =
-      '<div id="stat-buttons"><button></button></div><p id="round-message"></p>';
+      '<div id="stat-buttons" data-tooltip-id="ui.selectStat"><button></button></div><p id="round-message"></p>';
     expect(getStatButtons().length).toBe(1);
     expect(getRoundMessageEl()).toBeInstanceOf(HTMLElement);
   });

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -51,7 +51,8 @@ describe("classicBattle stat selection", () => {
   });
 
   beforeEach(async () => {
-    document.body.innerHTML += '<div id="stat-buttons"><button data-stat="power"></button></div>';
+    document.body.innerHTML +=
+      '<div id="stat-buttons" data-tooltip-id="ui.selectStat"><button data-stat="power"></button></div>';
     ({ handleStatSelection, _resetForTest } = await import(
       "../../../src/helpers/classicBattle.js"
     ));

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -184,7 +184,7 @@ describe("randomJudokaPage module", () => {
       const inner = document.createElement("div");
       inner.className = "judoka-card";
       inner.innerHTML =
-        '<div class="card-top-bar"></div><div class="card-portrait"></div><div class="card-stats"></div><div class="signature-move-container"></div>';
+        '<div class="card-top-bar"></div><div class="card-portrait"></div><div class="card-stats"></div><div class="signature-move-container" data-tooltip-id="ui.signatureBar"></div>';
       card.appendChild(inner);
       container.appendChild(card);
     });

--- a/tests/helpers/renderJudokaCard.test.js
+++ b/tests/helpers/renderJudokaCard.test.js
@@ -62,7 +62,7 @@ describe("renderJudokaCard", () => {
     const cardEl = document.createElement("div");
     cardEl.className = "judoka-card";
     cardEl.innerHTML =
-      '<div class="card-top-bar"></div><div class="card-portrait"></div><div class="card-stats"></div><div class="signature-move-container"></div>';
+      '<div class="card-top-bar"></div><div class="card-portrait"></div><div class="card-stats"></div><div class="signature-move-container" data-tooltip-id="ui.signatureBar"></div>';
     wrapper.className = "card-container";
     wrapper.appendChild(cardEl);
     generateMock = vi.fn(async () => wrapper);
@@ -86,7 +86,7 @@ describe("renderJudokaCard", () => {
     const card = document.createElement("div");
     card.className = "judoka-card";
     card.innerHTML =
-      '<div class="card-top-bar"></div><div class="card-portrait"></div><div class="card-stats"></div><div class="signature-move-container"></div>';
+      '<div class="card-top-bar"></div><div class="card-portrait"></div><div class="card-stats"></div><div class="signature-move-container" data-tooltip-id="ui.signatureBar"></div>';
     container.appendChild(card);
     document.body.appendChild(container);
     const { toggleInspectorPanels } = await import("../../src/helpers/cardUtils.js");


### PR DESCRIPTION
## Summary
- revise signature bar tooltip text
- attach `data-tooltip-id` to generated signature move
- enable tooltip on stat button container
- update test markup for new attribute
- check `.signature-move-container` dataset in unit test

## Testing
- `npx prettier src/helpers/cardRender.js src/data/tooltips.json src/pages/battleJudoka.html tests/helpers/classicBattle.test.js tests/helpers/classicBattle/statSelection.test.js tests/helpers/renderJudokaCard.test.js tests/helpers/randomJudokaPage.test.js tests/card/judokaCardSignatureMove.test.js --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot for settings page)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_6887e973097c83268c1b10a9c9684697