### PR TITLE
Add tag filter and embedding stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ higher value, for example
 - The page displays “Embeddings could not be loaded – please check console.” if loading fails, or “No close matches found” when nothing is returned.
 - Users can submit the form by pressing **Enter** in the search box.
 - The search page provides a tag filter dropdown so you can limit results to PRDs, tooltips, character data, or a particular intent tag.
+- A statistics line in the header displays how many embeddings are loaded based on `client_embeddings.meta.json`.
 - Agent scripts can import `findMatches` from `src/helpers/vectorSearch.js` to query embeddings programmatically.
 - The transformer library is loaded from jsDelivr on first use, so network connectivity is required for that initial download.
 

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -88,6 +88,7 @@ than an entire file.
 - [x] Agent prompt templates are provided with guidance on embedding format and retrieval usage
 - [x] Agents can request adjacent chunks or the full document by passing the result `id` to `fetchContextById`
 - [x] Search function accepts optional tag filters so agents can restrict matches to specific categories
+- [x] Vector search UI displays how many embeddings are loaded using the meta file
 - [x] The system handles malformed or missing embeddings gracefully (e.g. logs a warning or returns empty result)
 - [x] The `client_embeddings.json` file stays under the 3.6MB threshold to ensure quick page load and GitHub Pages compatibility
 - [ ] Match text longer than 200 characters is truncated in the UI with a "Show
@@ -195,8 +196,9 @@ No user settings or toggles are included. This is appropriate since the feature 
   - [ ] 4.1 Design and implement offline query UI
   - [ ] 4.2 Add keyboard accessibility and result display
   - [ ] 4.3 Provide example queries with results
-    - [ ] 4.4 Add tag filter controls so users or agents can restrict results by source or topic
+    - [x] 4.4 Add tag filter controls so users or agents can restrict results by source or topic
     - [ ] 4.5 Truncate long matches in the results table and provide a "Show more" toggle
+    - [x] 4.6 Show embedding count from the meta file in the UI header
 
 - [ ] 5.0 Agent Integration and Demos
 

--- a/src/pages/vectorSearch.html
+++ b/src/pages/vectorSearch.html
@@ -34,9 +34,11 @@
 
       <main class="container vector-search-container" role="main">
         <h1>Vector Search</h1>
+        <p id="embedding-stats" class="small-text"></p>
         <form id="vector-search-form" role="search" class="search-form">
           <label for="vector-search-input" class="visually-hidden">Search</label>
           <input id="vector-search-input" type="search" placeholder="Enter query" required />
+          <select id="tag-filter" aria-label="Tag filter"></select>
           <button id="vector-search-btn" type="submit">Search</button>
         </form>
         <p class="small-text" id="context-note">


### PR DESCRIPTION
## Summary
- display embedding count in vector search page
- add tag filtering functionality
- document new UI elements
- test tag filter and stats initialization

## Testing
- `npx prettier tests/helpers/vectorSearchPage.test.js src/helpers/vectorSearchPage.js README.md design/productRequirementsDocuments/prdVectorDatabaseRAG.md --write`
- `npx eslint .`
- `npx vitest run` *(fails: fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888da0806888326be581abba08f0769