### PR TITLE
Add shared country code and weight class enums

### DIFF
--- a/src/data/countryCodeMapping.json
+++ b/src/data/countryCodeMapping.json
@@ -102,6 +102,12 @@
     "active": true
   },
   {
+    "country": "Bhutan",
+    "code": "bt",
+    "lastUpdated": "2025-04-23T10:00:00Z",
+    "active": true
+  },
+  {
     "country": "Jamaica",
     "code": "jm",
     "lastUpdated": "2025-04-23T10:00:00Z",

--- a/src/schemas/commonDefinitions.schema.json
+++ b/src/schemas/commonDefinitions.schema.json
@@ -12,6 +12,51 @@
         "newaza": { "type": "integer" }
       },
       "required": ["power", "speed", "technique", "kumikata", "newaza"]
+    },
+    "CountryCode": {
+      "type": "string",
+      "enum": [
+        "vu",
+        "pt",
+        "fr",
+        "jp",
+        "br",
+        "us",
+        "de",
+        "ru",
+        "kr",
+        "gb",
+        "ca",
+        "it",
+        "es",
+        "nl",
+        "cn",
+        "mn",
+        "ge",
+        "bt",
+        "jm"
+      ],
+      "description": "ISO 3166-1 alpha-2 country codes"
+    },
+    "WeightClass": {
+      "type": "string",
+      "enum": [
+        "-60",
+        "-66",
+        "-73",
+        "-81",
+        "-90",
+        "-100",
+        "+100",
+        "-48",
+        "-52",
+        "-57",
+        "-63",
+        "-70",
+        "-78",
+        "+78"
+      ],
+      "description": "IJF weight class identifiers"
     }
   }
 }

--- a/src/schemas/countryCodeMapping.schema.json
+++ b/src/schemas/countryCodeMapping.schema.json
@@ -10,8 +10,7 @@
         "description": "The name of the country."
       },
       "code": {
-        "type": "string",
-        "pattern": "^[a-z]{2}$",
+        "$ref": "https://judokon.dev/schemas/commonDefinitions.schema.json#/definitions/CountryCode",
         "description": "The country code in ISO 3166-1 alpha-2 format."
       },
       "lastUpdated": {

--- a/src/schemas/judoka.schema.json
+++ b/src/schemas/judoka.schema.json
@@ -21,49 +21,11 @@
       "description": "Country of the judoka."
     },
     "countryCode": {
-      "type": "string",
-      "pattern": "^[a-z]{2}$",
-      "enum": [
-        "vu",
-        "pt",
-        "fr",
-        "jp",
-        "br",
-        "us",
-        "de",
-        "ru",
-        "kr",
-        "gb",
-        "ca",
-        "it",
-        "es",
-        "nl",
-        "cn",
-        "mn",
-        "ge",
-        "bt",
-        "jm"
-      ],
+      "$ref": "https://judokon.dev/schemas/commonDefinitions.schema.json#/definitions/CountryCode",
       "description": "ISO 3166-1 alpha-2 country code."
     },
     "weightClass": {
-      "type": "string",
-      "enum": [
-        "-60",
-        "-66",
-        "-73",
-        "-81",
-        "-90",
-        "-100",
-        "+100",
-        "-48",
-        "-52",
-        "-57",
-        "-63",
-        "-70",
-        "-78",
-        "+78"
-      ],
+      "$ref": "https://judokon.dev/schemas/commonDefinitions.schema.json#/definitions/WeightClass",
       "description": "Weight class of the judoka."
     },
     "stats": {

--- a/src/schemas/weightCategories.schema.json
+++ b/src/schemas/weightCategories.schema.json
@@ -18,8 +18,7 @@
           "type": "object",
           "properties": {
             "weight": {
-              "type": "string",
-              "pattern": "^[-+]?\\d+$"
+              "$ref": "https://judokon.dev/schemas/commonDefinitions.schema.json#/definitions/WeightClass"
             },
             "descriptor": {
               "type": "string"


### PR DESCRIPTION
## Summary
- extend commonDefinitions with `CountryCode` and `WeightClass` definitions
- reference new definitions in judoka.schema
- update countryCodeMapping and weightCategories schemas
- add Bhutan entry to countryCodeMapping data

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6888d5659fbc83269aee884a8b3d8ed0