### PR TITLE
Add markdownToHtml helper

### DIFF
--- a/src/helpers/markdownToHtml.js
+++ b/src/helpers/markdownToHtml.js
@@ -1,0 +1,17 @@
+import { marked } from "../vendor/marked.esm.js";
+
+/**
+ * Convert Markdown text to HTML using the marked parser.
+ *
+ * @pseudocode
+ * 1. Normalize the input text:
+ *    - Use an empty string when `text` is null or undefined.
+ * 2. Parse the Markdown using `marked.parse`.
+ * 3. Return the generated HTML string.
+ *
+ * @param {string} [text] - Markdown content to convert.
+ * @returns {string} HTML string produced by `marked`.
+ */
+export function markdownToHtml(text) {
+  return marked.parse(text || "");
+}

--- a/tests/helpers/markdownToHtml.test.js
+++ b/tests/helpers/markdownToHtml.test.js
@@ -1,0 +1,18 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { markdownToHtml } from "../../src/helpers/markdownToHtml.js";
+import { marked } from "../../src/vendor/marked.esm.js";
+
+describe("markdownToHtml", () => {
+  it("converts markdown to HTML", () => {
+    const md = "**bold** text";
+    expect(markdownToHtml(md)).toBe(marked.parse(md));
+  });
+
+  it("handles empty or null input", () => {
+    const empty = marked.parse("");
+    expect(markdownToHtml("")).toBe(empty);
+    expect(markdownToHtml(null)).toBe(empty);
+    expect(markdownToHtml()).toBe(empty);
+  });
+});


### PR DESCRIPTION
## Summary
- add helper to convert markdown to HTML
- test markdownToHtml conversion and default behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6888c4794c188326aafac3b8399b1ce0