### PR TITLE
Add tests for seeded randomness and classic battle flag

### DIFF
--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -43,3 +43,36 @@ describe("classicBattlePage stat help tooltip", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 });
+
+describe("classicBattlePage test mode flag", () => {
+  it("applies data attribute and banner visibility when enabled", async () => {
+    const startRound = vi.fn();
+    const waitForComputerCard = vi.fn();
+    const loadSettings = vi.fn().mockResolvedValue({ featureFlags: { enableTestMode: true } });
+    const initTooltips = vi.fn().mockResolvedValue();
+    const setTestMode = vi.fn();
+
+    vi.doMock("../../src/helpers/classicBattle.js", () => ({
+      startRound,
+      handleStatSelection: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
+    vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
+    vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
+
+    const battleArea = document.createElement("div");
+    battleArea.id = "battle-area";
+    const banner = document.createElement("div");
+    banner.id = "test-mode-banner";
+    banner.className = "hidden";
+    document.body.append(battleArea, banner);
+
+    const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
+    await setupClassicBattlePage();
+
+    expect(battleArea.dataset.testMode).toBe("true");
+    expect(banner.classList.contains("hidden")).toBe(false);
+    expect(setTestMode).toHaveBeenCalledWith(true);
+  });
+});

--- a/tests/helpers/testModeUtils.test.js
+++ b/tests/helpers/testModeUtils.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import { seededRandom, setTestMode } from "../../src/helpers/testModeUtils.js";
+
+describe("testModeUtils", () => {
+  it("returns reproducible sequences in test mode", () => {
+    setTestMode(true, 5);
+    const seq1 = [seededRandom(), seededRandom(), seededRandom()];
+    setTestMode(true, 5);
+    const seq2 = [seededRandom(), seededRandom(), seededRandom()];
+    expect(seq2).toEqual(seq1);
+  });
+
+  it("uses Math.random when test mode is disabled", () => {
+    const original = Math.random;
+    const spy = vi.fn(() => 0.42);
+    Math.random = spy;
+    setTestMode(false);
+    const value = seededRandom();
+    Math.random = original;
+    expect(spy).toHaveBeenCalled();
+    expect(value).toBe(0.42);
+  });
+});


### PR DESCRIPTION
## Summary
- test seededRandom reproducibility and fallback to Math.random
- verify test mode flag in `setupClassicBattlePage`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Screenshot suite › screenshot /src/pages/vectorSearch.html)*

------
https://chatgpt.com/codex/tasks/task_e_6888ba45da4883268f13347f885b0a1a