### PR TITLE
Show stat help tooltip once

### DIFF
--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -17,6 +17,7 @@
  *    c. Load feature flags, set `data-*` attributes on `#battle-area`, and
  *       toggle the debug panel based on the `battleDebugPanel` flag.
  *    d. Invoke `startRoundWrapper` to begin the match.
+ *    e. Initialize tooltips and show the stat help tooltip once for new users.
  * 5. Execute `setupClassicBattlePage` with `onDomReady`.
  */
 import { startRound as classicStartRound, handleStatSelection } from "./classicBattle.js";
@@ -97,7 +98,23 @@ export async function setupClassicBattlePage() {
 
   window.startRoundOverride = startRoundWrapper;
   startRoundWrapper();
-  initTooltips();
+  await initTooltips();
+
+  try {
+    if (typeof localStorage !== "undefined") {
+      const hintShown = localStorage.getItem("statHintShown");
+      if (!hintShown) {
+        const help = document.getElementById("stat-help");
+        help?.dispatchEvent(new Event("mouseenter"));
+        setTimeout(() => {
+          help?.dispatchEvent(new Event("mouseleave"));
+        }, 3000);
+        localStorage.setItem("statHintShown", "true");
+      }
+    }
+  } catch {
+    // ignore localStorage errors
+  }
 }
 
 onDomReady(setupClassicBattlePage);

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  localStorage.clear();
+});
+
+describe("classicBattlePage stat help tooltip", () => {
+  it("shows tooltip only once", async () => {
+    vi.useFakeTimers();
+    const startRound = vi.fn();
+    const waitForComputerCard = vi.fn();
+    const loadSettings = vi.fn().mockResolvedValue({ featureFlags: {} });
+    const initTooltips = vi.fn().mockResolvedValue();
+    const setTestMode = vi.fn();
+
+    vi.doMock("../../src/helpers/classicBattle.js", () => ({
+      startRound,
+      handleStatSelection: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
+    vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
+    vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
+
+    const help = document.createElement("button");
+    help.id = "stat-help";
+    document.body.appendChild(help);
+    const spy = vi.spyOn(help, "dispatchEvent");
+
+    const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
+    await setupClassicBattlePage();
+    await vi.runAllTimersAsync();
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.mock.calls[0][0].type).toBe("mouseenter");
+    expect(spy.mock.calls[1][0].type).toBe("mouseleave");
+    expect(localStorage.getItem("statHintShown")).toBe("true");
+
+    spy.mockClear();
+    await setupClassicBattlePage();
+    await vi.runAllTimersAsync();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- show the stat help tooltip when first visiting the Classic Battle page
- avoid showing the help again after the flag is set in localStorage
- test tooltip behavior only appears once

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6887f1c0e4ec8326a4cb8926b665ff0d