### PR TITLE
Fix inconsistent spacing token

### DIFF
--- a/src/styles/changeLog.css
+++ b/src/styles/changeLog.css
@@ -4,7 +4,7 @@
   grid-template-columns: var(--touch-target-size) var(--touch-target-size) 1fr 1fr 1fr;
   width: 100%;
   padding: var(--space-lg);
-  gap: var(--space-med);
+  gap: var(--space-md);
   box-sizing: border-box;
 }
 

--- a/src/styles/vectorSearch.css
+++ b/src/styles/vectorSearch.css
@@ -18,7 +18,7 @@
   grid-template-columns: 2fr 0.75fr 0.75fr 0.15fr;
   width: 100%;
   padding: var(--space-lg);
-  gap: var(--space-med);
+  gap: var(--space-md);
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- use `--space-md` token consistently

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Change log screenshot and VectorSearch screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6887f02ceeec83268289e8a7b70c69ea