### PR TITLE
Add markdownToHtml tests

### DIFF
--- a/src/helpers/markdownToHtml.js
+++ b/src/helpers/markdownToHtml.js
@@ -4,14 +4,15 @@ import { marked } from "../vendor/marked.esm.js";
  * Convert Markdown text to HTML using the marked parser.
  *
  * @pseudocode
- * 1. Normalize the input text:
- *    - Use an empty string when `text` is null or undefined.
- * 2. Parse the Markdown using `marked.parse`.
+ * 1. If `text` is empty, null or undefined:
+ *    - Return an empty string.
+ * 2. Otherwise, parse the Markdown using `marked.parse`.
  * 3. Return the generated HTML string.
  *
  * @param {string} [text] - Markdown content to convert.
  * @returns {string} HTML string produced by `marked`.
  */
 export function markdownToHtml(text) {
-  return marked.parse(text || "");
+  if (!text) return "";
+  return marked.parse(text);
 }

--- a/tests/helpers/markdownToHtml.test.js
+++ b/tests/helpers/markdownToHtml.test.js
@@ -4,15 +4,29 @@ import { markdownToHtml } from "../../src/helpers/markdownToHtml.js";
 import { marked } from "../../src/vendor/marked.esm.js";
 
 describe("markdownToHtml", () => {
-  it("converts markdown to HTML", () => {
+  it("converts headings", () => {
+    const md = "# Title";
+    expect(markdownToHtml(md)).toBe(marked.parse(md));
+  });
+
+  it("converts bold text", () => {
     const md = "**bold** text";
     expect(markdownToHtml(md)).toBe(marked.parse(md));
   });
 
+  it("converts lists", () => {
+    const md = "- one\n- two";
+    expect(markdownToHtml(md)).toBe(marked.parse(md));
+  });
+
+  it("converts tables", () => {
+    const md = "| a | b |\n| --- | --- |\n| c | d |";
+    expect(markdownToHtml(md)).toBe(marked.parse(md));
+  });
+
   it("handles empty or null input", () => {
-    const empty = marked.parse("");
-    expect(markdownToHtml("")).toBe(empty);
-    expect(markdownToHtml(null)).toBe(empty);
-    expect(markdownToHtml()).toBe(empty);
+    expect(markdownToHtml("")).toBe("");
+    expect(markdownToHtml(null)).toBe("");
+    expect(markdownToHtml()).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- refine `markdownToHtml` to return an empty string when input is empty
- add table, list, heading and bold text checks in `markdownToHtml.test.js`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot comparison for randomJudoka page)*

------
https://chatgpt.com/codex/tasks/task_e_6888d9bb58f08326a21f8c1b76d473a7