### PR TITLE
Fix non-goals placement

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -38,6 +38,12 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - **Ensure all round messages, timers, and score are surfaced via the Info Bar (see prdBattleInfoBar.md) for clarity and accessibility.**
 
 ---
+## Non-Goals
+
+- Online multiplayer battles.
+- Adjustable timer settings for stat selection (may be considered in future versions).
+
+---
 
 ## User Stories
 
@@ -154,12 +160,6 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 ---
 
-## Non-Goals
-
-- Online multiplayer battles.
-- Adjustable timer settings for stat selection (may be considered in future versions).
-
----
 
 ## Dependencies
 

--- a/design/productRequirementsDocuments/prdCountryPickerFilter.md
+++ b/design/productRequirementsDocuments/prdCountryPickerFilter.md
@@ -31,6 +31,12 @@ This issue is timely as our player base is expanding internationally, and region
 - Ensure full accessibility compliance (see Accessibility section).
 
 ---
+## Non-Goals
+
+- Does not cover creation of new flag assets outside the existing judoka roster.
+- Omits multi-country selection to keep interactions simple.
+
+---
 
 ## User Stories
 
@@ -146,12 +152,6 @@ On in-scope screens (e.g., the Browse Judoka screen), there should be an option 
 
 ---
 
-## Non-Goals
-
-- Does not cover creation of new flag assets outside the existing judoka roster.
-- Omits multi-country selection to keep interactions simple.
-
----
 
 ## Dependencies and Integrations
 

--- a/design/productRequirementsDocuments/prdDrawRandomCard.md
+++ b/design/productRequirementsDocuments/prdDrawRandomCard.md
@@ -112,6 +112,14 @@ Motion** enabled, ensuring the card appears instantly without movement.
 - Allow players sensitive to motion to control animation settings for comfort.
 
 ---
+## Non-Goals
+
+- Balancing or adjusting card rarity odds.
+- Complex particle effects or 3D animations.
+- Deck customization, trading, or collection management.
+- Expansive sound design beyond a simple chime.
+
+---
 
 ## Draw Card Flow
 
@@ -134,14 +142,6 @@ Motion** enabled, ensuring the card appears instantly without movement.
 
 ---
 
-## Non-Goals
-
-- Balancing or adjusting card rarity odds.
-- Complex particle effects or 3D animations.
-- Deck customization, trading, or collection management.
-- Expansive sound design beyond a simple chime.
-
----
 
 ## Prioritized Functional Requirements
 

--- a/design/productRequirementsDocuments/prdHomePageNavigation.md
+++ b/design/productRequirementsDocuments/prdHomePageNavigation.md
@@ -37,6 +37,12 @@ The list of available modes is defined in `gameModes.json`. `navigationItems.jso
 - Navigate easily regardless of device or ability.
 
 ---
+## Non-Goals
+
+- The home page will not expose account or profile management.
+- Advanced battle or team composition settings are out of scope.
+
+---
 
 ## User Stories
 
@@ -158,12 +164,6 @@ Each tile contains:
 
 ---
 
-## Non-Goals
-
-- The home page will not expose account or profile management.
-- Advanced battle or team composition settings are out of scope.
-
----
 
 ## Non-Functional Requirements
 

--- a/design/productRequirementsDocuments/prdMeditationScreen.md
+++ b/design/productRequirementsDocuments/prdMeditationScreen.md
@@ -41,6 +41,14 @@ Players benefit from rhythm and pacing. Periods of calm after periods of intensi
 - Offer an experience that aligns with judo’s real-world ethos of reflection.
 
 ---
+## Non-Goals
+
+- No guided meditation instruction, breathing audio, or meditation music.
+- No translation of the entire UI into Japanese or other languages (quotes only).
+- Not intended to replace existing downtime screens outside the Meditation feature.
+- No scoring, competitive mechanics, or gamification within the meditation screen.
+
+---
 
 ## User Stories
 
@@ -74,14 +82,6 @@ Players benefit from rhythm and pacing. Periods of calm after periods of intensi
 
 ---
 
-## Non-Goals
-
-- No guided meditation instruction, breathing audio, or meditation music.
-- No translation of the entire UI into Japanese or other languages (quotes only).
-- Not intended to replace existing downtime screens outside the Meditation feature.
-- No scoring, competitive mechanics, or gamification within the meditation screen.
-
----
 
 ## Dependencies / Integrations
 

--- a/design/productRequirementsDocuments/prdNavigationMap.md
+++ b/design/productRequirementsDocuments/prdNavigationMap.md
@@ -26,6 +26,13 @@ Currently, the menu is purely functional but lacks the thematic cohesion that dr
 - Allow quick, frustration-free discovery of all game modes (**reach destination in ≤3 s**).
 
 ---
+## Non-Goals
+
+- No dynamic pathfinding or open-world navigation beyond the village map.
+- Does not introduce multiplayer map interactions.
+- Excludes voice-over or cutscene content.
+
+---
 
 ## User Stories
 
@@ -154,13 +161,6 @@ Currently, the menu is purely functional but lacks the thematic cohesion that dr
 
 ---
 
-## Non-Goals
-
-- No dynamic pathfinding or open-world navigation beyond the village map.
-- Does not introduce multiplayer map interactions.
-- Excludes voice-over or cutscene content.
-
----
 
 ## Dependencies & Integrations
 

--- a/design/productRequirementsDocuments/prdPseudoJapanese.md
+++ b/design/productRequirementsDocuments/prdPseudoJapanese.md
@@ -29,6 +29,13 @@ As this game is about a Japanese martial art, authentic cultural immersion is ke
 - Enable quick, easy switching between English and pseudo-Japanese text (**toggle ≤200 ms**).
 
 ---
+## Non-Goals
+
+- No real Japanese translation or full localization; this feature is purely stylistic and does not provide actual Japanese language output.
+- Not intended for use beyond the Meditation screen.
+- No support for dynamic language packs or runtime localization updates.
+
+---
 
 ## User Stories
 
@@ -122,13 +129,6 @@ Prevents accidental taps and creates distinct flow—finish reading before proce
 
 ---
 
-## Non-Goals
-
-- No real Japanese translation or full localization; this feature is purely stylistic and does not provide actual Japanese language output.
-- Not intended for use beyond the Meditation screen.
-- No support for dynamic language packs or runtime localization updates.
-
----
 
 ## Player Flow
 

--- a/design/productRequirementsDocuments/prdRandomJudoka.md
+++ b/design/productRequirementsDocuments/prdRandomJudoka.md
@@ -36,6 +36,14 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 - ≥80% of players use the Draw button at least once per session in the first week post-launch
 
 ---
+## Non-Goals
+
+- Complex filters or search
+- Persistent card history or logs of previous draws
+- Weighted draws (favoring certain judoka)
+- Advanced filters or rarity-based restrictions
+
+---
 
 ## Prioritized Functional Requirements
 
@@ -60,14 +68,6 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 
 ---
 
-## Non-Goals
-
-- Complex filters or search
-- Persistent card history or logs of previous draws
-- Weighted draws (favoring certain judoka)
-- Advanced filters or rarity-based restrictions
-
----
 
 ## Dependencies
 

--- a/design/productRequirementsDocuments/prdTeamBattleSelection.md
+++ b/design/productRequirementsDocuments/prdTeamBattleSelection.md
@@ -22,6 +22,11 @@ This selection screen is the gateway to the three Team Battle modes:
 - Guide players to choose the correct team battle format.
 
 ---
+## Non-Goals
+
+- Team management or roster editing beyond mode choice.
+
+---
 
 ## User Stories
 
@@ -59,11 +64,6 @@ This selection screen is the gateway to the three Team Battle modes:
 
 ---
 
-## Non-Goals
-
-- Team management or roster editing beyond mode choice.
-
----
 
 ## Dependencies
 

--- a/design/productRequirementsDocuments/prdUpdateJudoka.md
+++ b/design/productRequirementsDocuments/prdUpdateJudoka.md
@@ -33,6 +33,12 @@ This feature will empower players to develop their roster continuously, enhancin
 - **G6:** Decide and implement whether to lock edits once a judoka enters ranked play (pending).
 
 ---
+## Non-Goals
+
+- Full version history or undo/redo for edits is not included.
+- Advanced stat calculation or suggestions are out of scope.
+
+---
 
 ## User Stories
 
@@ -127,12 +133,6 @@ And the form fields refresh with the newest data
 
 ---
 
-## Non-Goals
-
-- Full version history or undo/redo for edits is not included.
-- Advanced stat calculation or suggestions are out of scope.
-
----
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- move `Non-Goals` sections directly after `Goals` in PRDs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6888d16ea1d883269da097c04f6f6f71