### PR TITLE
Animate theme changes with ViewTransition

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 
 ## Display Modes
 
-Light, dark and gray themes are supported. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode switch applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running. The `--link-color` token controls anchor colors and is overridden to `#3399ff` in dark mode (along with `--color-primary: #ff4530`).
+Light, dark and gray themes are supported. Theme changes animate via the View Transitions API when available, falling back gracefully. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode switch applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running. The `--link-color` token controls anchor colors and is overridden to `#3399ff` in dark mode (along with `--color-primary: #ff4530`).
 
 ## Settings & Feature Flags
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -129,7 +129,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - AC-4.2 Selected mode persists through a page refresh within the same session.
 - AC-4.3 Current display mode is correctly pulled from `settings.json` on page load.
 - AC-4.4 Transition to new display mode completes without visible flickering or rendering artifacts.
-- Implementation uses the `applyDisplayMode` helper which sets a `data-theme` attribute on `<body>` so `base.css` variables can switch values per theme.
+- Implementation uses the `applyDisplayMode` helper which sets a `data-theme` attribute on `<body>` so `base.css` variables can switch values per theme. Theme changes animate using the View Transitions API when supported.
 
 ### Game Modes Toggles
 

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -1,5 +1,6 @@
 import { createToggleSwitch } from "../../components/ToggleSwitch.js";
 import { applyDisplayMode } from "../displayMode.js";
+import { withViewTransition } from "../viewTransition.js";
 import { applyMotionPreference } from "../motionUtils.js";
 import { updateNavigationItemHidden } from "../gameModeUtils.js";
 import { showSettingsError } from "../showSettingsError.js";
@@ -83,14 +84,18 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
         displayRadios.forEach((r) => {
           r.tabIndex = r === radio ? 0 : -1;
         });
-        applyDisplayMode(mode);
+        withViewTransition(() => {
+          applyDisplayMode(mode);
+        });
         handleUpdate("displayMode", mode, () => {
           const prevRadio = Array.from(displayRadios).find((r) => r.value === previous);
           if (prevRadio) prevRadio.checked = true;
           displayRadios.forEach((r) => {
             r.tabIndex = r.value === previous ? 0 : -1;
           });
-          applyDisplayMode(previous);
+          withViewTransition(() => {
+            applyDisplayMode(previous);
+          });
         });
       });
     });

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -11,6 +11,7 @@ import { loadNavigationItems } from "./gameModeUtils.js";
 import { showSettingsError } from "./showSettingsError.js";
 import { showSettingsInfo } from "./showSettingsInfo.js";
 import { applyDisplayMode } from "./displayMode.js";
+import { withViewTransition } from "./viewTransition.js";
 import { applyMotionPreference } from "./motionUtils.js";
 import { onDomReady } from "./domReady.js";
 import { initTooltips } from "./tooltip.js";
@@ -141,7 +142,9 @@ function initializeControls(settings, gameModes) {
   const resetModal = createResetConfirmation(() => {
     currentSettings = resetSettings();
     applyInitialControlValues(controls, currentSettings);
-    applyDisplayMode(currentSettings.displayMode);
+    withViewTransition(() => {
+      applyDisplayMode(currentSettings.displayMode);
+    });
     applyMotionPreference(currentSettings.motionEffects);
     clearToggles(modesContainer);
     renderGameModeSwitches(modesContainer, gameModes, getCurrentSettings, handleUpdate);

--- a/src/helpers/viewTransition.js
+++ b/src/helpers/viewTransition.js
@@ -1,0 +1,17 @@
+/**
+ * Execute a function within a View Transition when supported.
+ *
+ * @pseudocode
+ * 1. Check if `document.startViewTransition` exists.
+ * 2. If available, call `document.startViewTransition(fn)`.
+ * 3. Otherwise, invoke `fn` directly.
+ *
+ * @param {Function} fn - Operation to run inside the transition.
+ * @returns {Promise<void>|void} Result of the call.
+ */
+export function withViewTransition(fn) {
+  if (typeof document !== "undefined" && document.startViewTransition) {
+    return document.startViewTransition(fn);
+  }
+  return fn();
+}

--- a/tests/helpers/viewTransitionTheme.test.js
+++ b/tests/helpers/viewTransitionTheme.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createSettingsDom, resetDom } from "../utils/testUtils.js";
+
+const controlsFromDom = () => ({
+  soundToggle: null,
+  motionToggle: null,
+  displayRadios: document.querySelectorAll('input[name="display-mode"]'),
+  typewriterToggle: null
+});
+
+describe("display mode transitions", () => {
+  let startTransition;
+
+  beforeEach(() => {
+    document.body.appendChild(createSettingsDom());
+    startTransition = vi.fn((fn) => {
+      fn();
+      return Promise.resolve();
+    });
+    document.startViewTransition = startTransition;
+  });
+
+  afterEach(() => {
+    delete document.startViewTransition;
+    resetDom();
+  });
+
+  it("uses startViewTransition when mode changes", async () => {
+    const { attachToggleListeners } = await import("../../src/helpers/settings/formUtils.js");
+    const controls = controlsFromDom();
+    const getCurrentSettings = () => ({ displayMode: "light" });
+    const handleUpdate = vi.fn();
+
+    attachToggleListeners(controls, getCurrentSettings, handleUpdate);
+
+    const dark = document.getElementById("display-mode-dark");
+    dark.checked = true;
+    dark.dispatchEvent(new Event("change"));
+
+    expect(startTransition).toHaveBeenCalledTimes(1);
+  });
+
+  it("reverts with a transition when update fails", async () => {
+    const { attachToggleListeners } = await import("../../src/helpers/settings/formUtils.js");
+    const controls = controlsFromDom();
+    const getCurrentSettings = () => ({ displayMode: "light" });
+    const handleUpdate = vi.fn((_, __, revert) => revert());
+
+    attachToggleListeners(controls, getCurrentSettings, handleUpdate);
+
+    const dark = document.getElementById("display-mode-dark");
+    dark.checked = true;
+    dark.dispatchEvent(new Event("change"));
+
+    expect(startTransition).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `withViewTransition` helper
- animate display mode changes in settings helpers
- transition back smoothly when updates fail
- wrap default restore logic in view transition
- document View Transition behavior
- test theme changes call `startViewTransition`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688a59d371288326b87ee79d907f35ea