### PR TITLE
Improve carousel scroll buttons

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -39,12 +39,10 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("scroll buttons have labels", async ({ page }) => {
-    const left = page.locator(".scroll-button.left");
-    const right = page.locator(".scroll-button.right");
-    await page.waitForSelector(".scroll-button.left");
-    await page.waitForSelector(".scroll-button.right");
-    await expect(left).toHaveAttribute("aria-label", /scroll left/i);
-    await expect(right).toHaveAttribute("aria-label", /scroll right/i);
+    const left = page.getByRole("button", { name: /previous/i });
+    const right = page.getByRole("button", { name: /next/i });
+    await expect(left).toBeVisible();
+    await expect(right).toBeVisible();
   });
 
   test("country filter updates carousel", async ({ page }) => {

--- a/src/helpers/carousel/scroll.js
+++ b/src/helpers/carousel/scroll.js
@@ -10,7 +10,8 @@
  * 2. Create a button element:
  *    - Assign a class based on the `direction` (e.g., "scroll-button left" or "scroll-button right").
  *    - Set the inner HTML to display an inline SVG chevron pointing left or right.
- *    - Add an accessible label (`aria-label`) for screen readers (e.g., "Scroll Left").
+ *    - Include a visible `<span class="label">` with "Previous" or "Next" text.
+ *    - Add an accessible label (`aria-label`) matching the visible text.
  *
  * 3. Add a click event listener to the button:
  *    - Scroll the `container` by the specified `scrollAmount`.
@@ -40,15 +41,15 @@ export function createScrollButton(direction, container, scrollAmount) {
 
   button.className = `scroll-button ${direction}`;
 
-  button.innerHTML =
-    direction === "left"
-      ? '<svg xmlns="http://www.w3.org/2000/svg" height="24px" width="24px" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z"/></svg>'
-      : '<svg xmlns="http://www.w3.org/2000/svg" height="24px" width="24px" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z"/></svg>';
+  const labelText = direction === "left" ? "Previous" : "Next";
 
-  button.setAttribute(
-    "aria-label",
-    `Scroll ${direction.charAt(0).toUpperCase() + direction.slice(1)}`
-  );
+  button.innerHTML =
+    (direction === "left"
+      ? '<svg xmlns="http://www.w3.org/2000/svg" height="36px" width="36px" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z"/></svg>'
+      : '<svg xmlns="http://www.w3.org/2000/svg" height="36px" width="36px" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z"/></svg>') +
+    `<span class="label">${labelText}</span>`;
+
+  button.setAttribute("aria-label", labelText);
 
   button.addEventListener("click", () => {
     container.scrollBy({

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -194,8 +194,6 @@ export async function buildCardCarousel(judokaList, gokyoData) {
 
   const leftButton = createScrollButton("left", container, CAROUSEL_SCROLL_DISTANCE);
   const rightButton = createScrollButton("right", container, CAROUSEL_SCROLL_DISTANCE);
-  leftButton.setAttribute("aria-label", "Scroll left");
-  rightButton.setAttribute("aria-label", "Scroll right");
 
   wrapper.appendChild(leftButton);
   wrapper.appendChild(container);

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -480,6 +480,7 @@ svg {
 }
 
 .scroll-button {
+  --touch-target-size: 56px;
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -502,9 +503,14 @@ svg {
 }
 
 .scroll-button svg {
-  width: 24px;
-  height: 24px;
+  width: 36px;
+  height: 36px;
   fill: currentColor;
+}
+
+.scroll-button .label {
+  margin-left: 4px;
+  font-size: var(--font-small);
 }
 
 .scroll-button:hover {

--- a/tests/card/cardBuilder.test.js
+++ b/tests/card/cardBuilder.test.js
@@ -24,16 +24,16 @@ describe("createScrollButton", () => {
     const button = createScrollButton("left", container, 100);
     expect(button.className).toBe("scroll-button left");
     expect(button.innerHTML).toContain("<svg");
-    expect(button.innerHTML).toContain("</svg>");
-    expect(button).toHaveAttribute("aria-label", "Scroll Left");
+    expect(button.innerHTML).toContain("Previous</span>");
+    expect(button).toHaveAttribute("aria-label", "Previous");
   });
 
   it("should create a scroll button with the correct class and inner HTML when direction is right", () => {
     const button = createScrollButton("right", container, 100);
     expect(button.className).toBe("scroll-button right");
     expect(button.innerHTML).toContain("<svg");
-    expect(button.innerHTML).toContain("</svg>");
-    expect(button).toHaveAttribute("aria-label", "Scroll Right");
+    expect(button.innerHTML).toContain("Next</span>");
+    expect(button).toHaveAttribute("aria-label", "Next");
   });
 
   it("should throw an error when the direction is invalid", () => {


### PR DESCRIPTION
## Summary
- enlarge carousel scroll button touch targets and icon size
- label scroll buttons with visible Previous/Next text
- update aria labels and remove redundant attributes
- test scroll button labels in Playwright
- align unit tests with new button labels

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688924176428832688593b3ebc632c83