### PR TITLE
Add task summary to PRD viewer

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -36,7 +36,7 @@ and builds result snippets with `snippetFormatter.js`.
 `src/helpers/prdReaderPage.js` to display the Product Requirements
 Documents. The Markdown files live in
 `design/productRequirementsDocuments`. The helper fetches each file,
-converts it with `markdownToHtml`—a wrapper around the minimal **Marked** parser (supporting headings, paragraphs, bold text, mixed ordered and unordered lists, tables, and horizontal rules rendered as `<br/><hr/><br/>` for extra spacing)—and injects the HTML into the `#prd-content` container. It also builds the sidebar list in `#prd-list` and loads the chosen document when an item is clicked. Arrow keys and swipe gestures cycle through the loaded documents, and the logo links back to `index.html`.
+converts it with `markdownToHtml`—a wrapper around the minimal **Marked** parser (supporting headings, paragraphs, bold text, mixed ordered and unordered lists, tables, and horizontal rules rendered as `<br/><hr/><br/>` for extra spacing)—and injects the HTML into the `#prd-content` container. It also builds the sidebar list in `#prd-list` and loads the chosen document when an item is clicked. Arrow keys and swipe gestures cycle through the loaded documents, and the logo links back to `index.html`. The viewer additionally displays each PRD's task completion summary above the document content.
 
 ## components/
 

--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -67,6 +67,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 - Given a markdown file fails to load, then an error is logged to the console, a fallback message is shown, and other files remain navigable.
 - Given malformed markdown content, then partial content is rendered with a warning badge visually indicating an issue.
 - Given navigation occurs, then the document renders within 200ms on a standard desktop device.
+- Given a PRD includes a Tasks section, then the viewer displays the total number of tasks and completion percentage above the document content.
 
 ## Non-Functional Requirements / Design Considerations
 
@@ -137,4 +138,6 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 - [ ] 6.0 Finalize Visuals and UX Guidelines
   - [ ] 6.1 Create detailed wireframes/mockups with annotations
   - [ ] 6.2 Define UI element sizes, spacing, and animation durations
-  - [ ] 6.3 Specify visual designs for error/warning badges and loading indicators
+- [ ] 6.3 Specify visual designs for error/warning badges and loading indicators
+- [ ] 7.0 Display PRD Task Summary
+  - [ ] 7.1 Show total task count and completion percentage above the document content

--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -2,6 +2,7 @@ import { onDomReady } from "./domReady.js";
 import { markdownToHtml } from "./markdownToHtml.js";
 import { initTooltips } from "./tooltip.js";
 import { createSidebarList } from "../components/SidebarList.js";
+import { getPrdTaskStats } from "./prdTaskStats.js";
 
 /**
  * Initialize the Product Requirements Document reader page.
@@ -50,15 +51,21 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
       ];
 
   const documents = [];
+  const taskStats = [];
   if (docsMap) {
     for (const name of FILES) {
-      if (docsMap[name]) documents.push(parserFn(docsMap[name]));
+      if (docsMap[name]) {
+        const md = docsMap[name];
+        documents.push(parserFn(md));
+        taskStats.push(getPrdTaskStats(md));
+      }
     }
   } else {
     for (const name of FILES) {
       const res = await fetch(`${PRD_DIR}${name}`);
       const text = await res.text();
       documents.push(parserFn(text));
+      taskStats.push(getPrdTaskStats(text));
     }
   }
   const container = document.getElementById("prd-content");
@@ -83,6 +90,12 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
     container.classList.remove("fade-in");
     void container.offsetWidth;
     container.classList.add("fade-in");
+    const summaryEl = document.getElementById("task-summary");
+    if (summaryEl) {
+      const { total, completed } = taskStats[current] || { total: 0, completed: 0 };
+      const percent = total ? Math.round((completed / total) * 100) : 0;
+      summaryEl.textContent = `Tasks: ${completed}/${total} (${percent}%)`;
+    }
     initTooltips();
   });
   listEl.id = "prd-list";
@@ -97,6 +110,12 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
     container.classList.remove("fade-in");
     void container.offsetWidth;
     container.classList.add("fade-in");
+    const summaryEl = document.getElementById("task-summary");
+    if (summaryEl) {
+      const { total, completed } = taskStats[index] || { total: 0, completed: 0 };
+      const percent = total ? Math.round((completed / total) * 100) : 0;
+      summaryEl.textContent = `Tasks: ${completed}/${total} (${percent}%)`;
+    }
     initTooltips();
   }
 

--- a/src/helpers/prdTaskStats.js
+++ b/src/helpers/prdTaskStats.js
@@ -1,0 +1,27 @@
+/**
+ * Extract task statistics from a PRD markdown string.
+ *
+ * @pseudocode
+ * 1. Find text between the `## Tasks` heading and the next `##` heading or EOF.
+ * 2. Split this section into lines and check for `- [ ]` or `- [x]` markers.
+ * 3. Increment counts for each task line and completed task.
+ * 4. Return an object with `total` and `completed` counts.
+ *
+ * @param {string} [text=""] - Markdown content to parse.
+ * @returns {{ total: number, completed: number }} Task counts.
+ */
+export function getPrdTaskStats(text = "") {
+  const match = text.match(/##\s*Tasks([\s\S]*?)(?:\n##\s|$)/);
+  if (!match) return { total: 0, completed: 0 };
+  const lines = match[1].split(/\n/);
+  let total = 0;
+  let completed = 0;
+  for (const line of lines) {
+    const result = line.match(/-\s*\[( |x)\]/i);
+    if (result) {
+      total += 1;
+      if (result[1].toLowerCase() === "x") completed += 1;
+    }
+  }
+  return { total, completed };
+}

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -27,6 +27,7 @@
       <main class="prd-viewer" role="main">
         <aside class="sidebar"><ul id="prd-list" class="sidebar-list"></ul></aside>
         <section class="preview">
+          <div id="task-summary" class="task-summary"></div>
           <div id="prd-content"></div>
         </section>
       </main>

--- a/src/styles/prdViewer.css
+++ b/src/styles/prdViewer.css
@@ -34,3 +34,8 @@
     flex-direction: column;
   }
 }
+
+.task-summary {
+  font-weight: 600;
+  margin-bottom: var(--space-sm);
+}

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -95,4 +95,27 @@ describe("prdReaderPage", () => {
     items[1].click();
     expect(container.innerHTML).toContain("Beta");
   });
+
+  it("displays task summary when element exists", async () => {
+    const docs = {
+      "task.md": "## Tasks\n- [x] done\n- [ ] todo"
+    };
+    const parser = (md) => `<h1>${md}</h1>`;
+
+    document.body.innerHTML = `
+      <ul id="prd-list"></ul>
+      <div id="task-summary"></div>
+      <div id="prd-content"></div>
+      <button data-nav="prev">Prev</button>
+      <button data-nav="next">Next</button>
+    `;
+
+    globalThis.SKIP_PRD_AUTO_INIT = true;
+    const { setupPrdReaderPage } = await import("../../src/helpers/prdReaderPage.js");
+
+    await setupPrdReaderPage(docs, parser);
+
+    const summary = document.getElementById("task-summary");
+    expect(summary.textContent).toContain("1/2");
+  });
 });

--- a/tests/helpers/prdTaskStats.test.js
+++ b/tests/helpers/prdTaskStats.test.js
@@ -1,0 +1,18 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { getPrdTaskStats } from "../../src/helpers/prdTaskStats.js";
+
+describe("getPrdTaskStats", () => {
+  it("counts total and completed tasks", () => {
+    const md = `## Tasks\n- [x] task1\n  - [ ] subtask\n- [ ] task2`;
+    const stats = getPrdTaskStats(md);
+    expect(stats.total).toBe(3);
+    expect(stats.completed).toBe(1);
+  });
+
+  it("handles missing section", () => {
+    const stats = getPrdTaskStats("No tasks here");
+    expect(stats.total).toBe(0);
+    expect(stats.completed).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- display task completion stats in PRD viewer
- parse task lists using new `getPrdTaskStats` helper
- show summary above PRD content with basic styling
- document the new feature in architecture docs and PRD
- add unit tests for stats extraction and viewer behaviour

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npx playwright test` *(fails: 403 Forbidden fetching playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688cf8a97b188326bdd68c68ea807bd7