### PR TITLE
Handle classic battle quit flow

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -117,6 +117,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - If the selected stats are equal, a tie message displays and the round ends.
 - Summary screen shows match result (win/loss/tie), player stats, and option to replay.
 - Player can quit mid-match; confirmation prompt appears; if confirmed, match ends with player loss recorded.
+- After confirming the quit action, the player is returned to the main menu (index.html).
 - If AI difficulty affects stat selection, AI uses correct logic per difficulty setting.
 - Animation flow: transitions between card reveal, stat selection, and result screens complete smoothly without stalling (**each ≤400 ms at ≥60 fps**).
 - Stat buttons reset between rounds so no previous selection remains highlighted. The CSS rule `#stat-buttons button { -webkit-tap-highlight-color: transparent; }` combined with a reflow ensures Safari clears the red touch overlay.

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -73,6 +73,7 @@ function createQuitConfirmation(onConfirm) {
   quit.addEventListener("click", () => {
     onConfirm();
     modal.close();
+    window.location.href = "../../index.html";
   });
   document.body.appendChild(modal.element);
   return modal;
@@ -284,7 +285,7 @@ export async function handleStatSelection(stat) {
  * 1. Display a confirmation dialog.
  * 2. When confirmed, stop the timer and mark the match as ended.
  * 3. Show a loss message in the result area.
- * 4. Return `true` when the player confirms quitting, otherwise `false`.
+ * 4. Redirect the player to the main menu.
  */
 export function quitMatch() {
   if (!quitModal) {

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -26,6 +26,7 @@ vi.mock("../../../src/helpers/utils.js", () => ({
 describe("classicBattle button handlers", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
+    window.location.href = "http://localhost/src/pages/battleJudoka.html";
     const { playerCard, computerCard } = createBattleCardContainers();
     const header = createBattleHeader();
     const nextBtn = document.createElement("button");
@@ -65,5 +66,6 @@ describe("classicBattle button handlers", () => {
     expect(confirmBtn).not.toBeNull();
     confirmBtn.dispatchEvent(new Event("click"));
     expect(document.querySelector("#round-message").textContent).toMatch(/quit/i);
+    expect(window.location.href).toMatch(/index\.html$/);
   });
 });


### PR DESCRIPTION
## Summary
- return to index after confirming Quit Match
- document quit behaviour in Classic Battle PRD
- unit test ensures Quit redirects to index

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails to install dependencies)*
- `npx playwright test` *(fails to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888ecfbc250832691518186e6fd47c9