### PR TITLE
Refactor settings tooltips

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -14,56 +14,38 @@
   "featureFlags": {
     "battleDebugPanel": {
       "enabled": false,
-      "label": "Battle Debug Panel",
-      "description": "Adds a collapsible debug panel using the `.debug-panel` class for verbose state outputs",
       "tooltipId": "settings.battleDebugPanel"
     },
     "fullNavigationMap": {
       "enabled": false,
-      "label": "Full Navigation Map",
-      "description": "An immersive, thematic expanded map view for Ju-Do-Kon!’s navigation, transforming mode selection into a Judo Training Village experience",
       "tooltipId": "settings.fullNavigationMap"
     },
     "enableTestMode": {
       "enabled": false,
-      "label": "Test Mode",
-      "description": "Card draws and stat choices become deterministic for repeat tests and debugging",
       "tooltipId": "settings.enableTestMode"
     },
     "enableCardInspector": {
       "enabled": false,
-      "label": "Card Inspector",
-      "description": "Adds a collapsible panel displaying raw card JSON on each card",
       "tooltipId": "settings.enableCardInspector"
     },
     "showCardOfTheDay": {
       "enabled": false,
-      "label": "Card Of The Day",
-      "description": "Displays a rotating featured judoka card on the landing screen",
       "tooltipId": "settings.showCardOfTheDay"
     },
     "viewportSimulation": {
       "enabled": false,
-      "label": "Viewport Simulation",
-      "description": "Adds a dropdown to simulate common device viewport sizes",
       "tooltipId": "settings.viewportSimulation"
     },
     "tooltipOverlayDebug": {
       "enabled": false,
-      "label": "Tooltip Overlay Debug",
-      "description": "Shows bounding boxes for tooltip targets",
       "tooltipId": "settings.tooltipOverlayDebug"
     },
     "layoutDebugPanel": {
       "enabled": false,
-      "label": "Layout Debug Panel",
-      "description": "Displays CSS grid and flex outlines for debugging layout issues",
       "tooltipId": "settings.layoutDebugPanel"
     },
     "navCacheResetButton": {
       "enabled": false,
-      "label": "Navigation Cache Reset",
-      "description": "Adds a button to clear cached navigation data for troubleshooting",
       "tooltipId": "settings.navCacheResetButton"
     }
   }

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -40,19 +40,58 @@
     "home": "**Home**\nReturn to the main screen."
   },
   "settings": {
-    "sound": "Toggle all game audio on or off.",
-    "motionEffects": "Enable smooth animations throughout the UI.",
-    "typewriterEffect": "Animate meditation quotes one letter at a time.",
-    "tooltips": "Show helpful pop-up hints when hovering controls.",
-    "battleDebugPanel": "Show a panel with live match data for debugging.",
-    "fullNavigationMap": "Display an overlay map linking to every page.",
-    "enableTestMode": "Run deterministic matches for testing.",
-    "enableCardInspector": "Reveal raw card JSON in a collapsible panel.",
-    "showCardOfTheDay": "Highlight a featured judoka on the home page.",
-    "viewportSimulation": "Choose preset sizes to simulate different devices.",
-    "tooltipOverlayDebug": "Outline tooltip targets to debug placement.",
-    "layoutDebugPanel": "Show CSS outlines to inspect page layout.",
-    "navCacheResetButton": "Add a button to clear cached navigation data."
+    "sound": {
+      "label": "Sound",
+      "description": "Toggle all game audio on or off."
+    },
+    "motionEffects": {
+      "label": "Motion Effects",
+      "description": "Enable smooth animations throughout the UI."
+    },
+    "typewriterEffect": {
+      "label": "Typewriter Effect",
+      "description": "Animate meditation quotes one letter at a time."
+    },
+    "tooltips": {
+      "label": "Tooltips",
+      "description": "Show helpful pop-up hints when hovering controls."
+    },
+    "battleDebugPanel": {
+      "label": "Battle Debug Panel",
+      "description": "Show a panel with live match data for debugging."
+    },
+    "fullNavigationMap": {
+      "label": "Full Navigation Map",
+      "description": "Display an overlay map linking to every page."
+    },
+    "enableTestMode": {
+      "label": "Test Mode",
+      "description": "Run deterministic matches for testing."
+    },
+    "enableCardInspector": {
+      "label": "Card Inspector",
+      "description": "Reveal raw card JSON in a collapsible panel."
+    },
+    "showCardOfTheDay": {
+      "label": "Card Of The Day",
+      "description": "Highlight a featured judoka on the home page."
+    },
+    "viewportSimulation": {
+      "label": "Viewport Simulation",
+      "description": "Choose preset sizes to simulate different devices."
+    },
+    "tooltipOverlayDebug": {
+      "label": "Tooltip Overlay Debug",
+      "description": "Outline tooltip targets to debug placement."
+    },
+    "layoutDebugPanel": {
+      "label": "Layout Debug Panel",
+      "description": "Show CSS outlines to inspect page layout."
+    },
+    "navCacheResetButton": {
+      "label": "Navigation Cache Reset",
+      "description": "Add a button to clear cached navigation data."
+    }
   },
   "card": {
     "flag": "**Country flag**\nRepresents the judoka’s nation.",

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -38,16 +38,29 @@ function applyInputState(element, value) {
  *
  * @param {Object} controls - Collection of form elements.
  * @param {import("../settingsUtils.js").Settings} settings - Current settings.
+ * @param {Record<string, string>} [tooltipMap] - Flattened tooltip lookup.
  */
-export function applyInitialControlValues(controls, settings) {
+export function applyInitialControlValues(controls, settings, tooltipMap = {}) {
   applyInputState(controls.soundToggle, settings.sound);
   if (controls.soundToggle && settings.tooltipIds?.sound) {
     controls.soundToggle.dataset.tooltipId = settings.tooltipIds.sound;
   }
+  const soundLabel = tooltipMap["settings.sound.label"];
+  const soundDesc = tooltipMap["settings.sound.description"];
+  const soundLabelEl = controls.soundToggle?.closest("label")?.querySelector("span");
+  const soundDescEl = document.getElementById("sound-desc");
+  if (soundLabel && soundLabelEl) soundLabelEl.textContent = soundLabel;
+  if (soundDesc && soundDescEl) soundDescEl.textContent = soundDesc;
   applyInputState(controls.motionToggle, settings.motionEffects);
   if (controls.motionToggle && settings.tooltipIds?.motionEffects) {
     controls.motionToggle.dataset.tooltipId = settings.tooltipIds.motionEffects;
   }
+  const motionLabel = tooltipMap["settings.motionEffects.label"];
+  const motionDesc = tooltipMap["settings.motionEffects.description"];
+  const motionLabelEl = controls.motionToggle?.closest("label")?.querySelector("span");
+  const motionDescEl = document.getElementById("motion-desc");
+  if (motionLabel && motionLabelEl) motionLabelEl.textContent = motionLabel;
+  if (motionDesc && motionDescEl) motionDescEl.textContent = motionDesc;
   if (controls.displayRadios) {
     controls.displayRadios.forEach((radio) => {
       const isSelected = radio.value === settings.displayMode;
@@ -59,10 +72,22 @@ export function applyInitialControlValues(controls, settings) {
   if (controls.typewriterToggle && settings.tooltipIds?.typewriterEffect) {
     controls.typewriterToggle.dataset.tooltipId = settings.tooltipIds.typewriterEffect;
   }
+  const typeLabel = tooltipMap["settings.typewriterEffect.label"];
+  const typeDesc = tooltipMap["settings.typewriterEffect.description"];
+  const typeLabelEl = controls.typewriterToggle?.closest("label")?.querySelector("span");
+  const typeDescEl = document.getElementById("typewriter-desc");
+  if (typeLabel && typeLabelEl) typeLabelEl.textContent = typeLabel;
+  if (typeDesc && typeDescEl) typeDescEl.textContent = typeDesc;
   applyInputState(controls.tooltipsToggle, settings.tooltips);
   if (controls.tooltipsToggle && settings.tooltipIds?.tooltips) {
     controls.tooltipsToggle.dataset.tooltipId = settings.tooltipIds.tooltips;
   }
+  const tipsLabel = tooltipMap["settings.tooltips.label"];
+  const tipsDesc = tooltipMap["settings.tooltips.description"];
+  const tipsLabelEl = controls.tooltipsToggle?.closest("label")?.querySelector("span");
+  const tipsDescEl = document.getElementById("tooltips-desc");
+  if (tipsLabel && tipsLabelEl) tipsLabelEl.textContent = tipsLabel;
+  if (tipsDesc && tipsDescEl) tipsDescEl.textContent = tipsDesc;
 }
 
 /**
@@ -223,20 +248,30 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
  * 4. When toggling `viewportSimulation`, call `toggleViewportSimulation`.
  *
  * @param {HTMLElement} container - Container for the switches.
- * @param {Record<string, { enabled: boolean, label: string, description: string }>} flags - Feature flag metadata.
+ * @param {Record<string, { enabled: boolean, tooltipId?: string }>} flags - Feature flag metadata.
  * @param {Function} getCurrentSettings - Returns current settings.
  * @param {Function} handleUpdate - Persist function.
+ * @param {Record<string, string>} [tooltipMap] - Flattened tooltip lookup.
  */
-export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, handleUpdate) {
+export function renderFeatureFlagSwitches(
+  container,
+  flags,
+  getCurrentSettings,
+  handleUpdate,
+  tooltipMap = {}
+) {
   if (!container || !flags) return;
   Object.keys(flags).forEach((flag) => {
     const kebab = flag.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
     const info = flags[flag];
-    const wrapper = createToggleSwitch(info.label, {
+    const tipId = info.tooltipId || `settings.${flag}`;
+    const label = tooltipMap[`${tipId}.label`] || flag;
+    const description = tooltipMap[`${tipId}.description`] || "";
+    const wrapper = createToggleSwitch(label, {
       id: `feature-${kebab}`,
       name: flag,
       checked: Boolean(getCurrentSettings().featureFlags[flag]?.enabled),
-      ariaLabel: info.label,
+      ariaLabel: label,
       tooltipId: info.tooltipId
     });
     const input = wrapper.querySelector("input");
@@ -244,7 +279,7 @@ export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, 
     const desc = document.createElement("p");
     desc.className = "settings-description";
     desc.id = `feature-${kebab}-desc`;
-    desc.textContent = info.description;
+    desc.textContent = description;
     wrapper.appendChild(desc);
     if (input) input.setAttribute("aria-describedby", desc.id);
     container.appendChild(wrapper);
@@ -260,7 +295,7 @@ export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, 
           input.checked = prev;
         })
       ).then(() => {
-        showSnackbar(`${info.label} ${input.checked ? "enabled" : "disabled"}`);
+        showSnackbar(`${label} ${input.checked ? "enabled" : "disabled"}`);
         if (flag === "viewportSimulation") {
           toggleViewportSimulation(input.checked);
         }
@@ -278,7 +313,7 @@ export function renderFeatureFlagSwitches(container, flags, getCurrentSettings, 
             "layoutDebugPanel"
           ].includes(flag)
         ) {
-          showSettingsInfo(info.label, info.description);
+          showSettingsInfo(label, description);
         }
       });
     });

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -187,8 +187,6 @@ export function resetSettings() {
  * @property {Record<string, boolean>} [gameModes]
  * @property {Record<string, {
  *   enabled: boolean,
- *   label: string,
- *   description: string,
  *   tooltipId?: string
  * }>} [featureFlags]
  */

--- a/src/helpers/tooltip.js
+++ b/src/helpers/tooltip.js
@@ -53,6 +53,15 @@ async function loadTooltips() {
 }
 
 /**
+ * Retrieve the flattened tooltip map.
+ *
+ * @returns {Promise<Record<string, string>>} Tooltip lookup object.
+ */
+export function getTooltips() {
+  return loadTooltips();
+}
+
+/**
  * Converts tooltip markdown to sanitized HTML.
  *
  * @pseudocode

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -45,20 +45,12 @@
             "type": "boolean",
             "description": "Whether the flag is active."
           },
-          "label": {
-            "type": "string",
-            "description": "Human readable label for the flag."
-          },
-          "description": {
-            "type": "string",
-            "description": "Brief explanation of the feature."
-          },
           "tooltipId": {
             "type": "string",
             "description": "Tooltip identifier for this flag."
           }
         },
-        "required": ["enabled", "label", "description"],
+        "required": ["enabled"],
         "additionalProperties": false
       }
     }

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -149,26 +149,10 @@ describe("populateNavbar", () => {
       displayMode: "light",
       gameModes: { 2: false },
       featureFlags: {
-        battleDebugPanel: {
-          enabled: false,
-          label: "Battle Debug Panel",
-          description: "Adds a collapsible debug panel"
-        },
-        fullNavigationMap: {
-          enabled: true,
-          label: "Full Navigation Map",
-          description: "Expanded map navigation"
-        },
-        enableTestMode: {
-          enabled: false,
-          label: "Test Mode",
-          description: "Deterministic card draws for testing"
-        },
-        enableCardInspector: {
-          enabled: false,
-          label: "Card Inspector",
-          description: "Shows raw card JSON in a panel"
-        }
+        battleDebugPanel: { enabled: false },
+        fullNavigationMap: { enabled: true },
+        enableTestMode: { enabled: false },
+        enableCardInspector: { enabled: false }
       }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
@@ -229,26 +213,10 @@ describe("populateNavbar", () => {
       displayMode: "light",
       gameModes: {},
       featureFlags: {
-        battleDebugPanel: {
-          enabled: false,
-          label: "Battle Debug Panel",
-          description: "Adds a collapsible debug panel"
-        },
-        fullNavigationMap: {
-          enabled: true,
-          label: "Full Navigation Map",
-          description: "Expanded map navigation"
-        },
-        enableTestMode: {
-          enabled: false,
-          label: "Test Mode",
-          description: "Deterministic card draws for testing"
-        },
-        enableCardInspector: {
-          enabled: false,
-          label: "Card Inspector",
-          description: "Shows raw card JSON in a panel"
-        }
+        battleDebugPanel: { enabled: false },
+        fullNavigationMap: { enabled: true },
+        enableTestMode: { enabled: false },
+        enableCardInspector: { enabled: false }
       }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);
@@ -297,26 +265,10 @@ describe("populateNavbar", () => {
       displayMode: "light",
       gameModes: {},
       featureFlags: {
-        battleDebugPanel: {
-          enabled: false,
-          label: "Battle Debug Panel",
-          description: "Adds a collapsible debug panel"
-        },
-        fullNavigationMap: {
-          enabled: true,
-          label: "Full Navigation Map",
-          description: "Expanded map navigation"
-        },
-        enableTestMode: {
-          enabled: false,
-          label: "Test Mode",
-          description: "Deterministic card draws for testing"
-        },
-        enableCardInspector: {
-          enabled: false,
-          label: "Card Inspector",
-          description: "Shows raw card JSON in a panel"
-        }
+        battleDebugPanel: { enabled: false },
+        fullNavigationMap: { enabled: true },
+        enableTestMode: { enabled: false },
+        enableCardInspector: { enabled: false }
       }
     });
     const loadNavigationItems = vi.fn().mockResolvedValue(data);

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -13,31 +13,11 @@ const baseSettings = {
   displayMode: "light",
   gameModes: {},
   featureFlags: {
-    randomStatMode: {
-      enabled: false,
-      label: "Random Stat Mode",
-      description: "Auto-selects a random stat when timer expires"
-    },
-    battleDebugPanel: {
-      enabled: false,
-      label: "Battle Debug Panel",
-      description: "Adds a collapsible debug panel"
-    },
-    fullNavigationMap: {
-      enabled: true,
-      label: "Full Navigation Map",
-      description: "Expanded map navigation"
-    },
-    enableTestMode: {
-      enabled: false,
-      label: "Test Mode",
-      description: "Deterministic card draws for testing"
-    },
-    enableCardInspector: {
-      enabled: false,
-      label: "Card Inspector",
-      description: "Shows raw card JSON in a panel"
-    }
+    randomStatMode: { enabled: false },
+    battleDebugPanel: { enabled: false },
+    fullNavigationMap: { enabled: true },
+    enableTestMode: { enabled: false },
+    enableCardInspector: { enabled: false }
   }
 };
 

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -9,57 +9,49 @@ const baseSettings = {
   displayMode: "light",
   gameModes: {},
   featureFlags: {
-    randomStatMode: {
-      enabled: true,
-      label: "Random Stat Mode",
-      description: "Auto-selects a random stat when timer expires"
-    },
-    battleDebugPanel: {
-      enabled: false,
-      label: "Battle Debug Panel",
-      description: "Adds a collapsible debug panel"
-    },
-    fullNavigationMap: {
-      enabled: true,
-      label: "Full Navigation Map",
-      description: "Expanded map navigation"
-    },
-    enableTestMode: {
-      enabled: false,
-      label: "Test Mode",
-      description: "Deterministic card draws for testing"
-    },
-    enableCardInspector: {
-      enabled: false,
-      label: "Card Inspector",
-      description: "Shows raw card JSON in a panel"
-    },
-    showCardOfTheDay: {
-      enabled: false,
-      label: "Card Of The Day",
-      description: "Displays a rotating featured judoka card on the landing screen"
-    },
-    viewportSimulation: {
-      enabled: false,
-      label: "Viewport Simulation",
-      description: "Adds a dropdown to simulate common device viewport sizes"
-    },
-    tooltipOverlayDebug: {
-      enabled: false,
-      label: "Tooltip Overlay Debug",
-      description: "Shows bounding boxes for tooltip targets"
-    },
-    layoutDebugPanel: {
-      enabled: false,
-      label: "Layout Debug Panel",
-      description: "Displays CSS grid and flex outlines for debugging layout issues"
-    },
-    navCacheResetButton: {
-      enabled: false,
-      label: "Navigation Cache Reset",
-      description: "Adds a button to clear cached navigation data for troubleshooting"
-    }
+    randomStatMode: { enabled: true },
+    battleDebugPanel: { enabled: false },
+    fullNavigationMap: { enabled: true },
+    enableTestMode: { enabled: false },
+    enableCardInspector: { enabled: false },
+    showCardOfTheDay: { enabled: false },
+    viewportSimulation: { enabled: false },
+    tooltipOverlayDebug: { enabled: false },
+    layoutDebugPanel: { enabled: false },
+    navCacheResetButton: { enabled: false }
   }
+};
+
+vi.mock("../../src/helpers/tooltip.js", () => ({
+  initTooltips: vi.fn(),
+  getTooltips: vi.fn().mockResolvedValue(tooltipMap)
+}));
+
+const tooltipMap = {
+  "settings.randomStatMode.label": "Random Stat Mode",
+  "settings.randomStatMode.description": "Auto-selects a random stat when timer expires",
+  "settings.battleDebugPanel.label": "Battle Debug Panel",
+  "settings.battleDebugPanel.description": "Adds a collapsible debug panel",
+  "settings.fullNavigationMap.label": "Full Navigation Map",
+  "settings.fullNavigationMap.description": "Expanded map navigation",
+  "settings.enableTestMode.label": "Test Mode",
+  "settings.enableTestMode.description": "Deterministic card draws for testing",
+  "settings.enableCardInspector.label": "Card Inspector",
+  "settings.enableCardInspector.description": "Shows raw card JSON in a panel",
+  "settings.showCardOfTheDay.label": "Card Of The Day",
+  "settings.showCardOfTheDay.description":
+    "Displays a rotating featured judoka card on the landing screen",
+  "settings.viewportSimulation.label": "Viewport Simulation",
+  "settings.viewportSimulation.description":
+    "Adds a dropdown to simulate common device viewport sizes",
+  "settings.tooltipOverlayDebug.label": "Tooltip Overlay Debug",
+  "settings.tooltipOverlayDebug.description": "Shows bounding boxes for tooltip targets",
+  "settings.layoutDebugPanel.label": "Layout Debug Panel",
+  "settings.layoutDebugPanel.description":
+    "Displays CSS grid and flex outlines for debugging layout issues",
+  "settings.navCacheResetButton.label": "Navigation Cache Reset",
+  "settings.navCacheResetButton.description":
+    "Adds a button to clear cached navigation data for troubleshooting"
 };
 
 describe("settingsPage module", () => {
@@ -318,7 +310,7 @@ describe("settingsPage module", () => {
     await vi.runAllTimersAsync();
 
     expect(showSnackbar).toHaveBeenCalledWith(
-      `${baseSettings.featureFlags.randomStatMode.label} disabled`
+      `${tooltipMap["settings.randomStatMode.label"]} disabled`
     );
   });
 
@@ -411,8 +403,8 @@ describe("settingsPage module", () => {
 
     expect(updateSetting).toHaveBeenCalledWith("featureFlags", updatedSettings.featureFlags);
     expect(showSettingsInfo).toHaveBeenCalledWith(
-      baseSettings.featureFlags.showCardOfTheDay.label,
-      baseSettings.featureFlags.showCardOfTheDay.description
+      tooltipMap["settings.showCardOfTheDay.label"],
+      tooltipMap["settings.showCardOfTheDay.description"]
     );
   });
 
@@ -454,8 +446,8 @@ describe("settingsPage module", () => {
 
     expect(updateSetting).toHaveBeenCalledWith("featureFlags", updatedSettings.featureFlags);
     expect(showSettingsInfo).toHaveBeenCalledWith(
-      baseSettings.featureFlags.viewportSimulation.label,
-      baseSettings.featureFlags.viewportSimulation.description
+      tooltipMap["settings.viewportSimulation.label"],
+      tooltipMap["settings.viewportSimulation.description"]
     );
   });
 
@@ -497,8 +489,8 @@ describe("settingsPage module", () => {
 
     expect(updateSetting).toHaveBeenCalledWith("featureFlags", updatedSettings.featureFlags);
     expect(showSettingsInfo).toHaveBeenCalledWith(
-      baseSettings.featureFlags.tooltipOverlayDebug.label,
-      baseSettings.featureFlags.tooltipOverlayDebug.description
+      tooltipMap["settings.tooltipOverlayDebug.label"],
+      tooltipMap["settings.tooltipOverlayDebug.description"]
     );
   });
 
@@ -540,8 +532,8 @@ describe("settingsPage module", () => {
 
     expect(updateSetting).toHaveBeenCalledWith("featureFlags", updatedSettings.featureFlags);
     expect(showSettingsInfo).toHaveBeenCalledWith(
-      baseSettings.featureFlags.layoutDebugPanel.label,
-      baseSettings.featureFlags.layoutDebugPanel.description
+      tooltipMap["settings.layoutDebugPanel.label"],
+      tooltipMap["settings.layoutDebugPanel.description"]
     );
   });
 

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -55,26 +55,10 @@ describe("settings utils", () => {
       displayMode: "dark",
       gameModes: {},
       featureFlags: {
-        battleDebugPanel: {
-          enabled: false,
-          label: "Battle Debug Panel",
-          description: "Adds a collapsible debug panel"
-        },
-        fullNavigationMap: {
-          enabled: false,
-          label: "Full Navigation Map",
-          description: "Expanded map navigation"
-        },
-        enableTestMode: {
-          enabled: false,
-          label: "Test Mode",
-          description: "Deterministic card draws for testing"
-        },
-        enableCardInspector: {
-          enabled: false,
-          label: "Card Inspector",
-          description: "Shows raw card JSON in a panel"
-        }
+        battleDebugPanel: { enabled: false },
+        fullNavigationMap: { enabled: false },
+        enableTestMode: { enabled: false },
+        enableCardInspector: { enabled: false }
       }
     };
     const promise = saveSettings(data);
@@ -142,26 +126,10 @@ describe("settings utils", () => {
         displayMode: "light",
         gameModes: {},
         featureFlags: {
-          battleDebugPanel: {
-            enabled: false,
-            label: "Battle Debug Panel",
-            description: "Adds a collapsible debug panel"
-          },
-          fullNavigationMap: {
-            enabled: false,
-            label: "Full Navigation Map",
-            description: "Expanded map navigation"
-          },
-          enableTestMode: {
-            enabled: false,
-            label: "Test Mode",
-            description: "Deterministic card draws for testing"
-          },
-          enableCardInspector: {
-            enabled: false,
-            label: "Card Inspector",
-            description: "Shows raw card JSON in a panel"
-          }
+          battleDebugPanel: { enabled: false },
+          fullNavigationMap: { enabled: false },
+          enableTestMode: { enabled: false },
+          enableCardInspector: { enabled: false }
         }
       })
     ).rejects.toThrow("fail");
@@ -196,26 +164,10 @@ describe("settings utils", () => {
       displayMode: "light",
       gameModes: {},
       featureFlags: {
-        battleDebugPanel: {
-          enabled: false,
-          label: "Battle Debug Panel",
-          description: "Adds a collapsible debug panel"
-        },
-        fullNavigationMap: {
-          enabled: false,
-          label: "Full Navigation Map",
-          description: "Expanded map navigation"
-        },
-        enableTestMode: {
-          enabled: false,
-          label: "Test Mode",
-          description: "Deterministic card draws for testing"
-        },
-        enableCardInspector: {
-          enabled: false,
-          label: "Card Inspector",
-          description: "Shows raw card JSON in a panel"
-        }
+        battleDebugPanel: { enabled: false },
+        fullNavigationMap: { enabled: false },
+        enableTestMode: { enabled: false },
+        enableCardInspector: { enabled: false }
       }
     };
     const data2 = {
@@ -225,26 +177,10 @@ describe("settings utils", () => {
       displayMode: "dark",
       gameModes: {},
       featureFlags: {
-        battleDebugPanel: {
-          enabled: false,
-          label: "Battle Debug Panel",
-          description: "Adds a collapsible debug panel"
-        },
-        fullNavigationMap: {
-          enabled: false,
-          label: "Full Navigation Map",
-          description: "Expanded map navigation"
-        },
-        enableTestMode: {
-          enabled: false,
-          label: "Test Mode",
-          description: "Deterministic card draws for testing"
-        },
-        enableCardInspector: {
-          enabled: false,
-          label: "Card Inspector",
-          description: "Shows raw card JSON in a panel"
-        }
+        battleDebugPanel: { enabled: false },
+        fullNavigationMap: { enabled: false },
+        enableTestMode: { enabled: false },
+        enableCardInspector: { enabled: false }
       }
     };
     saveSettings(data1);


### PR DESCRIPTION
## Summary
- restructure settings tooltips with label/description pairs
- expose `getTooltips()` helper
- wire tooltips into settings page initialization
- read labels and descriptions from tooltip map in form utils
- update settings schema and remove labels/descriptions from defaults
- adjust unit tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 1 file, 7 tests)*
- `npx playwright test` *(fails: 1, skipped: 1)*

------
https://chatgpt.com/codex/tasks/task_e_688c8d8d29c88326bf6dcce730443f97