### PR TITLE
Add info modal tests

### DIFF
--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -7,6 +7,8 @@ import { showSettingsError } from "../showSettingsError.js";
 import { showSnackbar } from "../showSnackbar.js";
 import { toggleViewportSimulation } from "../viewportDebug.js";
 import { toggleTooltipOverlayDebug } from "../tooltipOverlayDebug.js";
+import { toggleLayoutDebugPanel } from "../layoutDebugPanel.js";
+import { showSettingsInfo } from "../showSettingsInfo.js";
 
 /**
  * Apply a value to an input or checkbox element.
@@ -244,6 +246,19 @@ export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, 
         }
         if (flag === "tooltipOverlayDebug") {
           toggleTooltipOverlayDebug(input.checked);
+        }
+        if (flag === "layoutDebugPanel") {
+          toggleLayoutDebugPanel(input.checked);
+        }
+        if (
+          [
+            "showCardOfTheDay",
+            "viewportSimulation",
+            "tooltipOverlayDebug",
+            "layoutDebugPanel"
+          ].includes(flag)
+        ) {
+          showSettingsInfo(info.label, info.description);
         }
       });
     });

--- a/tests/helpers/layoutDebugPanel.test.js
+++ b/tests/helpers/layoutDebugPanel.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("toggleLayoutDebugPanel", () => {
+  it("adds and removes the panel", () => {
+    const create = vi.fn(() => {
+      const el = document.createElement("div");
+      el.id = "layout-debug-panel";
+      return el;
+    });
+    vi.doMock("../../src/components/LayoutDebugPanel.js", () => ({
+      createLayoutDebugPanel: create
+    }));
+    // reload module after mocking
+    return import("../../src/helpers/layoutDebugPanel.js").then((mod) => {
+      mod.toggleLayoutDebugPanel(true);
+      expect(document.getElementById("layout-debug-panel")).toBeTruthy();
+      mod.toggleLayoutDebugPanel(false);
+      expect(document.getElementById("layout-debug-panel")).toBeNull();
+    });
+  });
+});

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -34,6 +34,26 @@ const baseSettings = {
       label: "Card Inspector",
       description: "Shows raw card JSON in a panel"
     },
+    showCardOfTheDay: {
+      enabled: false,
+      label: "Card Of The Day",
+      description: "Displays a rotating featured judoka card on the landing screen"
+    },
+    viewportSimulation: {
+      enabled: false,
+      label: "Viewport Simulation",
+      description: "Adds a dropdown to simulate common device viewport sizes"
+    },
+    tooltipOverlayDebug: {
+      enabled: false,
+      label: "Tooltip Overlay Debug",
+      description: "Shows bounding boxes for tooltip targets"
+    },
+    layoutDebugPanel: {
+      enabled: false,
+      label: "Layout Debug Panel",
+      description: "Displays CSS grid and flex outlines for debugging layout issues"
+    },
     navCacheResetButton: {
       enabled: false,
       label: "Navigation Cache Reset",
@@ -345,8 +365,184 @@ describe("settingsPage module", () => {
       fullNavigationMap: baseSettings.featureFlags.fullNavigationMap,
       enableTestMode: baseSettings.featureFlags.enableTestMode,
       enableCardInspector: baseSettings.featureFlags.enableCardInspector,
+      showCardOfTheDay: baseSettings.featureFlags.showCardOfTheDay,
+      viewportSimulation: baseSettings.featureFlags.viewportSimulation,
+      tooltipOverlayDebug: baseSettings.featureFlags.tooltipOverlayDebug,
+      layoutDebugPanel: baseSettings.featureFlags.layoutDebugPanel,
       navCacheResetButton: baseSettings.featureFlags.navCacheResetButton
     });
+  });
+
+  it("toggling showCardOfTheDay updates setting and shows info modal", async () => {
+    vi.useFakeTimers();
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updatedSettings = {
+      ...baseSettings,
+      featureFlags: {
+        ...baseSettings.featureFlags,
+        showCardOfTheDay: {
+          ...baseSettings.featureFlags.showCardOfTheDay,
+          enabled: true
+        }
+      }
+    };
+    const updateSetting = vi.fn().mockResolvedValue(updatedSettings);
+    const loadNavigationItems = vi.fn().mockResolvedValue([]);
+    const showSettingsInfo = vi.fn();
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
+      updateNavigationItemHidden: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/showSettingsInfo.js", () => ({ showSettingsInfo }));
+
+    await import("../../src/helpers/settingsPage.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const input = document.querySelector("#feature-show-card-of-the-day");
+    input.checked = true;
+    input.dispatchEvent(new Event("change"));
+    await vi.runAllTimersAsync();
+
+    expect(updateSetting).toHaveBeenCalledWith("featureFlags", updatedSettings.featureFlags);
+    expect(showSettingsInfo).toHaveBeenCalledWith(
+      baseSettings.featureFlags.showCardOfTheDay.label,
+      baseSettings.featureFlags.showCardOfTheDay.description
+    );
+  });
+
+  it("toggling viewportSimulation updates setting and shows info modal", async () => {
+    vi.useFakeTimers();
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updatedSettings = {
+      ...baseSettings,
+      featureFlags: {
+        ...baseSettings.featureFlags,
+        viewportSimulation: {
+          ...baseSettings.featureFlags.viewportSimulation,
+          enabled: true
+        }
+      }
+    };
+    const updateSetting = vi.fn().mockResolvedValue(updatedSettings);
+    const loadNavigationItems = vi.fn().mockResolvedValue([]);
+    const showSettingsInfo = vi.fn();
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
+      updateNavigationItemHidden: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/showSettingsInfo.js", () => ({ showSettingsInfo }));
+
+    await import("../../src/helpers/settingsPage.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const input = document.querySelector("#feature-viewport-simulation");
+    input.checked = true;
+    input.dispatchEvent(new Event("change"));
+    await vi.runAllTimersAsync();
+
+    expect(updateSetting).toHaveBeenCalledWith("featureFlags", updatedSettings.featureFlags);
+    expect(showSettingsInfo).toHaveBeenCalledWith(
+      baseSettings.featureFlags.viewportSimulation.label,
+      baseSettings.featureFlags.viewportSimulation.description
+    );
+  });
+
+  it("toggling tooltipOverlayDebug updates setting and shows info modal", async () => {
+    vi.useFakeTimers();
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updatedSettings = {
+      ...baseSettings,
+      featureFlags: {
+        ...baseSettings.featureFlags,
+        tooltipOverlayDebug: {
+          ...baseSettings.featureFlags.tooltipOverlayDebug,
+          enabled: true
+        }
+      }
+    };
+    const updateSetting = vi.fn().mockResolvedValue(updatedSettings);
+    const loadNavigationItems = vi.fn().mockResolvedValue([]);
+    const showSettingsInfo = vi.fn();
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
+      updateNavigationItemHidden: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/showSettingsInfo.js", () => ({ showSettingsInfo }));
+
+    await import("../../src/helpers/settingsPage.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const input = document.querySelector("#feature-tooltip-overlay-debug");
+    input.checked = true;
+    input.dispatchEvent(new Event("change"));
+    await vi.runAllTimersAsync();
+
+    expect(updateSetting).toHaveBeenCalledWith("featureFlags", updatedSettings.featureFlags);
+    expect(showSettingsInfo).toHaveBeenCalledWith(
+      baseSettings.featureFlags.tooltipOverlayDebug.label,
+      baseSettings.featureFlags.tooltipOverlayDebug.description
+    );
+  });
+
+  it("toggling layoutDebugPanel updates setting and shows info modal", async () => {
+    vi.useFakeTimers();
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updatedSettings = {
+      ...baseSettings,
+      featureFlags: {
+        ...baseSettings.featureFlags,
+        layoutDebugPanel: {
+          ...baseSettings.featureFlags.layoutDebugPanel,
+          enabled: true
+        }
+      }
+    };
+    const updateSetting = vi.fn().mockResolvedValue(updatedSettings);
+    const loadNavigationItems = vi.fn().mockResolvedValue([]);
+    const showSettingsInfo = vi.fn();
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
+      updateNavigationItemHidden: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/showSettingsInfo.js", () => ({ showSettingsInfo }));
+
+    await import("../../src/helpers/settingsPage.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const input = document.querySelector("#feature-layout-debug-panel");
+    input.checked = true;
+    input.dispatchEvent(new Event("change"));
+    await vi.runAllTimersAsync();
+
+    expect(updateSetting).toHaveBeenCalledWith("featureFlags", updatedSettings.featureFlags);
+    expect(showSettingsInfo).toHaveBeenCalledWith(
+      baseSettings.featureFlags.layoutDebugPanel.label,
+      baseSettings.featureFlags.layoutDebugPanel.description
+    );
   });
 
   it("clicking restore defaults requires confirmation", async () => {

--- a/tests/helpers/showSettingsInfo.test.js
+++ b/tests/helpers/showSettingsInfo.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { showSettingsInfo } from "../../src/helpers/showSettingsInfo.js";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("showSettingsInfo", () => {
+  it("creates and opens the modal", () => {
+    const modal = showSettingsInfo("Flag", "desc");
+    const title = document.getElementById("settings-info-title");
+    const desc = document.getElementById("settings-info-desc");
+    expect(title.textContent).toBe("Flag");
+    expect(desc.textContent).toBe("desc");
+    expect(document.body.contains(modal.element)).toBe(true);
+    const ok = document.getElementById("settings-info-ok");
+    ok.click();
+    expect(document.body.contains(modal.element)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- extend settings feature flag toggles to call `showSettingsInfo`
- test `toggleLayoutDebugPanel` and `showSettingsInfo`
- expand settings page tests for new flags

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_688b4a42042c8326ace02464d8f39f7f