### PR TITLE
Add link color token with dark theme overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 
 ## Display Modes
 
-Light, dark and gray themes are supported. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode switch applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running.
+Light, dark and gray themes are supported. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode switch applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running. The `--link-color` token controls anchor colors and is overridden to `#3399ff` in dark mode (along with `--color-primary: #ff4530`).
 
 ## Settings & Feature Flags
 

--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -50,6 +50,7 @@ Ju-Do-Kon! uses a **bold, high-contrast design system** grounded in clear hierar
 | --color-primary     | #CB2504  | Buttons, highlights         |
 | --color-secondary   | #0C3F7A  | Nav bar, stat blocks        |
 | --color-tertiary    | #E8E8E8  | Backgrounds, outlines       |
+| --link-color        | var(--color-secondary) | Anchor tags               |
 | --button-bg         | #CB2504  | Primary button background   |
 | --button-hover-bg   | #0B5BB0  | Hover state for buttons     |
 | --button-active-bg  | #0C3F7A  | Active button state         |
@@ -57,7 +58,7 @@ Ju-Do-Kon! uses a **bold, high-contrast design system** grounded in clear hierar
 | --switch-off-bg     | #878787  | Toggle off state background |
 | --switch-on-bg      | #08A700  | Toggle on state background  |
 
-The hex values above correspond to CSS custom properties used throughout the project. See [Tokens](#10-tokens) for the complete list.
+The hex values above correspond to CSS custom properties used throughout the project. See [Tokens](#10-tokens) for the complete list. In dark mode `--color-primary` is overridden to `#ff4530` and `--link-color` to `#3399ff` to maintain contrast.
 
 ### Rarity Colours
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -11,6 +11,7 @@
   --color-background: #ffffff; /* Light mode background */
   --color-text: #000000; /* Light mode text */
   --color-text-inverted: #ffffff;
+  --link-color: var(--color-secondary);
 
   --button-bg: var(--color-primary);
   --button-hover-bg: #0b5bb0;
@@ -74,6 +75,8 @@
   --color-text: #ffffff;
   --color-tertiary: #333333;
   --color-text-inverted: #ffffff;
+  --color-primary: #ff4530;
+  --link-color: #3399ff;
 }
 
 /* Gray mode variable overrides */
@@ -98,6 +101,10 @@ body {
   line-height: 1.4; /* Line height */
   color: var(--color-text);
   background-color: var(--color-tertiary);
+}
+
+a {
+  color: var(--link-color);
 }
 
 h1,

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -25,21 +25,21 @@
   margin: 0;
   font-size: clamp(18px, 4vw, 30px);
   font-weight: bold;
-  color: var(--color-secondary);
+  color: var(--link-color);
 }
 
 .battle-header #next-round-timer {
   margin: 0;
   font-size: clamp(15px, 3vw, 18px);
   font-weight: bold;
-  color: var(--color-secondary);
+  color: var(--link-color);
 }
 
 .battle-header #score-display {
   margin: 0;
   font-size: clamp(18px, 3.5vw, 26px);
   font-weight: bold;
-  color: var(--color-secondary);
+  color: var(--link-color);
   text-align: right;
 }
 


### PR DESCRIPTION
## Summary
- add `--link-color` token and apply to anchor tags
- override link and primary colors in dark theme
- use new token for info bar text colors
- document the new token and dark theme overrides
- mention link color token in README

Screenshot tests had one failure (`playwright/screenshot.spec.js` for settings page) due to the color update.

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68894e1ee6d48326a619c19d945d0302