### PR TITLE
Enable CSS outlines when Layout Debug is toggled

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ Feature flags allow temporary or advanced tools without code changes:
 - **Full Navigation Map** – overlays a map linking to every page for quick testing.
 - **Test Mode** – forces deterministic draws and stats with a visible "Test Mode Active" banner.
 - **Card Inspector** – adds a collapsible panel on each card displaying its raw JSON.
+- **Layout Debug Panel** – outlines key elements for debugging layout whenever the flag is enabled.
 
 Advanced or debug-oriented flags live under a collapsible **Advanced Settings** section. This keeps experimental options out of sight for younger players while remaining accessible to testers.
 

--- a/src/helpers/layoutDebugPanel.js
+++ b/src/helpers/layoutDebugPanel.js
@@ -29,7 +29,16 @@ export function toggleLayoutDebugPanel(enabled, selectors = DEFAULT_SELECTORS) {
       document.body.appendChild(panel);
       const toggle = panel.querySelector("#layout-debug-toggle");
       if (toggle && toggle.getAttribute("aria-expanded") === "false") {
-        toggle.click();
+        toggle.setAttribute("aria-expanded", "true");
+        // If the panel uses a class to show expanded state, add it here:
+        const panelContent = panel.querySelector("#layout-debug-content");
+        if (panelContent) {
+          panelContent.classList.add("expanded");
+        }
+        // If outlines are applied via JS, apply them here:
+        selectors.forEach(sel => {
+          document.querySelectorAll(sel).forEach(el => el.classList.add("layout-debug-outline"));
+        });
       }
     }
   } else if (panel) {

--- a/src/helpers/layoutDebugPanel.js
+++ b/src/helpers/layoutDebugPanel.js
@@ -15,6 +15,7 @@ const DEFAULT_SELECTORS = [
  * @pseudocode
  * 1. Exit early if `document.body` is unavailable.
  * 2. When `enabled` is true and no panel exists, create it and append to `body`.
+ *    a. Automatically expand the panel so outlines are applied immediately.
  * 3. When disabled and a panel exists, remove outline classes and the panel.
  *
  * @param {boolean} enabled - Whether to show the panel.
@@ -26,6 +27,10 @@ export function toggleLayoutDebugPanel(enabled, selectors = DEFAULT_SELECTORS) {
     if (!panel) {
       panel = createLayoutDebugPanel(selectors);
       document.body.appendChild(panel);
+      const toggle = panel.querySelector("#layout-debug-toggle");
+      if (toggle && toggle.getAttribute("aria-expanded") === "false") {
+        toggle.click();
+      }
     }
   } else if (panel) {
     document

--- a/tests/helpers/layoutDebugPanel.test.js
+++ b/tests/helpers/layoutDebugPanel.test.js
@@ -1,25 +1,18 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 
 beforeEach(() => {
   document.body.innerHTML = "";
 });
 
 describe("toggleLayoutDebugPanel", () => {
-  it("adds and removes the panel", () => {
-    const create = vi.fn(() => {
-      const el = document.createElement("div");
-      el.id = "layout-debug-panel";
-      return el;
-    });
-    vi.doMock("../../src/components/LayoutDebugPanel.js", () => ({
-      createLayoutDebugPanel: create
-    }));
-    // reload module after mocking
-    return import("../../src/helpers/layoutDebugPanel.js").then((mod) => {
-      mod.toggleLayoutDebugPanel(true);
-      expect(document.getElementById("layout-debug-panel")).toBeTruthy();
-      mod.toggleLayoutDebugPanel(false);
-      expect(document.getElementById("layout-debug-panel")).toBeNull();
-    });
+  it("adds outlines when enabled and cleans up when disabled", async () => {
+    const { toggleLayoutDebugPanel } = await import("../../src/helpers/layoutDebugPanel.js");
+    toggleLayoutDebugPanel(true, ["body"]);
+    const panel = document.getElementById("layout-debug-panel");
+    expect(panel).toBeTruthy();
+    expect(document.body.classList.contains("layout-debug-outline")).toBe(true);
+    toggleLayoutDebugPanel(false, ["body"]);
+    expect(document.getElementById("layout-debug-panel")).toBeNull();
+    expect(document.body.classList.contains("layout-debug-outline")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- auto-expand layout debug panel when enabled so outlines show immediately
- document Layout Debug Panel in README
- update tests for new default behavior

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: cannot find package)*
- `npx vitest run` *(fails: E403 Forbidden)
- `npx playwright test` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688ce076dfd083269f7ac25b7e42704d