### PR TITLE
Highlight search terms in vector search

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ higher value, for example
 - Both the generation script and the search page use **mean pooled** embeddings so the query vector matches the stored vectors.
 
 - Results appear below the form with up to five entries that show match score, source, and tags. Each entry also displays a short `qaContext` snippet when available.
+- Query terms are highlighted within each snippet so matches stand out.
 - Search results are displayed in a responsive table with alternating row colors for readability.
 - The Match column takes up more space than Source, Tags, and Score so the text is easier to read.
 - The Tags column lists the categories provided in `client_embeddings.json`.


### PR DESCRIPTION
## Summary
- add `highlightTerms` helper to emphasize query tokens
- highlight tokens when creating snippet elements in vector search page
- test highlighting logic
- document snippet highlighting in the README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Module "file:///workspace/judokon/src/data/settings.json" needs an import attribute of "type: json")*

------
https://chatgpt.com/codex/tasks/task_e_6888e39814908326907877657f4cdfd5