### PR TITLE
Fix restore defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Advanced or debug-oriented flags live under a collapsible **Advanced Settings** 
 
 Game mode data now falls back to a bundled JSON import if the network request fails, so navigation works offline.
 Corrupted settings are detected and automatically reset to defaults, ensuring the Settings page always remains usable.
-Use the **Restore Defaults** button in the Links section to reset all settings. A confirmation dialog now appears before applying the defaults.
+Use the **Restore Defaults** button in the Links section to reset all settings. A confirmation dialog now appears before applying the defaults. The action also turns off any active debug overlays, including the Layout Debug Panel.
 
 ## Browser Compatibility
 

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -19,6 +19,7 @@ import { createModal } from "../components/Modal.js";
 import { createButton } from "../components/Button.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
 import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
+import { toggleLayoutDebugPanel } from "./layoutDebugPanel.js";
 import { populateNavbar } from "./navigationBar.js";
 import { showSnackbar } from "./showSnackbar.js";
 
@@ -178,6 +179,7 @@ function initializeControls(settings, gameModes) {
     applyMotionPreference(currentSettings.motionEffects);
     toggleViewportSimulation(Boolean(currentSettings.featureFlags.viewportSimulation?.enabled));
     toggleTooltipOverlayDebug(Boolean(currentSettings.featureFlags.tooltipOverlayDebug?.enabled));
+    toggleLayoutDebugPanel(Boolean(currentSettings.featureFlags.layoutDebugPanel?.enabled));
     clearToggles(modesContainer);
     renderGameModeSwitches(modesContainer, gameModes, getCurrentSettings, handleUpdate);
     clearToggles(flagsContainer);
@@ -207,6 +209,7 @@ async function initializeSettingsPage() {
     applyMotionPreference(settings.motionEffects);
     toggleViewportSimulation(Boolean(settings.featureFlags.viewportSimulation?.enabled));
     toggleTooltipOverlayDebug(Boolean(settings.featureFlags.tooltipOverlayDebug?.enabled));
+    toggleLayoutDebugPanel(Boolean(settings.featureFlags.layoutDebugPanel?.enabled));
     initializeControls(settings, gameModes);
     setupSectionToggles();
     initTooltips();


### PR DESCRIPTION
## Summary
- disable Layout Debug Panel when restoring default settings
- mention that Restore Defaults clears debug overlays

## Testing
- `npx prettier README.md src/helpers/settingsPage.js --check`
- `npx eslint README.md src/helpers/settingsPage.js` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688ba119b6ec8326ac224a2397263949