### PR TITLE
Update documentation for statNames.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
     also includes `tooltipViewer.html`, a searchable viewer for
     exploring tooltip text used across the UI.
   - `data/`
+    JSON files powering the game. `statNames.json` lists the canonical stat
+    names—changing a label here updates the UI everywhere.
   - `schemas/`
     JSON Schema definitions used to validate the data files.
   - `assets/`

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -66,7 +66,11 @@ document.body.appendChild(card);
 
 ## data and schemas
 
-Structured gameplay data lives in `src/data`. Matching JSON Schemas in `src/schemas` describe and validate these files. The `npm run validate:data` script uses Ajv to ensure data integrity.
+Structured gameplay data lives in `src/data`. Matching JSON Schemas in
+`src/schemas` describe and validate these files. The file
+`src/data/statNames.json` contains the canonical list of stats displayed across
+the UI—changing a name here updates labels everywhere. The `npm run
+validate:data` script uses Ajv to ensure data integrity.
 
 ## tooltip helper
 

--- a/design/dataSchemas/README.md
+++ b/design/dataSchemas/README.md
@@ -10,7 +10,16 @@ Run `npm run validate:data` to check all schema and data pairs at once. The comm
 npx ajv validate -s src/schemas/judoka.schema.json -d src/data/judoka.json
 ```
 
-Run the command for every pair of schema and data file (e.g. `gameModes`, `weightCategories`). The CLI reports any mismatches so they can be fixed before runtime. A new schema, `navigationItems.schema.json`, validates the structure of `navigationItems.json` which drives navigation order and visibility. Another schema, `aesopsMeta.schema.json`, describes the quote metadata file used on the meditation screen. A third schema, `statNames.schema.json`, defines the structure of `statNames.json` which lists all available stats. Tests also verify that each ID in `aesopsMeta.json` exists in `aesopsFables.json`.
+Run the command for every pair of schema and data file (e.g. `gameModes`,
+`weightCategories`). The CLI reports any mismatches so they can be fixed before
+runtime. A new schema, `navigationItems.schema.json`, validates the structure of
+`navigationItems.json` which drives navigation order and visibility. Another
+schema, `aesopsMeta.schema.json`, describes the quote metadata file used on the
+meditation screen. A third schema, `statNames.schema.json`, defines the
+structure of `statNames.json` which lists all available stats. This file is the
+canonical source for stat labels—update it to change the names shown across the
+UI. Tests also verify that each ID in `aesopsMeta.json` exists in
+`aesopsFables.json`.
 
 ## Updating Schemas
 


### PR DESCRIPTION
## Summary
- mention statNames.json in the architecture overview
- note statNames.json as the canonical stat file in the data schema docs
- describe statNames.json in the project structure section of the README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688b8a1dcae48326b5c8253a270cfde7