### PR TITLE
Update embedding output limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,10 +329,10 @@ the updated file alongside your documentation changes so other agents have the
 latest vectors.
 
 The generator skips the large `aesopsFables.json` quote dataset to keep the
-output file under the 3.6MB limit defined in the PRD.
+output file under the 6.8MB limit defined in the PRD.
 
 If the output would exceed that limit, `scripts/generateEmbeddings.js` aborts
-with `"Output exceeds 3.6MB"`. Increase the `CHUNK_SIZE` constant or exclude
+with `"Output exceeds 6.8MB"`. Increase the `CHUNK_SIZE` constant or exclude
 large files to reduce the result size before rerunning the script.
 
 If generation still fails because of memory limits, rerun the script with a

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -87,6 +87,6 @@ scripts/generateEmbeddings.js`). This rebuilds `client_embeddings.json`, now
 pretty-printed for easier diffing, so agents search the latest content. Commit
 the regenerated JSON file along with your changes.
 
-If the result would be larger than 3.6MB, the generator exits with
-`"Output exceeds 3.6MB"`. Increase the `CHUNK_SIZE` constant or omit large files to
+If the result would be larger than 6.8MB, the generator exits with
+`"Output exceeds 6.8MB"`. Increase the `CHUNK_SIZE` constant or omit large files to
 reduce the output size before running the script again.

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -32,7 +32,7 @@ Ultimately, these issues increase the risk of bugs reaching players, slow down t
 | Response accuracy | ≥90% agent-retrieved responses align with top 3 relevant matches                                                         |
 | Search latency    | ≤200ms average similarity lookup on mid-tier desktop browsers (e.g., 2022 MacBook Air M1 or Windows laptop with 8GB RAM) |
 | Coverage          | ≥90% of PRDs/tooltips indexed within the system                                                                          |
-| File size         | <3.6MB total JSON size to ensure fast client-side loading                                                                |
+| File size         | <6.8MB total JSON size to ensure fast client-side loading                                                                |
 
 ---
 
@@ -90,7 +90,7 @@ than an entire file.
 - [x] Search function accepts optional tag filters so agents can restrict matches to specific categories
 - [x] Vector search UI displays how many embeddings are loaded using the meta file
 - [x] The system handles malformed or missing embeddings gracefully (e.g. logs a warning or returns empty result)
-- [x] The `client_embeddings.json` file stays under the 3.6MB threshold to ensure quick page load and GitHub Pages compatibility
+- [x] The `client_embeddings.json` file stays under the 6.8MB threshold to ensure quick page load and GitHub Pages compatibility
 - [ ] Match text longer than 200 characters is truncated in the UI with a "Show
       more" toggle to reveal the full snippet
 
@@ -184,7 +184,7 @@ No user settings or toggles are included. This is appropriate since the feature 
 - [ ] 2.0 Implement Client-Side Embedding Store
 
   - [ ] 2.1 Structure JSON with `id`, `text`, `embedding`, `source`, `tags`
-  - [ ] 2.2 Ensure total file size stays below the 3.6MB threshold
+  - [ ] 2.2 Ensure total file size stays below the 6.8MB threshold
   - [ ] 2.3 Validate JSON loading in-browser
 
 - [ ] 3.0 Develop Similarity Search Function

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -25,7 +25,7 @@
  *      analysis.
  * 6. Stream each output object directly to `client_embeddings.json` using
  *    `fs.createWriteStream`.
- *    - Track bytes written and abort if the total exceeds MAX_OUTPUT_SIZE (3.6 MB).
+ *    - Track bytes written and abort if the total exceeds MAX_OUTPUT_SIZE (6.8 MB).
  * 7. After writing the file, record the total count, average vector length,
  *    and output size in `client_embeddings.meta.json`.
  */
@@ -40,10 +40,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
 
 // Larger chunks reduce the total embedding count and help keep the
-// final JSON under the 3.6MB limit. Bump slightly to shrink output.
+// final JSON under the 6.8MB limit. Bump slightly to shrink output.
 const CHUNK_SIZE = 2000;
 const OVERLAP = 100;
-const MAX_OUTPUT_SIZE = 3.6 * 1024 * 1024;
+const MAX_OUTPUT_SIZE = 6.8 * 1024 * 1024;
 
 /**
  * Recursively flatten a nested object using dot notation keys.
@@ -200,7 +200,7 @@ async function generate() {
     const size = Buffer.byteLength(chunk + "\n]", "utf8");
     if (bytesWritten + size > MAX_OUTPUT_SIZE) {
       writer.end();
-      throw new Error("Output exceeds 3.6MB");
+      throw new Error("Output exceeds 6.8MB");
     }
     writer.write(chunk);
     bytesWritten += Buffer.byteLength(chunk, "utf8");
@@ -277,7 +277,7 @@ async function generate() {
   const endStr = "\n]\n";
   if (bytesWritten + Buffer.byteLength(endStr, "utf8") > MAX_OUTPUT_SIZE) {
     writer.end();
-    throw new Error("Output exceeds 3.6MB");
+    throw new Error("Output exceeds 6.8MB");
   }
   writer.end(endStr);
   await new Promise((resolve) => writer.on("finish", resolve));


### PR DESCRIPTION
## Summary
- increase MAX_OUTPUT_SIZE constant
- update related error messages and documentation

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Module "file:///workspace/judokon/src/data/settings.json" needs an import attribute of "type: json")*

------
https://chatgpt.com/codex/tasks/task_e_6889130cf38c83268e540ac7ffcd4bad