### PR TITLE
Update snackbar styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Light, dark and gray themes are supported. Changing modes uses a slide-over tran
 
 The Settings page (`src/pages/settings.html`) groups all player preferences, including experimental **feature flags**. Toggle a flag to enable an optional feature without modifying code. Flag values persist across pages and apply immediately. Implementation guidelines live in [settingsPageDesignGuidelines.md](design/codeStandards/settingsPageDesignGuidelines.md#feature-flags--agent-observability).
 Default flag states and descriptions now live in `src/data/settings.json`. The **Tooltips** toggle on this page lets you turn help tooltips on or off globally.
-Each change triggers a small snackbar at the bottom of the screen confirming the new setting. Every feature flag input also includes a `data-flag` attribute with the camelCase flag name so automation scripts can locate specific toggles.
+Each change triggers a small snackbar at the bottom of the screen confirming the new setting. The snackbar background uses the `--color-tertiary` token so it doesn't conflict with the navigation bar. Every feature flag input also includes a `data-flag` attribute with the camelCase flag name so automation scripts can locate specific toggles.
 
 ### Tooltip Availability
 

--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -91,7 +91,9 @@ Reuse the following markup for general settings, game modes, and feature flags:
 
   - Use CSS variables: `--color-primary`, `--button-bg`, etc.
   - Do not hard-code color values.
-  - Ensure all new elements work across Light, Dark, and Gray themes.
+- Ensure all new elements work across Light, Dark, and Gray themes.
+  - Snackbars should use `--color-tertiary` as the background to avoid
+    clashing with the bottom navigation bar.
 
 - **Spacing and Sizing**
   - Use `--space-sm`, `--space-md`, etc. for margins/padding

--- a/src/data/battleRounds.json
+++ b/src/data/battleRounds.json
@@ -1,27 +1,26 @@
 [
-    {
-      "id": 1,
-      "skill": 1,
-      "value": 5,
-      "default": false,
-      "category": "classicBattle",
-      "description": "A LOW round count total"
-    },
-    {
-      "id": 1,
-      "skill": 2,
-      "value": 10,
-      "default": true,
-      "category": "classicBattle",
-      "description": "A MEDIUM round count total that IS required"
-    },
-    {
-      "id": 3,
-      "skill": 3,
-      "value": 15,
-      "default": false,
-      "category": "classicBattle",
-      "description": "A HIGH round count total that IS required"
-    }
-  ]
-  
+  {
+    "id": 1,
+    "skill": 1,
+    "value": 5,
+    "default": false,
+    "category": "classicBattle",
+    "description": "A LOW round count total"
+  },
+  {
+    "id": 1,
+    "skill": 2,
+    "value": 10,
+    "default": true,
+    "category": "classicBattle",
+    "description": "A MEDIUM round count total that IS required"
+  },
+  {
+    "id": 3,
+    "skill": 3,
+    "value": 15,
+    "default": false,
+    "category": "classicBattle",
+    "description": "A HIGH round count total that IS required"
+  }
+]

--- a/src/styles/snackbar.css
+++ b/src/styles/snackbar.css
@@ -2,8 +2,8 @@
   visibility: hidden;
   min-width: 250px;
   margin-left: -125px;
-  background-color: var(--color-secondary);
-  color: var(--color-text-inverted);
+  background-color: var(--color-tertiary);
+  color: var(--color-text);
   text-align: center;
   border-radius: var(--radius-sm);
   padding: var(--space-md);

--- a/src/styles/snackbar.css
+++ b/src/styles/snackbar.css
@@ -3,7 +3,7 @@
   min-width: 250px;
   margin-left: -125px;
   background-color: var(--color-tertiary);
-  color: var(--color-text);
+  color: color-contrast(var(--color-tertiary) vs var(--color-text), var(--color-text-inverted));
   text-align: center;
   border-radius: var(--radius-sm);
   padding: var(--space-md);


### PR DESCRIPTION
## Summary
- use `--color-tertiary` background in snackbar
- document snackbar color rule in settings guidelines
- note snackbar color in README
- run Prettier on battleRounds.json

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688c8fc01e508326ba57d1a7b8aa9dbd