### PR TITLE
Fix stat reset test initialization wait

### DIFF
--- a/playwright/statReset.spec.js
+++ b/playwright/statReset.spec.js
@@ -6,6 +6,8 @@ import { test, expect } from "./fixtures/commonSetup.js";
 test.describe("Classic battle button reset", () => {
   test("no button stays selected after next round", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
+    const timer = page.locator("header #next-round-timer");
+    await timer.waitFor();
     await page.locator("#stat-buttons button[data-stat='power']").click();
     await page.locator("#next-round-button").click();
     await page.waitForFunction(() => {
@@ -17,6 +19,8 @@ test.describe("Classic battle button reset", () => {
 
   test("tap highlight color cleared after reset", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
+    const timer = page.locator("header #next-round-timer");
+    await timer.waitFor();
     const btn = page.locator("#stat-buttons button[data-stat='power']");
     await btn.click();
     await page.locator("#next-round-button").click();


### PR DESCRIPTION
## Summary
- wait for the round timer before interacting with stat buttons in statReset tests

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688b7584421c8326a627670b822a7ecb