### PR TITLE
Use seeded RNG in helpers

### DIFF
--- a/src/helpers/pseudoJapanese.js
+++ b/src/helpers/pseudoJapanese.js
@@ -1,5 +1,6 @@
 import { DATA_DIR } from "./constants.js";
 import { fetchJson } from "./dataUtils.js";
+import { seededRandom } from "./testModeUtils.js";
 
 const STATIC_FALLBACK = "\u65e5\u672c\u8a9e\u98a8\u30c6\u30ad\u30b9\u30c8"; // 日本語風テキスト
 let converterPromise;
@@ -26,6 +27,7 @@ async function loadConverter() {
  *    - Preserve whitespace characters as-is.
  *    - Map letters (case-insensitive) using the converter table when possible.
  *    - Replace digits and unmapped letters with a random fallback character.
+ *      - Use `seededRandom()` for deterministic output in Test Mode.
  * 7. Join and return the converted string.
  *
  * @param {string} input - The text to convert.
@@ -56,11 +58,11 @@ export async function convertToPseudoJapanese(input) {
 
       const letters = mapping[char.toLowerCase()];
       if (letters) {
-        return letters[Math.floor(Math.random() * letters.length)];
+        return letters[Math.floor(seededRandom() * letters.length)];
       }
 
       // digits or unmapped letters
-      return fallbackChars[Math.floor(Math.random() * fallbackChars.length)];
+      return fallbackChars[Math.floor(seededRandom() * fallbackChars.length)];
     })
     .join("");
 }

--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -21,6 +21,7 @@
  * @throws {Error} If the fetch request fails or the response is not successful.
  */
 import { DATA_DIR } from "./constants.js";
+import { seededRandom } from "./testModeUtils.js";
 
 let kgImageLoaded = false;
 let quoteLoaded = false;
@@ -149,6 +150,7 @@ function displayFable(fable) {
  * 2. Select a random fable:
  *    - Determine the maximum ID from the fables data.
  *    - Generate a random ID within the range of available IDs.
+ *      - Use `seededRandom()` when Test Mode is active.
  *    - Find the fable corresponding to the random ID.
  *
  * 3. Display the fable:
@@ -166,7 +168,7 @@ async function displayRandomQuote() {
   try {
     const fables = await fetchFables();
     const maxId = Math.max(...fables.map((fable) => fable.id));
-    const randomId = Math.floor(Math.random() * maxId) + 1;
+    const randomId = Math.floor(seededRandom() * maxId) + 1;
     const randomFable = fables.find((fable) => fable.id === randomId);
     displayFable(randomFable);
   } catch (error) {


### PR DESCRIPTION
## Summary
- allow deterministic output in `convertToPseudoJapanese`
- use seeded randomness for quote selection

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688ce1c914e48326a3cdaf040f5c8398