### PR TITLE
Update docs for markdownToHtml helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 - **CSS3**: For styling and layout.
 - **JavaScript (ES6)**: For game logic and interactivity.
 - **Vite**: For building and bundling the project.
-- **Marked**: Minimal parser used in the PRD reader that now supports nested ordered and unordered lists, bold text, tables, and horizontal rules rendered as `<br/><hr/><br/>` for extra spacing.
+- **markdownToHtml**: Shared Markdown parser built on the minimal **Marked** library. Supports nested ordered and unordered lists, bold text, tables, and horizontal rules rendered as `<br/><hr/><br/>` for extra spacing.
 - **GitHub Pages**: For hosting the live demo.
 
 ## Known Issues

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -33,7 +33,7 @@ initialize page-specific behavior. The change log view uses
 `src/helpers/prdReaderPage.js` to display the Product Requirements
 Documents. The Markdown files live in
 `design/productRequirementsDocuments`. The helper fetches each file,
-parses it through the **Marked** library (supporting headings, paragraphs, bold text, mixed ordered and unordered lists, tables, and horizontal rules rendered as `<br/><hr/><br/>` for extra spacing) and injects the HTML into the
+converts it with `markdownToHtml`—a wrapper around the minimal **Marked** parser (supporting headings, paragraphs, bold text, mixed ordered and unordered lists, tables, and horizontal rules rendered as `<br/><hr/><br/>` for extra spacing)—and injects the HTML into the
 `#prd-content` container. Buttons marked with `data-nav="prev"` or `data-nav="next"`
 appear in both the header and footer. Arrow keys and swipe gestures cycle through
 the loaded documents. A Home button in the header returns to `index.html`.

--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -88,7 +88,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
 ## Dependencies and Open Questions
 
-- Depends on the `marked` library for markdown parsing.
+- Depends on the `markdownToHtml` helper for markdown parsing (uses the `marked` library).
 - Requires an up-to-date file list from the `design/productRequirementsDocuments` directory.
 - **Open:** Should the viewer support deep-linking to specific PRDs via URL hash or query parameters? This affects navigation and state restoration.
 

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -161,6 +161,7 @@ No user settings or toggles are included. This is appropriate since the feature 
 - Sentence embedding model (e.g. `all-MiniLM-L6-v2`, or simulated offline)
 - JSON corpus (e.g. `tooltips.json`, PRDs, `judoka.json`)
 - Cosine similarity JS implementation
+- `markdownToHtml` helper to display markdown chunks in the browser demo
 
 ### Open Questions:
 


### PR DESCRIPTION
## Summary
- update architecture docs with new markdownToHtml helper
- update PRD viewer dependencies section
- note helper in vector database PRD
- clarify README tech section

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6888d51276cc8326b75a3076e5c7d0f1