### PR TITLE
Fix settings page label test

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -49,9 +49,10 @@ test.describe("Settings page", () => {
       .map((item) => gameModes.find((m) => m.id === item.gameModeId)?.name)
       .filter(Boolean);
 
-    const flagLabels = Object.keys(DEFAULT_SETTINGS.featureFlags).map(
-      (f) => DEFAULT_SETTINGS.featureFlags[f].label
-    );
+    const tooltips = JSON.parse(fs.readFileSync("src/data/tooltips.json", "utf8"));
+    const flagLabels = Object.keys(DEFAULT_SETTINGS.featureFlags)
+      .map((f) => tooltips.settings?.[f]?.label)
+      .filter(Boolean);
 
     const expectedLabels = [
       "Light",


### PR DESCRIPTION
## Summary
- fix Playwright label loop to pull feature labels from `tooltips.json`

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden to download vitest)*
- `npx playwright test` *(fails: 403 Forbidden to download playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688ca517ff208326842a6d6181ef5516