### PR TITLE
Fix default settings load in tests

### DIFF
--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -48,11 +48,12 @@ export async function loadDefaultSettings() {
       })
       .catch(async () => {
         const { readFile } = await import("fs/promises");
+        const { fileURLToPath } = await import("node:url");
         let filePath = new URL("../data/settings.json", import.meta.url);
         if (filePath.protocol !== "file:") {
           filePath = new URL("./src/data/settings.json", `file://${process.cwd()}/`);
         }
-        const file = await readFile(filePath, "utf8");
+        const file = await readFile(fileURLToPath(filePath), "utf8");
         return JSON.parse(file);
       });
   }


### PR DESCRIPTION
## Summary
- ensure fallback file reading works in jsdom

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6888dc8dcfd88326bc00e7ae7b44273a