### PR TITLE
Add sidebar navigation for mockups

### DIFF
--- a/design/productRequirementsDocuments/prdMockupViewer.md
+++ b/design/productRequirementsDocuments/prdMockupViewer.md
@@ -34,6 +34,7 @@ Designers and developers previously relied on scattered folder structures to fin
 | P1       | Filename Display    | Shows filename of the currently displayed image              |
 | P1       | Mouse Navigation    | Next/Previous buttons for cycling images                     |
 | P1       | Keyboard Navigation | Supports left/right arrow keys for navigation                |
+| P1       | Sidebar File List   | Left panel lists all mockups for direct selection            |
 | P1       | Image Preloading    | Loads adjacent images to reduce wait time                    |
 | P2       | Accessibility       | Keyboard interaction, ARIA labels, and screen reader support |
 | P2       | Responsive Layout   | Adapts layout for desktop, tablet, and mobile                |
@@ -80,6 +81,7 @@ Designers and developers previously relied on scattered folder structures to fin
 
 **Layout Elements (Desktop View):**
 
+- Left sidebar lists all mockup files for quick navigation.
 - Image centered with filename below.
 - Images must scale to fit the viewport so wide mockups remain fully
   visible without horizontal scrolling.
@@ -98,6 +100,7 @@ Designers and developers previously relied on scattered folder structures to fin
   - [x] 1.1 Load and display mockup images from `design/mockups/`
   - [x] 1.2 Display filename below the image
   - [x] 1.3 Show first image on page load
+  - [x] 1.4 Provide sidebar list of mockups for selection
 - [x] 2.0 Implement Image Navigation
   - [x] 2.1 Add "Next" and "Previous" mouse buttons
   - [x] 2.2 Add left/right keyboard arrow navigation

--- a/src/helpers/mockupViewerPage.js
+++ b/src/helpers/mockupViewerPage.js
@@ -6,11 +6,11 @@ import { initTooltips } from "./tooltip.js";
  * Initialize the mockup image carousel.
  *
  * @pseudocode
- * 1. Select the image, filename display, and navigation buttons.
+ * 1. Select the image, filename display, sidebar list, and navigation buttons.
  * 2. Define an array of mockup filenames and compute their base URL.
- * 3. Implement `showImage(index)` to update the image source, alt text, and filename.
- * 4. Attach click handlers to cycle forward or backward with wraparound.
- * 5. Support arrow key navigation for accessibility.
+ * 3. Build sidebar list items that call `showImage(index)` when activated.
+ * 4. Implement `showImage(index)` to update the image, alt text, filename, and sidebar highlight.
+ * 5. Attach click handlers and keyboard events to cycle images with wraparound.
  * 6. Show the first image and apply button ripple effects.
  */
 export function setupMockupViewerPage() {
@@ -18,8 +18,9 @@ export function setupMockupViewerPage() {
   const filenameEl = document.getElementById("mockup-filename");
   const prevBtn = document.getElementById("prev-btn");
   const nextBtn = document.getElementById("next-btn");
+  const listEl = document.getElementById("mockup-list");
 
-  if (!imgEl || !filenameEl || !prevBtn || !nextBtn) {
+  if (!imgEl || !filenameEl || !prevBtn || !nextBtn || !listEl) {
     return;
   }
 
@@ -62,6 +63,20 @@ export function setupMockupViewerPage() {
     "mockupUpdateJudoka1.png"
   ];
 
+  files.forEach((file, i) => {
+    const li = document.createElement("li");
+    li.tabIndex = 0;
+    li.textContent = file;
+    li.addEventListener("click", () => showImage(i));
+    li.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        showImage(i);
+      }
+    });
+    listEl.appendChild(li);
+  });
+
   let currentIndex = 0;
 
   function showImage(index) {
@@ -72,6 +87,9 @@ export function setupMockupViewerPage() {
     filenameEl.textContent = file;
     imgEl.classList.add("fade");
     imgEl.style.display = "block";
+    Array.from(listEl.children).forEach((li, idx) => {
+      li.classList.toggle("selected", idx === currentIndex);
+    });
   }
 
   prevBtn.addEventListener("click", () => showImage(currentIndex - 1));
@@ -87,4 +105,6 @@ export function setupMockupViewerPage() {
   initTooltips();
 }
 
-onDomReady(setupMockupViewerPage);
+if (!window.SKIP_MOCKUP_AUTO_INIT) {
+  onDomReady(setupMockupViewerPage);
+}

--- a/src/pages/mockupViewer.html
+++ b/src/pages/mockupViewer.html
@@ -31,13 +31,18 @@
         </div>
         <div class="header-spacer right"></div>
       </header>
-      <main class="kodokan-grid center-content" role="main">
-        <div class="slideshow-container">
-          <img id="mockup-image" class="mockup-image" src="" alt="mockup" />
-          <div id="mockup-filename" class="mockup-filename"></div>
-          <button class="prev" id="prev-btn" aria-label="Previous image">&#10094;</button>
-          <button class="next" id="next-btn" aria-label="Next image">&#10095;</button>
-        </div>
+      <main class="mockup-viewer" role="main">
+        <aside class="sidebar">
+          <ul id="mockup-list"></ul>
+        </aside>
+        <section class="preview">
+          <div class="slideshow-container">
+            <img id="mockup-image" class="mockup-image" src="" alt="mockup" />
+            <div id="mockup-filename" class="mockup-filename"></div>
+            <button class="prev" id="prev-btn" aria-label="Previous image">&#10094;</button>
+            <button class="next" id="next-btn" aria-label="Next image">&#10095;</button>
+          </div>
+        </section>
       </main>
       <footer>
         <nav class="bottom-navbar" data-testid="bottom-nav"></nav>

--- a/src/styles/mockupViewer.css
+++ b/src/styles/mockupViewer.css
@@ -121,6 +121,54 @@ body {
   }
 }
 
+.mockup-viewer {
+  display: flex;
+  height: 100%;
+  width: 100%;
+}
+
+.mockup-viewer .sidebar {
+  flex: 0 0 35%;
+  max-width: 320px;
+  border-right: 1px solid var(--color-secondary);
+  padding: var(--space-md);
+  overflow-y: auto;
+}
+
+.mockup-viewer .sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mockup-viewer .sidebar li {
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+}
+
+.mockup-viewer .sidebar li.selected {
+  background: var(--color-secondary);
+  color: var(--color-text-inverted);
+}
+
+.mockup-viewer .preview {
+  flex: 1;
+  padding: var(--space-md);
+  overflow-y: auto;
+}
+
+@media (max-width: 600px) {
+  .mockup-viewer {
+    flex-direction: column;
+  }
+
+  .mockup-viewer .sidebar {
+    max-width: none;
+    border-right: none;
+    border-bottom: 1px solid var(--color-secondary);
+  }
+}
+
 .center-content {
   justify-items: center;
   grid-template-columns: 1fr;

--- a/tests/helpers/mockupViewerPage.test.js
+++ b/tests/helpers/mockupViewerPage.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+
+describe("mockupViewerPage", () => {
+  it("navigates images and updates sidebar", async () => {
+    document.body.innerHTML = `
+      <ul id="mockup-list"></ul>
+      <img id="mockup-image" />
+      <div id="mockup-filename"></div>
+      <button id="prev-btn">Prev</button>
+      <button id="next-btn">Next</button>
+    `;
+
+    globalThis.SKIP_MOCKUP_AUTO_INIT = true;
+    const { setupMockupViewerPage } = await import("../../src/helpers/mockupViewerPage.js");
+
+    setupMockupViewerPage();
+
+    const list = document.getElementById("mockup-list");
+    const img = document.getElementById("mockup-image");
+    const nextBtn = document.getElementById("next-btn");
+
+    expect(list.children.length).toBeGreaterThan(0);
+    const firstSrc = img.src;
+    nextBtn.click();
+    expect(list.children[1].classList.contains("selected")).toBe(true);
+    expect(img.src).not.toBe(firstSrc);
+  });
+
+  it("selects image via sidebar", async () => {
+    document.body.innerHTML = `
+      <ul id="mockup-list"></ul>
+      <img id="mockup-image" />
+      <div id="mockup-filename"></div>
+      <button id="prev-btn">Prev</button>
+      <button id="next-btn">Next</button>
+    `;
+
+    globalThis.SKIP_MOCKUP_AUTO_INIT = true;
+    const { setupMockupViewerPage } = await import("../../src/helpers/mockupViewerPage.js");
+
+    setupMockupViewerPage();
+
+    const list = document.getElementById("mockup-list");
+    const img = document.getElementById("mockup-image");
+    const item = list.children[1];
+
+    item.click();
+
+    expect(item.classList.contains("selected")).toBe(true);
+    expect(img.src).toContain(item.textContent);
+  });
+});


### PR DESCRIPTION
## Summary
- add sidebar layout and list to mockup viewer page
- mirror PRD viewer layout styles for mockup viewer
- update mockup viewer script to populate sidebar and highlight selection
- mention sidebar in PRD documentation
- test mockup viewer navigation

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688b735cdba88326892757441352ffc3