### PR TITLE
Add PRD viewer CSS and layout

### DIFF
--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -8,63 +8,8 @@
     <link rel="stylesheet" href="../styles/base.css" />
     <link rel="stylesheet" href="../styles/layout.css" />
     <link rel="stylesheet" href="../styles/components.css" />
+    <link rel="stylesheet" href="../styles/prdViewer.css" />
     <link rel="stylesheet" href="../styles/utilities.css" />
-    <style>
-      body {
-        font-family: sans-serif;
-        background: #f5f5f5;
-        /* margin: 2rem; */
-        padding: 2rem;
-        padding-bottom: calc(2rem + var(--footer-height) + env(safe-area-inset-bottom));
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        line-height: 1.5;
-        width: auto;
-      }
-
-      header {
-        text-align: center;
-        margin-bottom: 2rem;
-      }
-
-      #prd-content {
-        background: #fff;
-        border: 1px solid #ccc;
-        border-radius: 8px;
-        padding: 2rem 3rem;
-        max-width: 800px;
-        width: 100%;
-        min-height: 200px;
-        overflow-x: auto;
-        box-sizing: border-box;
-        line-height: 1.5;
-      }
-
-      #prd-content img {
-        max-width: 100%;
-        height: auto;
-      }
-
-      #prd-content pre,
-      #prd-content code {
-        white-space: pre-wrap;
-        word-break: break-word;
-      }
-
-      #prd-content table {
-        width: 100%;
-        overflow-x: auto;
-      }
-
-      .nav-buttons {
-        margin-top: 1rem;
-        display: flex;
-        gap: 2rem;
-        align-items: center;
-        justify-content: flex-start;
-      }
-    </style>
   </head>
   <body>
     <header>
@@ -83,8 +28,11 @@
       </div>
     </header>
 
-    <main>
-      <div id="prd-content"></div>
+    <main class="prd-viewer">
+      <aside class="sidebar"><ul id="prd-list"></ul></aside>
+      <section class="preview">
+        <div id="prd-content"></div>
+      </section>
     </main>
 
     <footer>

--- a/src/styles/prdViewer.css
+++ b/src/styles/prdViewer.css
@@ -1,0 +1,75 @@
+.prd-viewer {
+  display: flex;
+  height: 100%;
+  width: 100%;
+}
+
+.prd-viewer .sidebar {
+  flex: 0 0 35%;
+  max-width: 320px;
+  border-right: 1px solid var(--color-secondary);
+  padding: var(--space-md);
+  overflow-y: auto;
+}
+
+.prd-viewer .sidebar input {
+  width: 100%;
+  margin-bottom: var(--space-md);
+}
+
+.prd-viewer .sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.prd-viewer .sidebar li {
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+}
+
+.prd-viewer .sidebar li.selected {
+  background: var(--color-secondary);
+  color: var(--color-text-inverted);
+}
+
+.prd-viewer .sidebar li.invalid {
+  color: #c62828;
+}
+
+.prd-viewer .preview {
+  flex: 1;
+  padding: var(--space-md);
+  overflow-y: auto;
+}
+
+.copy-buttons {
+  display: flex;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+}
+
+.fade-in {
+  animation: fadeIn 0.1s ease-in;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 600px) {
+  .prd-viewer {
+    flex-direction: column;
+  }
+
+  .prd-viewer .sidebar {
+    max-width: none;
+    border-right: none;
+    border-bottom: 1px solid var(--color-secondary);
+  }
+}


### PR DESCRIPTION
## Summary
- copy tooltipViewer.css to create prdViewer.css
- load prdViewer.css in prdViewer.html
- restructure prdViewer main section

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688a7bd81dcc8326a87ed70dd1d1821a