### PR TITLE
Add tests for timer defaults

### DIFF
--- a/tests/helpers/battleEngineTimer.test.js
+++ b/tests/helpers/battleEngineTimer.test.js
@@ -14,7 +14,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  timerSpy.clearAllTimers();
+  vi.clearAllTimers();
 });
 
 describe("timer defaults", () => {


### PR DESCRIPTION
## Summary
- create `battleEngineTimer.test.js` to verify `getDefaultTimer` and `startRound`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688c8d9c0c188326b2d027687835dc0b