### PR TITLE
Use touch target variable

### DIFF
--- a/src/styles/bottom-navbar.css
+++ b/src/styles/bottom-navbar.css
@@ -26,7 +26,7 @@
 }
 
 .bottom-navbar ul li {
-  min-height: 48px;
+  min-height: var(--touch-target-size);
   padding: var(--space-sm);
 }
 

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -487,8 +487,8 @@ svg {
   color: var(--color-text);
   border: 1px solid var(--color-primary);
   border-radius: 50%;
-  min-width: 48px;
-  min-height: 48px;
+  min-width: var(--touch-target-size);
+  min-height: var(--touch-target-size);
   aspect-ratio: 1/1;
   display: flex;
   flex: 0 0 auto;

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -177,8 +177,8 @@
   border: none;
   color: var(--color-text-inverted);
   cursor: pointer;
-  min-width: 48px;
-  min-height: 48px;
+  min-width: var(--touch-target-size);
+  min-height: var(--touch-target-size);
 }
 
 .flag-button:focus {

--- a/src/styles/quote.css
+++ b/src/styles/quote.css
@@ -103,7 +103,7 @@
 /* cta button styles */
 .cta-button {
   display: inline-block;
-  min-height: 48px;
+  min-height: var(--touch-target-size);
   padding: var(--space-md) var(--space-lg);
   font-size: var(--font-medium);
   margin-top: var(--space-md);

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -42,15 +42,15 @@
   display: flex;
   align-items: center;
   gap: var(--space-sm);
-  min-height: 48px;
+  min-height: var(--touch-target-size);
 }
 
 .settings-form input[type="checkbox"],
 .settings-form input[type="radio"] {
   accent-color: var(--button-bg);
   cursor: pointer;
-  min-width: 48px;
-  min-height: 48px;
+  min-width: var(--touch-target-size);
+  min-height: var(--touch-target-size);
   border-radius: var(--radius-sm);
   transition:
     transform var(--transition-fast),
@@ -58,7 +58,7 @@
 }
 
 .settings-form select {
-  min-height: 48px;
+  min-height: var(--touch-target-size);
   padding: 0.5rem;
   background-color: var(--button-bg);
   color: var(--button-text-color);

--- a/tests/helpers/bottomNavbarCss.test.js
+++ b/tests/helpers/bottomNavbarCss.test.js
@@ -22,7 +22,7 @@ describe("bottom-navbar touch target", () => {
     const minHeight = rule.nodes.find((d) => d.prop === "min-height")?.value;
     const padding = rule.nodes.find((d) => d.prop === "padding")?.value;
     expect(minHeight).toBeDefined();
-    expect(parseInt(minHeight)).toBeGreaterThanOrEqual(48);
+    expect(minHeight).toBe("var(--touch-target-size)");
     expect(padding).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- replace hardcoded 48px tap targets with `var(--touch-target-size)`
- update bottom navbar CSS test for new value

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6887eb800de48326839071e27d35a762