### PR TITLE
Add stat name loader

### DIFF
--- a/src/helpers/stats.js
+++ b/src/helpers/stats.js
@@ -1,0 +1,52 @@
+import { fetchJson } from "./dataUtils.js";
+import { DATA_DIR } from "./constants.js";
+
+let namesPromise;
+let cachedNames;
+let labelMap;
+
+function slug(name) {
+  return name.toLowerCase().replace(/[-\s]/g, "");
+}
+
+/**
+ * Load stat definitions once and return those matching the category.
+ *
+ * @pseudocode
+ * 1. When cached data exists, filter by `category` and return it.
+ * 2. Otherwise fetch `statNames.json` via `fetchJson` and cache the promise.
+ * 3. Sort the data by `statIndex` and store a lookup of slugified names.
+ * 4. Return the entries matching `category`.
+ *
+ * @param {string} [category="Judo"] - Category of stats to load.
+ * @returns {Promise<Array<{id:number,statIndex:number,name:string,category:string,japanese:string,description:string}>>} Sorted stat objects.
+ */
+export async function loadStatNames(category = "Judo") {
+  if (!cachedNames) {
+    if (!namesPromise) {
+      namesPromise = fetchJson(`${DATA_DIR}statNames.json`).catch((err) => {
+        console.error("Failed to load stat names:", err);
+        return [];
+      });
+    }
+    cachedNames = (await namesPromise).sort((a, b) => a.statIndex - b.statIndex);
+    labelMap = Object.fromEntries(cachedNames.map((s) => [slug(s.name), s.name]));
+  }
+  return cachedNames.filter((s) => s.category === category);
+}
+
+/**
+ * Get the English label for a stat key.
+ *
+ * @pseudocode
+ * 1. Ensure stat data is loaded with `loadStatNames()`.
+ * 2. Look up the key in the cached label map.
+ * 3. Return the mapped label or an empty string when missing.
+ *
+ * @param {string} key - Stat key like `power` or `speed`.
+ * @returns {Promise<string>} English label for the stat or empty string.
+ */
+export async function getStatLabel(key) {
+  if (!labelMap) await loadStatNames();
+  return labelMap[key] || "";
+}

--- a/tests/helpers/stats.test.js
+++ b/tests/helpers/stats.test.js
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const sample = [
+  {
+    id: 12,
+    statIndex: 2,
+    name: "Speed",
+    category: "Judo",
+    japanese: "S",
+    description: ""
+  },
+  {
+    id: 11,
+    statIndex: 1,
+    name: "Power",
+    category: "Judo",
+    japanese: "P",
+    description: ""
+  },
+  {
+    id: 99,
+    statIndex: 1,
+    name: "Other",
+    category: "Other",
+    japanese: "O",
+    description: ""
+  }
+];
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("stats helper", () => {
+  it("loads and caches stat names", async () => {
+    const fetchJson = vi.fn().mockResolvedValue(sample);
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
+    const { loadStatNames } = await import("../../src/helpers/stats.js");
+    const first = await loadStatNames();
+    const second = await loadStatNames();
+    expect(first.map((s) => s.name)).toEqual(["Power", "Speed"]);
+    expect(second).toEqual(first);
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+  });
+
+  it("gets label by key", async () => {
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue(sample)
+    }));
+    const { getStatLabel } = await import("../../src/helpers/stats.js");
+    const label = await getStatLabel("speed");
+    expect(label).toBe("Speed");
+  });
+});


### PR DESCRIPTION
## Summary
- load statNames.json once and cache labels
- test stats helper functions

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688b7150d49c8326ae9118ff2f1ad581