### PR TITLE
Fix sidebar position in mockup viewer

### DIFF
--- a/design/productRequirementsDocuments/prdMockupViewer.md
+++ b/design/productRequirementsDocuments/prdMockupViewer.md
@@ -81,7 +81,7 @@ Designers and developers previously relied on scattered folder structures to fin
 
 **Layout Elements (Desktop View):**
 
-- Left sidebar lists all mockup files for quick navigation.
+ - Left sidebar lists all mockup files for quick navigation and remains fixed to the left edge of the screen.
 - Image centered with filename below.
 - Images must scale to fit the viewport so wide mockups remain fully
   visible without horizontal scrolling.

--- a/src/styles/mockupViewer.css
+++ b/src/styles/mockupViewer.css
@@ -7,11 +7,6 @@ body {
   background: #f5f5f5;
   margin: 0;
   padding: 2rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
 }
 
 .slideshow-container {


### PR DESCRIPTION
## Summary
- prevent body style from centering mockup viewer layout
- clarify PRD that sidebar stays fixed to the left

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688b91963f908326928d3f7261aac074