### PR TITLE
Update tooltip guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,13 @@ The Settings page (`src/pages/settings.html`) groups all player preferences, inc
 Default flag states and descriptions now live in `src/data/settings.json`. The **Tooltips** toggle on this page lets you turn help tooltips on or off globally.
 Each change triggers a small snackbar at the bottom of the screen confirming the new setting. Every feature flag input also includes a `data-flag` attribute with the camelCase flag name so automation scripts can locate specific toggles.
 
+### Tooltip Availability
+
+Every toggle on the Settings page exposes contextual help via a `data-tooltip-id` attribute.
+Hovering or focusing the info icon beside a toggle displays text from `tooltips.json`.
+Feature flag inputs also include `data-flag` for automated scripts, so agents can
+reliably enable or disable individual flags.
+
 Settings tooltips are referenced with `settings.*` keys in `tooltips.json`:
 
 ```

--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -58,13 +58,23 @@ Reuse the following markup for general settings, game modes, and feature flags:
   - Reuse section `<legend>` headings with consistent styles (font: Russo One, 24px).
 
 - **Toggle Switch Pattern**
-  Use the existing custom toggle structure:
+  Use the existing custom toggle structure. Inputs must include a
+  `data-tooltip-id` attribute so the help text can be displayed. Feature flag
+  toggles must additionally provide `data-flag` for automation.
+  Example markup:
 
   ```html
-  <label for="new-toggle-id" class="switch">
-    <input type="checkbox" id="new-toggle-id" name="newSetting" aria-label="New Setting Name" />
+  <label for="feature-random-stat-mode" class="switch">
+    <input
+      type="checkbox"
+      id="feature-random-stat-mode"
+      name="randomStatMode"
+      data-tooltip-id="settings.randomStatMode"
+      data-flag="randomStatMode"
+      aria-label="Random Stat Mode"
+    />
     <div class="slider round"></div>
-    <span>New Setting Name</span>
+    <span>Random Stat Mode</span>
   </label>
   ```
 


### PR DESCRIPTION
## Summary
- document global tooltip availability on Settings page
- specify `data-tooltip-id` and `data-flag` attributes in design guidelines

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688b8fe783648326b70d7f2580bdbb00