### PR TITLE
Add navigation tooltip ids

### DIFF
--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -30,6 +30,15 @@
     "randomJudoka": "**Random Judoka** picks a random card for quick inspiration.",
     "browseJudoka": "**Browse Judoka** opens the full roster in a carousel."
   },
+
+  "nav": {
+    "classicBattle": "Begin a head-to-head match.",
+    "randomJudoka": "Show a random judoka card.",
+    "browseJudoka": "Browse every judoka card.",
+    "meditation": "Compare cards at your own pace.",
+    "settings": "Adjust game options.",
+    "home": "Return to the main screen."
+  },
   "card": {
     "flag": "**Country flag**\nRepresents the judoka’s nation.",
     "weightClass": "**Weight class**\nCompetition weight category."

--- a/src/helpers/navigation/navMenu.js
+++ b/src/helpers/navigation/navMenu.js
@@ -1,6 +1,27 @@
 import { validateGameModes } from "./navData.js";
 
 /**
+ * Convert a game mode name to a camelCase key for tooltip ids.
+ *
+ * @pseudocode
+ * 1. Replace non-alphanumeric characters with spaces.
+ * 2. Split into words.
+ * 3. Lowercase the first word and capitalize the rest.
+ * 4. Join the words without spaces.
+ *
+ * @param {string} name - Game mode name.
+ * @returns {string} camelCase key.
+ */
+export function navTooltipKey(name) {
+  return String(name)
+    .replace(/[^a-zA-Z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .map((w, i) => (i === 0 ? w.toLowerCase() : w[0].toUpperCase() + w.slice(1)))
+    .join("");
+}
+
+/**
  * Base path for navigation links derived from the current module location.
  */
 export const BASE_PATH = (() => {
@@ -49,7 +70,7 @@ export function toggleExpandedMapView(gameModes) {
       (mode) =>
         `<div class="map-tile">
           <img src="${mode.image}" alt="${mode.name}" loading="lazy">
-          <a href="${BASE_PATH}${mode.url}" aria-label="${mode.name}">${mode.name}</a>
+          <a href="${BASE_PATH}${mode.url}" aria-label="${mode.name}" data-tooltip-id="nav.${navTooltipKey(mode.name)}">${mode.name}</a>
         </div>`
     )
     .join("");
@@ -89,7 +110,7 @@ export function togglePortraitTextMenu(gameModes) {
   textMenu.innerHTML = validModes
     .map(
       (mode) =>
-        `<li><a href="${BASE_PATH}${mode.url}" aria-label="${mode.name}">${mode.name}</a></li>`
+        `<li><a href="${BASE_PATH}${mode.url}" aria-label="${mode.name}" data-tooltip-id="nav.${navTooltipKey(mode.name)}">${mode.name}</a></li>`
     )
     .join("");
 

--- a/src/helpers/navigationBar.js
+++ b/src/helpers/navigationBar.js
@@ -1,5 +1,5 @@
 import { loadMenuModes } from "./navigation/navData.js";
-import { BASE_PATH, clearBottomNavbar } from "./navigation/navMenu.js";
+import { BASE_PATH, clearBottomNavbar, navTooltipKey } from "./navigation/navMenu.js";
 
 /**
  * Adds touch feedback animations to navigation links.
@@ -64,7 +64,7 @@ export async function populateNavbar() {
         const linkPath = new URL(href, window.location.href).pathname.replace(/^\//, "");
         const isCurrent = linkPath === currentPath || linkPath.endsWith(currentPath);
         const attrs = isCurrent ? ` class="active" aria-current="page"` : "";
-        return `<li><a href="${href}" data-testid="nav-${mode.id}"${attrs}>${mode.name}</a></li>`;
+        return `<li><a href="${href}" data-testid="nav-${mode.id}" data-tooltip-id="nav.${navTooltipKey(mode.name)}"${attrs}>${mode.name}</a></li>`;
       })
       .join("");
     navBar.appendChild(ul);
@@ -104,7 +104,7 @@ export async function populateNavbar() {
         const linkPath = new URL(href, window.location.href).pathname.replace(/^\//, "");
         const isCurrent = linkPath === currentPath || linkPath.endsWith(currentPath);
         const attrs = isCurrent ? ` class="active" aria-current="page"` : "";
-        return `<li><a href="${href}" data-testid="nav-${item.name.replace(/\s+/g, "")}"${attrs}>${item.name}</a></li>`;
+        return `<li><a href="${href}" data-testid="nav-${item.name.replace(/\s+/g, "")}" data-tooltip-id="nav.${navTooltipKey(item.name)}"${attrs}>${item.name}</a></li>`;
       })
       .join("");
     navBar.appendChild(ul);

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -61,6 +61,7 @@ describe("toggleExpandedMapView", () => {
     expect(tiles).toHaveLength(2);
     expect(tiles[0].querySelector("a")).toHaveAttribute("href", `${BASE_PATH}mode1.html`);
     expect(tiles[0].querySelector("a")).toHaveAttribute("aria-label", "Mode1");
+    expect(tiles[0].querySelector("a")).toHaveAttribute("data-tooltip-id", "nav.mode1");
     expect(tiles[0].textContent).toContain("Mode1");
   });
 
@@ -80,6 +81,7 @@ describe("toggleExpandedMapView", () => {
     const link = tile.querySelector("a");
     const img = tile.querySelector("img");
     expect(link).toHaveAttribute("aria-label", "Mode1");
+    expect(link).toHaveAttribute("data-tooltip-id", "nav.mode1");
     expect(img).toHaveAttribute("alt", "Mode1");
   });
 });
@@ -110,6 +112,7 @@ describe("togglePortraitTextMenu", () => {
     expect(items).toHaveLength(2);
     expect(items[1].querySelector("a")).toHaveAttribute("href", `${BASE_PATH}mode2.html`);
     expect(items[1].querySelector("a")).toHaveAttribute("aria-label", "Mode2");
+    expect(items[1].querySelector("a")).toHaveAttribute("data-tooltip-id", "nav.mode2");
     expect(items[1].textContent).toContain("Mode2");
   });
 
@@ -127,6 +130,7 @@ describe("togglePortraitTextMenu", () => {
     togglePortraitTextMenu(modes);
     const link = navBar.querySelector(".portrait-text-menu li a");
     expect(link).toHaveAttribute("aria-label", "Mode1");
+    expect(link).toHaveAttribute("data-tooltip-id", "nav.mode1");
   });
 });
 
@@ -180,6 +184,8 @@ describe("populateNavbar", () => {
     const items = navBar.querySelectorAll("li");
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toBe("A");
+    const link = items[0].querySelector("a");
+    expect(link).toHaveAttribute("data-tooltip-id", "nav.a");
     expect(loadSettings).toHaveBeenCalled();
     expect(loadNavigationItems).toHaveBeenCalled();
   });
@@ -201,8 +207,11 @@ describe("populateNavbar", () => {
     const items = navBar.querySelectorAll("li");
     expect(items).toHaveLength(3);
     expect(items[0].textContent).toBe("Random Judoka");
+    expect(items[0].querySelector("a")).toHaveAttribute("data-tooltip-id", "nav.randomJudoka");
     expect(items[1].textContent).toBe("Home");
+    expect(items[1].querySelector("a")).toHaveAttribute("data-tooltip-id", "nav.home");
     expect(items[2].textContent).toBe("Classic Battle");
+    expect(items[2].querySelector("a")).toHaveAttribute("data-tooltip-id", "nav.classicBattle");
   });
 
   it("uses cached game modes when offline", async () => {
@@ -254,6 +263,7 @@ describe("populateNavbar", () => {
     const items = navBar.querySelectorAll("li");
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toBe("X");
+    expect(items[0].querySelector("a")).toHaveAttribute("data-tooltip-id", "nav.x");
     expect(loadNavigationItems).toHaveBeenCalled();
   });
 
@@ -322,6 +332,7 @@ describe("populateNavbar", () => {
     const activeLink = navBar.querySelector("a.active");
     expect(activeLink).toBeTruthy();
     expect(activeLink).toHaveAttribute("aria-current", "page");
+    expect(activeLink).toHaveAttribute("data-tooltip-id", "nav.home");
     expect(activeLink.textContent).toBe("Home");
   });
 });


### PR DESCRIPTION
## Summary
- add `navTooltipKey` helper
- show tooltip IDs on bottom nav links
- document nav tooltips
- test tooltip attributes

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Module needs an import attribute)*

------
https://chatgpt.com/codex/tasks/task_e_6888fd548b848326848f76416a668edd