### PR TITLE
Add schema and cross-file test for Aesop metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ npx ajv validate -s src/schemas/judoka.schema.json -d src/data/judoka.json
 ```
 
 See [design/dataSchemas/README.md](design/dataSchemas/README.md) for full details
-and instructions on updating schemas when data changes.
+and instructions on updating schemas when data changes. Additional tests ensure that every entry in `aesopsMeta.json` corresponds to an ID in `aesopsFables.json`.
 
 ## Tooltip Helper
 

--- a/design/dataSchemas/README.md
+++ b/design/dataSchemas/README.md
@@ -10,7 +10,7 @@ Run `npm run validate:data` to check all schema and data pairs at once. The comm
 npx ajv validate -s src/schemas/judoka.schema.json -d src/data/judoka.json
 ```
 
-Run the command for every pair of schema and data file (e.g. `gameModes`, `weightCategories`). The CLI reports any mismatches so they can be fixed before runtime. A new schema, `navigationItems.schema.json`, validates the structure of `navigationItems.json` which drives navigation order and visibility.
+Run the command for every pair of schema and data file (e.g. `gameModes`, `weightCategories`). The CLI reports any mismatches so they can be fixed before runtime. A new schema, `navigationItems.schema.json`, validates the structure of `navigationItems.json` which drives navigation order and visibility. Another schema, `aesopsMeta.schema.json`, describes the quote metadata file used on the meditation screen. Tests also verify that each ID in `aesopsMeta.json` exists in `aesopsFables.json`.
 
 ## Updating Schemas
 

--- a/src/schemas/aesopsMeta.schema.json
+++ b/src/schemas/aesopsMeta.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/aesopsMeta.schema.json",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "integer",
+        "description": "Unique identifier for the fable."
+      },
+      "title": {
+        "type": "string",
+        "description": "Title of the fable."
+      },
+      "tags": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "readingTime": { "type": "string" },
+      "moral": { "type": "string" },
+      "haiku": { "type": "string" }
+    },
+    "required": ["id", "title", "tags", "readingTime", "moral", "haiku"],
+    "additionalProperties": false
+  }
+}

--- a/tests/data/aesopsMetaCrossCheck.test.js
+++ b/tests/data/aesopsMetaCrossCheck.test.js
@@ -1,0 +1,26 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFile } from "fs/promises";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dataDir = path.resolve(__dirname, "../../src/data");
+
+async function loadJson(name) {
+  const file = path.join(dataDir, name);
+  return JSON.parse(await readFile(file, "utf8"));
+}
+
+describe("aesopsMeta cross-file consistency", () => {
+  it("each meta id exists in aesopsFables.json", async () => {
+    const [fables, meta] = await Promise.all([
+      loadJson("aesopsFables.json"),
+      loadJson("aesopsMeta.json")
+    ]);
+    const fableIds = new Set(fables.map((f) => f.id));
+    for (const entry of meta) {
+      expect(fableIds.has(entry.id)).toBe(true);
+    }
+  });
+});

--- a/tests/data/schemaValidation.test.js
+++ b/tests/data/schemaValidation.test.js
@@ -17,6 +17,7 @@ const pairs = [
   ["judoka.json", "judoka.schema.json"],
   ["weightCategories.json", "weightCategories.schema.json"],
   ["aesopsFables.json", "aesopsFables.schema.json"],
+  ["aesopsMeta.json", "aesopsMeta.schema.json"],
   ["japaneseConverter.json", "japaneseConverter.schema.json"],
   ["locations.json", "locations.schema.json"],
   ["settings.json", "settings.schema.json"]


### PR DESCRIPTION
## Summary
- add `aesopsMeta.schema.json`
- validate `aesopsMeta.json` in schemaValidation test
- check that each meta entry maps to a fable
- document the new schema and consistency test

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden to registry.npmjs.org)*
- `npx playwright test` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6888e4fd54688326817c7eaf8b9e982f