### PR TITLE
Use cooldown timer from gameTimers

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -12,6 +12,7 @@ import {
   getScores,
   getTimerState,
   isMatchEnded,
+  startCoolDown,
   STATS,
   _resetForTest as engineReset
 } from "./battleEngine.js";
@@ -263,9 +264,21 @@ export function scheduleNextRound(result) {
     await start();
   };
 
-  btn.addEventListener("click", onClick, { once: true });
-  enableNextRoundButton();
-  updateDebugPanel();
+  const timerEl = document.getElementById("next-round-timer");
+
+  const onTick = (remaining) => {
+    if (timerEl) timerEl.textContent = `Next round in: ${remaining}s`;
+  };
+
+  const onExpired = () => {
+    btn.addEventListener("click", onClick, { once: true });
+    enableNextRoundButton();
+    updateDebugPanel();
+  };
+
+  setTimeout(() => {
+    startCoolDown(onTick, onExpired);
+  }, 2000);
 }
 
 /**

--- a/tests/helpers/battleEngine.coolDown.test.js
+++ b/tests/helpers/battleEngine.coolDown.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.useFakeTimers();
+
+describe("battleEngine startCoolDown", () => {
+  it("runs countdown using default timer", async () => {
+    vi.doMock("../../src/helpers/timerUtils.js", () => ({
+      getDefaultTimer: vi.fn().mockResolvedValue(3)
+    }));
+    const { startCoolDown, _resetForTest } = await import("../../src/helpers/battleEngine.js");
+    const onTick = vi.fn();
+    const onExpired = vi.fn();
+    _resetForTest();
+    await startCoolDown(onTick, onExpired);
+    expect(onTick).toHaveBeenCalledWith(3);
+    vi.advanceTimersByTime(3000);
+    expect(onExpired).toHaveBeenCalled();
+  });
+});

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -139,11 +139,15 @@ describe("classicBattle match flow", () => {
     );
   });
 
-  it("scheduleNextRound enables button and starts next round on click", async () => {
+  it("scheduleNextRound waits for cooldown then enables button", async () => {
     document.body.innerHTML += '<button id="next-round-button" disabled></button>';
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     battleMod.scheduleNextRound({ matchEnded: false });
     const btn = document.getElementById("next-round-button");
+    expect(btn.disabled).toBe(true);
+    timerSpy.advanceTimersByTime(2000);
+    timerSpy.advanceTimersByTime(3000);
+    await Promise.resolve();
     expect(btn.disabled).toBe(false);
     btn.click();
     await Promise.resolve();


### PR DESCRIPTION
## Summary
- add `startCoolDown` helper in battle engine
- use cooldown timer in `scheduleNextRound`
- update tests for cooldown logic

## Testing
- `npx prettier . --check` *(fails: Could not download due to network)*
- `npx eslint .` *(fails: missing dependencies)*
- `npx vitest run` *(fails: could not download vitest)*
- `npx playwright test` *(fails: could not download playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688c8e545ac083269076b09c7dfd1411