### PR TITLE
Update PRD reader to use markdownToHtml

### DIFF
--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -1,5 +1,5 @@
 import { onDomReady } from "./domReady.js";
-import { marked } from "../vendor/marked.esm.js";
+import { markdownToHtml } from "./markdownToHtml.js";
 import { initTooltips } from "./tooltip.js";
 
 /**
@@ -7,18 +7,16 @@ import { initTooltips } from "./tooltip.js";
  *
  * @pseudocode
  * 1. Load all markdown files from the PRD directory using `import.meta.glob`.
- * 2. Convert each file to HTML with `marked.parse`.
+ * 2. Convert each file to HTML with `parserFn` (defaults to `markdownToHtml`).
  * 3. Display the first document inside the content container.
  * 4. Provide next/previous navigation with wrap-around.
  *    - Attach click handlers to all navigation buttons.
  * 5. Support arrow key and swipe gestures for navigation.
  *
  * @param {Record<string, string>} [docsMap] Optional preloaded docs for testing.
- * @param {{parse: Function}} [markedLib] Optional marked instance for testing.
+ * @param {Function} [parserFn=markdownToHtml] Parser used to convert Markdown to HTML.
  */
-export async function setupPrdReaderPage(docsMap, markedLib) {
-  const parser = markedLib || marked;
-
+export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
   const PRD_DIR = new URL("../../design/productRequirementsDocuments/", import.meta.url).href;
 
   const FILES = docsMap
@@ -52,13 +50,13 @@ export async function setupPrdReaderPage(docsMap, markedLib) {
   const documents = [];
   if (docsMap) {
     for (const name of FILES) {
-      if (docsMap[name]) documents.push(parser.parse(docsMap[name]));
+      if (docsMap[name]) documents.push(parserFn(docsMap[name]));
     }
   } else {
     for (const name of FILES) {
       const res = await fetch(`${PRD_DIR}${name}`);
       const text = await res.text();
-      documents.push(parser.parse(text));
+      documents.push(parserFn(text));
     }
   }
   const container = document.getElementById("prd-content");

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -6,7 +6,7 @@ describe("prdReaderPage", () => {
       "file1.md": "# First doc",
       "file2.md": "# Second doc"
     };
-    const marked = { parse: (md) => `<h1>${md}</h1>` };
+    const parser = (md) => `<h1>${md}</h1>`;
 
     document.body.innerHTML = `
       <div id="prd-content"></div>
@@ -19,7 +19,7 @@ describe("prdReaderPage", () => {
     globalThis.SKIP_PRD_AUTO_INIT = true;
     const { setupPrdReaderPage } = await import("../../src/helpers/prdReaderPage.js");
 
-    await setupPrdReaderPage(docs, marked);
+    await setupPrdReaderPage(docs, parser);
 
     const container = document.getElementById("prd-content");
     const nextBtns = document.querySelectorAll('[data-nav="next"]');


### PR DESCRIPTION
## Summary
- import `markdownToHtml` helper in the PRD reader
- default `setupPrdReaderPage` parser argument to `markdownToHtml`
- update unit test to supply custom parser

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6888c7b2882c8326943d7f1de0489c8f