### PR TITLE
Add tooltip for Ne-waza stat

### DIFF
--- a/design/productRequirementsDocuments/prdTooltipSystem.md
+++ b/design/productRequirementsDocuments/prdTooltipSystem.md
@@ -105,7 +105,7 @@ Currently, JU-DO-KON! has no way of surfacing explanatory text in the UI without
 
 - [ ] 1.0 Setup Tooltip Content Source
   - [ ] 1.1 Create `tooltips.json` in `/data/` with at least 10 entries
-  - [ ] 1.2 Define unique keys like `stat.power`, `stat.kumikata`
+  - [ ] 1.2 Define unique keys like `stat.power`, `stat.kumikata`, `stat.newaza`
   - [ ] 1.3 Plan for optional localization structure (future-proof keys)
 
 - [ ] 2.0 Implement Tooltip Trigger Logic

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -3,6 +3,7 @@
   "stat.kumikata": "_Kumi-kata_ means **grip fighting**.\nThis stat reflects how well a judoka can control grips and deny their opponent’s attacks.",
   "stat.speed": "**Speed** affects how quickly a judoka can attack or react.\nUseful for counterattacks and surprise techniques.",
   "stat.technique": "**Technique** measures mastery of judo throws and transitions.\nHigh values indicate sharp, precise execution.",
+  "stat.newaza": "_Ne-waza_ means **ground grappling**.\nThis stat reflects skill in pins, holds, and other mat techniques.",
 
   "ui.countryFilter": "Toggle the country filter panel to pick flags and narrow the roster.",
   "ui.clearFilter": "Clear the current country filter and show all judoka.",


### PR DESCRIPTION
## Summary
- define `stat.newaza` tooltip so ground grappling has help text
- mention the new key in the Tooltip System PRD

## Testing
- `npx prettier src/data/tooltips.json design/productRequirementsDocuments/prdTooltipSystem.md --check`
- `npx eslint src/data/tooltips.json design/productRequirementsDocuments/prdTooltipSystem.md` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden when fetching vitest)*
- `npx playwright test` *(fails: 403 Forbidden when fetching playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6887ed1e06e083269c2609e02bc3600d