### PR TITLE
Remove obsolete PRD viewer buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,14 +222,11 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
 Product Requirements Documents live in `design/productRequirementsDocuments`.
 Add new Markdown files there and include the filename in the `FILES` array of
 `src/helpers/prdReaderPage.js`. Open `src/pages/prdViewer.html` in your browser
-to browse the documents with next/previous navigation. A sidebar lists all
-available PRDs and clicking an entry loads it immediately. Buttons tagged with
-`data-nav="prev"` and `data-nav="next"` appear in both the header and footer.
-The page now imports `base.css` and `layout.css` so wide elements stay wrapped
-inside the viewport. Navigation buttons remain left-aligned with a gap so they
-don't interfere with the centered content, and the body adds bottom padding so
-the footer buttons clear the persistent navigation bar. Users can return to the
- main menu via the Home button.
+to browse the documents. A sidebar lists all available PRDs and clicking an
+entry loads it immediately. Arrow keys and swipe gestures also cycle through the
+documents. The page imports `base.css` and `layout.css` so wide elements stay
+wrapped inside the viewport. Users can return to the main menu by clicking the
+logo in the header.
 
 ### CSS Organization
 

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -33,7 +33,7 @@ initialize page-specific behavior. The change log view uses
 `src/helpers/prdReaderPage.js` to display the Product Requirements
 Documents. The Markdown files live in
 `design/productRequirementsDocuments`. The helper fetches each file,
-converts it with `markdownToHtml`—a wrapper around the minimal **Marked** parser (supporting headings, paragraphs, bold text, mixed ordered and unordered lists, tables, and horizontal rules rendered as `<br/><hr/><br/>` for extra spacing)—and injects the HTML into the `#prd-content` container. It also builds the sidebar list in `#prd-list` and loads the chosen document when an item is clicked. Buttons marked with `data-nav="prev"` or `data-nav="next"` appear in both the header and footer. Arrow keys and swipe gestures cycle through the loaded documents. A Home button in the header returns to `index.html`.
+converts it with `markdownToHtml`—a wrapper around the minimal **Marked** parser (supporting headings, paragraphs, bold text, mixed ordered and unordered lists, tables, and horizontal rules rendered as `<br/><hr/><br/>` for extra spacing)—and injects the HTML into the `#prd-content` container. It also builds the sidebar list in `#prd-list` and loads the chosen document when an item is clicked. Arrow keys and swipe gestures cycle through the loaded documents, and the logo links back to `index.html`.
 
 ## components/
 

--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -33,11 +33,11 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 - The viewer loads all markdown files from the `design/productRequirementsDocuments` directory.
 - The player views the first PRD rendered as styled HTML.
 - The player navigates between PRDs by:
-  - Clicking “Next” or “Previous” buttons,
+  - Selecting a document from the sidebar list,
   - Pressing left/right arrow keys,
   - Swiping left/right on touch devices.
 - Navigation loops around at the ends of the PRD list.
-- The player can click the JU-DO-KON! logo or a dedicated “Home” link to exit the viewer at any time.
+- The player can click the JU-DO-KON! logo to exit the viewer at any time.
 - If loading a markdown file fails, an error message is shown for that document, and the player can continue navigating others.
 - If a markdown file is malformed, partial content is shown with a warning badge.
 - The viewer is fully keyboard operable, supports screen readers, and adapts layout for desktop, tablet, and mobile screens.
@@ -48,7 +48,6 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 | -------- | -------------------------- | -------------------------------------------------------------------- |
 | P1       | Markdown PRD Loading       | Load all markdown files from the PRD directory and display them.     |
 | P1       | Markdown-to-HTML Rendering | Convert markdown to styled HTML with accurate formatting.            |
-| P1       | Next/Previous Navigation   | Buttons for navigating PRDs with wrap-around at ends.                |
 | P1       | Keyboard Navigation        | Allow navigation via arrow keys with focus management.               |
 | P1       | Touch/Swipe Navigation     | Support swipe gestures with gesture threshold to avoid misfires.     |
 | P1       | Sidebar Document List      | Sidebar lists all PRDs and selecting one loads that document.       |
@@ -60,12 +59,10 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
 - Given the PRD Viewer is opened, when loading the markdown files in `design/productRequirementsDocuments/`, then all files are loaded and displayed in sequence.
 - Given a markdown file is rendered, then headings, tables, lists, and code blocks appear styled as readable HTML.
-- Given the player clicks “Next” or “Prev” buttons, then navigation moves to the next/previous PRD, looping from last to first or vice versa.
 - Given the player presses the right or left arrow keys, then navigation moves accordingly between PRDs.
 - Given the player selects a document from the sidebar list, then that PRD is displayed in the viewer.
 - Given the player swipes left or right on a touch device, then the viewer navigates to the next or previous PRD respecting a minimum gesture threshold.
 - Given the player is on any screen size, then the layout adapts to desktop, tablet, or mobile formats responsively.
-- Given the navigation buttons are rendered, then they are keyboard focusable with ARIA labels and visible focus outlines.
 - Given the player clicks the JU-DO-KON! logo or “Home” link, then the viewer exits to the main homepage.
 - Given a markdown file fails to load, then an error is logged to the console, a fallback message is shown, and other files remain navigable.
 - Given malformed markdown content, then partial content is rendered with a warning badge visually indicating an issue.
@@ -96,7 +93,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
 ## Mockups / Visual Reference
 
-- Header with clickable JU-DO-KON! logo (links Home), page title, and Prev/Next navigation buttons.
+- Header with clickable JU-DO-KON! logo and page title.
 - Large scrollable markdown-rendered content area.
 - Warning badge in content area if markdown partially rendered.
 - Bottom footer with keyboard and swipe navigation instructions.
@@ -118,9 +115,8 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
 - [x] 3.0 Build Navigation System
 
-  - [x] 3.1 Add Prev and Next buttons with wrap-around navigation
-  - [x] 3.2 Implement keyboard arrow key navigation and focus management
-  - [x] 3.3 Add swipe gesture detection with minimum threshold to avoid accidental triggers
+  - [x] 3.1 Implement keyboard arrow key navigation and focus management
+  - [x] 3.2 Add swipe gesture detection with minimum threshold to avoid accidental triggers
 
 - [x] 4.0 Ensure Accessibility and Responsiveness
 

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -18,14 +18,6 @@
           <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
         </a>
       </div>
-      <br />
-      <div class="nav-buttons">
-        <button id="prev-doc" data-nav="prev" aria-label="Previous document">Prev</button>
-        <a href="../../index.html" data-testid="home-link">Home</a>
-        <button id="next-doc" data-nav="next" aria-label="Next document">Next</button>
-        <!--     <button data-nav="prev" aria-label="Previous document">Prev</button>
-        <button data-nav="next" aria-label="Next document">Next</button> -->
-      </div>
     </header>
 
     <main class="prd-viewer">
@@ -37,11 +29,6 @@
 
     <footer>
       <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
-      <div class="nav-buttons">
-        <button data-nav="prev" aria-label="Previous document">Prev</button>
-        <a href="../../index.html" data-testid="home-link">Home</a>
-        <button data-nav="next" aria-label="Next document">Next</button>
-      </div>
     </footer>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
     <script type="module" src="../helpers/setupDisplaySettings.js"></script>


### PR DESCRIPTION
## Summary
- remove Prev/Next/Home buttons from `prdViewer.html`
- revise PRD viewer documentation for sidebar navigation
- update architecture overview and README

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npx playwright test` *(fails: 403 Forbidden fetching playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688b7291f0f48326b4786dc0da675dd3