### PR TITLE
Update docs for unified settings data

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Light, dark and gray themes are supported. See [prdSettingsMenu.md](design/produ
 ## Settings & Feature Flags
 
 The Settings page (`src/pages/settings.html`) groups all player preferences, including experimental **feature flags**. Toggle a flag to enable an optional feature without modifying code. Flag values persist across pages and apply immediately. Implementation guidelines live in [settingsPageDesignGuidelines.md](design/codeStandards/settingsPageDesignGuidelines.md#feature-flags--agent-observability).
+Default flag states and descriptions now live in `src/data/settings.json`.
 
 Battle pages include a collapsible debug panel. Enable the **Battle Debug Panel** feature flag in **Settings** to reveal real-time match state in a `<pre>` element. The panel is keyboard accessible and hidden by default so normal gameplay remains unaffected.
 Toggle the **Full Navigation Map** flag to display a map overlay with links to all pages for easier orientation during testing.

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -83,6 +83,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 ## Data & Persistence
 
 - The Settings page **must pull current states** from data sources (`settings.json`, `gameModes.json`, and `navigationItems.json`) on load.
+- Feature flag descriptions and default values live in `settings.json` with the other settings.
 - `gameModes.json` defines all available modes, while `navigationItems.json` references each by `id` to control order and hidden status.
 - Changes should trigger **immediate data writes** without requiring a “Save Changes” button.
 - All live updates must persist across page refreshes within the same session.


### PR DESCRIPTION
## Summary
- mention new default flag location in Settings & Feature Flags docs
- reference settings.json instead of featureFlags.json in PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_6888dc98e9688326a3e40778fb905b28