### PR TITLE
Refactor classic battle helpers

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -1,26 +1,21 @@
-import { generateRandomCard } from "./randomCard.js";
-import { getRandomJudoka, renderJudokaCard } from "./cardUtils.js";
-import { seededRandom, isTestModeEnabled, getCurrentSeed } from "./testModeUtils.js";
-import { fetchJson } from "./dataUtils.js";
-import { createGokyoLookup } from "./utils.js";
-import { DATA_DIR } from "./constants.js";
-import { getDefaultTimer } from "./timerUtils.js";
+import { drawCards, _resetForTest as resetSelection } from "./classicBattle/cardSelection.js";
+import { startTimer, scheduleNextRound } from "./classicBattle/timerControl.js";
 import {
-  startRound as engineStartRound,
+  showSelectionPrompt,
+  revealComputerCard,
+  disableNextRoundButton,
+  updateDebugPanel
+} from "./classicBattle/uiHelpers.js";
+import {
   handleStatSelection as engineHandleStatSelection,
   quitMatch as engineQuitMatch,
   getScores,
-  getTimerState,
-  isMatchEnded,
-  startCoolDown,
-  STATS,
   _resetForTest as engineReset
 } from "./battleEngine.js";
 import * as infoBar from "./setupBattleInfoBar.js";
+import { getStatValue, resetStatButtons, showResult } from "./battle/index.js";
 import { createModal } from "../components/Modal.js";
 import { createButton } from "../components/Button.js";
-
-import { getStatValue, resetStatButtons, showResult } from "./battle/index.js";
 
 export function getStartRound() {
   if (typeof window !== "undefined" && window.startRoundOverride) {
@@ -29,24 +24,7 @@ export function getStartRound() {
   return startRound;
 }
 
-let judokaData = null;
-let gokyoLookup = null;
-let computerJudoka = null;
 let quitModal = null;
-
-function updateDebugPanel() {
-  const pre = document.getElementById("debug-output");
-  if (!pre) return;
-  const state = {
-    ...getScores(),
-    timer: getTimerState(),
-    matchEnded: isMatchEnded()
-  };
-  if (isTestModeEnabled()) {
-    state.seed = getCurrentSeed();
-  }
-  pre.textContent = JSON.stringify(state, null, 2);
-}
 
 function createQuitConfirmation(onConfirm) {
   const title = document.createElement("h2");
@@ -81,148 +59,17 @@ function createQuitConfirmation(onConfirm) {
   return modal;
 }
 
-/**
- * Display a persistent prompt instructing the player to choose a stat.
- *
- * @pseudocode
- * 1. Locate the `#round-message` element.
- * 2. Set the text to "Select your move".
- * 3. Add the fade transition class and ensure the element is fully visible.
- */
-export function showSelectionPrompt() {
-  const el = document.getElementById("round-message");
-  if (!el) return;
-  el.classList.add("fade-transition");
-  el.textContent = "Select your move";
-  el.classList.remove("fading");
-}
-
-async function startTimer() {
-  const timerEl = document.getElementById("next-round-timer");
-  let duration;
-  try {
-    duration = await getDefaultTimer("roundTimer");
-  } catch {
-    duration = 30;
-  }
-  if (typeof duration !== "number") duration = 30;
-  engineStartRound(
-    (remaining) => {
-      if (timerEl) timerEl.textContent = `Time Left: ${remaining}s`;
-    },
-    () => {
-      const randomStat = STATS[Math.floor(seededRandom() * STATS.length)];
-      infoBar.showMessage(`Time's up! Auto-selecting ${randomStat}`);
-      handleStatSelection(randomStat);
-    },
-    duration
-  );
-}
-
-export function enableNextRoundButton(enable = true) {
-  const btn = document.getElementById("next-round-button");
-  if (btn) btn.disabled = !enable;
-}
-
-export function disableNextRoundButton() {
-  enableNextRoundButton(false);
-}
-
-/**
- * Reveal the computer's hidden card.
- *
- * @pseudocode
- * 1. Exit early when no stored judoka exists.
- * 2. Render `computerJudoka` into the computer card container.
- * 3. Clear `computerJudoka` after rendering.
- *
- * @returns {Promise<void>} Resolves when the card is displayed.
- */
-export async function revealComputerCard() {
-  if (!computerJudoka) return;
-  const container = document.getElementById("computer-card");
-  await renderJudokaCard(computerJudoka, gokyoLookup, container, {
-    animate: false
-  });
-  computerJudoka = null;
-}
-
-/**
- * Start a new battle round by drawing cards for both players.
- *
- * @pseudocode
- * 1. Clear any previously selected stat button.
- * 2. Load judoka and gokyo data if not already cached.
- * 3. Filter out judoka marked with `isHidden`.
- * 4. Draw a random card for the player using `generateRandomCard` and capture
- *    the selected judoka.
- * 5. Select a random judoka for the computer from the filtered list.
- *    - If it matches the player's judoka, retry up to a safe limit.
- *    - Render the mystery placeholder card (`judokaId=1`) with obscured stats.
- * 6. Display the selection prompt and initialize the round timer.
- *
- * @returns {Promise<void>} Resolves when cards are displayed.
- */
 export async function startRound() {
   resetStatButtons();
   disableNextRoundButton();
-  if (!judokaData) {
-    judokaData = await fetchJson(`${DATA_DIR}judoka.json`);
-  }
-  const availableJudoka = Array.isArray(judokaData) ? judokaData.filter((j) => !j.isHidden) : [];
-  if (!gokyoLookup) {
-    const gokyoData = await fetchJson(`${DATA_DIR}gokyo.json`);
-    gokyoLookup = createGokyoLookup(gokyoData);
-  }
-  const playerContainer = document.getElementById("player-card");
-  const computerContainer = document.getElementById("computer-card");
-  let playerJudoka = null;
-  await generateRandomCard(
-    availableJudoka,
-    null,
-    playerContainer,
-    false,
-    (j) => {
-      playerJudoka = j;
-    },
-    { enableInspector: false }
-  );
-  let compJudoka = getRandomJudoka(availableJudoka);
-  if (playerJudoka) {
-    // avoid showing the same judoka, but guard against infinite loops
-    let attempts = 0;
-    const maxAttempts = Math.max(availableJudoka.length || 0, 5);
-    while (compJudoka.id === playerJudoka.id && attempts < maxAttempts) {
-      compJudoka = getRandomJudoka(availableJudoka);
-      attempts += 1;
-    }
-  }
-  computerJudoka = compJudoka;
-  const placeholder = judokaData.find((j) => j.id === 1) || compJudoka;
-  await renderJudokaCard(placeholder, gokyoLookup, computerContainer, {
-    animate: false,
-    useObscuredStats: true,
-    enableInspector: false
-  });
+  await drawCards();
   showSelectionPrompt();
   const { playerScore, computerScore } = getScores();
   infoBar.updateScore(playerScore, computerScore);
-  await startTimer();
+  await startTimer(handleStatSelection);
   updateDebugPanel();
 }
 
-/**
- * Evaluate the selected stat values and update the match state.
- *
- * @pseudocode
- * 1. Retrieve the stat values from both player and computer cards.
- * 2. Let the battle engine compare the values to update scores.
- * 3. Display the result message and refresh the score display.
- * 4. Return the comparison result to the caller.
- *
- * @param {string} stat - The stat name to compare.
- * @returns {{message: string, matchEnded: boolean}}
- */
 export function evaluateRound(stat) {
   const playerContainer = document.getElementById("player-card");
   const computerContainer = document.getElementById("computer-card");
@@ -232,87 +79,20 @@ export function evaluateRound(stat) {
   if (result.message) {
     showResult(result.message);
   }
-  {
-    const { playerScore, computerScore } = getScores();
-    infoBar.updateScore(playerScore, computerScore);
-  }
+  const { playerScore, computerScore } = getScores();
+  infoBar.updateScore(playerScore, computerScore);
   updateDebugPanel();
   return result;
 }
 
-/**
- * Enable the Next Round button so the player can continue.
- *
- * @pseudocode
- * 1. Exit if the match has ended.
- * 2. Find `#next-round-button` and set up the click handler to:
- *    a. Disable the button.
- *    b. Call `startRound()` to begin the next round.
- * 3. After a short delay start a 3s cooldown timer that:
- *    a. Updates the timer display each second.
- *    b. Enables the button and attaches the click handler when expired.
- *
- * @param {{matchEnded: boolean}} result - Result from evaluateRound.
- */
-export function scheduleNextRound(result) {
-  if (result.matchEnded) return;
-
-  const btn = document.getElementById("next-round-button");
-  if (!btn) return;
-
-  const onClick = async () => {
-    disableNextRoundButton();
-    const start = getStartRound();
-    await start();
-  };
-
-  const timerEl = document.getElementById("next-round-timer");
-
-  const onTick = (remaining) => {
-    if (timerEl) timerEl.textContent = `Next round in: ${remaining}s`;
-  };
-
-  const onExpired = () => {
-    btn.addEventListener("click", onClick, { once: true });
-    enableNextRoundButton();
-    updateDebugPanel();
-  };
-
-  // use the default 3 second cooldown to avoid async timer lookup
-  // during the short delay before the next round
-  setTimeout(() => {
-    startCoolDown(onTick, onExpired, 3);
-  }, 2000);
-}
-
-/**
- * Compare the chosen stat and trigger the next round.
- *
- * @pseudocode
- * 1. Reveal the computer's real card.
- * 2. Evaluate the round using `evaluateRound` to update scores.
- * 3. Clear the selected state from all stat buttons.
- * 4. Call `scheduleNextRound` with the evaluation result.
- *
- * @param {string} stat - The stat name to compare.
- */
 export async function handleStatSelection(stat) {
   await revealComputerCard();
   const result = evaluateRound(stat);
   resetStatButtons();
-  scheduleNextRound(result);
+  scheduleNextRound(result, getStartRound());
   updateDebugPanel();
 }
 
-/**
- * End the current match after user confirmation.
- *
- * @pseudocode
- * 1. Display a confirmation dialog.
- * 2. When confirmed, stop the timer and mark the match as ended.
- * 3. Show a loss message in the result area.
- * 4. Redirect the player to the main menu.
- */
 export function quitMatch() {
   if (!quitModal) {
     quitModal = createQuitConfirmation(() => {
@@ -325,9 +105,7 @@ export function quitMatch() {
 }
 
 export function _resetForTest() {
-  judokaData = null;
-  gokyoLookup = null;
-  computerJudoka = null;
+  resetSelection();
   engineReset();
   if (typeof window !== "undefined") {
     delete window.startRoundOverride;
@@ -350,16 +128,19 @@ export function _resetForTest() {
     quitModal.element.remove();
     quitModal = null;
   }
-  {
-    const { playerScore, computerScore } = getScores();
-    infoBar.updateScore(playerScore, computerScore);
-  }
+  const { playerScore, computerScore } = getScores();
+  infoBar.updateScore(playerScore, computerScore);
   updateDebugPanel();
 }
 
-export function getComputerJudoka() {
-  return computerJudoka;
-}
+export {
+  revealComputerCard,
+  enableNextRoundButton,
+  disableNextRoundButton,
+  updateDebugPanel
+} from "./classicBattle/uiHelpers.js";
+export { getComputerJudoka } from "./classicBattle/cardSelection.js";
+export { scheduleNextRound } from "./classicBattle/timerControl.js";
 
 const quitButton = document.getElementById("quit-match-button");
 if (quitButton) {

--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -1,0 +1,87 @@
+import { generateRandomCard } from "../randomCard.js";
+import { getRandomJudoka, renderJudokaCard } from "../cardUtils.js";
+import { fetchJson } from "../dataUtils.js";
+import { createGokyoLookup } from "../utils.js";
+import { DATA_DIR } from "../constants.js";
+
+let judokaData = null;
+let gokyoLookup = null;
+let computerJudoka = null;
+
+/**
+ * Draw battle cards for the player and computer.
+ *
+ * @pseudocode
+ * 1. Load judoka and gokyo data when not cached.
+ * 2. Filter out judoka marked `isHidden`.
+ * 3. Render a random player card using `generateRandomCard` and store the result.
+ * 4. Choose a random opponent judoka avoiding duplicates.
+ * 5. Render a placeholder card for the computer with obscured stats.
+ * 6. Return the selected judoka objects.
+ *
+ * @returns {Promise<{playerJudoka: object|null, computerJudoka: object|null}>}
+ */
+export async function drawCards() {
+  if (!judokaData) {
+    judokaData = await fetchJson(`${DATA_DIR}judoka.json`);
+  }
+  const available = Array.isArray(judokaData) ? judokaData.filter((j) => !j.isHidden) : [];
+
+  if (!gokyoLookup) {
+    const gokyoData = await fetchJson(`${DATA_DIR}gokyo.json`);
+    gokyoLookup = createGokyoLookup(gokyoData);
+  }
+
+  const playerContainer = document.getElementById("player-card");
+  const computerContainer = document.getElementById("computer-card");
+
+  let playerJudoka = null;
+  await generateRandomCard(
+    available,
+    null,
+    playerContainer,
+    false,
+    (j) => {
+      playerJudoka = j;
+    },
+    { enableInspector: false }
+  );
+
+  let compJudoka = getRandomJudoka(available);
+  if (playerJudoka) {
+    let attempts = 0;
+    const maxAttempts = Math.max(available.length || 0, 5);
+    while (compJudoka.id === playerJudoka.id && attempts < maxAttempts) {
+      compJudoka = getRandomJudoka(available);
+      attempts += 1;
+    }
+  }
+  computerJudoka = compJudoka;
+
+  const placeholder = judokaData.find((j) => j.id === 1) || compJudoka;
+  await renderJudokaCard(placeholder, gokyoLookup, computerContainer, {
+    animate: false,
+    useObscuredStats: true,
+    enableInspector: false
+  });
+
+  return { playerJudoka, computerJudoka };
+}
+
+export function getComputerJudoka() {
+  return computerJudoka;
+}
+
+export function clearComputerJudoka() {
+  computerJudoka = null;
+}
+
+export function getGokyoLookup() {
+  return gokyoLookup;
+}
+
+export function _resetForTest() {
+  judokaData = null;
+  gokyoLookup = null;
+  computerJudoka = null;
+}

--- a/src/helpers/classicBattle/timerControl.js
+++ b/src/helpers/classicBattle/timerControl.js
@@ -1,0 +1,78 @@
+import { seededRandom } from "../testModeUtils.js";
+import { getDefaultTimer } from "../timerUtils.js";
+import { startRound as engineStartRound, startCoolDown, STATS } from "../battleEngine.js";
+import * as infoBar from "../setupBattleInfoBar.js";
+import { enableNextRoundButton, disableNextRoundButton, updateDebugPanel } from "./uiHelpers.js";
+
+/**
+ * Start the round timer and auto-select a random stat when time expires.
+ *
+ * @pseudocode
+ * 1. Determine timer duration using `getDefaultTimer('roundTimer')`.
+ * 2. Call `engineStartRound` to update the countdown each second.
+ * 3. When expired, auto-select a random stat via `onExpired`.
+ *
+ * @param {function(string): void} onExpiredSelect - Callback to handle stat auto-selection.
+ * @returns {Promise<void>} Resolves when the timer begins.
+ */
+export async function startTimer(onExpiredSelect) {
+  const timerEl = document.getElementById("next-round-timer");
+  let duration;
+  try {
+    duration = await getDefaultTimer("roundTimer");
+  } catch {
+    duration = 30;
+  }
+  if (typeof duration !== "number") duration = 30;
+  engineStartRound(
+    (remaining) => {
+      if (timerEl) timerEl.textContent = `Time Left: ${remaining}s`;
+    },
+    () => {
+      const randomStat = STATS[Math.floor(seededRandom() * STATS.length)];
+      infoBar.showMessage(`Time's up! Auto-selecting ${randomStat}`);
+      onExpiredSelect(randomStat);
+    },
+    duration
+  );
+}
+
+/**
+ * Enable the Next Round button after a cooldown period.
+ *
+ * @pseudocode
+ * 1. If the match ended, return early.
+ * 2. Setup a click handler that disables the button and calls `startRoundFn`.
+ * 3. Start a 3 second cooldown via `startCoolDown` after a short delay.
+ * 4. When expired, enable the button and attach the click handler.
+ *
+ * @param {{matchEnded: boolean}} result - Result from a completed round.
+ * @param {function(): Promise<void>} startRoundFn - Function to begin the next round.
+ */
+export function scheduleNextRound(result, startRoundFn) {
+  if (result.matchEnded) return;
+
+  const btn = document.getElementById("next-round-button");
+  if (!btn) return;
+
+  const onClick = async () => {
+    disableNextRoundButton();
+    await startRoundFn();
+  };
+
+  const timerEl = document.getElementById("next-round-timer");
+
+  const onTick = (remaining) => {
+    if (timerEl) timerEl.textContent = `Next round in: ${remaining}s`;
+  };
+
+  const onExpired = () => {
+    btn.addEventListener("click", onClick, { once: true });
+    enableNextRoundButton();
+    updateDebugPanel();
+  };
+
+  setTimeout(() => {
+    startCoolDown(onTick, onExpired, 3);
+  }, 2000);
+}

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -1,0 +1,62 @@
+import { getComputerJudoka, getGokyoLookup, clearComputerJudoka } from "./cardSelection.js";
+import { renderJudokaCard } from "../cardUtils.js";
+import { getScores, getTimerState, isMatchEnded } from "../battleEngine.js";
+import { isTestModeEnabled, getCurrentSeed } from "../testModeUtils.js";
+
+function getDebugOutputEl() {
+  return document.getElementById("debug-output");
+}
+
+/**
+ * Display a persistent prompt instructing the player to choose a stat.
+ *
+ * @pseudocode
+ * 1. Locate `#round-message` and set text to "Select your move".
+ * 2. Add fade transition class and ensure the element is visible.
+ */
+export function showSelectionPrompt() {
+  const el = document.getElementById("round-message");
+  if (!el) return;
+  el.classList.add("fade-transition");
+  el.textContent = "Select your move";
+  el.classList.remove("fading");
+}
+
+/**
+ * Reveal the computer's hidden card.
+ *
+ * @pseudocode
+ * 1. Exit early if no stored judoka exists.
+ * 2. Render `computerJudoka` into the computer card container.
+ * 3. Clear the stored judoka after rendering.
+ */
+export async function revealComputerCard() {
+  const judoka = getComputerJudoka();
+  if (!judoka) return;
+  const container = document.getElementById("computer-card");
+  await renderJudokaCard(judoka, getGokyoLookup(), container, { animate: false });
+  clearComputerJudoka();
+}
+
+export function enableNextRoundButton(enable = true) {
+  const btn = document.getElementById("next-round-button");
+  if (btn) btn.disabled = !enable;
+}
+
+export function disableNextRoundButton() {
+  enableNextRoundButton(false);
+}
+
+export function updateDebugPanel() {
+  const pre = getDebugOutputEl();
+  if (!pre) return;
+  const state = {
+    ...getScores(),
+    timer: getTimerState(),
+    matchEnded: isMatchEnded()
+  };
+  if (isTestModeEnabled()) {
+    state.seed = getCurrentSeed();
+  }
+  pre.textContent = JSON.stringify(state, null, 2);
+}


### PR DESCRIPTION
## Summary
- split classicBattle helpers into cardSelection, timerControl, uiHelpers
- orchestrate battle flow with a slim classicBattle module
- update imports and re-export public helpers

## Testing
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npx prettier . --check`


------
https://chatgpt.com/codex/tasks/task_e_688cc52fadcc8326a58411d6391222b1