### PR TITLE
Add link to tooltip viewer

### DIFF
--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -225,6 +225,11 @@
               >
             </div>
             <div class="settings-item">
+              <a href="../pages/tooltipViewer.html" id="tooltipviewer-link" tabindex="103"
+                >View Tooltip Descriptions</a
+              >
+            </div>
+            <div class="settings-item">
               <a href="../pages/vectorSearch.html" id="vectorSearch-link" tabindex="102"
                 >Vector Search for RAG</a
               >


### PR DESCRIPTION
## Summary
- add Tooltip Descriptions link in settings page

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot /src/pages/settings.html)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68893f46cb548326a95521216bd9c361