### PR TITLE
Add aria-describedby for settings toggles

### DIFF
--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -105,6 +105,8 @@ Reuse the following markup for general settings, game modes, and feature flags:
 
   - Use `<label>` where possible
   - For custom toggles, add `aria-label` to `<input>`
+  - When a toggle includes descriptive text, give the `<p>` an `id` and
+    reference it with `aria-describedby` on the checkbox input
   - Fieldsets should include meaningful `<legend>`
 
 - **Screen Reader Considerations**

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -183,14 +183,17 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
       checked: isChecked,
       ariaLabel: mode.name
     });
+    const input = wrapper.querySelector("input");
     if (mode.description) {
       const desc = document.createElement("p");
       desc.className = "settings-description";
+      desc.id = `mode-${mode.id}-desc`;
       desc.textContent = mode.description;
       wrapper.appendChild(desc);
+      if (input) input.setAttribute("aria-describedby", desc.id);
     }
     container.appendChild(wrapper);
-    const input = wrapper.querySelector("input");
+    if (!input) return;
     input.addEventListener("change", () => {
       const prev = !input.checked;
       const updated = { ...getCurrentSettings().gameModes, [mode.id]: input.checked };
@@ -236,12 +239,15 @@ export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, 
       ariaLabel: info.label,
       tooltipId: info.tooltipId
     });
+    const input = wrapper.querySelector("input");
     const desc = document.createElement("p");
     desc.className = "settings-description";
+    desc.id = `feature-${kebab}-desc`;
     desc.textContent = info.description;
     wrapper.appendChild(desc);
+    if (input) input.setAttribute("aria-describedby", desc.id);
     container.appendChild(wrapper);
-    const input = wrapper.querySelector("input");
+    if (!input) return;
     input.addEventListener("change", () => {
       const prev = !input.checked;
       const updated = {

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -128,11 +128,17 @@
                 <legend>General Settings</legend>
                 <div class="settings-item">
                   <label for="sound-toggle" class="switch">
-                    <input type="checkbox" id="sound-toggle" name="sound" aria-label="Sound" />
+                    <input
+                      type="checkbox"
+                      id="sound-toggle"
+                      name="sound"
+                      aria-label="Sound"
+                      aria-describedby="sound-desc"
+                    />
                     <div class="slider round"></div>
                     <span>Sound</span>
                   </label>
-                  <p class="settings-description">Enable or mute game audio.</p>
+                  <p id="sound-desc" class="settings-description">Enable or mute game audio.</p>
                 </div>
                 <div class="settings-item">
                   <label for="motion-toggle" class="switch">
@@ -141,11 +147,14 @@
                       id="motion-toggle"
                       name="motion"
                       aria-label="Motion Effects"
+                      aria-describedby="motion-desc"
                     />
                     <div class="slider round"></div>
                     <span>Motion Effects</span>
                   </label>
-                  <p class="settings-description">Disable animations for a calmer interface.</p>
+                  <p id="motion-desc" class="settings-description">
+                    Disable animations for a calmer interface.
+                  </p>
                 </div>
                 <div class="settings-item">
                   <label for="typewriter-toggle" class="switch">
@@ -154,11 +163,14 @@
                       id="typewriter-toggle"
                       name="typewriter"
                       aria-label="Typewriter Effect"
+                      aria-describedby="typewriter-desc"
                     />
                     <div class="slider round"></div>
                     <span>Typewriter Effect</span>
                   </label>
-                  <p class="settings-description">Toggle the quote typing animation.</p>
+                  <p id="typewriter-desc" class="settings-description">
+                    Toggle the quote typing animation.
+                  </p>
                 </div>
                 <div class="settings-item">
                   <label for="tooltips-toggle" class="switch">
@@ -167,11 +179,14 @@
                       id="tooltips-toggle"
                       name="tooltips"
                       aria-label="Tooltips"
+                      aria-describedby="tooltips-desc"
                     />
                     <div class="slider round"></div>
                     <span>Tooltips</span>
                   </label>
-                  <p class="settings-description">Show or hide helpful tooltips.</p>
+                  <p id="tooltips-desc" class="settings-description">
+                    Show or hide helpful tooltips.
+                  </p>
                 </div>
               </fieldset>
             </div>

--- a/tests/helpers/settingsFormUtils.test.js
+++ b/tests/helpers/settingsFormUtils.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderGameModeSwitches,
+  renderFeatureFlagSwitches
+} from "../../src/helpers/settings/formUtils.js";
+
+describe("formUtils ARIA", () => {
+  it("adds aria-describedby for game mode descriptions", () => {
+    const container = document.createElement("div");
+    const modes = [{ id: 1, name: "Classic", category: "main", order: 1, description: "desc" }];
+    renderGameModeSwitches(
+      container,
+      modes,
+      () => ({ gameModes: {} }),
+      () => {}
+    );
+    const input = container.querySelector("#mode-1");
+    const desc = container.querySelector("#mode-1-desc");
+    expect(desc).toBeTruthy();
+    expect(input).toHaveAttribute("aria-describedby", "mode-1-desc");
+  });
+
+  it("adds aria-describedby for feature flag descriptions", () => {
+    const container = document.createElement("div");
+    const flags = {
+      testFlag: { label: "Test", description: "flag desc" }
+    };
+    renderFeatureFlagSwitches(
+      container,
+      flags,
+      () => ({ featureFlags: {} }),
+      () => {}
+    );
+    const input = container.querySelector("#feature-test-flag");
+    const desc = container.querySelector("#feature-test-flag-desc");
+    expect(desc).toBeTruthy();
+    expect(input).toHaveAttribute("aria-describedby", "feature-test-flag-desc");
+  });
+});


### PR DESCRIPTION
## Summary
- link toggle descriptions with `aria-describedby`
- update game mode/feature flag rendering to apply same pattern
- document new ARIA guidance for the settings page
- test that `renderGameModeSwitches` and `renderFeatureFlagSwitches` set description ids

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/settingsFormUtils.test.js`
- `npx vitest run`
- `npx playwright test` *(fails: classicBattleFlow, prd-reader, vectorSearch screenshot, statReset)*
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688b75c0ed388326b183d42bb9d7ac62