### PR TITLE
Improve carousel markers

### DIFF
--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -52,6 +52,7 @@
   left: 50%;
   transform: translateX(-50%);
   display: flex;
+  align-items: center;
   gap: 0.5rem;
   z-index: 5;
 }
@@ -67,6 +68,11 @@
 .scroll-marker.active {
   background: var(--color-primary);
   opacity: 1;
+}
+
+.page-counter {
+  color: var(--color-text-inverted);
+  font-size: var(--font-small);
 }
 
 .loading-spinner {


### PR DESCRIPTION
## Summary
- revise scroll marker logic for paging
- show page counter text in carousel
- ensure marker container realigns
- update UI tests for counter

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 3 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68893edd7a0c8326a44e67d9d6444adb