### PR TITLE
Implement countdown timer utility

### DIFF
--- a/tests/helpers/countdownTimer.test.js
+++ b/tests/helpers/countdownTimer.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { createCountdownTimer } from "../../src/helpers/timerUtils.js";
+
+describe("createCountdownTimer", () => {
+  it("counts down and calls expired", () => {
+    vi.useFakeTimers();
+    const onTick = vi.fn();
+    const onExpired = vi.fn();
+    const timer = createCountdownTimer(2, { onTick, onExpired });
+    timer.start();
+    expect(onTick).toHaveBeenCalledWith(2);
+    vi.advanceTimersByTime(1000);
+    expect(onTick).toHaveBeenCalledWith(1);
+    vi.advanceTimersByTime(1000);
+    expect(onExpired).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("pauses and resumes", () => {
+    vi.useFakeTimers();
+    const onExpired = vi.fn();
+    const timer = createCountdownTimer(2, { onExpired });
+    timer.start();
+    vi.advanceTimersByTime(1000);
+    timer.pause();
+    vi.advanceTimersByTime(2000);
+    expect(onExpired).not.toHaveBeenCalled();
+    timer.resume();
+    vi.advanceTimersByTime(1000);
+    expect(onExpired).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("auto pauses when hidden", () => {
+    vi.useFakeTimers();
+    const onExpired = vi.fn();
+    const timer = createCountdownTimer(2, { onExpired, pauseOnHidden: true });
+    timer.start();
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => true
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(2000);
+    expect(onExpired).not.toHaveBeenCalled();
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => false
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(2000);
+    expect(onExpired).toHaveBeenCalled();
+    delete document.hidden;
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add countdown timer helper with pause/resume
- export countdown timer from timerUtils
- test countdown timer behaviour

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Settings page › controls expose correct labels and follow tab order)*

------
https://chatgpt.com/codex/tasks/task_e_688caa19c53c8326be3702bbdc6ad5f4