### PR TITLE
Add tooltip IDs for settings switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,24 @@ The Settings page (`src/pages/settings.html`) groups all player preferences, inc
 Default flag states and descriptions now live in `src/data/settings.json`. The **Tooltips** toggle on this page lets you turn help tooltips on or off globally.
 Each change triggers a small snackbar at the bottom of the screen confirming the new setting.
 
+Settings tooltips are referenced with `settings.*` keys in `tooltips.json`:
+
+```
+settings.sound
+settings.motionEffects
+settings.typewriterEffect
+settings.tooltips
+settings.battleDebugPanel
+settings.fullNavigationMap
+settings.enableTestMode
+settings.enableCardInspector
+settings.showCardOfTheDay
+settings.viewportSimulation
+settings.tooltipOverlayDebug
+settings.layoutDebugPanel
+settings.navCacheResetButton
+```
+
 Feature flags allow temporary or advanced tools without code changes:
 
 - **Battle Debug Panel** – shows a collapsible `<pre>` on battle pages with live match data.

--- a/src/components/ToggleSwitch.js
+++ b/src/components/ToggleSwitch.js
@@ -5,7 +5,7 @@
  * 1. Create a wrapper div with class `settings-item`.
  * 2. Create a label with class `switch` and set `htmlFor` when an id is provided.
  * 3. Inside the label, add an `input` of type checkbox using provided options
- *    for `id`, `name`, `checked` and `aria-label`.
+ *    for `id`, `name`, `checked`, `aria-label` and optional `tooltipId`.
  * 4. Add a `div` acting as the slider and a `span` containing the label text.
  * 5. Append the input, slider and span to the label and return the wrapper
  *    containing the complete toggle switch markup.
@@ -16,10 +16,11 @@
  * @param {string} [options.name] - Name attribute for the input.
  * @param {boolean} [options.checked=false] - Initial checked state.
  * @param {string} [options.ariaLabel] - Custom ARIA label, defaults to labelText.
+ * @param {string} [options.tooltipId] - Tooltip identifier to attach to the input.
  * @returns {HTMLDivElement} Wrapper element containing the toggle switch.
  */
 export function createToggleSwitch(labelText, options = {}) {
-  const { id, name, checked = false, ariaLabel = labelText } = options;
+  const { id, name, checked = false, ariaLabel = labelText, tooltipId } = options;
 
   const wrapper = document.createElement("div");
   wrapper.className = "settings-item";
@@ -34,6 +35,7 @@ export function createToggleSwitch(labelText, options = {}) {
   if (name) input.name = name;
   input.checked = checked;
   input.setAttribute("aria-label", ariaLabel);
+  if (tooltipId) input.dataset.tooltipId = tooltipId;
 
   const slider = document.createElement("div");
   slider.className = "slider round";

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -4,52 +4,67 @@
   "typewriterEffect": false,
   "tooltips": true,
   "displayMode": "light",
+  "tooltipIds": {
+    "sound": "settings.sound",
+    "motionEffects": "settings.motionEffects",
+    "typewriterEffect": "settings.typewriterEffect",
+    "tooltips": "settings.tooltips"
+  },
   "gameModes": {},
   "featureFlags": {
     "battleDebugPanel": {
       "enabled": false,
       "label": "Battle Debug Panel",
-      "description": "Adds a collapsible debug panel using the `.debug-panel` class for verbose state outputs"
+      "description": "Adds a collapsible debug panel using the `.debug-panel` class for verbose state outputs",
+      "tooltipId": "settings.battleDebugPanel"
     },
     "fullNavigationMap": {
       "enabled": false,
       "label": "Full Navigation Map",
-      "description": "An immersive, thematic expanded map view for Ju-Do-Kon!’s navigation, transforming mode selection into a Judo Training Village experience"
+      "description": "An immersive, thematic expanded map view for Ju-Do-Kon!’s navigation, transforming mode selection into a Judo Training Village experience",
+      "tooltipId": "settings.fullNavigationMap"
     },
     "enableTestMode": {
       "enabled": false,
       "label": "Test Mode",
-      "description": "Card draws and stat choices become deterministic for repeat tests and debugging"
+      "description": "Card draws and stat choices become deterministic for repeat tests and debugging",
+      "tooltipId": "settings.enableTestMode"
     },
     "enableCardInspector": {
       "enabled": false,
       "label": "Card Inspector",
-      "description": "Adds a collapsible panel displaying raw card JSON on each card"
+      "description": "Adds a collapsible panel displaying raw card JSON on each card",
+      "tooltipId": "settings.enableCardInspector"
     },
     "showCardOfTheDay": {
       "enabled": false,
       "label": "Card Of The Day",
-      "description": "Displays a rotating featured judoka card on the landing screen"
+      "description": "Displays a rotating featured judoka card on the landing screen",
+      "tooltipId": "settings.showCardOfTheDay"
     },
     "viewportSimulation": {
       "enabled": false,
       "label": "Viewport Simulation",
-      "description": "Adds a dropdown to simulate common device viewport sizes"
+      "description": "Adds a dropdown to simulate common device viewport sizes",
+      "tooltipId": "settings.viewportSimulation"
     },
     "tooltipOverlayDebug": {
       "enabled": false,
       "label": "Tooltip Overlay Debug",
-      "description": "Shows bounding boxes for tooltip targets"
+      "description": "Shows bounding boxes for tooltip targets",
+      "tooltipId": "settings.tooltipOverlayDebug"
     },
     "layoutDebugPanel": {
       "enabled": false,
       "label": "Layout Debug Panel",
-      "description": "Displays CSS grid and flex outlines for debugging layout issues"
+      "description": "Displays CSS grid and flex outlines for debugging layout issues",
+      "tooltipId": "settings.layoutDebugPanel"
     },
     "navCacheResetButton": {
       "enabled": false,
       "label": "Navigation Cache Reset",
-      "description": "Adds a button to clear cached navigation data for troubleshooting"
+      "description": "Adds a button to clear cached navigation data for troubleshooting",
+      "tooltipId": "settings.navCacheResetButton"
     }
   }
 }

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -39,6 +39,21 @@
     "settings": "**Settings**\nAdjust game options.",
     "home": "**Home**\nReturn to the main screen."
   },
+  "settings": {
+    "sound": "Toggle all game audio on or off.",
+    "motionEffects": "Enable smooth animations throughout the UI.",
+    "typewriterEffect": "Animate meditation quotes one letter at a time.",
+    "tooltips": "Show helpful pop-up hints when hovering controls.",
+    "battleDebugPanel": "Show a panel with live match data for debugging.",
+    "fullNavigationMap": "Display an overlay map linking to every page.",
+    "enableTestMode": "Run deterministic matches for testing.",
+    "enableCardInspector": "Reveal raw card JSON in a collapsible panel.",
+    "showCardOfTheDay": "Highlight a featured judoka on the home page.",
+    "viewportSimulation": "Choose preset sizes to simulate different devices.",
+    "tooltipOverlayDebug": "Outline tooltip targets to debug placement.",
+    "layoutDebugPanel": "Show CSS outlines to inspect page layout.",
+    "navCacheResetButton": "Add a button to clear cached navigation data."
+  },
   "card": {
     "flag": "**Country flag**\nRepresents the judoka’s nation.",
     "weightClass": "**Weight class**\nCompetition weight category."

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -41,7 +41,13 @@ function applyInputState(element, value) {
  */
 export function applyInitialControlValues(controls, settings) {
   applyInputState(controls.soundToggle, settings.sound);
+  if (controls.soundToggle && settings.tooltipIds?.sound) {
+    controls.soundToggle.dataset.tooltipId = settings.tooltipIds.sound;
+  }
   applyInputState(controls.motionToggle, settings.motionEffects);
+  if (controls.motionToggle && settings.tooltipIds?.motionEffects) {
+    controls.motionToggle.dataset.tooltipId = settings.tooltipIds.motionEffects;
+  }
   if (controls.displayRadios) {
     controls.displayRadios.forEach((radio) => {
       const isSelected = radio.value === settings.displayMode;
@@ -50,7 +56,13 @@ export function applyInitialControlValues(controls, settings) {
     });
   }
   applyInputState(controls.typewriterToggle, settings.typewriterEffect);
+  if (controls.typewriterToggle && settings.tooltipIds?.typewriterEffect) {
+    controls.typewriterToggle.dataset.tooltipId = settings.tooltipIds.typewriterEffect;
+  }
   applyInputState(controls.tooltipsToggle, settings.tooltips);
+  if (controls.tooltipsToggle && settings.tooltipIds?.tooltips) {
+    controls.tooltipsToggle.dataset.tooltipId = settings.tooltipIds.tooltips;
+  }
 }
 
 /**
@@ -221,7 +233,8 @@ export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, 
       id: `feature-${kebab}`,
       name: flag,
       checked: Boolean(getCurrentSettings().featureFlags[flag]?.enabled),
-      ariaLabel: info.label
+      ariaLabel: info.label,
+      tooltipId: info.tooltipId
     });
     const desc = document.createElement("p");
     desc.className = "settings-description";

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -178,7 +178,6 @@ function initializeControls(settings, gameModes) {
     applyMotionPreference(currentSettings.motionEffects);
     toggleViewportSimulation(Boolean(currentSettings.featureFlags.viewportSimulation?.enabled));
     toggleTooltipOverlayDebug(Boolean(currentSettings.featureFlags.tooltipOverlayDebug?.enabled));
-    initTooltips();
     clearToggles(modesContainer);
     renderGameModeSwitches(modesContainer, gameModes, getCurrentSettings, handleUpdate);
     clearToggles(flagsContainer);
@@ -189,6 +188,7 @@ function initializeControls(settings, gameModes) {
       handleUpdate
     );
     addNavResetButton();
+    initTooltips();
     document.getElementById("feature-nav-cache-reset-button")?.addEventListener("change", () => {
       setTimeout(addNavResetButton);
     });

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -183,11 +183,13 @@ export function resetSettings() {
  * @property {boolean} motionEffects
  * @property {boolean} typewriterEffect
  * @property {"light"|"dark"|"gray"} displayMode
+ * @property {Record<string, string>} [tooltipIds]
  * @property {Record<string, boolean>} [gameModes]
  * @property {Record<string, {
  *   enabled: boolean,
  *   label: string,
- *   description: string
+ *   description: string,
+ *   tooltipId?: string
  * }>} [featureFlags]
  */
 

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -25,6 +25,11 @@
       "enum": ["light", "dark", "gray"],
       "description": "Visual display mode."
     },
+    "tooltipIds": {
+      "type": "object",
+      "description": "Mapping of setting keys to tooltip identifiers.",
+      "additionalProperties": { "type": "string" }
+    },
     "gameModes": {
       "type": "object",
       "description": "Per-mode enable/disable flags.",
@@ -47,6 +52,10 @@
           "description": {
             "type": "string",
             "description": "Brief explanation of the feature."
+          },
+          "tooltipId": {
+            "type": "string",
+            "description": "Tooltip identifier for this flag."
           }
         },
         "required": ["enabled", "label", "description"],

--- a/tests/helpers/toggleSwitch.test.js
+++ b/tests/helpers/toggleSwitch.test.js
@@ -7,7 +7,8 @@ describe("createToggleSwitch", () => {
       id: "sound-toggle",
       name: "sound",
       checked: true,
-      ariaLabel: "Sound toggle"
+      ariaLabel: "Sound toggle",
+      tooltipId: "settings.sound"
     });
     const label = wrapper.querySelector("label.switch");
     const input = wrapper.querySelector("input[type='checkbox']");
@@ -23,6 +24,7 @@ describe("createToggleSwitch", () => {
     expect(input).toHaveAttribute("aria-label", "Sound toggle");
     expect(slider?.classList.contains("round")).toBe(true);
     expect(span?.textContent).toBe("Sound");
+    expect(input?.dataset.tooltipId).toBe("settings.sound");
   });
 
   it("defaults to unchecked when not specified", () => {
@@ -35,5 +37,11 @@ describe("createToggleSwitch", () => {
     const wrapper = createToggleSwitch("AutoToggle");
     const input = wrapper.querySelector("input[type='checkbox']");
     expect(input).toHaveAttribute("aria-label", "AutoToggle");
+  });
+
+  it("omits tooltip attribute when none provided", () => {
+    const wrapper = createToggleSwitch("NoTip");
+    const input = wrapper.querySelector("input[type='checkbox']");
+    expect(input?.dataset.tooltipId).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- allow `createToggleSwitch` to set data-tooltip-id
- store tooltip IDs for settings in `settings.json`
- surface tooltip strings under new `settings` section
- attach tooltip IDs when rendering settings toggles
- move `initTooltips` after switches are rebuilt
- document available `settings.*` tooltip keys
- test `createToggleSwitch` tooltip option

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688b713f79348326a1a3a12c2ac73616