### PR TITLE
Fix tooltipOverlayDebug test setup

### DIFF
--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -22,10 +22,12 @@ const baseSettings = {
   }
 };
 
-vi.mock("../../src/helpers/tooltip.js", () => ({
-  initTooltips: vi.fn(),
-  getTooltips: vi.fn().mockResolvedValue(tooltipMap)
-}));
+beforeEach(() => {
+  vi.doMock("../../src/helpers/tooltip.js", () => ({
+    initTooltips: vi.fn(),
+    getTooltips: vi.fn().mockResolvedValue(tooltipMap)
+  }));
+});
 
 const tooltipMap = {
   "settings.randomStatMode.label": "Random Stat Mode",


### PR DESCRIPTION
## Summary
- ensure tooltip module is mocked in each test

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688c968e9d2883268cc6f5c8321c5d22