### PR TITLE
Improve feature flag labels

### DIFF
--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -11,6 +11,19 @@ import { toggleLayoutDebugPanel } from "../layoutDebugPanel.js";
 import { showSettingsInfo } from "../showSettingsInfo.js";
 
 /**
+ * Convert a camelCase flag name into a readable label.
+ *
+ * @pseudocode
+ * 1. Insert spaces before capital letters.
+ * 2. Capitalize the first character.
+ */
+function formatFlagLabel(flag) {
+  return String(flag)
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
+/**
  * Apply a value to an input or checkbox element.
  *
  * @pseudocode
@@ -243,9 +256,10 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
  *
  * @pseudocode
  * 1. For each flag, generate a labelled toggle switch element and description.
- * 2. Persist updates via `handleUpdate` when toggled.
- * 3. After saving, show a snackbar confirming the new state.
- * 4. When toggling `viewportSimulation`, call `toggleViewportSimulation`.
+ * 2. When tooltip text is missing, convert the flag name to a readable label.
+ * 3. Persist updates via `handleUpdate` when toggled.
+ * 4. After saving, show a snackbar confirming the new state.
+ * 5. When toggling `viewportSimulation`, call `toggleViewportSimulation`.
  *
  * @param {HTMLElement} container - Container for the switches.
  * @param {Record<string, { enabled: boolean, tooltipId?: string }>} flags - Feature flag metadata.
@@ -265,8 +279,10 @@ export function renderFeatureFlagSwitches(
     const kebab = flag.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
     const info = flags[flag];
     const tipId = info.tooltipId || `settings.${flag}`;
-    const label = tooltipMap[`${tipId}.label`] || flag;
-    const description = tooltipMap[`${tipId}.description`] || "";
+    const getLabel = () => tooltipMap[`${tipId}.label`] || formatFlagLabel(flag);
+    const getDescription = () => tooltipMap[`${tipId}.description`] || "";
+    const label = getLabel();
+    const description = getDescription();
     const wrapper = createToggleSwitch(label, {
       id: `feature-${kebab}`,
       name: flag,
@@ -313,7 +329,7 @@ export function renderFeatureFlagSwitches(
             "layoutDebugPanel"
           ].includes(flag)
         ) {
-          showSettingsInfo(label, description);
+          showSettingsInfo(getLabel(), getDescription());
         }
       });
     });

--- a/src/helpers/settings/formUtils.js
+++ b/src/helpers/settings/formUtils.js
@@ -279,9 +279,8 @@ export function renderFeatureFlagSwitches(
     const kebab = flag.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
     const info = flags[flag];
     const tipId = info.tooltipId || `settings.${flag}`;
-    const getLabel = () => tooltipMap[`${tipId}.label`] || formatFlagLabel(flag);
+    const label = tooltipMap[`${tipId}.label`] || formatFlagLabel(flag);
     const getDescription = () => tooltipMap[`${tipId}.description`] || "";
-    const label = getLabel();
     const description = getDescription();
     const wrapper = createToggleSwitch(label, {
       id: `feature-${kebab}`,


### PR DESCRIPTION
## Summary
- add formatFlagLabel helper to convert camelCase to human readable form
- fallback to formatted labels when tooltip text is missing
- update pseudocode in renderFeatureFlagSwitches

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: fetch errors and missing mocks)*

------
https://chatgpt.com/codex/tasks/task_e_688c97acb92483268a61a131fb7b8106