### PR TITLE
Add tooltip overlay debug feature

### DIFF
--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -26,6 +26,7 @@ import { applyMotionPreference } from "./motionUtils.js";
 import { onDomReady } from "./domReady.js";
 import { initTooltips } from "./tooltip.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
+import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
 
 const DRAW_ICON =
   '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#1f1f1f"><path d="m600-200-56-57 143-143H300q-75 0-127.5-52.5T120-580q0-75 52.5-127.5T300-760h20v80h-20q-42 0-71 29t-29 71q0 42 29 71t71 29h387L544-624l56-56 240 240-240 240Z"/></svg>';
@@ -45,6 +46,7 @@ export async function setupRandomJudokaPage() {
   applyMotionPreference(settings.motionEffects);
   toggleViewportSimulation(Boolean(settings.featureFlags.viewportSimulation?.enabled));
   toggleInspectorPanels(Boolean(settings.featureFlags?.enableCardInspector?.enabled));
+  toggleTooltipOverlayDebug(Boolean(settings.featureFlags.tooltipOverlayDebug?.enabled));
   const prefersReducedMotion =
     !settings.motionEffects || window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
@@ -157,6 +159,7 @@ export async function setupRandomJudokaPage() {
         const s = JSON.parse(e.newValue);
         toggleInspectorPanels(Boolean(s.featureFlags?.enableCardInspector?.enabled));
         toggleViewportSimulation(Boolean(s.featureFlags?.viewportSimulation?.enabled));
+        toggleTooltipOverlayDebug(Boolean(s.featureFlags?.tooltipOverlayDebug?.enabled));
       } catch {}
     }
   });

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -6,6 +6,7 @@ import { updateNavigationItemHidden } from "../gameModeUtils.js";
 import { showSettingsError } from "../showSettingsError.js";
 import { showSnackbar } from "../showSnackbar.js";
 import { toggleViewportSimulation } from "../viewportDebug.js";
+import { toggleTooltipOverlayDebug } from "../tooltipOverlayDebug.js";
 
 /**
  * Apply a value to an input or checkbox element.
@@ -240,6 +241,9 @@ export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, 
         showSnackbar(`${info.label} ${input.checked ? "enabled" : "disabled"}`);
         if (flag === "viewportSimulation") {
           toggleViewportSimulation(input.checked);
+        }
+        if (flag === "tooltipOverlayDebug") {
+          toggleTooltipOverlayDebug(input.checked);
         }
       });
     });

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -18,6 +18,7 @@ import { initTooltips } from "./tooltip.js";
 import { createModal } from "../components/Modal.js";
 import { createButton } from "../components/Button.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
+import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
 
 import {
   applyInitialControlValues,
@@ -148,6 +149,7 @@ function initializeControls(settings, gameModes) {
     });
     applyMotionPreference(currentSettings.motionEffects);
     toggleViewportSimulation(Boolean(currentSettings.featureFlags.viewportSimulation?.enabled));
+    toggleTooltipOverlayDebug(Boolean(currentSettings.featureFlags.tooltipOverlayDebug?.enabled));
     initTooltips();
     clearToggles(modesContainer);
     renderGameModeSwitches(modesContainer, gameModes, getCurrentSettings, handleUpdate);
@@ -172,6 +174,7 @@ async function initializeSettingsPage() {
     applyDisplayMode(settings.displayMode);
     applyMotionPreference(settings.motionEffects);
     toggleViewportSimulation(Boolean(settings.featureFlags.viewportSimulation?.enabled));
+    toggleTooltipOverlayDebug(Boolean(settings.featureFlags.tooltipOverlayDebug?.enabled));
     initializeControls(settings, gameModes);
     setupSectionToggles();
     initTooltips();

--- a/src/helpers/tooltip.js
+++ b/src/helpers/tooltip.js
@@ -2,6 +2,7 @@ import { fetchJson } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
 import { escapeHTML } from "./utils.js";
 import { loadSettings } from "./settingsUtils.js";
+import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
 
 let tooltipDataPromise;
 let cachedData;
@@ -99,12 +100,18 @@ function ensureTooltipElement() {
  * @returns {Promise<void>} Resolves when listeners are attached.
  */
 export async function initTooltips(root = document) {
+  let overlay = false;
   try {
-    const { tooltips = true } = await loadSettings();
-    if (!tooltips) return;
+    const settings = await loadSettings();
+    overlay = Boolean(settings.featureFlags?.tooltipOverlayDebug?.enabled);
+    if (!settings.tooltips) {
+      toggleTooltipOverlayDebug(false);
+      return;
+    }
   } catch {
     // ignore settings errors and assume enabled
   }
+  toggleTooltipOverlayDebug(overlay);
   const data = await loadTooltips();
   const elements = root.querySelectorAll?.("[data-tooltip-id]") || [];
   if (elements.length === 0) return;

--- a/src/helpers/tooltipOverlayDebug.js
+++ b/src/helpers/tooltipOverlayDebug.js
@@ -1,0 +1,4 @@
+export function toggleTooltipOverlayDebug(enabled) {
+  if (!document.body) return;
+  document.body.classList.toggle("tooltip-overlay-debug", Boolean(enabled));
+}

--- a/src/styles/tooltip.css
+++ b/src/styles/tooltip.css
@@ -21,3 +21,8 @@
 .tooltip em {
   font-style: italic;
 }
+
+/* Debug overlay for tooltip targets */
+.tooltip-overlay-debug [data-tooltip-id] {
+  outline: 1px dashed var(--color-primary);
+}

--- a/tests/helpers/tooltip.test.js
+++ b/tests/helpers/tooltip.test.js
@@ -110,6 +110,42 @@ describe("initTooltips", () => {
       el.dispatchEvent(new Event("mouseleave"));
     });
   });
+
+  it("applies overlay class when flag enabled", async () => {
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ stat: { test: "text" } })
+    }));
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings: vi.fn().mockResolvedValue({
+        tooltips: true,
+        featureFlags: { tooltipOverlayDebug: { enabled: true } }
+      })
+    }));
+    const { initTooltips } = await import("../../src/helpers/tooltip.js");
+    const el = document.createElement("div");
+    el.dataset.tooltipId = "stat.test";
+    document.body.appendChild(el);
+    await initTooltips();
+    expect(document.body.classList.contains("tooltip-overlay-debug")).toBe(true);
+  });
+
+  it("does not apply overlay class when flag disabled", async () => {
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ stat: { test: "text" } })
+    }));
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings: vi.fn().mockResolvedValue({
+        tooltips: true,
+        featureFlags: { tooltipOverlayDebug: { enabled: false } }
+      })
+    }));
+    const { initTooltips } = await import("../../src/helpers/tooltip.js");
+    const el = document.createElement("div");
+    el.dataset.tooltipId = "stat.test";
+    document.body.appendChild(el);
+    await initTooltips();
+    expect(document.body.classList.contains("tooltip-overlay-debug")).toBe(false);
+  });
 });
 
 describe("flattenTooltips", () => {

--- a/tests/helpers/tooltipOverlayDebug.test.js
+++ b/tests/helpers/tooltipOverlayDebug.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { toggleTooltipOverlayDebug } from "../../src/helpers/tooltipOverlayDebug.js";
+
+beforeEach(() => {
+  document.body.className = "";
+});
+
+describe("toggleTooltipOverlayDebug", () => {
+  it("adds and removes the class based on argument", () => {
+    toggleTooltipOverlayDebug(true);
+    expect(document.body.classList.contains("tooltip-overlay-debug")).toBe(true);
+    toggleTooltipOverlayDebug(false);
+    expect(document.body.classList.contains("tooltip-overlay-debug")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- highlight tooltip targets with `tooltip-overlay-debug` class
- toggle overlay via helper and apply when `tooltipOverlayDebug` flag is enabled
- wire overlay toggling into Settings and Random Judoka pages
- test overlay helper and initTooltips behavior

## Testing
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688b353a0d1883269877658ab3c27f75