### PR TITLE
Add randomStatMode feature flag

### DIFF
--- a/src/data/featureFlags.json
+++ b/src/data/featureFlags.json
@@ -33,5 +33,12 @@
     "label": "Card Of The Day",
     "description": "A valid judoka card appears on the landing screen and the featured card changes once every 24 hours",
     "defaultState": false
+  },
+  {
+    "id": 6,
+    "name": "randomStatMode",
+    "label": "Random Stat Mode",
+    "description": "Classic Battle selects a random stat each round instead of allowing manual choice",
+    "defaultState": false
   }
 ]

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -5,6 +5,7 @@
   "displayMode": "light",
   "gameModes": {},
   "featureFlags": {
+    "randomStatMode": false,
     "battleDebugPanel": false,
     "fullNavigationMap": false,
     "enableTestMode": false,

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -33,6 +33,7 @@ const DEFAULT_SETTINGS = {
   displayMode: "light",
   gameModes: {},
   featureFlags: {
+    randomStatMode: false,
     battleDebugPanel: false,
     fullNavigationMap: false,
     enableTestMode: false,

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -46,6 +46,7 @@ describe("settings utils", () => {
       displayMode: "light",
       gameModes: {},
       featureFlags: {
+        randomStatMode: false,
         battleDebugPanel: false,
         fullNavigationMap: false,
         enableTestMode: false,
@@ -67,6 +68,7 @@ describe("settings utils", () => {
       displayMode: "dark",
       gameModes: {},
       featureFlags: {
+        randomStatMode: false,
         battleDebugPanel: false,
         fullNavigationMap: false,
         enableTestMode: false,
@@ -101,6 +103,7 @@ describe("settings utils", () => {
       displayMode: "light",
       gameModes: {},
       featureFlags: {
+        randomStatMode: false,
         battleDebugPanel: false,
         fullNavigationMap: false,
         enableTestMode: false,
@@ -150,6 +153,7 @@ describe("settings utils", () => {
         displayMode: "light",
         gameModes: {},
         featureFlags: {
+          randomStatMode: false,
           battleDebugPanel: false,
           fullNavigationMap: false,
           enableTestMode: false,
@@ -188,6 +192,7 @@ describe("settings utils", () => {
       displayMode: "light",
       gameModes: {},
       featureFlags: {
+        randomStatMode: false,
         battleDebugPanel: false,
         fullNavigationMap: false,
         enableTestMode: false,
@@ -201,6 +206,7 @@ describe("settings utils", () => {
       displayMode: "dark",
       gameModes: {},
       featureFlags: {
+        randomStatMode: false,
         battleDebugPanel: false,
         fullNavigationMap: false,
         enableTestMode: false,


### PR DESCRIPTION
## Summary
- include `randomStatMode` default in settings
- document the flag in featureFlags list
- update settings utils and tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6888d54e899c8326b0ae7af6f02416e7