### PR TITLE
Add stat help tooltip

### DIFF
--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -57,56 +57,66 @@
           </div>
 
           <div id="controls">
-            <div
-              id="stat-buttons"
-              role="group"
-              aria-label="Select a stat to battle"
-              class="responsive-stat-buttons"
-            >
-              <button
-                data-stat="power"
-                type="button"
-                tabindex="0"
-                aria-label="Select Power"
-                data-tooltip-id="stat.power"
+            <div class="stat-controls">
+              <div
+                id="stat-buttons"
+                role="group"
+                aria-label="Select a stat to battle"
+                class="responsive-stat-buttons"
               >
-                Power
-              </button>
+                <button
+                  data-stat="power"
+                  type="button"
+                  tabindex="0"
+                  aria-label="Select Power"
+                  data-tooltip-id="stat.power"
+                >
+                  Power
+                </button>
+                <button
+                  data-stat="speed"
+                  type="button"
+                  tabindex="0"
+                  aria-label="Select Speed"
+                  data-tooltip-id="stat.speed"
+                >
+                  Speed
+                </button>
+                <button
+                  data-stat="technique"
+                  type="button"
+                  tabindex="0"
+                  aria-label="Select Technique"
+                  data-tooltip-id="stat.technique"
+                >
+                  Technique
+                </button>
+                <button
+                  data-stat="kumikata"
+                  type="button"
+                  tabindex="0"
+                  aria-label="Select Kumi-kata"
+                  data-tooltip-id="stat.kumikata"
+                >
+                  Kumi-kata
+                </button>
+                <button
+                  data-stat="newaza"
+                  type="button"
+                  tabindex="0"
+                  aria-label="Select Ne-waza"
+                  data-tooltip-id="stat.newaza"
+                >
+                  Ne-waza
+                </button>
+              </div>
               <button
-                data-stat="speed"
-                type="button"
-                tabindex="0"
-                aria-label="Select Speed"
-                data-tooltip-id="stat.speed"
+                id="stat-help"
+                class="info-button"
+                aria-label="Stat selection help"
+                data-tooltip-id="ui.selectStat"
               >
-                Speed
-              </button>
-              <button
-                data-stat="technique"
-                type="button"
-                tabindex="0"
-                aria-label="Select Technique"
-                data-tooltip-id="stat.technique"
-              >
-                Technique
-              </button>
-              <button
-                data-stat="kumikata"
-                type="button"
-                tabindex="0"
-                aria-label="Select Kumi-kata"
-                data-tooltip-id="stat.kumikata"
-              >
-                Kumi-kata
-              </button>
-              <button
-                data-stat="newaza"
-                type="button"
-                tabindex="0"
-                aria-label="Select Ne-waza"
-                data-tooltip-id="stat.newaza"
-              >
-                Ne-waza
+                ?
               </button>
             </div>
 

--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -72,6 +72,33 @@ button:focus-visible,
   background-color: var(--button-active-bg);
 }
 
+.info-button {
+  width: var(--touch-target-size, 44px);
+  height: var(--touch-target-size, 44px);
+  min-width: var(--touch-target-size, 44px);
+  min-height: var(--touch-target-size, 44px);
+  border-radius: 50%;
+  background-color: transparent;
+  color: var(--button-bg);
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+
+.info-button:hover,
+.info-button:focus-visible,
+.info-button:focus {
+  background-color: var(--button-hover-bg);
+  color: var(--button-text-color);
+}
+
+.info-button:active {
+  background-color: var(--button-active-bg);
+  transform: scale(0.95);
+}
+
 a:focus,
 a:focus-visible {
   outline-offset: 2px;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -220,6 +220,13 @@ body {
   text-align: center;
 }
 
+#battle-area #controls .stat-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+}
+
 @media (max-width: 480px) {
   #battle-area {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- add Stat selection help icon next to battle stat buttons
- style `.info-button` for circular info icons
- align help icon beside stat buttons

## Testing
- `npx prettier src/pages/battleJudoka.html src/styles/buttons.css src/styles/layout.css --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6887eb71bfd08326babaf3680c2030e3