### PR TITLE
Remove enableLowConfidenceResults flag

### DIFF
--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -36,8 +36,7 @@ const DEFAULT_SETTINGS = {
     battleDebugPanel: false,
     fullNavigationMap: false,
     enableTestMode: false,
-    enableCardInspector: false,
-    enableLowConfidenceResults: false
+    enableCardInspector: false
   }
 };
 export { DEFAULT_SETTINGS };

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -147,8 +147,7 @@ describe("populateNavbar", () => {
         battleDebugPanel: false,
         fullNavigationMap: true,
         enableTestMode: false,
-        enableCardInspector: false,
-        enableLowConfidenceResults: false
+        enableCardInspector: false
       }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
@@ -206,8 +205,7 @@ describe("populateNavbar", () => {
         battleDebugPanel: false,
         fullNavigationMap: true,
         enableTestMode: false,
-        enableCardInspector: false,
-        enableLowConfidenceResults: false
+        enableCardInspector: false
       }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
@@ -257,8 +255,7 @@ describe("populateNavbar", () => {
         battleDebugPanel: false,
         fullNavigationMap: true,
         enableTestMode: false,
-        enableCardInspector: false,
-        enableLowConfidenceResults: false
+        enableCardInspector: false
       }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -16,8 +16,7 @@ const baseSettings = {
     battleDebugPanel: false,
     fullNavigationMap: true,
     enableTestMode: false,
-    enableCardInspector: false,
-    enableLowConfidenceResults: false
+    enableCardInspector: false
   }
 };
 

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -12,8 +12,7 @@ const baseSettings = {
     battleDebugPanel: false,
     fullNavigationMap: true,
     enableTestMode: false,
-    enableCardInspector: false,
-    enableLowConfidenceResults: false
+    enableCardInspector: false
   }
 };
 
@@ -210,8 +209,7 @@ describe("settingsPage module", () => {
       battleDebugPanel: true,
       fullNavigationMap: true,
       enableTestMode: false,
-      enableCardInspector: false,
-      enableLowConfidenceResults: false
+      enableCardInspector: false
     });
   });
 

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -49,8 +49,7 @@ describe("settings utils", () => {
         battleDebugPanel: false,
         fullNavigationMap: false,
         enableTestMode: false,
-        enableCardInspector: false,
-        enableLowConfidenceResults: false
+        enableCardInspector: false
       }
     });
   });
@@ -71,8 +70,7 @@ describe("settings utils", () => {
         battleDebugPanel: false,
         fullNavigationMap: false,
         enableTestMode: false,
-        enableCardInspector: false,
-        enableLowConfidenceResults: false
+        enableCardInspector: false
       }
     };
     const promise = saveSettings(data);
@@ -106,8 +104,7 @@ describe("settings utils", () => {
         battleDebugPanel: false,
         fullNavigationMap: false,
         enableTestMode: false,
-        enableCardInspector: false,
-        enableLowConfidenceResults: false
+        enableCardInspector: false
       }
     });
     Storage.prototype.getItem = originalGetItem;
@@ -156,8 +153,7 @@ describe("settings utils", () => {
           battleDebugPanel: false,
           fullNavigationMap: false,
           enableTestMode: false,
-          enableCardInspector: false,
-          enableLowConfidenceResults: false
+          enableCardInspector: false
         }
       })
     ).rejects.toThrow("fail");
@@ -195,8 +191,7 @@ describe("settings utils", () => {
         battleDebugPanel: false,
         fullNavigationMap: false,
         enableTestMode: false,
-        enableCardInspector: false,
-        enableLowConfidenceResults: false
+        enableCardInspector: false
       }
     };
     const data2 = {
@@ -209,8 +204,7 @@ describe("settings utils", () => {
         battleDebugPanel: false,
         fullNavigationMap: false,
         enableTestMode: false,
-        enableCardInspector: false,
-        enableLowConfidenceResults: false
+        enableCardInspector: false
       }
     };
     saveSettings(data1);


### PR DESCRIPTION
## Summary
- remove `enableLowConfidenceResults` from default settings
- update tests to match new feature flag list

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68889bcb6abc8326ad06b719361890aa