### PR TITLE
Remove meditation typewriter animation

### DIFF
--- a/design/productRequirementsDocuments/prdMeditationScreen.md
+++ b/design/productRequirementsDocuments/prdMeditationScreen.md
@@ -154,7 +154,7 @@ Sets the emotional tone. Not a reward, but a rest—balancing the intensity of g
 - Dynamic font scaling for different screen sizes using CSS `clamp()`
 - Skeleton loader animation while quote loads
 - 200ms fade animation when language is toggled
-- Optional typewriter animation for the quote text (default ON, user can disable in Settings)
+- Typewriter animation code exists but is no longer used on this screen
 
 **Why:**
 
@@ -192,7 +192,7 @@ Provides agency without pressure. Allows the player to re-enter gameplay at thei
 - KG character assets from the core game.
 - Navigation system for entering and exiting the screen.
 - Pseudo-Japanese Text Conversion Function for quote toggle ([prdPseudoJapanese.md](prdPseudoJapanese.md)).
-- Typewriter effect toggle stored in `settings.json` and managed on the Settings screen.
+- Typewriter effect module retained in codebase for potential reuse.
 
 ---
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -43,7 +43,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 | P1       | Full Navigation Map Feature Flag | Enable or disable the full navigation map via feature flag; updates `settings.json` live on change. |
 | P3       | Test Mode Feature Flag           | Enables deterministic battles for automated testing.                                                |
 | P1       | Motion Effects Toggle            | Binary toggle updating `settings.json` live on change.                                              |
-| P1       | Typewriter Effect Toggle         | Enable or disable quote animation on the meditation screen.                                         |
+| P1       | Typewriter Effect Toggle         | Enable or disable quote animation where supported (not used on the meditation screen). |
 | P1       | Display Mode Switch              | Three-option switch applying mode instantly across UI.                                              |
 | P2       | Game Modes Toggles               | A list of all defined game modes with binary toggles from `navigationItems.json`.                   |
 | P3       | Settings Menu Integration        | Ensure settings appear as a game mode in `navigationItems.json`.                                    |
@@ -61,7 +61,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - **Sound (binary):** ON/OFF (default: ON)
 - **Full navigation map feature flag (binary):** ON/OFF (default: ON)
 - **Motion effects (binary):** ON/OFF (default: ON)
-- **Typewriter effect (binary):** ON/OFF (default: ON)
+- **Typewriter effect (binary):** ON/OFF (default: ON, not currently used on the meditation screen)
 - **Display mode (three options):** Light, Dark, Gray (default: Light)
   - _Gray mode_ provides a grayscale display to reduce visual noise for neurodivergent users.
 - **Game modes list:** Pulled from `gameModes.json` and cross-referenced with `navigationItems.json` to determine order and visibility; each mode has a binary toggle.
@@ -120,7 +120,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 
 ### Typewriter Effect Toggle
 
-- AC-4.1 Disabling the toggle prevents the quote typewriter animation on the meditation screen.
+- AC-4.1 Toggle enables or disables the quote typewriter animation where implemented.
 - AC-4.2 Setting is stored in `settings.json` within 50ms of change.
 
 ### Display Mode Switch

--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -21,7 +21,6 @@
  * @throws {Error} If the fetch request fails or the response is not successful.
  */
 import { DATA_DIR } from "./constants.js";
-import { shouldEnableTypewriter, runTypewriterEffect } from "./typewriter.js";
 
 let kgImageLoaded = false;
 let quoteLoaded = false;
@@ -107,9 +106,6 @@ function formatFableStory(story) {
  * 5. Toggle visibility:
  *    - Hide the loader element and remove the `hidden` class from the quote element.
  *
- * 6. If the typewriter effect setting is enabled:
- *    - Run the typewriter animation on `#quote-content` and restore the HTML when complete.
- *
  * @param {Object|null} fable - The fable object containing the title and story, or `null` if no fable is available.
  */
 function displayFable(fable) {
@@ -130,10 +126,6 @@ function displayFable(fable) {
   }
   loaderDiv.classList.add("hidden");
   quoteDiv.classList.remove("hidden");
-  if (shouldEnableTypewriter()) {
-    const contentEl = document.getElementById("quote-content");
-    runTypewriterEffect(contentEl, quoteDiv.querySelector("#quote-content")?.innerHTML || "");
-  }
   const toggleBtn = document.getElementById("language-toggle");
   if (toggleBtn) {
     toggleBtn.classList.remove("hidden");


### PR DESCRIPTION
## Summary
- strip typewriter effect usage from meditation quote builder
- update product docs about the typewriter feature

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npx playwright test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6889eb5f29c48326b490d82918e272b3