### PR TITLE
Add JSDoc for initializeSettingsPage

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -204,6 +204,19 @@ function initializeControls(settings, gameModes, tooltipMap) {
   });
 }
 
+/**
+ * Load saved settings and render the Settings page UI.
+ *
+ * @pseudocode
+ * 1. Fetch settings, navigation items, and tooltip text.
+ * 2. Apply display and motion preferences from the settings.
+ * 3. Enable debug utilities based on feature flags.
+ * 4. Initialize page controls and section toggles.
+ * 5. Set up tooltips for all controls.
+ * 6. On error, show a fallback message to the user.
+ *
+ * @returns {Promise<void>}
+ */
 async function initializeSettingsPage() {
   try {
     const settings = await loadSettings();


### PR DESCRIPTION
## Summary
- document initializeSettingsPage in settingsPage helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Settings page controls expose correct labels)*

------
https://chatgpt.com/codex/tasks/task_e_688ca51f1c548326a658596f41d0fe60