### PR TITLE
Fix Settings Display Mode tab order

### DIFF
--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -38,7 +38,9 @@ export function applyInitialControlValues(controls, settings) {
   applyInputState(controls.motionToggle, settings.motionEffects);
   if (controls.displayRadios) {
     controls.displayRadios.forEach((radio) => {
-      radio.checked = radio.value === settings.displayMode;
+      const isSelected = radio.value === settings.displayMode;
+      radio.checked = isSelected;
+      radio.tabIndex = isSelected ? 0 : -1;
     });
   }
   applyInputState(controls.typewriterToggle, settings.typewriterEffect);
@@ -78,10 +80,16 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
         if (!radio.checked) return;
         const previous = getCurrentSettings().displayMode;
         const mode = radio.value;
+        displayRadios.forEach((r) => {
+          r.tabIndex = r === radio ? 0 : -1;
+        });
         applyDisplayMode(mode);
         handleUpdate("displayMode", mode, () => {
           const prevRadio = Array.from(displayRadios).find((r) => r.value === previous);
           if (prevRadio) prevRadio.checked = true;
+          displayRadios.forEach((r) => {
+            r.tabIndex = r.value === previous ? 0 : -1;
+          });
           applyDisplayMode(previous);
         });
       });

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -73,7 +73,7 @@
                 id="display-mode-light"
                 name="display-mode"
                 value="light"
-                tabindex="1"
+                tabindex="0"
               />
               <label for="display-mode-light">Light</label>
               <input
@@ -81,7 +81,7 @@
                 id="display-mode-dark"
                 name="display-mode"
                 value="dark"
-                tabindex="2"
+                tabindex="-1"
               />
               <label for="display-mode-dark">Dark</label>
               <input
@@ -89,7 +89,7 @@
                 id="display-mode-gray"
                 name="display-mode"
                 value="gray"
-                tabindex="3"
+                tabindex="-1"
               />
               <label for="display-mode-gray">Gray</label>
             </div>


### PR DESCRIPTION
## Summary
- ensure only one display mode option is tabbable at a time
- update display mode controls on settings page

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68892a5a48d48326ba0beed4e459021f