### PR TITLE
Add statNames JSON schema

### DIFF
--- a/design/dataSchemas/README.md
+++ b/design/dataSchemas/README.md
@@ -10,7 +10,7 @@ Run `npm run validate:data` to check all schema and data pairs at once. The comm
 npx ajv validate -s src/schemas/judoka.schema.json -d src/data/judoka.json
 ```
 
-Run the command for every pair of schema and data file (e.g. `gameModes`, `weightCategories`). The CLI reports any mismatches so they can be fixed before runtime. A new schema, `navigationItems.schema.json`, validates the structure of `navigationItems.json` which drives navigation order and visibility. Another schema, `aesopsMeta.schema.json`, describes the quote metadata file used on the meditation screen. Tests also verify that each ID in `aesopsMeta.json` exists in `aesopsFables.json`.
+Run the command for every pair of schema and data file (e.g. `gameModes`, `weightCategories`). The CLI reports any mismatches so they can be fixed before runtime. A new schema, `navigationItems.schema.json`, validates the structure of `navigationItems.json` which drives navigation order and visibility. Another schema, `aesopsMeta.schema.json`, describes the quote metadata file used on the meditation screen. A third schema, `statNames.schema.json`, defines the structure of `statNames.json` which lists all available stats. Tests also verify that each ID in `aesopsMeta.json` exists in `aesopsFables.json`.
 
 ## Updating Schemas
 

--- a/scripts/validateData.js
+++ b/scripts/validateData.js
@@ -11,6 +11,9 @@ const schemaFiles = await glob("src/schemas/*.schema.json", { cwd: rootDir });
 if (!schemaFiles.includes("src/schemas/tooltips.schema.json")) {
   schemaFiles.push("src/schemas/tooltips.schema.json");
 }
+if (!schemaFiles.includes("src/schemas/statNames.schema.json")) {
+  schemaFiles.push("src/schemas/statNames.schema.json");
+}
 
 let hasErrors = false;
 for (const schemaPath of schemaFiles) {

--- a/src/schemas/statNames.schema.json
+++ b/src/schemas/statNames.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://judokon.dev/schemas/statNames.schema.json",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "integer",
+        "description": "Unique identifier for the stat"
+      },
+      "statIndex": {
+        "type": "integer",
+        "enum": [1, 2, 3, 4, 5],
+        "description": "Ordering index for display"
+      },
+      "name": {
+        "type": "string",
+        "description": "English label for the stat"
+      },
+      "category": {
+        "type": "string",
+        "description": "Stat category such as 'Judo'"
+      },
+      "japanese": {
+        "type": "string",
+        "description": "Japanese name of the stat"
+      },
+      "description": {
+        "type": "string",
+        "description": "Short explanation of the stat"
+      }
+    },
+    "required": [
+      "id",
+      "statIndex",
+      "name",
+      "category",
+      "japanese",
+      "description"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/tests/data/schemaValidation.test.js
+++ b/tests/data/schemaValidation.test.js
@@ -20,7 +20,8 @@ const pairs = [
   ["aesopsMeta.json", "aesopsMeta.schema.json"],
   ["japaneseConverter.json", "japaneseConverter.schema.json"],
   ["locations.json", "locations.schema.json"],
-  ["settings.json", "settings.schema.json"]
+  ["settings.json", "settings.schema.json"],
+  ["statNames.json", "statNames.schema.json"]
 ];
 
 let ajv;


### PR DESCRIPTION
## Summary
- define schema for `statNames.json`
- validate `statNames.json` in the data validation script and unit tests
- document the new schema in the data schemas README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run validate:data` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_688b543ccd0c83268e5570a16886e3ea