### PR TITLE
Add snackbars for feature flags and game modes

### DIFF
--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -251,7 +251,7 @@ To support AI-assisted testing, variant gameplay modes, and scalable development
       </div>
     </div>
     ```
-  - When a flag changes, call `showSettingsInfo(label, description)` to open a modal explaining the feature. The modal uses `createModal` with a single **OK** button.
+  - When a flag changes, display a short confirmation using `showSnackbar()` to inform the user of the new state.
 
 ---
 

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -145,6 +145,7 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
  * 1. Sort `gameModes` by `order` and create a toggle for each.
  * 2. When toggled, update navigation visibility via `updateNavigationItemHidden`.
  * 3. Persist the updated `gameModes` setting using `handleUpdate`.
+ * 4. Show a snackbar confirming the new mode state.
  *
  * @param {HTMLElement} container - Target container for switches.
  * @param {Array} gameModes - List of mode definitions.
@@ -176,8 +177,12 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
     input.addEventListener("change", () => {
       const prev = !input.checked;
       const updated = { ...getCurrentSettings().gameModes, [mode.id]: input.checked };
-      handleUpdate("gameModes", updated, () => {
-        input.checked = prev;
+      Promise.resolve(
+        handleUpdate("gameModes", updated, () => {
+          input.checked = prev;
+        })
+      ).then(() => {
+        showSnackbar(`${mode.name} ${input.checked ? "enabled" : "disabled"}`);
       });
       updateNavigationItemHidden(mode.id, !input.checked).catch((err) => {
         console.error("Failed to update navigation item", err);
@@ -194,19 +199,14 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
  * @pseudocode
  * 1. For each flag, generate a labelled toggle switch element and description.
  * 2. Persist updates via `handleUpdate` when toggled.
+ * 3. After saving, show a snackbar confirming the new state.
  *
  * @param {HTMLElement} container - Container for the switches.
  * @param {Record<string, { enabled: boolean, label: string, description: string }>} flags - Feature flag metadata.
  * @param {Function} getCurrentSettings - Returns current settings.
  * @param {Function} handleUpdate - Persist function.
  */
-export function renderFeatureFlagSwitches(
-  container,
-  flags,
-  getCurrentSettings,
-  handleUpdate,
-  onToggleInfo
-) {
+export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, handleUpdate) {
   if (!container || !flags) return;
   Object.keys(flags).forEach((flag) => {
     const kebab = flag.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
@@ -234,7 +234,7 @@ export function renderFeatureFlagSwitches(
           input.checked = prev;
         })
       ).then(() => {
-        if (onToggleInfo) onToggleInfo(info.label, info.description);
+        showSnackbar(`${info.label} ${input.checked ? "enabled" : "disabled"}`);
       });
     });
   });

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -9,7 +9,6 @@
 import { loadSettings, updateSetting, resetSettings } from "./settingsUtils.js";
 import { loadNavigationItems } from "./gameModeUtils.js";
 import { showSettingsError } from "./showSettingsError.js";
-import { showSettingsInfo } from "./showSettingsInfo.js";
 import { applyDisplayMode } from "./displayMode.js";
 import { withViewTransition } from "./viewTransition.js";
 import { applyMotionPreference } from "./motionUtils.js";
@@ -136,8 +135,7 @@ function initializeControls(settings, gameModes) {
     flagsContainer,
     currentSettings.featureFlags,
     getCurrentSettings,
-    handleUpdate,
-    showSettingsInfo
+    handleUpdate
   );
 
   const resetModal = createResetConfirmation(() => {
@@ -155,8 +153,7 @@ function initializeControls(settings, gameModes) {
       flagsContainer,
       currentSettings.featureFlags,
       getCurrentSettings,
-      handleUpdate,
-      showSettingsInfo
+      handleUpdate
     );
   });
 

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -147,6 +147,7 @@ describe("settingsPage module", () => {
     const updateNavigationItemHidden = vi
       .fn()
       .mockResolvedValue([{ ...gameModes[0], isHidden: true }]);
+    const showSnackbar = vi.fn();
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
@@ -156,6 +157,7 @@ describe("settingsPage module", () => {
       loadGameModes: loadNavigationItems,
       updateNavigationItemHidden
     }));
+    vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar }));
 
     await import("../../src/helpers/settingsPage.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
@@ -166,6 +168,8 @@ describe("settingsPage module", () => {
     input.dispatchEvent(new Event("change"));
 
     expect(updateNavigationItemHidden).toHaveBeenCalledWith(1, true);
+    await vi.runAllTimersAsync();
+    expect(showSnackbar).toHaveBeenCalledWith("Classic disabled");
   });
 
   it("renders tooltip toggle and updates setting", async () => {
@@ -252,7 +256,7 @@ describe("settingsPage module", () => {
     expect(section.contains(container)).toBe(true);
   });
 
-  it("shows info popup when feature flag changes", async () => {
+  it("shows snackbar when feature flag changes", async () => {
     vi.useFakeTimers();
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
     const updatedSettings = {
@@ -267,7 +271,7 @@ describe("settingsPage module", () => {
     };
     const updateSetting = vi.fn().mockResolvedValue(updatedSettings);
     const loadNavigationItems = vi.fn().mockResolvedValue([]);
-    const showSettingsInfo = vi.fn();
+    const showSnackbar = vi.fn();
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings,
       updateSetting
@@ -277,7 +281,7 @@ describe("settingsPage module", () => {
       loadGameModes: loadNavigationItems,
       updateNavigationItemHidden: vi.fn()
     }));
-    vi.doMock("../../src/helpers/showSettingsInfo.js", () => ({ showSettingsInfo }));
+    vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar }));
 
     await import("../../src/helpers/settingsPage.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
@@ -288,9 +292,8 @@ describe("settingsPage module", () => {
     input.dispatchEvent(new Event("change"));
     await vi.runAllTimersAsync();
 
-    expect(showSettingsInfo).toHaveBeenCalledWith(
-      baseSettings.featureFlags.randomStatMode.label,
-      baseSettings.featureFlags.randomStatMode.description
+    expect(showSnackbar).toHaveBeenCalledWith(
+      `${baseSettings.featureFlags.randomStatMode.label} disabled`
     );
   });
 


### PR DESCRIPTION
## Summary
- remove modal use when toggling feature flags
- show a snackbar when game mode or feature flag toggles are changed
- update settings guidelines accordingly
- update unit tests for snackbar behavior

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688a9ef663fc832693d1cf8a7c8b8b1d