### PR TITLE
Add tooltip viewer page

### DIFF
--- a/src/helpers/tooltipViewerPage.js
+++ b/src/helpers/tooltipViewerPage.js
@@ -1,0 +1,109 @@
+import { fetchJson } from "./dataUtils.js";
+import { parseTooltipText, flattenTooltips, initTooltips } from "./tooltip.js";
+import { DATA_DIR } from "./constants.js";
+import { onDomReady } from "./domReady.js";
+
+/**
+ * Initialize the Tooltip Viewer page.
+ *
+ * @pseudocode
+ * 1. Load and flatten `tooltips.json` using `fetchJson` and `flattenTooltips`.
+ * 2. Render a clickable list of keys filtered by the search box (300ms debounce).
+ * 3. When a key is selected, display its parsed HTML and raw text in the preview.
+ * 4. Provide copy buttons for the key and body using `navigator.clipboard`.
+ * 5. On page load, select the key from the URL hash when present and scroll to it.
+ * 6. Call `initTooltips()` so help icons inside the page gain tooltips.
+ */
+export async function setupTooltipViewerPage() {
+  const searchInput = document.getElementById("tooltip-search");
+  const listEl = document.getElementById("tooltip-list");
+  const previewEl = document.getElementById("tooltip-preview");
+  const rawEl = document.getElementById("tooltip-raw");
+  const keyCopyBtn = document.getElementById("copy-key-btn");
+  const bodyCopyBtn = document.getElementById("copy-body-btn");
+
+  let data;
+  try {
+    const json = await fetchJson(`${DATA_DIR}tooltips.json`);
+    data = flattenTooltips(json);
+  } catch (err) {
+    console.error("Failed to load tooltips", err);
+    previewEl.textContent = "Error loading tooltips.";
+    return;
+  }
+
+  function createItem(key, body) {
+    const li = document.createElement("li");
+    li.tabIndex = 0;
+    li.textContent = key;
+    const valid = typeof body === "string" && body.trim().length > 0;
+    li.dataset.key = key;
+    li.dataset.body = body;
+    li.dataset.valid = String(valid);
+    if (!valid) li.classList.add("invalid");
+    li.addEventListener("click", () => select(key));
+    li.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        select(key);
+      }
+    });
+    return li;
+  }
+
+  function renderList(filter = "") {
+    listEl.textContent = "";
+    const terms = filter.toLowerCase().split(/\s+/).filter(Boolean);
+    Object.entries(data).forEach(([key, body]) => {
+      const haystack = `${key} ${body}`.toLowerCase();
+      const match = terms.every((t) => haystack.includes(t));
+      if (match) listEl.appendChild(createItem(key, body));
+    });
+  }
+
+  let selectedKey;
+  function select(key) {
+    selectedKey = key;
+    const body = data[key] ?? "";
+    Array.from(listEl.children).forEach((el) => {
+      el.classList.toggle("selected", el.dataset.key === key);
+    });
+    previewEl.innerHTML = parseTooltipText(body);
+    rawEl.textContent = body;
+    keyCopyBtn.dataset.copy = key;
+    bodyCopyBtn.dataset.copy = body;
+    previewEl.classList.remove("fade-in");
+    void previewEl.offsetWidth;
+    previewEl.classList.add("fade-in");
+  }
+
+  function copy(btn) {
+    const text = btn.dataset.copy || "";
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(text).catch(() => {});
+    }
+  }
+
+  keyCopyBtn.addEventListener("click", () => copy(keyCopyBtn));
+  bodyCopyBtn.addEventListener("click", () => copy(bodyCopyBtn));
+
+  let timer;
+  searchInput.addEventListener("input", () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => renderList(searchInput.value), 300);
+  });
+
+  renderList();
+  if (location.hash) {
+    const key = decodeURIComponent(location.hash.slice(1));
+    const el = listEl.querySelector(`[data-key="${key}"]`);
+    if (el) {
+      select(key);
+      el.scrollIntoView({ block: "center" });
+    }
+  }
+
+  initTooltips();
+}
+
+onDomReady(setupTooltipViewerPage);

--- a/src/pages/tooltipViewer.html
+++ b/src/pages/tooltipViewer.html
@@ -1,1 +1,69 @@
-<body></body>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="keywords" content="judo, card game, web game, tooltips" />
+    <meta name="author" content="Marc Scheimann" />
+    <meta name="description" content="JU-DO-KON! tooltip viewer" />
+    <meta property="og:title" content="JU-DO-KON!" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://cyanautomation.github.io/judokon/" />
+    <meta property="og:description" content="JU-DO-KON! tooltip viewer" />
+    <meta name="theme-color" content="#ffffff" />
+    <title>Ju-Do-Kon! Tooltips</title>
+    <link rel="stylesheet" href="../styles/fonts.css" />
+    <link rel="stylesheet" href="../styles/base.css" />
+    <link rel="stylesheet" href="../styles/layout.css" />
+    <link rel="stylesheet" href="../styles/components.css" />
+    <link rel="stylesheet" href="../styles/tooltipViewer.css" />
+    <link rel="stylesheet" href="../styles/utilities.css" />
+    <link rel="icon" type="image/png" href="../assets/images/favicon.ico" />
+  </head>
+  <body>
+    <div class="home-screen">
+      <header class="header">
+        <div class="header-spacer left"></div>
+        <div class="logo-container">
+          <a href="../../index.html" data-testid="home-link">
+            <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
+          </a>
+        </div>
+        <div class="header-spacer right"></div>
+      </header>
+      <main class="tooltip-viewer" role="main">
+        <aside class="sidebar">
+          <input
+            id="tooltip-search"
+            type="text"
+            placeholder="Search"
+            aria-label="Search tooltips"
+          />
+          <ul id="tooltip-list"></ul>
+        </aside>
+        <section class="preview">
+          <div class="copy-buttons">
+            <button id="copy-key-btn" class="secondary-button" aria-label="Copy key">
+              Copy Key
+            </button>
+            <button id="copy-body-btn" class="secondary-button" aria-label="Copy body">
+              Copy Body
+            </button>
+          </div>
+          <div id="tooltip-preview" class="preview-body"></div>
+          <pre id="tooltip-raw" class="raw-body"></pre>
+        </section>
+      </main>
+      <footer>
+        <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
+      </footer>
+      <script type="module" src="../helpers/setupBottomNavbar.js"></script>
+      <script type="module" src="../helpers/setupDisplaySettings.js"></script>
+      <script type="module" src="../helpers/tooltipViewerPage.js"></script>
+      <script type="module" src="../helpers/setupSvgFallback.js"></script>
+      <noscript>
+        <p class="noscript-warning">JU-DO-KON! requires JavaScript to run.</p>
+      </noscript>
+    </div>
+  </body>
+</html>

--- a/src/styles/tooltipViewer.css
+++ b/src/styles/tooltipViewer.css
@@ -1,0 +1,75 @@
+.tooltip-viewer {
+  display: flex;
+  height: 100%;
+  width: 100%;
+}
+
+.tooltip-viewer .sidebar {
+  flex: 0 0 35%;
+  max-width: 320px;
+  border-right: 1px solid var(--color-secondary);
+  padding: var(--space-md);
+  overflow-y: auto;
+}
+
+.tooltip-viewer .sidebar input {
+  width: 100%;
+  margin-bottom: var(--space-md);
+}
+
+.tooltip-viewer .sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tooltip-viewer .sidebar li {
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+}
+
+.tooltip-viewer .sidebar li.selected {
+  background: var(--color-secondary);
+  color: var(--color-text-inverted);
+}
+
+.tooltip-viewer .sidebar li.invalid {
+  color: #c62828;
+}
+
+.tooltip-viewer .preview {
+  flex: 1;
+  padding: var(--space-md);
+  overflow-y: auto;
+}
+
+.copy-buttons {
+  display: flex;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+}
+
+.fade-in {
+  animation: fadeIn 0.1s ease-in;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 600px) {
+  .tooltip-viewer {
+    flex-direction: column;
+  }
+
+  .tooltip-viewer .sidebar {
+    max-width: none;
+    border-right: none;
+    border-bottom: 1px solid var(--color-secondary);
+  }
+}


### PR DESCRIPTION
## Summary
- implement tooltipViewerPage.js to browse tooltips
- style new tooltip viewer layout
- update tooltipViewer.html with sidebar/preview layout

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68893a25638483268bc456aa409e0009