### PR TITLE
Add advanced settings section with info popups

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,8 @@ Toggle the **Full Navigation Map** flag to display a map overlay with links to a
 Enable the **Test Mode** flag for deterministic card draws and stat results. A "Test Mode Active" banner appears on battle pages, and the battle area receives `data-test-mode="true"` for automated checks. See `src/helpers/classicBattlePage.js` and `testModeUtils.js` for how deterministic behavior is applied.
 Enable the **Card Inspector** flag to add a collapsible panel on each card containing its raw JSON. Opening the panel sets `data-inspector="true"` on the card for automated checks.
 
+Advanced or debug-oriented flags live under a collapsible **Advanced Settings** section. This keeps experimental options out of sight for younger players while remaining accessible to testers.
+
 Game mode data now falls back to a bundled JSON import if the network request fails, so navigation works offline.
 Corrupted settings are detected and automatically reset to defaults, ensuring the Settings page always remains usable.
 Use the **Restore Defaults** button in the Links section to reset all settings. A confirmation dialog now appears before applying the defaults.

--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -225,6 +225,16 @@ To support AI-assisted testing, variant gameplay modes, and scalable development
 - **Grouping**
   - Place all feature flags in a dedicated `<fieldset>` titled `Feature Flags`
   - For advanced/experimental features, nest under `Advanced Settings` with appropriate section toggling
+  - Markup example:
+    ```html
+    <div class="settings-section">
+      <button type="button" class="settings-section-toggle" id="advanced-settings-toggle" aria-expanded="false" aria-controls="advanced-settings-content">Advanced Settings</button>
+      <div class="settings-section-content" id="advanced-settings-content" role="region" aria-labelledby="advanced-settings-toggle" hidden>
+        <fieldset id="feature-flags-container" class="game-mode-toggle-container settings-form">...</fieldset>
+      </div>
+    </div>
+    ```
+  - When a flag changes, call `showSettingsInfo(label, description)` to open a modal explaining the feature. The modal uses `createModal` with a single **OK** button.
 
 ---
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -136,6 +136,13 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - AC-5.2 Each game mode toggle accurately reflects its state on page reload.
 - AC-5.3 If `navigationItems.json` is missing or invalid, the game modes list does not render, and an error message appears in the settings UI.
 
+### Advanced Settings & Feature Flag Info
+
+- Experimental and debug flags are grouped under a collapsible **Advanced Settings** section.
+- When a flag is toggled, a modal explains the feature using the description text from `featureFlags[flag].description`.
+- The modal is created via `createModal` with an OK button to dismiss it.
+- Debug-focused flags remain tucked away so younger players do not accidentally enable them.
+
 ### Data Persistence & Refresh
 
 - AC-6.1 All settings changes persist through page refresh within the same session.

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -151,7 +151,13 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
  * @param {Function} getCurrentSettings - Returns current settings.
  * @param {Function} handleUpdate - Persist function.
  */
-export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, handleUpdate) {
+export function renderFeatureFlagSwitches(
+  container,
+  flags,
+  getCurrentSettings,
+  handleUpdate,
+  onToggleInfo
+) {
   if (!container || !flags) return;
   Object.keys(flags).forEach((flag) => {
     const kebab = flag.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
@@ -176,6 +182,8 @@ export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, 
       };
       handleUpdate("featureFlags", updated, () => {
         input.checked = prev;
+      }).then(() => {
+        if (onToggleInfo) onToggleInfo(info.label, info.description);
       });
     });
   });

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -9,6 +9,7 @@
 import { loadSettings, updateSetting, resetSettings } from "./settingsUtils.js";
 import { loadNavigationItems } from "./gameModeUtils.js";
 import { showSettingsError } from "./showSettingsError.js";
+import { showSettingsInfo } from "./showSettingsInfo.js";
 import { applyDisplayMode } from "./displayMode.js";
 import { applyMotionPreference } from "./motionUtils.js";
 import { onDomReady } from "./domReady.js";
@@ -112,7 +113,7 @@ function initializeControls(settings, gameModes) {
   }
 
   function handleUpdate(key, value, revert) {
-    updateSetting(key, value)
+    return updateSetting(key, value)
       .then((updated) => {
         currentSettings = updated;
       })
@@ -133,7 +134,8 @@ function initializeControls(settings, gameModes) {
     flagsContainer,
     currentSettings.featureFlags,
     getCurrentSettings,
-    handleUpdate
+    handleUpdate,
+    showSettingsInfo
   );
 
   const resetModal = createResetConfirmation(() => {
@@ -148,7 +150,8 @@ function initializeControls(settings, gameModes) {
       flagsContainer,
       currentSettings.featureFlags,
       getCurrentSettings,
-      handleUpdate
+      handleUpdate,
+      showSettingsInfo
     );
   });
 

--- a/src/helpers/showSettingsInfo.js
+++ b/src/helpers/showSettingsInfo.js
@@ -1,0 +1,39 @@
+/**
+ * Display a modal describing a feature flag when toggled.
+ *
+ * @pseudocode
+ * 1. Build title and description nodes from provided text.
+ * 2. Create an OK button via `createButton`.
+ * 3. Assemble modal with `createModal` and append to `document.body`.
+ * 4. When the button is clicked, close and remove the modal.
+ * 5. Open the modal immediately.
+ */
+import { createModal } from "../components/Modal.js";
+import { createButton } from "../components/Button.js";
+
+export function showSettingsInfo(label, description) {
+  const title = document.createElement("h2");
+  title.id = "settings-info-title";
+  title.textContent = label;
+
+  const desc = document.createElement("p");
+  desc.id = "settings-info-desc";
+  desc.textContent = description;
+
+  const actions = document.createElement("div");
+  actions.className = "modal-actions";
+  const ok = createButton("OK", { id: "settings-info-ok" });
+  actions.appendChild(ok);
+
+  const frag = document.createDocumentFragment();
+  frag.append(title, desc, actions);
+
+  const modal = createModal(frag, { labelledBy: title, describedBy: desc });
+  document.body.appendChild(modal.element);
+  ok.addEventListener("click", () => {
+    modal.close();
+    modal.element.remove();
+  });
+  modal.open(ok);
+  return modal;
+}

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -189,10 +189,32 @@
               </fieldset>
             </div>
           </div>
-          <fieldset id="feature-flags-container" class="game-mode-toggle-container settings-form">
-            <legend>Feature Flags</legend>
-            <!-- Flag toggles are inserted here dynamically -->
-          </fieldset>
+          <div class="settings-section">
+            <button
+              type="button"
+              class="settings-section-toggle"
+              id="advanced-settings-toggle"
+              aria-expanded="false"
+              aria-controls="advanced-settings-content"
+            >
+              Advanced Settings
+            </button>
+            <div
+              class="settings-section-content"
+              id="advanced-settings-content"
+              role="region"
+              aria-labelledby="advanced-settings-toggle"
+              hidden
+            >
+              <fieldset
+                id="feature-flags-container"
+                class="game-mode-toggle-container settings-form"
+              >
+                <legend>Feature Flags</legend>
+                <!-- Flag toggles are inserted here dynamically -->
+              </fieldset>
+            </div>
+          </div>
           <fieldset id="links-container" class="settings-form">
             <legend>Links</legend>
             <div class="settings-item">

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -69,9 +69,28 @@ export function createSettingsDom() {
   displayGray.value = "gray";
   const gameModeToggleContainer = document.createElement("section");
   gameModeToggleContainer.id = "game-mode-toggle-container";
+
   const featureFlagsContainer = document.createElement("section");
   featureFlagsContainer.id = "feature-flags-container";
   featureFlagsContainer.className = "game-mode-toggle-container settings-form";
+
+  const advancedSection = document.createElement("div");
+  advancedSection.className = "settings-section";
+  const advToggle = document.createElement("button");
+  advToggle.type = "button";
+  advToggle.className = "settings-section-toggle";
+  advToggle.id = "advanced-settings-toggle";
+  advToggle.setAttribute("aria-expanded", "false");
+  advToggle.setAttribute("aria-controls", "advanced-settings-content");
+  advToggle.textContent = "Advanced Settings";
+  const advContent = document.createElement("div");
+  advContent.className = "settings-section-content";
+  advContent.id = "advanced-settings-content";
+  advContent.setAttribute("role", "region");
+  advContent.setAttribute("aria-labelledby", "advanced-settings-toggle");
+  advContent.hidden = true;
+  advContent.appendChild(featureFlagsContainer);
+  advancedSection.append(advToggle, advContent);
   const resetButton = document.createElement("button");
   resetButton.id = "reset-settings-button";
   fragment.append(
@@ -82,7 +101,7 @@ export function createSettingsDom() {
     displayDark,
     displayGray,
     gameModeToggleContainer,
-    featureFlagsContainer,
+    advancedSection,
     resetButton
   );
   return fragment;


### PR DESCRIPTION
## Summary
- add an Advanced Settings collapsible section in `settings.html`
- show a modal when toggling feature flags
- expose `showSettingsInfo` helper
- document Advanced Settings area and popup usage
- update tests for new section and info helper

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch in settings.html and vectorSearch.html, tab order expectations)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68892313449c832683712ca805288363