### PR TITLE
Update docs for game timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
     exploring tooltip text used across the UI.
   - `data/`
     JSON files powering the game. `statNames.json` lists the canonical stat
-    names—changing a label here updates the UI everywhere.
+    names—changing a label here updates the UI everywhere. `gameTimers.json`
+    defines default timer values for battles.
   - `schemas/`
     JSON Schema definitions used to validate the data files.
   - `assets/`

--- a/design/dataSchemas/README.md
+++ b/design/dataSchemas/README.md
@@ -19,7 +19,8 @@ meditation screen. A third schema, `statNames.schema.json`, defines the
 structure of `statNames.json` which lists all available stats. This file is the
 canonical source for stat labels—update it to change the names shown across the
 UI. Tests also verify that each ID in `aesopsMeta.json` exists in
-`aesopsFables.json`.
+`aesopsFables.json`. A new file, `gameTimers.schema.json`, defines the structure
+of `gameTimers.json` which contains the default timer values used in battles.
 
 ## Updating Schemas
 


### PR DESCRIPTION
## Summary
- mention that `gameTimers.json` stores default values for battle timers
- list `gameTimers.schema.json` in the data schemas overview

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688c87bc28588326a6047f5d2c335537