### PR TITLE
Fix default settings loader

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -5,7 +5,6 @@
   "displayMode": "light",
   "gameModes": {},
   "featureFlags": {
-<<<<<<< HEAD
     "battleDebugPanel": {
       "enabled": false,
       "label": "Battle Debug Panel",
@@ -31,12 +30,5 @@
       "label": "Card Of The Day",
       "description": "Displays a rotating featured judoka card on the landing screen"
     }
-=======
-    "battleDebugPanel": false,
-    "randomStatMode": false,
-    "fullNavigationMap": false,
-    "enableTestMode": false,
-    "enableCardInspector": false
->>>>>>> main
   }
 }

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -46,16 +46,9 @@ export async function loadDefaultSettings() {
         }
         return response.json();
       })
-      .catch(async () => {
-        const { readFile } = await import("fs/promises");
-        const { fileURLToPath } = await import("node:url");
-        let filePath = new URL("../data/settings.json", import.meta.url);
-        if (filePath.protocol !== "file:") {
-          filePath = new URL("./src/data/settings.json", `file://${process.cwd()}/`);
-        }
-        const file = await readFile(fileURLToPath(filePath), "utf8");
-        return JSON.parse(file);
-      });
+      .catch(
+        async () => (await import("../data/settings.json", { assert: { type: "json" } })).default
+      );
   }
   const data = await defaultSettingsPromise;
   if (Object.keys(DEFAULT_SETTINGS).length === 0) {


### PR DESCRIPTION
## Summary
- clean up merge conflict in `settings.json`
- simplify fallback in `loadDefaultSettings` to dynamically import JSON

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6888e0c8e67483268d49efa28e7b672f