### PR TITLE
Initialize section toggles earlier

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -193,6 +193,7 @@ function initializeControls(settings, gameModes, tooltipMap) {
       tooltipMap
     );
     queueMicrotask(addNavResetButton);
+    setupSectionToggles();
     initTooltips();
     document.getElementById("feature-nav-cache-reset-button")?.addEventListener("change", () => {
       setTimeout(addNavResetButton);
@@ -208,17 +209,19 @@ function initializeControls(settings, gameModes, tooltipMap) {
  * Load saved settings and render the Settings page UI.
  *
  * @pseudocode
- * 1. Fetch settings, navigation items, and tooltip text.
- * 2. Apply display and motion preferences from the settings.
- * 3. Enable debug utilities based on feature flags.
- * 4. Initialize page controls and section toggles.
- * 5. Set up tooltips for all controls.
- * 6. On error, show a fallback message to the user.
+ * 1. Call `setupSectionToggles` so collapsible sections work immediately.
+ * 2. Fetch settings, navigation items, and tooltip text.
+ * 3. Apply display and motion preferences from the settings.
+ * 4. Enable debug utilities based on feature flags.
+ * 5. Initialize page controls and section toggles.
+ * 6. Set up tooltips for all controls.
+ * 7. On error, show a fallback message to the user.
  *
  * @returns {Promise<void>}
  */
 async function initializeSettingsPage() {
   try {
+    setupSectionToggles();
     const settings = await loadSettings();
     const gameModes = await loadNavigationItems();
     const tooltipMap = await getTooltips();
@@ -228,7 +231,6 @@ async function initializeSettingsPage() {
     toggleTooltipOverlayDebug(Boolean(settings.featureFlags.tooltipOverlayDebug?.enabled));
     toggleLayoutDebugPanel(Boolean(settings.featureFlags.layoutDebugPanel?.enabled));
     initializeControls(settings, gameModes, tooltipMap);
-    setupSectionToggles();
     initTooltips();
   } catch (error) {
     console.error("Error loading settings page:", error);

--- a/tests/fixtures/tooltips.json
+++ b/tests/fixtures/tooltips.json
@@ -1,3 +1,57 @@
 {
-  "info": "**Helpful** tip"
+  "info": "**Helpful** tip",
+  "settings": {
+    "sound": {
+      "label": "Sound",
+      "description": "Toggle all game audio on or off."
+    },
+    "motionEffects": {
+      "label": "Motion Effects",
+      "description": "Enable smooth animations throughout the UI."
+    },
+    "typewriterEffect": {
+      "label": "Typewriter Effect",
+      "description": "Animate meditation quotes one letter at a time."
+    },
+    "tooltips": {
+      "label": "Tooltips",
+      "description": "Show helpful pop-up hints when hovering controls."
+    },
+    "battleDebugPanel": {
+      "label": "Battle Debug Panel",
+      "description": "Show a panel with live match data for debugging."
+    },
+    "fullNavigationMap": {
+      "label": "Full Navigation Map",
+      "description": "Display an overlay map linking to every page."
+    },
+    "enableTestMode": {
+      "label": "Test Mode",
+      "description": "Run deterministic matches for testing."
+    },
+    "enableCardInspector": {
+      "label": "Card Inspector",
+      "description": "Reveal raw card JSON in a collapsible panel."
+    },
+    "showCardOfTheDay": {
+      "label": "Card Of The Day",
+      "description": "Highlight a featured judoka on the home page."
+    },
+    "viewportSimulation": {
+      "label": "Viewport Simulation",
+      "description": "Choose preset sizes to simulate different devices."
+    },
+    "tooltipOverlayDebug": {
+      "label": "Tooltip Overlay Debug",
+      "description": "Outline tooltip targets to debug placement."
+    },
+    "layoutDebugPanel": {
+      "label": "Layout Debug Panel",
+      "description": "Show CSS outlines to inspect page layout."
+    },
+    "navCacheResetButton": {
+      "label": "Navigation Cache Reset",
+      "description": "Add a button to clear cached navigation data."
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- set up section toggles before loading settings
- re-run section toggle setup after reset
- expand tooltip fixture with settings labels including Test Mode

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_688cbdcc5d7c8326a991a612b8ae41c9