### PR TITLE
Add tooltip ids to StatsPanel

### DIFF
--- a/src/components/StatsPanel.js
+++ b/src/components/StatsPanel.js
@@ -6,7 +6,7 @@
  * 2. Resolve panel classes from the provided `type` and `className` options.
  * 3. Build a `<div>` with class `card-stats` containing a `<ul>` list.
  *    - For each stat key (power, speed, technique, kumikata, newaza)
- *      create an `<li>` with a label and value.
+ *      create an `<li>` with a label, value, and tooltip ID.
  * 4. Apply an accessible `aria-label` to the panel when provided.
  * 5. Return the completed panel element.
  *
@@ -34,11 +34,12 @@ export function createStatsPanel(stats, options = {}) {
 
   const list = document.createElement("ul");
 
-  function addItem(label, value) {
+  function addItem(label, value, id) {
     const li = document.createElement("li");
     li.className = "stat";
     const strong = document.createElement("strong");
     strong.textContent = label;
+    if (id) strong.dataset.tooltipId = `stat.${id}`;
     const span = document.createElement("span");
     span.innerHTML = escapeHTML(value);
     li.append(strong, span);
@@ -46,14 +47,14 @@ export function createStatsPanel(stats, options = {}) {
   }
 
   const statsEntries = [
-    { label: "Power", key: power },
-    { label: "Speed", key: speed },
-    { label: "Technique", key: technique },
-    { label: "Kumi-kata", key: kumikata },
-    { label: "Ne-waza", key: newaza }
+    { label: "Power", key: power, id: "power" },
+    { label: "Speed", key: speed, id: "speed" },
+    { label: "Technique", key: technique, id: "technique" },
+    { label: "Kumi-kata", key: kumikata, id: "kumikata" },
+    { label: "Ne-waza", key: newaza, id: "newaza" }
   ];
 
-  statsEntries.forEach(({ label, key }) => addItem(label, key));
+  statsEntries.forEach(({ label, key, id }) => addItem(label, key, id));
   panel.appendChild(list);
   return panel;
 }

--- a/tests/card/cardBuilder.test.js
+++ b/tests/card/cardBuilder.test.js
@@ -80,11 +80,11 @@ describe("generateCardStats", () => {
 
     const expectedHtml =
       '<div class="card-stats common" aria-label="Judoka Stats"><ul>' +
-      '<li class="stat"><strong>Power</strong><span>9</span></li>' +
-      '<li class="stat"><strong>Speed</strong><span>6</span></li>' +
-      '<li class="stat"><strong>Technique</strong><span>7</span></li>' +
-      '<li class="stat"><strong>Kumi-kata</strong><span>7</span></li>' +
-      '<li class="stat"><strong>Ne-waza</strong><span>8</span></li>' +
+      '<li class="stat"><strong data-tooltip-id="stat.power">Power</strong><span>9</span></li>' +
+      '<li class="stat"><strong data-tooltip-id="stat.speed">Speed</strong><span>6</span></li>' +
+      '<li class="stat"><strong data-tooltip-id="stat.technique">Technique</strong><span>7</span></li>' +
+      '<li class="stat"><strong data-tooltip-id="stat.kumikata">Kumi-kata</strong><span>7</span></li>' +
+      '<li class="stat"><strong data-tooltip-id="stat.newaza">Ne-waza</strong><span>8</span></li>' +
       "</ul></div>";
 
     const result = generateCardStats(card);

--- a/tests/components/StatsPanel.test.js
+++ b/tests/components/StatsPanel.test.js
@@ -16,6 +16,12 @@ describe("createStatsPanel", () => {
     expect(items[0].textContent).toContain("5");
     expect(items[4].textContent).toContain("9");
     expect(panel).toHaveAttribute("aria-label", "Judoka Stats");
+    const labels = panel.querySelectorAll("li.stat > strong");
+    expect(labels[0]).toHaveAttribute("data-tooltip-id", "stat.power");
+    expect(labels[1]).toHaveAttribute("data-tooltip-id", "stat.speed");
+    expect(labels[2]).toHaveAttribute("data-tooltip-id", "stat.technique");
+    expect(labels[3]).toHaveAttribute("data-tooltip-id", "stat.kumikata");
+    expect(labels[4]).toHaveAttribute("data-tooltip-id", "stat.newaza");
   });
 
   it("applies custom type and class", () => {


### PR DESCRIPTION
## Summary
- add `data-tooltip-id` attributes when rendering stat labels
- test StatsPanel tooltip ids
- update cardBuilder stats HTML expectation

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Module needs JSON import attribute)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_6888eb89dcac832687d74e8855bb16ef