### PR TITLE
Add layout debug panel

### DIFF
--- a/src/components/LayoutDebugPanel.js
+++ b/src/components/LayoutDebugPanel.js
@@ -1,0 +1,78 @@
+/**
+ * Create a collapsible layout debug panel that outlines key elements.
+ *
+ * @pseudocode
+ * 1. Build a `.debug-panel` container with a toggle button and `<pre>` output.
+ * 2. The button toggles `aria-expanded` and shows or hides the output.
+ * 3. When expanded, add `.layout-debug-outline` to all matching elements and
+ *    populate the output with their bounding boxes.
+ * 4. When collapsed, remove the outline classes and hide the output.
+ *
+ * @param {string[]} selectors - CSS selectors for elements to inspect.
+ * @returns {HTMLDivElement} The debug panel element.
+ */
+export function createLayoutDebugPanel(selectors = []) {
+  const panel = document.createElement("div");
+  panel.id = "layout-debug-panel";
+  panel.className = "debug-panel";
+
+  const toggle = document.createElement("button");
+  toggle.type = "button";
+  toggle.id = "layout-debug-toggle";
+  toggle.textContent = "Show Layout Boxes";
+  toggle.setAttribute("aria-expanded", "false");
+  panel.appendChild(toggle);
+
+  const pre = document.createElement("pre");
+  pre.id = "layout-debug-output";
+  pre.setAttribute("role", "status");
+  pre.setAttribute("aria-live", "polite");
+  pre.hidden = true;
+  panel.appendChild(pre);
+
+  function applyOutline(enable) {
+    selectors.forEach((sel) => {
+      document.querySelectorAll(sel).forEach((el) => {
+        el.classList.toggle("layout-debug-outline", enable);
+      });
+    });
+  }
+
+  function updateOutput() {
+    const lines = [];
+    selectors.forEach((sel) => {
+      document.querySelectorAll(sel).forEach((el) => {
+        const rect = el.getBoundingClientRect();
+        const name = el.id
+          ? `#${el.id}`
+          : el.classList.length > 0
+            ? `.${el.classList[0]}`
+            : el.tagName.toLowerCase();
+        lines.push(
+          `${name}: ${Math.round(rect.left)},${Math.round(rect.top)} ` +
+            `${Math.round(rect.width)}x${Math.round(rect.height)}`
+        );
+      });
+    });
+    pre.textContent = lines.join("\n");
+  }
+
+  function handleToggle() {
+    const expanded = toggle.getAttribute("aria-expanded") === "true";
+    toggle.setAttribute("aria-expanded", String(!expanded));
+    toggle.textContent = expanded ? "Show Layout Boxes" : "Hide Layout Boxes";
+    pre.hidden = expanded;
+    applyOutline(!expanded);
+    if (!expanded) updateOutput();
+  }
+
+  toggle.addEventListener("click", handleToggle);
+  toggle.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleToggle();
+    }
+  });
+
+  return panel;
+}

--- a/src/helpers/layoutDebugPanel.js
+++ b/src/helpers/layoutDebugPanel.js
@@ -1,0 +1,37 @@
+import { createLayoutDebugPanel } from "../components/LayoutDebugPanel.js";
+
+let panel = null;
+const DEFAULT_SELECTORS = [
+  ".judoka-card",
+  ".card-container",
+  ".card-carousel",
+  ".home-screen",
+  ".kodokan-screen"
+];
+
+/**
+ * Toggle the global layout debug panel.
+ *
+ * @pseudocode
+ * 1. Exit early if `document.body` is unavailable.
+ * 2. When `enabled` is true and no panel exists, create it and append to `body`.
+ * 3. When disabled and a panel exists, remove outline classes and the panel.
+ *
+ * @param {boolean} enabled - Whether to show the panel.
+ * @param {string[]} [selectors] - Optional custom selectors.
+ */
+export function toggleLayoutDebugPanel(enabled, selectors = DEFAULT_SELECTORS) {
+  if (!document.body) return;
+  if (enabled) {
+    if (!panel) {
+      panel = createLayoutDebugPanel(selectors);
+      document.body.appendChild(panel);
+    }
+  } else if (panel) {
+    document
+      .querySelectorAll(".layout-debug-outline")
+      .forEach((el) => el.classList.remove("layout-debug-outline"));
+    panel.remove();
+    panel = null;
+  }
+}

--- a/src/helpers/setupDisplaySettings.js
+++ b/src/helpers/setupDisplaySettings.js
@@ -15,6 +15,7 @@ import { applyDisplayMode } from "./displayMode.js";
 import { applyMotionPreference } from "./motionUtils.js";
 import { onDomReady } from "./domReady.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
+import { toggleLayoutDebugPanel } from "./layoutDebugPanel.js";
 
 async function init() {
   try {
@@ -22,6 +23,7 @@ async function init() {
     applyDisplayMode(settings.displayMode);
     applyMotionPreference(settings.motionEffects);
     toggleViewportSimulation(Boolean(settings.featureFlags.viewportSimulation?.enabled));
+    toggleLayoutDebugPanel(Boolean(settings.featureFlags.layoutDebugPanel?.enabled));
   } catch (error) {
     console.error("Failed to apply display mode:", error);
   }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -21,3 +21,7 @@
   margin: 5vh auto;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
 }
+
+.layout-debug-outline {
+  outline: 2px dashed red;
+}

--- a/tests/components/LayoutDebugPanel.test.js
+++ b/tests/components/LayoutDebugPanel.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createLayoutDebugPanel } from "../../src/components/LayoutDebugPanel.js";
+
+describe("createLayoutDebugPanel", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("toggles outlines and aria-expanded", () => {
+    const panel = createLayoutDebugPanel(["body"]);
+    document.body.appendChild(panel);
+    const button = panel.querySelector("button");
+    const pre = panel.querySelector("pre");
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(pre.hidden).toBe(true);
+    button.click();
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(pre.hidden).toBe(false);
+    expect(document.body.classList.contains("layout-debug-outline")).toBe(true);
+    button.click();
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(document.body.classList.contains("layout-debug-outline")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `createLayoutDebugPanel` component and toggle helper
- wire layout debug panel to settings on page load
- outline elements when debug panel is active
- test layout debug panel component

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688b3e06aca88326b4a1f6226a4874bf