### PR TITLE
Add countdown timer tests and mock timer usage

### DIFF
--- a/tests/helpers/battleEngine.coolDown.test.js
+++ b/tests/helpers/battleEngine.coolDown.test.js
@@ -1,23 +1,25 @@
 import { describe, it, expect, vi } from "vitest";
 
-vi.useFakeTimers();
-
 describe("battleEngine startCoolDown", () => {
   it("runs countdown using default timer", async () => {
     vi.doMock("../../src/helpers/timerUtils.js", async (importOriginal) => {
       const actual = await importOriginal();
       return {
         ...actual,
-        getDefaultTimer: vi.fn().mockResolvedValue(3)
+        getDefaultTimer: vi.fn().mockResolvedValue(3),
+        createCountdownTimer: vi.fn(() => ({
+          start: vi.fn(),
+          stop: vi.fn(),
+          pause: vi.fn(),
+          resume: vi.fn()
+        }))
       };
     });
     const { startCoolDown, _resetForTest } = await import("../../src/helpers/battleEngine.js");
-    const onTick = vi.fn();
-    const onExpired = vi.fn();
+    const timerUtils = await import("../../src/helpers/timerUtils.js");
     _resetForTest();
-    await startCoolDown(onTick, onExpired);
-    expect(onTick).toHaveBeenCalledWith(3);
-    vi.advanceTimersByTime(3000);
-    expect(onExpired).toHaveBeenCalled();
+    await startCoolDown(vi.fn(), vi.fn());
+    expect(timerUtils.createCountdownTimer).toHaveBeenCalledWith(3, expect.any(Object));
+    expect(timerUtils.createCountdownTimer.mock.results[0].value.start).toHaveBeenCalled();
   });
 });

--- a/tests/helpers/createCountdownTimer.test.js
+++ b/tests/helpers/createCountdownTimer.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { createCountdownTimer } from "../../src/helpers/timerUtils.js";
+
+/**
+ * These tests cover the small countdown timer utility used by the battle engine
+ * and various pages. They focus on verifying the tick callback, pause/resume
+ * logic and final expiration behaviour.
+ */
+
+describe("createCountdownTimer", () => {
+  it("updates remaining time on each tick", () => {
+    vi.useFakeTimers();
+    const onTick = vi.fn();
+    const timer = createCountdownTimer(3, { onTick });
+    timer.start();
+    expect(onTick).toHaveBeenCalledWith(3);
+    vi.advanceTimersByTime(1000);
+    expect(onTick).toHaveBeenCalledWith(2);
+    vi.advanceTimersByTime(1000);
+    expect(onTick).toHaveBeenCalledWith(1);
+    vi.useRealTimers();
+  });
+
+  it("handles pause and resume", () => {
+    vi.useFakeTimers();
+    const onExpired = vi.fn();
+    const timer = createCountdownTimer(2, { onExpired });
+    timer.start();
+    timer.pause();
+    vi.advanceTimersByTime(2000);
+    expect(onExpired).not.toHaveBeenCalled();
+    timer.resume();
+    vi.advanceTimersByTime(2000);
+    expect(onExpired).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("calls expiration callback", () => {
+    vi.useFakeTimers();
+    const onExpired = vi.fn();
+    const timer = createCountdownTimer(1, { onExpired });
+    timer.start();
+    vi.advanceTimersByTime(1000);
+    expect(onExpired).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- test `createCountdownTimer` helper
- mock `createCountdownTimer` in battle engine timer tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688cc8fd317c8326826508e618efa290