### PR TITLE
Add timer utilities

### DIFF
--- a/src/helpers/battleEngine.js
+++ b/src/helpers/battleEngine.js
@@ -6,6 +6,7 @@
  */
 
 import { CLASSIC_BATTLE_POINTS_TO_WIN, CLASSIC_BATTLE_MAX_ROUNDS } from "./constants.js";
+import { getDefaultTimer } from "./timerUtils.js";
 
 export const STATS = ["power", "speed", "technique", "kumikata", "newaza"];
 
@@ -48,17 +49,28 @@ function endMatchIfNeeded() {
  * Start the round/stat selection timer with pause/resume and auto-selection support.
  *
  * @pseudocode
- * 1. Set remaining seconds and store callbacks.
- * 2. Call onTick immediately.
- * 3. Start a 1s interval: decrement remaining, call onTick.
- * 4. If timer reaches 0, stop and call onExpired.
- * 5. Listen for page visibility changes: pause timer if hidden, resume if visible.
+ * 1. Determine the timer duration when not provided using `getDefaultTimer('roundTimer')`.
+ *    - Fallback to 30 seconds on any error.
+ * 2. Set remaining seconds and store callbacks.
+ * 3. Call onTick immediately.
+ * 4. Start a 1s interval: decrement remaining, call onTick.
+ * 5. If timer reaches 0, stop and call onExpired.
+ * 6. Listen for page visibility changes: pause timer if hidden, resume if visible.
  *
  * @param {function} onTick - Callback each second with remaining time.
  * @param {function} onExpired - Callback when timer expires (auto-select logic).
- * @param {number} [duration=30] - Timer duration in seconds.
+ * @param {number} [duration] - Timer duration in seconds.
+ * @returns {Promise<void>} Resolves when the timer starts.
  */
-export function startRound(onTick, onExpired, duration = 30) {
+export async function startRound(onTick, onExpired, duration) {
+  if (duration === undefined) {
+    try {
+      duration = await getDefaultTimer("roundTimer");
+    } catch {
+      duration = 30;
+    }
+    if (typeof duration !== "number") duration = 30;
+  }
   stopTimer();
   remaining = duration;
   paused = false;

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -4,6 +4,7 @@ import { seededRandom, isTestModeEnabled, getCurrentSeed } from "./testModeUtils
 import { fetchJson } from "./dataUtils.js";
 import { createGokyoLookup } from "./utils.js";
 import { DATA_DIR } from "./constants.js";
+import { getDefaultTimer } from "./timerUtils.js";
 import {
   startRound as engineStartRound,
   handleStatSelection as engineHandleStatSelection,
@@ -95,8 +96,15 @@ export function showSelectionPrompt() {
   el.classList.remove("fading");
 }
 
-function startTimer() {
+async function startTimer() {
   const timerEl = document.getElementById("next-round-timer");
+  let duration;
+  try {
+    duration = await getDefaultTimer("roundTimer");
+  } catch {
+    duration = 30;
+  }
+  if (typeof duration !== "number") duration = 30;
   engineStartRound(
     (remaining) => {
       if (timerEl) timerEl.textContent = `Time Left: ${remaining}s`;
@@ -105,7 +113,8 @@ function startTimer() {
       const randomStat = STATS[Math.floor(seededRandom() * STATS.length)];
       infoBar.showMessage(`Time's up! Auto-selecting ${randomStat}`);
       handleStatSelection(randomStat);
-    }
+    },
+    duration
   );
 }
 
@@ -197,7 +206,7 @@ export async function startRound() {
   showSelectionPrompt();
   const { playerScore, computerScore } = getScores();
   infoBar.updateScore(playerScore, computerScore);
-  startTimer();
+  await startTimer();
   updateDebugPanel();
 }
 

--- a/src/helpers/timerUtils.js
+++ b/src/helpers/timerUtils.js
@@ -1,0 +1,34 @@
+import { fetchJson, importJsonModule } from "./dataUtils.js";
+import { DATA_DIR } from "./constants.js";
+
+let timersPromise;
+let cachedTimers;
+
+async function loadTimers() {
+  if (cachedTimers) return cachedTimers;
+  if (!timersPromise) {
+    timersPromise = fetchJson(`${DATA_DIR}gameTimers.json`).catch(async (err) => {
+      console.warn("Failed to fetch gameTimers.json", err);
+      return importJsonModule("../data/gameTimers.json");
+    });
+  }
+  cachedTimers = await timersPromise;
+  return cachedTimers;
+}
+
+/**
+ * Retrieve the default timer value for a category.
+ *
+ * @param {string} category - Timer category to search.
+ * @returns {Promise<number|undefined>} Resolved default timer value.
+ */
+export async function getDefaultTimer(category) {
+  const timers = await loadTimers();
+  const entry = timers.find((t) => t.category === category && t.default);
+  return entry ? entry.value : undefined;
+}
+
+export function _resetForTest() {
+  timersPromise = undefined;
+  cachedTimers = undefined;
+}

--- a/tests/helpers/timerUtils.test.js
+++ b/tests/helpers/timerUtils.test.js
@@ -1,0 +1,35 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("timerUtils", () => {
+  it("returns the default timer for a category", async () => {
+    const data = [
+      { id: 1, value: 10, default: false, category: "roundTimer" },
+      { id: 2, value: 20, default: true, category: "roundTimer" }
+    ];
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue(data),
+      importJsonModule: vi.fn()
+    }));
+    const { getDefaultTimer } = await import("../../src/helpers/timerUtils.js");
+    const val1 = await getDefaultTimer("roundTimer");
+    const val2 = await getDefaultTimer("roundTimer");
+    expect(val1).toBe(20);
+    expect(val2).toBe(20);
+  });
+
+  it("falls back to import when fetch fails", async () => {
+    const fallback = [{ id: 3, value: 5, default: true, category: "coolDownTimer" }];
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockRejectedValue(new Error("fail")),
+      importJsonModule: vi.fn().mockResolvedValue(fallback)
+    }));
+    const { getDefaultTimer } = await import("../../src/helpers/timerUtils.js");
+    const val = await getDefaultTimer("coolDownTimer");
+    expect(val).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- create `timerUtils` helper to load `gameTimers.json`
- fetch default round timer in `battleEngine`
- use new `getDefaultTimer` from Classic Battle
- test timer utility

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_688c87730c28832689d2e13dd47978a9