### PR TITLE
Add tooltip ids and tests

### DIFF
--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -14,6 +14,10 @@
   "ui.lossMessage": "**Defeat!**\nYour opponent had the upper hand.",
   "ui.drawMessage": "_It’s a draw._\nBoth stats were equal!",
   "ui.signatureBar": "The Signature Bar displays this judoka’s special move.",
+  "ui.languageToggle": "Switch quote language between English and pseudo-Japanese.",
+  "ui.nextRound": "Begin the next round when you’re ready.",
+  "ui.quitMatch": "End the match and return to the menu.",
+  "ui.drawCard": "Draw a new random judoka card.",
 
   "mode.classicBattle": "**Classic Battle Mode** pits you against an opponent.\nFirst to 10 round wins is the champion.",
   "mode.teamBattle": "**Team Battle Mode** uses your entire deck.\nWin more rounds than the opponent team to triumph!",

--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -121,6 +121,7 @@ export async function setupRandomJudokaPage() {
     icon: DRAW_ICON
   });
   drawButton.dataset.testid = "draw-button";
+  drawButton.dataset.tooltipId = "ui.drawCard";
   drawButton.style.minHeight = "64px";
   drawButton.style.minWidth = "300px";
   drawButton.style.borderRadius = "999px";

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -121,8 +121,10 @@
             </div>
 
             <p id="round-result" aria-live="polite" aria-atomic="true"></p>
-            <button id="next-round-button" disabled>Next Round</button>
-            <button id="quit-match-button">Quit Match</button>
+            <button id="next-round-button" disabled data-tooltip-id="ui.nextRound">
+              Next Round
+            </button>
+            <button id="quit-match-button" data-tooltip-id="ui.quitMatch">Quit Match</button>
             <div id="debug-panel" class="debug-panel hidden">
               <pre id="debug-output" role="status" aria-live="polite"></pre>
             </div>

--- a/src/pages/meditation.html
+++ b/src/pages/meditation.html
@@ -43,6 +43,7 @@
             <button
               id="language-toggle"
               data-testid="language-toggle"
+              data-tooltip-id="ui.languageToggle"
               class="language-toggle hidden"
             >
               <span class="jp-flag flag-icon"></span> 日本語風 / English

--- a/tests/data/tooltipsEntries.test.js
+++ b/tests/data/tooltipsEntries.test.js
@@ -1,0 +1,15 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const tooltips = JSON.parse(readFileSync(resolve("src/data/tooltips.json"), "utf8"));
+
+describe("tooltips.json", () => {
+  it("contains new ui tooltip entries", () => {
+    const keys = ["ui.languageToggle", "ui.nextRound", "ui.quitMatch", "ui.drawCard"];
+    for (const key of keys) {
+      expect(tooltips).toHaveProperty(key);
+    }
+  });
+});

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -27,7 +27,11 @@ describe("randomJudokaPage module", () => {
     window.matchMedia = vi.fn().mockReturnValue({ matches: false });
     const generateRandomCard = vi.fn();
     const fetchJson = vi.fn().mockResolvedValue([]);
-    const createButton = vi.fn(() => document.createElement("button"));
+    const createButton = vi.fn((_, opts = {}) => {
+      const btn = document.createElement("button");
+      if (opts.id) btn.id = opts.id;
+      return btn;
+    });
     const createToggleSwitch = vi.fn((_, opts) => {
       const wrapper = document.createElement("div");
       const input = document.createElement("input");
@@ -62,6 +66,7 @@ describe("randomJudokaPage module", () => {
     expect(applyMotionPreference).toHaveBeenCalledWith(baseSettings.motionEffects);
     expect(generateRandomCard.mock.calls[0][3]).toBe(false);
     expect(typeof setupRandomJudokaPage).toBe("function");
+    expect(document.getElementById("draw-card-btn").dataset.tooltipId).toBe("ui.drawCard");
   });
 
   it("renders card text with sufficient color contrast", async () => {

--- a/tests/helpers/tooltip.test.js
+++ b/tests/helpers/tooltip.test.js
@@ -74,4 +74,35 @@ describe("initTooltips", () => {
     expect(tip.style.top).toBe(`${window.innerHeight - 10}px`);
     expect(tip.style.left).toBe("0px");
   });
+
+  it("loads tooltip text for new UI elements", async () => {
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({
+        "ui.languageToggle": "toggle",
+        "ui.nextRound": "next",
+        "ui.quitMatch": "quit",
+        "ui.drawCard": "draw"
+      })
+    }));
+
+    const { initTooltips } = await import("../../src/helpers/tooltip.js");
+
+    const ids = ["ui.languageToggle", "ui.nextRound", "ui.quitMatch", "ui.drawCard"];
+    const text = ["toggle", "next", "quit", "draw"];
+    const els = ids.map((id) => {
+      const el = document.createElement("button");
+      el.dataset.tooltipId = id;
+      document.body.appendChild(el);
+      return el;
+    });
+
+    await initTooltips();
+
+    const tip = document.querySelector(".tooltip");
+    els.forEach((el, i) => {
+      el.dispatchEvent(new Event("mouseenter"));
+      expect(tip.textContent).toBe(text[i]);
+      el.dispatchEvent(new Event("mouseleave"));
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- expand tooltip data with language toggle, next round, quit match, and draw card help text
- wire tooltip ids in Meditation and Battle pages
- expose tooltip id for draw button in random judoka page
- test new tooltip entries and usage

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Change log and vectorSearch screenshots differ)*

------
https://chatgpt.com/codex/tasks/task_e_6887f22f1f508326b46f67056025bdbb