### PR TITLE
Add missing JSDoc for showSettingsInfo

### DIFF
--- a/src/helpers/showSettingsInfo.js
+++ b/src/helpers/showSettingsInfo.js
@@ -7,6 +7,10 @@
  * 3. Assemble modal with `createModal` and append to `document.body`.
  * 4. When the button is clicked, close and remove the modal.
  * 5. Open the modal immediately.
+ *
+ * @param {string} label - Title text for the modal.
+ * @param {string} description - Detailed description for the feature flag.
+ * @returns {Object} Modal controls.
  */
 import { createModal } from "../components/Modal.js";
 import { createButton } from "../components/Button.js";


### PR DESCRIPTION
## Summary
- document parameters and return type for `showSettingsInfo`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_688c7d243b148326a0eef8d6f64a1d0d