### PR TITLE
Flatten tooltip JSON on load

### DIFF
--- a/tests/helpers/tooltip.test.js
+++ b/tests/helpers/tooltip.test.js
@@ -106,3 +106,11 @@ describe("initTooltips", () => {
     });
   });
 });
+
+describe("flattenTooltips", () => {
+  it("flattens nested objects", async () => {
+    const { flattenTooltips } = await import("../../src/helpers/tooltip.js");
+    const result = flattenTooltips({ a: { b: "c" }, d: "e" });
+    expect(result).toEqual({ "a.b": "c", d: "e" });
+  });
+});


### PR DESCRIPTION
## Summary
- add `flattenTooltips` helper for dot-notation keys
- flatten tooltip data in `loadTooltips`
- test the flattening helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68889a824f988326938f6894bd402b5b