### PR TITLE
Fix JSDoc for settings form

### DIFF
--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -60,7 +60,8 @@ export function applyInitialControlValues(controls, settings) {
  *
  * @param {Object} controls - Form controls with DOM references.
  * @param {Function} getCurrentSettings - Returns the latest settings object.
- * @param {Function} handleUpdate - Persist function `(key,value,revert)=>void`.
+ * @param {(key: string, value: any, revert: Function) => Promise<any>} handleUpdate -
+ *   Persist function that returns a Promise.
  */
 export function attachToggleListeners(controls, getCurrentSettings, handleUpdate) {
   const { soundToggle, motionToggle, displayRadios, typewriterToggle, tooltipsToggle } = controls;


### PR DESCRIPTION
## Summary
- update JSDoc for `attachToggleListeners`
- clarify that `handleUpdate` returns a Promise

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688a9df6e67883268186bccaf3007eb0