### PR TITLE
Add snackbar notifications for settings changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Light, dark and gray themes are supported. Changing modes uses a smooth cross-fa
 
 The Settings page (`src/pages/settings.html`) groups all player preferences, including experimental **feature flags**. Toggle a flag to enable an optional feature without modifying code. Flag values persist across pages and apply immediately. Implementation guidelines live in [settingsPageDesignGuidelines.md](design/codeStandards/settingsPageDesignGuidelines.md#feature-flags--agent-observability).
 Default flag states and descriptions now live in `src/data/settings.json`. The **Tooltips** toggle on this page lets you turn help tooltips on or off globally.
+Each change triggers a small snackbar at the bottom of the screen confirming the new setting.
 
 Battle pages include a collapsible debug panel. Enable the **Battle Debug Panel** feature flag in **Settings** to reveal real-time match state in a `<pre>` element. The panel is keyboard accessible and hidden by default so normal gameplay remains unaffected.
 Toggle the **Full Navigation Map** flag to display a map overlay with links to all pages for easier orientation during testing.

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -32,6 +32,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - The settings screen loads fully within 200ms on mid-tier devices (e.g., 2GB RAM smartphones), avoiding delays that could frustrate players.
 - Allow players to personalize visual and audio experience to match their comfort.
 - Provide immediate and persistent feedback when changing settings.
+- Successful changes display a brief snackbar confirming the new state.
 
 ---
 
@@ -156,6 +157,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - AC-7.1 If reading `settings.json` fails, a CSS popup error message appears within 200ms.
 - AC-7.2 If writing to `settings.json` fails, a CSS popup error message appears within 200ms, and the toggle/selector reverts to its previous state.
 - AC-7.3 The settings screen remains stable and usable if an error occurs (no frozen or unresponsive UI).
+- AC-7.4 Successful changes display a snackbar confirmation within 3 seconds.
 
 ### Accessibility & UX
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -64,6 +64,20 @@ export const SETTINGS_FADE_MS = 1800;
 export const SETTINGS_REMOVE_MS = 2000;
 
 /**
+ * Duration in milliseconds before the snackbar begins fading out.
+ *
+ * @constant {number}
+ */
+export const SNACKBAR_FADE_MS = 2500;
+
+/**
+ * Duration in milliseconds before removing the snackbar element from the DOM.
+ *
+ * @constant {number}
+ */
+export const SNACKBAR_REMOVE_MS = 3000;
+
+/**
  * Maximum points needed to win a Classic Battle match.
  *
  * @constant {number}

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -4,6 +4,7 @@ import { withViewTransition } from "../viewTransition.js";
 import { applyMotionPreference } from "../motionUtils.js";
 import { updateNavigationItemHidden } from "../gameModeUtils.js";
 import { showSettingsError } from "../showSettingsError.js";
+import { showSnackbar } from "../showSnackbar.js";
 
 /**
  * Apply a value to an input or checkbox element.
@@ -55,6 +56,7 @@ export function applyInitialControlValues(controls, settings) {
  * 1. Listen for changes on each toggle or select element.
  * 2. Use `handleUpdate` to persist the new value, reverting if it fails.
  * 3. Apply side effects like `applyMotionPreference` and `applyDisplayMode`.
+ * 4. After a successful update, show a snackbar confirming the change.
  *
  * @param {Object} controls - Form controls with DOM references.
  * @param {Function} getCurrentSettings - Returns the latest settings object.
@@ -66,6 +68,8 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
     const prev = !soundToggle.checked;
     handleUpdate("sound", soundToggle.checked, () => {
       soundToggle.checked = prev;
+    }).then(() => {
+      showSnackbar(`Sound ${soundToggle.checked ? "enabled" : "disabled"}`);
     });
   });
   motionToggle?.addEventListener("change", () => {
@@ -74,6 +78,8 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
     handleUpdate("motionEffects", motionToggle.checked, () => {
       motionToggle.checked = prev;
       applyMotionPreference(prev);
+    }).then(() => {
+      showSnackbar(`Motion effects ${motionToggle.checked ? "enabled" : "disabled"}`);
     });
   });
   if (displayRadios) {
@@ -97,6 +103,9 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
           withViewTransition(() => {
             applyDisplayMode(previous);
           });
+        }).then(() => {
+          const label = mode.charAt(0).toUpperCase() + mode.slice(1);
+          showSnackbar(`${label} mode enabled`);
         });
       });
     });
@@ -105,12 +114,16 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
     const prev = !typewriterToggle.checked;
     handleUpdate("typewriterEffect", typewriterToggle.checked, () => {
       typewriterToggle.checked = prev;
+    }).then(() => {
+      showSnackbar(`Typewriter effect ${typewriterToggle.checked ? "enabled" : "disabled"}`);
     });
   });
   tooltipsToggle?.addEventListener("change", () => {
     const prev = !tooltipsToggle.checked;
     handleUpdate("tooltips", tooltipsToggle.checked, () => {
       tooltipsToggle.checked = prev;
+    }).then(() => {
+      showSnackbar(`Tooltips ${tooltipsToggle.checked ? "enabled" : "disabled"}`);
     });
   });
 }

--- a/src/helpers/showSnackbar.js
+++ b/src/helpers/showSnackbar.js
@@ -1,0 +1,30 @@
+/**
+ * Display a temporary snackbar message near the bottom of the screen.
+ *
+ * @pseudocode
+ * 1. Remove any existing `.snackbar` element.
+ * 2. Create a new div with that class containing the provided message.
+ * 3. Append the element to `document.body` and trigger the show animation.
+ * 4. After `SNACKBAR_FADE_MS`, remove the `show` class to start fading.
+ * 5. Remove the element from the DOM after `SNACKBAR_REMOVE_MS`.
+ *
+ * @param {string} message - Text content to display in the snackbar.
+ */
+import { SNACKBAR_FADE_MS, SNACKBAR_REMOVE_MS } from "./constants.js";
+
+export function showSnackbar(message) {
+  const existing = document.querySelector(".snackbar");
+  existing?.remove();
+
+  const bar = document.createElement("div");
+  bar.className = "snackbar";
+  bar.textContent = message;
+  bar.setAttribute("role", "status");
+  bar.setAttribute("aria-live", "polite");
+  document.body.appendChild(bar);
+  requestAnimationFrame(() => bar.classList.add("show"));
+  setTimeout(() => {
+    bar.classList.remove("show");
+  }, SNACKBAR_FADE_MS);
+  setTimeout(() => bar.remove(), SNACKBAR_REMOVE_MS);
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -6,6 +6,7 @@
 @import "./modal.css";
 @import "./battle.css";
 @import "./tooltip.css";
+@import "./snackbar.css";
 
 .debug-panel {
   background-color: #f9f9f9;

--- a/src/styles/snackbar.css
+++ b/src/styles/snackbar.css
@@ -1,0 +1,43 @@
+.snackbar {
+  visibility: hidden;
+  min-width: 250px;
+  margin-left: -125px;
+  background-color: var(--color-secondary);
+  color: var(--color-text-inverted);
+  text-align: center;
+  border-radius: var(--radius-sm);
+  padding: var(--space-md);
+  position: fixed;
+  z-index: 1000;
+  left: 50%;
+  bottom: 30px;
+}
+
+.snackbar.show {
+  visibility: visible;
+  animation:
+    snackbar-fadein 0.5s,
+    snackbar-fadeout 0.5s var(--snackbar-delay, 2.5s);
+}
+
+@keyframes snackbar-fadein {
+  from {
+    bottom: 0;
+    opacity: 0;
+  }
+  to {
+    bottom: 30px;
+    opacity: 1;
+  }
+}
+
+@keyframes snackbar-fadeout {
+  from {
+    bottom: 30px;
+    opacity: 1;
+  }
+  to {
+    bottom: 0;
+    opacity: 0;
+  }
+}

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -174,6 +174,7 @@ describe("settingsPage module", () => {
     const updated = { ...baseSettings, tooltips: false };
     const updateSetting = vi.fn().mockResolvedValue(updated);
     const loadNavigationItems = vi.fn().mockResolvedValue([]);
+    const showSnackbar = vi.fn();
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
@@ -183,6 +184,7 @@ describe("settingsPage module", () => {
       loadGameModes: loadNavigationItems,
       updateNavigationItemHidden: vi.fn()
     }));
+    vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar }));
 
     await import("../../src/helpers/settingsPage.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
@@ -193,6 +195,8 @@ describe("settingsPage module", () => {
     input.checked = false;
     input.dispatchEvent(new Event("change"));
     expect(updateSetting).toHaveBeenCalledWith("tooltips", false);
+    await vi.runAllTimersAsync();
+    expect(showSnackbar).toHaveBeenCalledWith("Tooltips disabled");
   });
 
   it("renders feature flag switches", async () => {

--- a/tests/helpers/showSnackbar.test.js
+++ b/tests/helpers/showSnackbar.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { showSnackbar } from "../../src/helpers/showSnackbar.js";
+import { SNACKBAR_FADE_MS, SNACKBAR_REMOVE_MS } from "../../src/helpers/constants.js";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("showSnackbar", () => {
+  it("shows and removes the snackbar", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", (cb) => cb());
+
+    showSnackbar("Hello");
+    let bar = document.querySelector(".snackbar");
+    expect(bar).toBeTruthy();
+    expect(bar.classList.contains("show")).toBe(true);
+
+    vi.advanceTimersByTime(SNACKBAR_FADE_MS);
+    bar = document.querySelector(".snackbar");
+    expect(bar).toBeTruthy();
+    expect(bar.classList.contains("show")).toBe(false);
+
+    vi.advanceTimersByTime(SNACKBAR_REMOVE_MS - SNACKBAR_FADE_MS);
+    expect(document.querySelector(".snackbar")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- implement snackbar component and styles
- update settings form utilities to show snackbars
- document new snackbar behavior
- test snackbar component and toggle feedback

## Testing
- `npx prettier . --write`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688a9484d94c832680c1150f77eb1c20