### PR TITLE
Update docs on tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,10 @@ and instructions on updating schemas when data changes.
 
 Add lightweight help text anywhere by tagging elements with
 `data-tooltip-id`. Tooltip text lives in `src/data/tooltips.json`.
-Each page's initialization script must call `initTooltips()` once the DOM
-is ready so hover and focus listeners are attached.
+Entries in this file are grouped by category (such as `stat` or `ui`), so
+IDs use dot notation like `ui.selectStat`. Each page's initialization script
+must call `initTooltips()` once the DOM is ready so hover and focus
+listeners are attached.
 
 ```html
 <button data-tooltip-id="draw-button">Draw</button>

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -76,7 +76,9 @@ Structured gameplay data lives in `src/data`. Matching JSON Schemas in `src/sche
 `src/helpers/tooltip.js` displays contextual help when elements with
 `data-tooltip-id` gain hover or focus. The helper loads text from
 `src/data/tooltips.json` and positions a small popup near the target.
-Initialize it after the DOM is ready so tooltip listeners are attached.
+Entries in `tooltips.json` are grouped by category (for example `stat`
+or `ui`), so IDs use dot notation. Initialize it after the DOM is ready
+so tooltip listeners are attached.
 
 ```html
 <span data-tooltip-id="draw-help">Draw a card</span>

--- a/design/productRequirementsDocuments/prdTooltipSystem.md
+++ b/design/productRequirementsDocuments/prdTooltipSystem.md
@@ -55,7 +55,7 @@ Currently, JU-DO-KON! has no way of surfacing explanatory text in the UI without
 
 ## Acceptance Criteria
 
-- [ ] The system loads `tooltips.json` once at app start and contains at least 10 tooltip entries in key-value format. (**P1: tooltips.json store**)
+ - [ ] The system loads `tooltips.json` once at app start. Entries are grouped by category (for example `stat.power` or `ui.selectStat`). (**P1: tooltips.json store**)
 - [ ] Hovering an element with `data-tooltip-id="stat.kumikata"` displays a tooltip with the parsed value from `tooltips.json`. (**P1: data-tooltip-id hook**)
 - [ ] Tooltip supports: `**bold**` as `<strong>`, `_italic_` as `<em>`, and `\n` as line breaks. (**P1: Markdown-like formatting**)
 - [ ] Tooltip appears within **150ms** of hover and is positioned relative to the element (bottom-left preferred). (**P1: Positioning logic**)


### PR DESCRIPTION
## Summary
- clarify tooltip categories in README and architecture docs
- mention nested categories in tooltip PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6888a9a2683c8326a564e4350c7aade3