### PR TITLE
Fix PRD reader navigation test

### DIFF
--- a/playwright/prd-reader.spec.js
+++ b/playwright/prd-reader.spec.js
@@ -23,7 +23,7 @@ test.describe("PRD Reader page", () => {
     await expect(container).not.toHaveText("");
     const original = await container.innerHTML();
 
-    await page.getByRole("banner").getByRole("button", { name: /next/i }).click();
+    await page.keyboard.press("ArrowRight");
     hasOverflow = await page.evaluate(
       () => document.documentElement.scrollWidth > document.documentElement.clientWidth
     );
@@ -31,10 +31,7 @@ test.describe("PRD Reader page", () => {
     const afterNext = await page.locator("#prd-content").innerHTML();
     expect(afterNext).not.toBe(original);
 
-    await page
-      .getByRole("banner")
-      .getByRole("button", { name: /previous/i })
-      .click();
+    await page.keyboard.press("ArrowLeft");
     const afterPrev = await page.locator("#prd-content").innerHTML();
     expect(afterPrev).toBe(original);
   });


### PR DESCRIPTION
## Summary
- update PRD Reader test to use arrow key navigation

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688b83b71010832696387d0f5f22bfe7