### PR TITLE
Fix nav cache reset button timing

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -86,8 +86,8 @@ function createResetConfirmation(onConfirm) {
  * 2. Query DOM elements for each control and the mode container.
  * 3. Provide helper functions to read and persist settings.
  * 4. Apply initial values, attach listeners, and render mode and flag switches.
- * 5. When `navCacheResetButton` is enabled, add a button that clears cached
- *    navigation data and refreshes the navbar.
+ * 5. When `navCacheResetButton` is enabled, queue a microtask to append a
+ *    button that clears cached navigation data and refreshes the navbar.
  *
  * @param {Settings} settings - Current settings object.
  * @param {Array} gameModes - Available game mode options.
@@ -166,7 +166,8 @@ function initializeControls(settings, gameModes, tooltipMap) {
     handleUpdate,
     tooltipMap
   );
-  addNavResetButton();
+  // Queue to ensure the section exists before inserting
+  queueMicrotask(addNavResetButton);
   document.getElementById("feature-nav-cache-reset-button")?.addEventListener("change", () => {
     setTimeout(addNavResetButton);
   });
@@ -191,7 +192,7 @@ function initializeControls(settings, gameModes, tooltipMap) {
       handleUpdate,
       tooltipMap
     );
-    addNavResetButton();
+    queueMicrotask(addNavResetButton);
     initTooltips();
     document.getElementById("feature-nav-cache-reset-button")?.addEventListener("change", () => {
       setTimeout(addNavResetButton);


### PR DESCRIPTION
## Summary
- ensure navigation cache reset button is added after DOM is ready

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688c96c835c0832690773e32bd37f02b