### PR TITLE
Add schema for game timers

### DIFF
--- a/src/schemas/gameTimers.schema.json
+++ b/src/schemas/gameTimers.schema.json
@@ -23,7 +23,7 @@
       },
       "required": {
         "type": "boolean",
-        "description": "Whether the timer choice is mandatory."
+        "description": "Indicates whether this timer must be included in the game configuration for the game to function properly."
       },
       "category": {
         "type": "string",


### PR DESCRIPTION
## Summary
- define `gameTimers.schema.json` to validate game timer data

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run validate:data` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_688c89f4bc308326a2820ac75a284e9c