### PR TITLE
Add data-flag attribute for feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Light, dark and gray themes are supported. Changing modes uses a slide-over tran
 
 The Settings page (`src/pages/settings.html`) groups all player preferences, including experimental **feature flags**. Toggle a flag to enable an optional feature without modifying code. Flag values persist across pages and apply immediately. Implementation guidelines live in [settingsPageDesignGuidelines.md](design/codeStandards/settingsPageDesignGuidelines.md#feature-flags--agent-observability).
 Default flag states and descriptions now live in `src/data/settings.json`. The **Tooltips** toggle on this page lets you turn help tooltips on or off globally.
-Each change triggers a small snackbar at the bottom of the screen confirming the new setting.
+Each change triggers a small snackbar at the bottom of the screen confirming the new setting. Every feature flag input also includes a `data-flag` attribute with the camelCase flag name so automation scripts can locate specific toggles.
 
 Settings tooltips are referenced with `settings.*` keys in `tooltips.json`:
 

--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -230,6 +230,7 @@ To support AI-assisted testing, variant gameplay modes, and scalable development
   - Name format: camelCase
   - Example: `id="feature-random-stat-mode" name="randomStatMode"`
   - Common example flags include `Battle Debug Panel`, `Full Navigation Map`, and `Card Inspector`
+  - Include `data-flag="<camelCaseName>"` on the input element so automation scripts can locate specific toggles
 
 - **ARIA and Accessibility**
 

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -240,6 +240,7 @@ export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, 
       tooltipId: info.tooltipId
     });
     const input = wrapper.querySelector("input");
+    if (input) input.dataset.flag = flag;
     const desc = document.createElement("p");
     desc.className = "settings-description";
     desc.id = `feature-${kebab}-desc`;

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -250,11 +250,11 @@ describe("settingsPage module", () => {
     const container = document.getElementById("feature-flags-container");
     expect(container.classList.contains("game-mode-toggle-container")).toBe(true);
     const randomInput = container.querySelector("#feature-random-stat-mode");
-    const debugInput = container.querySelector("#feature-battle-debug-panel");
+    const inspectorInput = container.querySelector('[data-flag="enableCardInspector"]');
     expect(randomInput).toBeTruthy();
-    expect(debugInput).toBeTruthy();
+    expect(inspectorInput).toBeTruthy();
     expect(randomInput.checked).toBe(true);
-    expect(debugInput.checked).toBe(false);
+    expect(inspectorInput.checked).toBe(false);
   });
 
   it("places feature flags inside the advanced settings section", async () => {


### PR DESCRIPTION
## Summary
- expose feature flag names via `data-flag` attribute in `renderFeatureFlagSwitches`
- adjust feature flag test to use the new attribute
- document data attribute usage in README and settings guidelines

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688b8a0fe0e08326add49e057b7391db