### PR TITLE
Ensure sidebar scrolls independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,9 @@ The repository follows a simple layout. GitHub Pages requires `index.html` to li
     under `design/mockups/`. It displays the filename overlay and now
     scales wide images to fit within the viewport while keeping every
     mockup centered on screen. The Prev and Next buttons are anchored
-    to the left and right edges so they never cover the content. It
-    also includes `tooltipViewer.html`, a searchable viewer for
+    to the left and right edges so they never cover the content. The
+    sidebar list scrolls independently so you can browse mockups
+    without moving the main image. It also includes `tooltipViewer.html`, a searchable viewer for
     exploring tooltip text used across the UI.
   - `data/`
     JSON files powering the game. `statNames.json` lists the canonical stat
@@ -227,9 +228,10 @@ Add new Markdown files there and include the filename in the `FILES` array of
 `src/helpers/prdReaderPage.js`. Open `src/pages/prdViewer.html` in your browser
 to browse the documents. A sidebar lists all available PRDs and clicking an
 entry loads it immediately. Arrow keys and swipe gestures also cycle through the
-documents. The page imports `base.css` and `layout.css` so wide elements stay
-wrapped inside the viewport. Users can return to the main menu by clicking the
-logo in the header.
+documents. The sidebar scrolls separately from the main preview so navigation
+remains visible while reading. The page imports `base.css` and `layout.css` so
+wide elements stay wrapped inside the viewport. Users can return to the main
+menu by clicking the logo in the header.
 
 ### CSS Organization
 

--- a/src/styles/mockupViewer.css
+++ b/src/styles/mockupViewer.css
@@ -118,8 +118,14 @@ body {
 
 .mockup-viewer {
   display: flex;
-  height: 100%;
+  height: calc(100dvh - var(--header-height) - var(--footer-height));
   width: 100%;
+  overflow: hidden;
+}
+
+.mockup-viewer .sidebar,
+.mockup-viewer .preview {
+  height: 100%;
 }
 
 .mockup-viewer .preview {

--- a/src/styles/prdViewer.css
+++ b/src/styles/prdViewer.css
@@ -1,7 +1,13 @@
 .prd-viewer {
   display: flex;
-  height: 100%;
+  height: calc(100dvh - var(--header-height) - var(--footer-height));
   width: 100%;
+  overflow: hidden;
+}
+
+.prd-viewer .sidebar,
+.prd-viewer .preview {
+  height: 100%;
 }
 
 .prd-viewer .preview {


### PR DESCRIPTION
## Summary
- constrain the PRD and mockup viewers to the viewport so the sidebar and content scroll separately
- mention independent sidebar scrolling in docs

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npx playwright test` *(fails: 403 Forbidden fetching playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688ccda1bd5c8326b81a61b9aa9d199c