### PR TITLE
Fix settings tab order test

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -58,6 +58,7 @@ test.describe("Settings page", () => {
       "Sound",
       "Motion Effects",
       "Typewriter Effect",
+      "Tooltips",
       ...sortedNames,
       ...flagLabels
     ];


### PR DESCRIPTION
## Summary
- update expected labels in settings playwright test

## Testing
- `npx prettier . --check`
- `npx eslint playwright/settings.spec.js` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688a6dbbb5d08326a261625b8144e92a