### PR TITLE
Fix tooltip modal data

### DIFF
--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -313,7 +313,9 @@ export function renderFeatureFlagSwitches(
             "layoutDebugPanel"
           ].includes(flag)
         ) {
-          showSettingsInfo(label, description);
+          const tipLabel = tooltipMap[`${tipId}.label`] || label;
+          const tipDesc = tooltipMap[`${tipId}.description`] || description;
+          showSettingsInfo(tipLabel, tipDesc);
         }
       });
     });

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -313,8 +313,8 @@ export function renderFeatureFlagSwitches(
             "layoutDebugPanel"
           ].includes(flag)
         ) {
-          const tipLabel = tooltipMap[`${tipId}.label`] || label;
-          const tipDesc = tooltipMap[`${tipId}.description`] || description;
+          const tipLabel = tooltipMap[`${currentTipId}.label`] || label;
+          const tipDesc = tooltipMap[`${currentTipId}.description`] || description;
           showSettingsInfo(tipLabel, tipDesc);
         }
       });


### PR DESCRIPTION
## Summary
- ensure feature flag info modals use tooltip translations when toggled

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688c966e5c248326b81f59be3a484a6b