### PR TITLE
Rearrange battle screen layout

### DIFF
--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -318,7 +318,7 @@ Each **game mode or feature area** is assigned a **unique dominant colour**, cre
 
 ### 8.8 Battle Layout
 
-- In Classic Battle screens, player and opponent cards align horizontally. They only stack vertically on very narrow screens (<480 px). Stat controls sit below the card row.
+- In Classic Battle screens, player and opponent cards align horizontally using a three-column grid. Stat controls occupy the center column. On very narrow screens (<480 px) the layout stacks vertically with stat controls below the cards.
 - Stat selection buttons should use a grid layout with equal widths and small gaps so players choose solely based on card stats.
 
 ---

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -140,8 +140,9 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Use consistent color coding for player (blue) vs opponent (red) as shown in attached mockups.
 - Display clear, large call-to-action text for "Choose an attribute to challenge!" to guide new players.
 - Provide a quit confirmation when the player clicks the logo in the header to return to the Home screen.
-- Match screens should follow the style and layouts demonstrated in shared mockups:
+  - Match screens should follow the style and layouts demonstrated in shared mockups:
   - Player and opponent cards side-by-side.
+  - Stat selection buttons sit in a center column between the two cards on screens wider than 480px; on narrow screens they appear below the cards.
   - Central score prominently displayed.
   - Tie or win/loss messages placed centrally.
   - Clear "Next Round" button with distinct state (enabled/disabled). When disabled, the button should remain visible using the `--button-disabled-bg` token.

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -50,12 +50,6 @@
       <main class="container" role="main">
         <section id="battle-area">
           <div id="player-card" class="card-slot"></div>
-          <div id="computer-card" class="card-slot" aria-label="Mystery Judoka: hidden card">
-            <!--
-  Mystery Judoka card is rendered here. ARIA attributes and stat labels should be set dynamically for accessibility compliance (see PRD: Mystery Card).
--->
-          </div>
-
           <div id="controls">
             <div class="stat-controls">
               <div
@@ -128,6 +122,11 @@
             <div id="debug-panel" class="debug-panel hidden">
               <pre id="debug-output" role="status" aria-live="polite"></pre>
             </div>
+          </div>
+          <div id="computer-card" class="card-slot" aria-label="Mystery Judoka: hidden card">
+            <!--
+  Mystery Judoka card is rendered here. ARIA attributes and stat labels should be set dynamically for accessibility compliance (see PRD: Mystery Card).
+ -->
           </div>
         </section>
       </main>

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -202,21 +202,21 @@ body {
 
 /* Battle screen layout */
 #battle-area {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  justify-items: center;
+  align-items: flex-start;
   gap: var(--space-lg);
 }
 
 #battle-area .card-slot {
   display: flex;
-  flex: 1 1 260px;
   justify-content: center;
   align-items: center;
 }
 
 #battle-area #controls {
-  flex-basis: 100%;
+  grid-column: 2;
   text-align: center;
 }
 
@@ -229,7 +229,11 @@ body {
 
 @media (max-width: 480px) {
   #battle-area {
-    flex-direction: column;
+    grid-template-columns: 1fr;
+  }
+
+  #battle-area #controls {
+    grid-column: 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- position battle stat controls between the two cards
- describe new 3‑column battle layout in PRD and style guide

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688b72164de8832683f08bad980429d6