### PR TITLE
Update settings test to open advanced settings

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -16,6 +16,7 @@ test.describe("Settings page", () => {
     await page.getByLabel(/Classic Battle/i).waitFor({ state: "attached" });
     await page.locator("#general-settings-toggle").click();
     await page.locator("#game-modes-toggle").click();
+    await page.locator("#advanced-settings-toggle").click();
   });
 
   test("page loads", async ({ page }) => {


### PR DESCRIPTION
## Summary
- open the advanced settings panel during Settings page Playwright setup

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot.spec.js and settings.tab-order test)*

------
https://chatgpt.com/codex/tasks/task_e_68892edac8dc8326ac43acd8981fe6eb