### PR TITLE
Fix scheduleNextRound test

### DIFF
--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -142,7 +142,8 @@ describe("classicBattle match flow", () => {
   it("scheduleNextRound waits for cooldown then enables button", async () => {
     document.body.innerHTML += '<button id="next-round-button" disabled></button>';
     const battleMod = await import("../../../src/helpers/classicBattle.js");
-    battleMod.scheduleNextRound({ matchEnded: false });
+    const startStub = vi.fn();
+    battleMod.scheduleNextRound({ matchEnded: false }, startStub);
     const btn = document.getElementById("next-round-button");
     expect(btn.disabled).toBe(true);
     timerSpy.advanceTimersByTime(2000);
@@ -152,6 +153,7 @@ describe("classicBattle match flow", () => {
     btn.click();
     await Promise.resolve();
     expect(btn.disabled).toBe(true);
+    expect(startStub).toHaveBeenCalled();
   });
 
   it("shows selection prompt until a stat is chosen", async () => {


### PR DESCRIPTION
## Summary
- fix scheduleNextRound test by passing a stub startRound function

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688ccb4d452c8326bdeb6364ff103c1b