### PR TITLE
Fix PRD viewer layout

### DIFF
--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -95,6 +95,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
 - Header with clickable JU-DO-KON! logo and page title.
 - Large scrollable markdown-rendered content area.
+- Sidebar scrolls independently from the main preview so the list remains visible while reading.
 - Warning badge in content area if markdown partially rendered.
 - Bottom footer with keyboard and swipe navigation instructions.
 - Responsive layout for desktop, tablet, and mobile.

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -12,24 +12,28 @@
     <link rel="stylesheet" href="../styles/utilities.css" />
   </head>
   <body>
-    <header>
-      <div class="logo-container">
-        <a href="../../index.html" data-testid="home-link">
-          <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
-        </a>
-      </div>
-    </header>
+    <div class="home-screen">
+      <header class="header">
+        <div class="header-spacer left"></div>
+        <div class="logo-container">
+          <a href="../../index.html" data-testid="home-link">
+            <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
+          </a>
+        </div>
+        <div class="header-spacer right"></div>
+      </header>
 
-    <main class="prd-viewer">
-      <aside class="sidebar"><ul id="prd-list" class="sidebar-list"></ul></aside>
-      <section class="preview">
-        <div id="prd-content"></div>
-      </section>
-    </main>
+      <main class="prd-viewer" role="main">
+        <aside class="sidebar"><ul id="prd-list" class="sidebar-list"></ul></aside>
+        <section class="preview">
+          <div id="prd-content"></div>
+        </section>
+      </main>
 
-    <footer>
-      <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
-    </footer>
+      <footer>
+        <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
+      </footer>
+    </div>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
     <script type="module" src="../helpers/setupDisplaySettings.js"></script>
     <script type="module" src="../helpers/prdReaderPage.js"></script>

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <div class="home-screen">
-      <header class="header">
+      <header class="header" role="banner">
         <div class="header-spacer left"></div>
         <div class="logo-container">
           <a href="../../index.html" data-testid="home-link">


### PR DESCRIPTION
## Summary
- use `home-screen` container in PRD viewer so the header and sidebar occupy the full viewport
- mention that the PRD viewer sidebar scrolls independently

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688cc84035f083268f46d3de44aad5fd