### PR TITLE
Fix vectorSearchPage test initialization

### DIFF
--- a/tests/helpers/vectorSearchPage.test.js
+++ b/tests/helpers/vectorSearchPage.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 
+// Prevent vectorSearchPage.js from auto-initializing during tests
+vi.doMock("../../src/helpers/domReady.js", () => ({
+  onDomReady: vi.fn()
+}));
+
 /**
  * Unit tests for selectMatches helper in vectorSearchPage.
  */


### PR DESCRIPTION
## Summary
- prevent `vectorSearchPage.js` from initializing automatically when imported in tests by mocking `onDomReady`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888e7da31248326aea4ebafd0549c21