### PR TITLE
Load default settings from JSON

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,9 @@ export default defineConfig([
       prettier: prettierPlugin
     },
     languageOptions: {
-      globals: globals.browser
+      globals: globals.browser,
+      ecmaVersion: "latest",
+      sourceType: "module"
     },
     rules: {
       eqeqeq: "error",

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -39,19 +39,7 @@ describe("settings utils", () => {
   it("loads defaults when storage is empty", async () => {
     const { loadSettings } = await import("../../src/helpers/settingsUtils.js");
     const settings = await loadSettings();
-    expect(settings).toEqual({
-      sound: false,
-      motionEffects: true,
-      typewriterEffect: false,
-      displayMode: "light",
-      gameModes: {},
-      featureFlags: {
-        battleDebugPanel: false,
-        fullNavigationMap: false,
-        enableTestMode: false,
-        enableCardInspector: false
-      }
-    });
+    expect(settings).toEqual(DEFAULT_SETTINGS);
   });
 
   /**
@@ -94,19 +82,7 @@ describe("settings utils", () => {
     Storage.prototype.getItem = vi.fn(() => null);
     const { loadSettings } = await import("../../src/helpers/settingsUtils.js");
     const settings = await loadSettings();
-    expect(settings).toEqual({
-      sound: false,
-      motionEffects: true,
-      typewriterEffect: false,
-      displayMode: "light",
-      gameModes: {},
-      featureFlags: {
-        battleDebugPanel: false,
-        fullNavigationMap: false,
-        enableTestMode: false,
-        enableCardInspector: false
-      }
-    });
+    expect(settings).toEqual(DEFAULT_SETTINGS);
     Storage.prototype.getItem = originalGetItem;
   });
 


### PR DESCRIPTION
## Summary
- fetch default settings JSON when needed
- use JSON-derived defaults in unit tests
- configure ESLint for modern syntax

## Testing
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: randomJudoka screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6888d1428f94832695c68d38381f4c01