### PR TITLE
Highlight top vector search result

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ higher value, for example
 - Results appear below the form with up to five entries that show match score, source, and tags. Each entry also displays a short `qaContext` snippet when available.
 - Query terms are highlighted within each snippet so matches stand out.
 - Search results are displayed in a responsive table with alternating row colors for readability.
+- The top match row is highlighted and scores use green/yellow/grey text based on similarity.
 - The Match column takes up more space than Source, Tags, and Score so the text is easier to read.
 - The Tags column lists the categories provided in `client_embeddings.json`.
 - The Source column wraps file paths at `/` characters so long locations stack vertically.

--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -215,8 +215,9 @@ function createSnippetElement(text, terms = []) {
  *    - When multiple strong matches exist, compare the top two scores and keep
  *      only the first when the difference exceeds `DROP_OFF_THRESHOLD`.
  * 7. Hide the spinner and handle empty or missing embeddings cases.
- * 8. Build a results table, highlighting query terms in each snippet. When no
- *    strong matches exist, show a warning and display up to three weak matches.
+ * 8. Build a results table, highlighting query terms in each snippet.
+ *    - Add a `top-match` class to the first row and color-code the Score cell.
+ *    - When no strong matches exist, show a warning and display up to three weak matches.
  * 9. Attach handlers to load surrounding context on result activation.
  * 10. On error, log the issue, hide the spinner, and display a fallback message.
  *
@@ -269,9 +270,10 @@ export async function handleSearch(event) {
         "\u26A0\uFE0F No strong matches found, but here are the closest matches based on similarity.";
     }
 
-    for (const match of toRender) {
+    for (const [idx, match] of toRender.entries()) {
       const row = document.createElement("tr");
       row.classList.add("search-result-item");
+      if (idx === 0) row.classList.add("top-match");
       row.dataset.id = match.id;
       row.setAttribute("role", "button");
       row.tabIndex = 0;
@@ -300,6 +302,9 @@ export async function handleSearch(event) {
 
       const scoreCell = document.createElement("td");
       scoreCell.textContent = match.score.toFixed(2);
+      if (match.score >= 0.8) scoreCell.classList.add("score-high");
+      else if (match.score >= 0.6) scoreCell.classList.add("score-mid");
+      else scoreCell.classList.add("score-low");
 
       row.append(textCell, sourceCell, tagsCell, scoreCell);
       row.addEventListener("click", () => loadResultContext(row));

--- a/src/styles/vectorSearch.css
+++ b/src/styles/vectorSearch.css
@@ -56,3 +56,20 @@
   text-decoration: underline;
   font: inherit;
 }
+
+.top-match {
+  font-weight: bold;
+  background-color: #fffbe6;
+}
+
+.score-high {
+  color: #0a7a00;
+}
+
+.score-mid {
+  color: #b88600;
+}
+
+.score-low {
+  color: #666666;
+}


### PR DESCRIPTION
## Summary
- mark the first vector search result as `.top-match`
- color-code score cells and style `.top-match`
- document new top-match and score colors in README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Module "file:///workspace/judokon/src/data/settings.json" needs an import attribute of "type: json")*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6888eb7b5f98832696d8264267bb3f06