### PR TITLE
Align quit modal style

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -139,6 +139,8 @@ This feedback highlights why Classic Battle is needed now: new players currently
   - Tie or win/loss messages placed centrally.
   - Clear "Next Round" button with distinct state (enabled/disabled).
   - Provide a dedicated "Quit Match" button below the controls.
+    Clicking it opens a confirmation modal styled like the
+    **Restore Defaults** dialog from the Settings page.
   - A small help icon (`#stat-help`) next to the stat buttons displays a tooltip
     explaining how to pick an attribute. The tooltip auto-opens once on first
     visit using `localStorage` to remember the dismissal.

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -59,10 +59,11 @@ describe("classicBattle button handlers", () => {
   });
 
   it("quit button invokes quitMatch", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     document.getElementById("quit-match-button").click();
-    expect(confirmSpy).toHaveBeenCalled();
+    const confirmBtn = document.getElementById("confirm-quit-button");
+    expect(confirmBtn).not.toBeNull();
+    confirmBtn.dispatchEvent(new Event("click"));
     expect(document.querySelector("#round-message").textContent).toMatch(/quit/i);
   });
 });

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -61,22 +61,22 @@ describe("classicBattle match flow", () => {
   });
 
   it("quits match after confirmation", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const { quitMatch } = await import("../../../src/helpers/classicBattle.js");
-    const result = quitMatch();
-    expect(confirmSpy).toHaveBeenCalled();
-    expect(result).toBe(true);
+    quitMatch();
+    const confirmBtn = document.getElementById("confirm-quit-button");
+    expect(confirmBtn).not.toBeNull();
+    confirmBtn.dispatchEvent(new Event("click"));
     expect(document.querySelector("header #round-message").textContent).toMatch(/quit/i);
   });
 
   it("does not quit match when cancel is chosen", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
     const { quitMatch, _resetForTest } = await import("../../../src/helpers/classicBattle.js");
     _resetForTest();
     document.querySelector("#round-message").textContent = "Select your move";
-    const result = quitMatch();
-    expect(confirmSpy).toHaveBeenCalled();
-    expect(result).toBe(false);
+    quitMatch();
+    const cancelBtn = document.getElementById("cancel-quit-button");
+    expect(cancelBtn).not.toBeNull();
+    cancelBtn.dispatchEvent(new Event("click"));
     expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
     expect(document.querySelector("header #score-display").textContent).toBe("You: 0\nOpponent: 0");
   });


### PR DESCRIPTION
## Summary
- style the Quit Match prompt like other modals
- document consistent quit-modal styling
- update unit tests for new confirmation flow

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6888a1bdd3288326ac25bbd94012564e