### PR TITLE
Fix JSON syntax in gokyo schema

### DIFF
--- a/src/schemas/gokyo.schema.json
+++ b/src/schemas/gokyo.schema.json
@@ -20,13 +20,13 @@
       },
       "category": {
         "type": "string",
-        "description": "The main category of the technique."
-        "enum": ["Nage-waza", "Katame-waza"],
+        "description": "The main category of the technique.",
+        "enum": ["Nage-waza", "Katame-waza"]
       },
       "subCategory": {
         "type": "string",
-        "description": "The subcategory of the technique."
-        "enum": ["Te-waza", "Koshi-waza", "Ashi-waza", "Ma-sutemi-waza", "Yoko-sutemi-waza", "Osae-komi-waza", "Shime-waza", "Kansetsu-waza"],
+        "description": "The subcategory of the technique.",
+        "enum": ["Te-waza", "Koshi-waza", "Ashi-waza", "Ma-sutemi-waza", "Yoko-sutemi-waza", "Osae-komi-waza", "Shime-waza", "Kansetsu-waza"]
       },
       "description": {
         "type": "string",


### PR DESCRIPTION
## Summary
- remove trailing commas in `gokyo.schema.json`

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package `@eslint/js`)*
- `npx vitest run` *(fails: 403 Forbidden to fetch `vitest`)*
- `npx playwright test` *(fails: 403 Forbidden to fetch `playwright`)*

------
https://chatgpt.com/codex/tasks/task_e_6888cb5114908326ae18c4f27cc33d38