### PR TITLE
Fix stat-help button placement

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -150,9 +150,10 @@ This feedback highlights why Classic Battle is needed now: new players currently
   - Provide a dedicated "Quit Match" button below the controls.
     Clicking it opens a confirmation modal styled like the
     **Restore Defaults** dialog from the Settings page.
-  - A small help icon (`#stat-help`) next to the stat buttons displays a tooltip
-    explaining how to pick an attribute. The tooltip auto-opens once on first
-    visit using `localStorage` to remember the dismissal.
+  - A small help icon (`#stat-help`) sits between the **Next Round** and
+    **Quit Match** buttons. It displays a tooltip explaining how to pick an
+    attribute and auto-opens on first visit using `localStorage` to remember the
+    dismissal.
   - Tooltips on stat names, country flags, weight indicators, and navigation icons provide accessible explanations.
   - **Accessibility:**
   - Minimum text contrast ratio: ≥4.5:1 (per WCAG).

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -89,19 +89,19 @@
                   data-tooltip-id="stat.newaza"
                 ></button>
               </div>
-              <button
-                id="stat-help"
-                class="info-button"
-                aria-label="Stat selection help"
-                data-tooltip-id="ui.selectStat"
-              >
-                ?
-              </button>
             </div>
 
             <p id="round-result" aria-live="polite" aria-atomic="true"></p>
             <button id="next-round-button" disabled data-tooltip-id="ui.nextRound">
               Next Round
+            </button>
+            <button
+              id="stat-help"
+              class="info-button"
+              aria-label="Stat selection help"
+              data-tooltip-id="ui.selectStat"
+            >
+              ?
             </button>
             <button id="quit-match-button" data-tooltip-id="ui.quitMatch">Quit Match</button>
             <div id="debug-panel" class="debug-panel hidden">


### PR DESCRIPTION
## Summary
- reposition `stat-help` button so it's between next round and quit buttons
- update classic battle PRD description

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688b923a325883268a7b144a1bedad4b