### PR TITLE
Load battle stat labels from helper

### DIFF
--- a/src/components/StatsPanel.js
+++ b/src/components/StatsPanel.js
@@ -4,11 +4,13 @@
  * @pseudocode
  * 1. Validate the `stats` object and throw an error when invalid.
  * 2. Resolve panel classes from the provided `type` and `className` options.
- * 3. Build a `<div>` with class `card-stats` containing a `<ul>` list.
- *    - For each stat key (power, speed, technique, kumikata, newaza)
- *      create an `<li>` with a label, value, and tooltip ID.
- * 4. Apply an accessible `aria-label` to the panel when provided.
- * 5. Return the completed panel element.
+ * 3. Load stat labels via `loadStatNames()` and pair them with the
+ *    corresponding values from the `stats` object.
+ * 4. Build a `<div>` with class `card-stats` containing a `<ul>` list.
+ *    - For each loaded label create an `<li>` with the label, value and
+ *      tooltip id.
+ * 5. Apply an accessible `aria-label` to the panel when provided.
+ * 6. Return the completed panel element.
  *
  * @param {object} stats - Object with stat values.
  * @param {object} [options] - Optional configuration.
@@ -18,8 +20,9 @@
  * @returns {HTMLDivElement} The stats panel element.
  */
 import { escapeHTML } from "../helpers/utils.js";
-
-export function createStatsPanel(stats, options = {}) {
+import { loadStatNames } from "../helpers/stats.js";
+import { STATS } from "../helpers/battleEngine.js";
+export async function createStatsPanel(stats, options = {}) {
   if (!stats || typeof stats !== "object") {
     throw new Error("Stats object is required");
   }
@@ -46,13 +49,13 @@ export function createStatsPanel(stats, options = {}) {
     list.appendChild(li);
   }
 
-  const statsEntries = [
-    { label: "Power", key: power, id: "power" },
-    { label: "Speed", key: speed, id: "speed" },
-    { label: "Technique", key: technique, id: "technique" },
-    { label: "Kumi-kata", key: kumikata, id: "kumikata" },
-    { label: "Ne-waza", key: newaza, id: "newaza" }
-  ];
+  const names = await loadStatNames();
+  const values = [power, speed, technique, kumikata, newaza];
+  const statsEntries = STATS.map((key, index) => ({
+    label: names[index]?.name || key,
+    key: values[index],
+    id: key
+  }));
 
   statsEntries.forEach(({ label, key, id }) => addItem(label, key, id));
   panel.appendChild(list);

--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -242,7 +242,7 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup, options = {}) 
   const portraitElement = createPortraitSection(judoka);
   judokaCard.appendChild(portraitElement);
 
-  const statsElement = createStatsSection(judoka, cardType);
+  const statsElement = await createStatsSection(judoka, cardType);
   judokaCard.appendChild(statsElement);
 
   const signatureMoveElement = createSignatureMoveSection(judoka, gokyoLookup, cardType);

--- a/src/helpers/cardRender.js
+++ b/src/helpers/cardRender.js
@@ -89,7 +89,7 @@ export function generateCardPortrait(card) {
  * @param {string} cardType - The type of card (e.g., "common", "rare").
  * @returns {string} The HTML string for the stats.
  */
-export function generateCardStats(card, cardType = "common") {
+export async function generateCardStats(card, cardType = "common") {
   if (!card || typeof card !== "object") {
     throw new Error("Card object is required");
   }
@@ -98,7 +98,7 @@ export function generateCardStats(card, cardType = "common") {
     throw new Error("Stats object is required");
   }
 
-  const panel = createStatsPanel(card.stats, { type: cardType });
+  const panel = await createStatsPanel(card.stats, { type: cardType });
   return panel.outerHTML;
 }
 

--- a/src/helpers/cardSections.js
+++ b/src/helpers/cardSections.js
@@ -39,16 +39,16 @@ export function createPortraitSection(judoka) {
  *
  * @pseudocode
  * 1. Call `createStatsPanel` with the judoka stats and card type.
- * 2. Return the generated element.
+ * 2. Await the generated element and return it.
  * 3. On error, log and return `createNoDataContainer()`.
  *
  * @param {import("./types.js").Judoka} judoka - Judoka data object.
  * @param {string} cardType - Card rarity type.
  * @returns {HTMLElement} Stats panel element.
  */
-export function createStatsSection(judoka, cardType) {
+export async function createStatsSection(judoka, cardType) {
   try {
-    return createStatsPanel(judoka.stats, { type: cardType });
+    return await createStatsPanel(judoka.stats, { type: cardType });
   } catch (error) {
     console.error("Failed to generate stats:", error);
     return createNoDataContainer();

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -28,6 +28,8 @@ import { loadSettings } from "./settingsUtils.js";
 import { initTooltips } from "./tooltip.js";
 import { setTestMode } from "./testModeUtils.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
+import { loadStatNames } from "./stats.js";
+import { STATS } from "./battleEngine.js";
 
 function enableStatButtons(enable = true) {
   document.querySelectorAll("#stat-buttons button").forEach((btn) => {
@@ -48,7 +50,20 @@ function onStatSelect(stat) {
   handleStatSelection(stat);
 }
 
+async function applyStatLabels() {
+  const names = await loadStatNames();
+  names.forEach((n, i) => {
+    const key = STATS[i];
+    const btn = document.querySelector(`#stat-buttons button[data-stat="${key}"]`);
+    if (btn) {
+      btn.textContent = n.name;
+      btn.setAttribute("aria-label", `Select ${n.name}`);
+    }
+  });
+}
+
 export async function setupClassicBattlePage() {
+  await applyStatLabels();
   const statButtons = document.querySelectorAll("#stat-buttons button");
   statButtons.forEach((btn) => {
     btn.addEventListener("click", () => {

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -62,47 +62,32 @@
                   data-stat="power"
                   type="button"
                   tabindex="0"
-                  aria-label="Select Power"
                   data-tooltip-id="stat.power"
-                >
-                  Power
-                </button>
+                ></button>
                 <button
                   data-stat="speed"
                   type="button"
                   tabindex="0"
-                  aria-label="Select Speed"
                   data-tooltip-id="stat.speed"
-                >
-                  Speed
-                </button>
+                ></button>
                 <button
                   data-stat="technique"
                   type="button"
                   tabindex="0"
-                  aria-label="Select Technique"
                   data-tooltip-id="stat.technique"
-                >
-                  Technique
-                </button>
+                ></button>
                 <button
                   data-stat="kumikata"
                   type="button"
                   tabindex="0"
-                  aria-label="Select Kumi-kata"
                   data-tooltip-id="stat.kumikata"
-                >
-                  Kumi-kata
-                </button>
+                ></button>
                 <button
                   data-stat="newaza"
                   type="button"
                   tabindex="0"
-                  aria-label="Select Ne-waza"
                   data-tooltip-id="stat.newaza"
-                >
-                  Ne-waza
-                </button>
+                ></button>
               </div>
               <button
                 id="stat-help"

--- a/tests/card/cardBuilder.test.js
+++ b/tests/card/cardBuilder.test.js
@@ -1,5 +1,16 @@
 import { createScrollButton } from "../../src/helpers/carousel/scroll.js";
 import { generateCardPortrait, generateCardStats } from "../../src/helpers/cardRender.js";
+
+vi.mock("../../src/helpers/stats.js", () => ({
+  loadStatNames: () =>
+    Promise.resolve([
+      { name: "Power" },
+      { name: "Speed" },
+      { name: "Technique" },
+      { name: "Kumi-kata" },
+      { name: "Ne-waza" }
+    ])
+}));
 import { vi } from "vitest";
 
 // Utility to normalize HTML for comparison
@@ -73,7 +84,7 @@ describe("createScrollButton", () => {
 });
 
 describe("generateCardStats", () => {
-  it("should return a valid HTML string for a judoka's stats", () => {
+  it("should return a valid HTML string for a judoka's stats", async () => {
     const card = {
       stats: { power: 9, speed: 6, technique: 7, kumikata: 7, newaza: 8 }
     };
@@ -87,49 +98,49 @@ describe("generateCardStats", () => {
       '<li class="stat"><strong data-tooltip-id="stat.newaza">Ne-waza</strong><span>8</span></li>' +
       "</ul></div>";
 
-    const result = generateCardStats(card);
+    const result = await generateCardStats(card);
     expect(normalizeHtml(result)).toBe(normalizeHtml(expectedHtml));
   });
 
-  it("should handle missing stats gracefully", () => {
+  it("should handle missing stats gracefully", async () => {
     const card = { stats: {} };
-    const result = generateCardStats(card);
+    const result = await generateCardStats(card);
     expect(result).toContain('<div class="card-stats common"');
   });
 
-  it("should throw an error if stats object is missing", () => {
+  it("should throw an error if stats object is missing", async () => {
     const card = {};
-    expect(() => generateCardStats(card)).toThrowError("Stats object is required");
+    await expect(generateCardStats(card)).rejects.toThrowError("Stats object is required");
   });
 
-  it("should throw an error if stats is null", () => {
+  it("should throw an error if stats is null", async () => {
     const card = { stats: null };
-    expect(() => generateCardStats(card)).toThrowError("Stats object is required");
+    await expect(generateCardStats(card)).rejects.toThrowError("Stats object is required");
   });
 
-  it("should throw an error if stats is undefined", () => {
+  it("should throw an error if stats is undefined", async () => {
     const card = { stats: undefined };
-    expect(() => generateCardStats(card)).toThrowError("Stats object is required");
+    await expect(generateCardStats(card)).rejects.toThrowError("Stats object is required");
   });
 
-  it("should throw an error if card is null", () => {
-    expect(() => generateCardStats(null)).toThrowError("Card object is required");
+  it("should throw an error if card is null", async () => {
+    await expect(generateCardStats(null)).rejects.toThrowError("Card object is required");
   });
 
-  it("should throw an error if card is undefined", () => {
-    expect(() => generateCardStats(undefined)).toThrowError("Card object is required");
+  it("should throw an error if card is undefined", async () => {
+    await expect(generateCardStats(undefined)).rejects.toThrowError("Card object is required");
   });
 
-  it("should handle stats with missing keys gracefully", () => {
+  it("should handle stats with missing keys gracefully", async () => {
     const card = { stats: { power: 5 } };
-    const result = generateCardStats(card);
+    const result = await generateCardStats(card);
     expect(result).toContain("Power");
     expect(result).toContain("5");
   });
 
-  it("should escape HTML in stat values", () => {
+  it("should escape HTML in stat values", async () => {
     const card = { stats: { power: "<b>9</b>", speed: 6, technique: 7, kumikata: 7, newaza: 8 } };
-    const result = generateCardStats(card);
+    const result = await generateCardStats(card);
     expect(result).toContain("&lt;b&gt;9&lt;/b&gt;");
   });
 });

--- a/tests/card/judokaCardAccessibility.test.js
+++ b/tests/card/judokaCardAccessibility.test.js
@@ -1,5 +1,16 @@
 import { generateJudokaCardHTML, generateJudokaCard } from "../../src/helpers/cardBuilder.js";
 
+vi.mock("../../src/helpers/stats.js", () => ({
+  loadStatNames: () =>
+    Promise.resolve([
+      { name: "Power" },
+      { name: "Speed" },
+      { name: "Technique" },
+      { name: "Kumi-kata" },
+      { name: "Ne-waza" }
+    ])
+}));
+
 const judoka = {
   id: 1,
   firstname: "John",

--- a/tests/card/judokaCardFlip.test.js
+++ b/tests/card/judokaCardFlip.test.js
@@ -1,6 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { generateJudokaCardHTML } from "../../src/helpers/cardBuilder.js";
 
+vi.mock("../../src/helpers/stats.js", () => ({
+  loadStatNames: () =>
+    Promise.resolve([
+      { name: "Power" },
+      { name: "Speed" },
+      { name: "Technique" },
+      { name: "Kumi-kata" },
+      { name: "Ne-waza" }
+    ])
+}));
+
 const judoka = {
   id: 1,
   firstname: "John",

--- a/tests/card/judokaCardHtmlFallback.test.js
+++ b/tests/card/judokaCardHtmlFallback.test.js
@@ -32,9 +32,9 @@ describe("generateJudokaCardHTML fallback containers", () => {
   });
 
   it("adds fallback when stats generation throws", async () => {
-    vi.spyOn(cardRender, "generateCardStats").mockImplementation(() => {
-      throw new Error("stats fail");
-    });
+    vi.spyOn(cardRender, "generateCardStats").mockImplementation(() =>
+      Promise.reject(new Error("stats fail"))
+    );
 
     const card = await generateJudokaCardHTML(judoka, gokyoLookup);
 
@@ -60,9 +60,7 @@ describe("generateJudokaCardHTML fallback containers", () => {
   });
 
   it("adds fallback when cardRender throws undefined", async () => {
-    vi.spyOn(cardRender, "generateCardStats").mockImplementation(() => {
-      throw undefined;
-    });
+    vi.spyOn(cardRender, "generateCardStats").mockImplementation(() => Promise.reject(undefined));
     const card = await generateJudokaCardHTML(judoka, gokyoLookup);
     expect(card.textContent).toContain("No data available");
   });

--- a/tests/card/judokaCardSignatureMove.test.js
+++ b/tests/card/judokaCardSignatureMove.test.js
@@ -1,5 +1,16 @@
 import { generateJudokaCardHTML } from "../../src/helpers/cardBuilder.js";
 
+vi.mock("../../src/helpers/stats.js", () => ({
+  loadStatNames: () =>
+    Promise.resolve([
+      { name: "Power" },
+      { name: "Speed" },
+      { name: "Technique" },
+      { name: "Kumi-kata" },
+      { name: "Ne-waza" }
+    ])
+}));
+
 const judoka = {
   id: 1,
   firstname: "John",

--- a/tests/card/judokaZeroId.test.js
+++ b/tests/card/judokaZeroId.test.js
@@ -1,5 +1,16 @@
 import { generateJudokaCardHTML } from "../../src/helpers/cardBuilder.js";
 
+vi.mock("../../src/helpers/stats.js", () => ({
+  loadStatNames: () =>
+    Promise.resolve([
+      { name: "Power" },
+      { name: "Speed" },
+      { name: "Technique" },
+      { name: "Kumi-kata" },
+      { name: "Ne-waza" }
+    ])
+}));
+
 const judoka = {
   id: 0,
   firstname: "Placeholder",

--- a/tests/components/StatsPanel.test.js
+++ b/tests/components/StatsPanel.test.js
@@ -1,9 +1,20 @@
 import { describe, it, expect } from "vitest";
 import { createStatsPanel } from "../../src/components/StatsPanel.js";
 
+vi.mock("../../src/helpers/stats.js", () => ({
+  loadStatNames: () =>
+    Promise.resolve([
+      { name: "Power" },
+      { name: "Speed" },
+      { name: "Technique" },
+      { name: "Kumi-kata" },
+      { name: "Ne-waza" }
+    ])
+}));
+
 describe("createStatsPanel", () => {
-  it("creates DOM structure with stat values", () => {
-    const panel = createStatsPanel({
+  it("creates DOM structure with stat values", async () => {
+    const panel = await createStatsPanel({
       power: 5,
       speed: 6,
       technique: 7,
@@ -24,8 +35,8 @@ describe("createStatsPanel", () => {
     expect(labels[4]).toHaveAttribute("data-tooltip-id", "stat.newaza");
   });
 
-  it("applies custom type and class", () => {
-    const panel = createStatsPanel(
+  it("applies custom type and class", async () => {
+    const panel = await createStatsPanel(
       { power: 1, speed: 2 },
       { type: "legendary", className: "extra", ariaLabel: "Player Stats" }
     );
@@ -34,7 +45,7 @@ describe("createStatsPanel", () => {
     expect(panel).toHaveAttribute("aria-label", "Player Stats");
   });
 
-  it("throws when stats is missing", () => {
-    expect(() => createStatsPanel(null)).toThrowError("Stats object is required");
+  it("throws when stats is missing", async () => {
+    await expect(createStatsPanel(null)).rejects.toThrowError("Stats object is required");
   });
 });


### PR DESCRIPTION
## Summary
- fetch stat labels in `StatsPanel`
- set stat labels dynamically in Classic Battle controls
- update battle page markup for dynamic labels
- adjust tests for async stat label loading

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: statReset & other playwright suites)*

------
https://chatgpt.com/codex/tasks/task_e_688b75af8c00832696d3b3757821d19c