### PR TITLE
Fix settings tab order

### DIFF
--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -122,13 +122,7 @@
                 <legend>General Settings</legend>
                 <div class="settings-item">
                   <label for="sound-toggle" class="switch">
-                    <input
-                      type="checkbox"
-                      id="sound-toggle"
-                      name="sound"
-                      aria-label="Sound"
-                      tabindex="4"
-                    />
+                    <input type="checkbox" id="sound-toggle" name="sound" aria-label="Sound" />
                     <div class="slider round"></div>
                     <span>Sound</span>
                   </label>
@@ -140,7 +134,6 @@
                       id="motion-toggle"
                       name="motion"
                       aria-label="Motion Effects"
-                      tabindex="5"
                     />
                     <div class="slider round"></div>
                     <span>Motion Effects</span>
@@ -153,7 +146,6 @@
                       id="typewriter-toggle"
                       name="typewriter"
                       aria-label="Typewriter Effect"
-                      tabindex="6"
                     />
                     <div class="slider round"></div>
                     <span>Typewriter Effect</span>


### PR DESCRIPTION
## Summary
- simplify inputs in settings page by removing custom tab indices

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688933dd20f483269aed2bed7ad8f750