### PR TITLE
Add tooltip ID to flag image

### DIFF
--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -29,5 +29,8 @@
     "meditation": "**Meditation Mode** lets you reflect and compare cards.\nNo battles, just peaceful analysis.",
     "randomJudoka": "**Random Judoka** picks a random card for quick inspiration.",
     "browseJudoka": "**Browse Judoka** opens the full roster in a carousel."
+  },
+  "card": {
+    "flag": "**Country flag**\nRepresents the judoka’s nation."
   }
 }

--- a/src/helpers/cardTopBar.js
+++ b/src/helpers/cardTopBar.js
@@ -110,6 +110,7 @@ export function createNameContainer(firstname, surname) {
  * @pseudocode
  * 1. Create a `<div>` container:
  *    - Set its `className` to `"card-flag"`.
+ *    - Add a `data-tooltip-id="card.flag"` attribute for tooltips.
  *
  * 2. Create an `<img>` element:
  *    - Set its `src` attribute to `finalFlagUrl` or fallback to `PLACEHOLDER_FLAG_URL`.
@@ -126,6 +127,7 @@ export function createFlagImage(finalFlagUrl, countryName) {
 
   const flagContainer = document.createElement("div");
   flagContainer.className = "card-flag";
+  flagContainer.dataset.tooltipId = "card.flag";
 
   const flagImg = document.createElement("img");
 

--- a/tests/card/cardTopBar.test.js
+++ b/tests/card/cardTopBar.test.js
@@ -30,7 +30,7 @@ describe("generateCardTopBar", () => {
           <span class="firstname">John</span>
           <span class="surname">Doe</span>
         </div>
-        <div class="card-flag">
+        <div class="card-flag" data-tooltip-id="card.flag">
           <img src="../assets/countryFlags/placeholder-flag.png" alt="Unknown flag" loading="lazy" onerror="this.src='../assets/countryFlags/placeholder-flag.png'">
         </div>
       </div>
@@ -153,6 +153,7 @@ describe("createFlagImage", () => {
       `<img src="https://flagcdn.com/w320/us.png" alt="United States flag"`
     );
     expect(flagImage.outerHTML).toContain('loading="lazy"');
+    expect(flagImage.dataset.tooltipId).toBe("card.flag");
   });
 
   it("escapes HTML in country name for alt attribute", () => {

--- a/tests/data/tooltipsEntries.test.js
+++ b/tests/data/tooltipsEntries.test.js
@@ -11,7 +11,7 @@ function get(obj, path) {
 
 describe("tooltips.json", () => {
   it("contains new ui tooltip entries", () => {
-    const keys = ["ui.languageToggle", "ui.nextRound", "ui.quitMatch", "ui.drawCard"];
+    const keys = ["ui.languageToggle", "ui.nextRound", "ui.quitMatch", "ui.drawCard", "card.flag"];
     for (const key of keys) {
       expect(get(tooltips, key)).toBeDefined();
     }


### PR DESCRIPTION
## Summary
- add `data-tooltip-id="card.flag"` on flag container
- document `card.flag` in tooltip data
- test for new tooltip id and verify cardTopBar tip entry

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Module needs import attribute)*

------
https://chatgpt.com/codex/tasks/task_e_6888ed3f5bdc8326b566b732b7b786f2