### PR TITLE
Add return tags for page setup helpers

### DIFF
--- a/src/helpers/meditationPage.js
+++ b/src/helpers/meditationPage.js
@@ -7,6 +7,8 @@
  *    a. Retrieves the quote element from the DOM.
  *    b. Calls `setupLanguageToggle` with the quote element.
  * 3. Use `onDomReady` to run `setupMeditationPage` once the DOM is ready.
+ *
+ * @returns {void}
  */
 import { setupLanguageToggle } from "./pseudoJapanese.js";
 import { onDomReady } from "./domReady.js";

--- a/src/helpers/mockupViewerPage.js
+++ b/src/helpers/mockupViewerPage.js
@@ -13,6 +13,8 @@ import { createSidebarList } from "../components/SidebarList.js";
  * 4. Implement `showImage(index)` to update the image, alt text, filename, and sidebar highlight.
  * 5. Attach click handlers and keyboard events to cycle images with wraparound.
  * 6. Show the first image and apply button ripple effects.
+ *
+ * @returns {void}
  */
 export function setupMockupViewerPage() {
   const imgEl = document.getElementById("mockup-image");


### PR DESCRIPTION
## Summary
- clarify return values for `setupMockupViewerPage` and `setupMeditationPage`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Settings page controls test)*

------
https://chatgpt.com/codex/tasks/task_e_688c9fe269e083268767f906fdb706fb