### PR TITLE
Update PRD Settings snackbar

### DIFF
--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -160,8 +160,8 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 ### Advanced Settings & Feature Flag Info
 
 - Experimental and debug flags are grouped under a collapsible **Advanced Settings** section.
-- When a flag is toggled, a modal explains the feature using text from `tooltips.json` keyed by `settings.<flagName>`.
-- The modal is created via `createModal` with an OK button to dismiss it.
+- When a flag is toggled, a snackbar appears with text from `tooltips.json` keyed by `settings.<flagName>`.
+- The snackbar confirms the change and hides itself after a short delay.
 - Debug-focused flags remain tucked away so younger players do not accidentally enable them.
 
 ### Data Persistence & Refresh


### PR DESCRIPTION
## Summary
- adjust settings PRD to use a snackbar for flag info

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Settings page controls test)*

------
https://chatgpt.com/codex/tasks/task_e_688ca8e96d608326a40c65cde03d1343