### PR TITLE
Add tooltip schema

### DIFF
--- a/scripts/validateData.js
+++ b/scripts/validateData.js
@@ -8,6 +8,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
 
 const schemaFiles = await glob("src/schemas/*.schema.json", { cwd: rootDir });
+if (!schemaFiles.includes("src/schemas/tooltips.schema.json")) {
+  schemaFiles.push("src/schemas/tooltips.schema.json");
+}
 
 let hasErrors = false;
 for (const schemaPath of schemaFiles) {

--- a/src/schemas/tooltips.schema.json
+++ b/src/schemas/tooltips.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/tooltips.schema.json",
+  "type": "object",
+  "properties": {
+    "stat": {
+      "type": "object",
+      "description": "Tooltip text for statistic labels.",
+      "additionalProperties": { "type": "string" }
+    },
+    "ui": {
+      "type": "object",
+      "description": "Tooltip text for user interface elements.",
+      "additionalProperties": { "type": "string" }
+    },
+    "mode": {
+      "type": "object",
+      "description": "Tooltip text for game modes.",
+      "additionalProperties": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add tooltip JSON schema
- ensure new schema is used when validating data

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6888a11f20c88326b2f58893b0e5a868