### PR TITLE
Add dynamic title and summary to PRD viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ entry loads it immediately. Arrow keys and swipe gestures also cycle through the
   remains visible while reading. The sidebar background uses `--color-surface`
   and rows alternate with `--color-tertiary` for zebra striping defined in `sidebar.css`. The page imports `base.css` and `layout.css` so
 wide elements stay wrapped inside the viewport. Users can return to the main
-menu by clicking the logo in the header.
+menu by clicking the logo in the header. The selected PRD title appears on the
+left side of the header with a task completion summary on the right.
 
 ### CSS Organization
 
@@ -259,8 +260,9 @@ Global rules should not be repeated across files.
 
 All pages include a fixed header and persistent bottom navigation bar. The body
 has top and bottom padding to ensure content scrolls under these elements.
-Each header uses two `.header-spacer` elements flanking the logo so it stays
-centered in the layout grid.
+Most headers use two `.header-spacer` elements flanking the logo so it stays
+centered in the layout grid. The PRD Viewer instead places `.info-left` and
+`.info-right` sections in the header for the document title and summary.
 
 The `.animate-card` class in `buttons.css` (imported via `components.css`)
 reveals new cards with a short fade and upward slide. A

--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -95,6 +95,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 ## Mockups / Visual Reference
 
 - Header with clickable JU-DO-KON! logo and page title.
+- PRD title appears on the left side of the header with a task summary on the right.
 - Large scrollable markdown-rendered content area.
 - Sidebar scrolls independently from the main preview so the list remains visible while reading.
 - Sidebar background uses the `--color-surface` token so zebra stripes stand out.
@@ -142,4 +143,4 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
   - [ ] 6.2 Define UI element sizes, spacing, and animation durations
 - [ ] 6.3 Specify visual designs for error/warning badges and loading indicators
 - [ ] 7.0 Display PRD Task Summary
-  - [ ] 7.1 Show total task count and completion percentage above the document content
+  - [ ] 7.1 Show total task count and completion percentage in the header next to the title

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -14,20 +14,21 @@
   </head>
   <body>
     <div class="home-screen">
-      <header class="header" role="banner">
-        <div class="header-spacer left"></div>
+      <header class="header prd-header" role="banner">
+        <div class="info-left" id="prd-title"></div>
         <div class="logo-container">
           <a href="../../index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
-        <div class="header-spacer right"></div>
+        <div class="info-right">
+          <span id="task-summary" class="task-summary"></span>
+        </div>
       </header>
 
       <main class="prd-viewer" role="main">
         <aside class="sidebar"><ul id="prd-list" class="sidebar-list"></ul></aside>
         <section class="preview">
-          <div id="task-summary" class="task-summary"></div>
           <div id="prd-content"></div>
         </section>
       </main>

--- a/src/styles/prdViewer.css
+++ b/src/styles/prdViewer.css
@@ -39,3 +39,26 @@
   font-weight: 600;
   margin-bottom: var(--space-sm);
 }
+
+.prd-header {
+  --logo-max-height: min(12dvh, 64px);
+}
+
+.prd-header .info-left,
+.prd-header .info-right {
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  font-size: clamp(18px, 3vw, 24px);
+}
+
+.prd-header .info-left {
+  grid-column: 1;
+  justify-self: start;
+}
+
+.prd-header .info-right {
+  grid-column: 3;
+  justify-self: end;
+  text-align: right;
+}

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -9,6 +9,8 @@ describe("prdReaderPage", () => {
     const parser = (md) => `<h1>${md}</h1>`;
 
     document.body.innerHTML = `
+      <div id="prd-title"></div>
+      <div id="task-summary"></div>
       <ul id="prd-list"></ul>
       <div id="prd-content"></div>
       <button data-nav="prev">Prev</button>
@@ -23,21 +25,26 @@ describe("prdReaderPage", () => {
     await setupPrdReaderPage(docs, parser);
 
     const container = document.getElementById("prd-content");
+    const titleEl = document.getElementById("prd-title");
     const nextBtns = document.querySelectorAll('[data-nav="next"]');
     const prevBtns = document.querySelectorAll('[data-nav="prev"]');
     const list = document.getElementById("prd-list");
 
     expect(container.innerHTML).toContain("First doc");
     expect(list.children[0].classList.contains("selected")).toBe(true);
+    expect(titleEl.textContent).toBe("First doc");
     nextBtns[0].click();
     expect(container.innerHTML).toContain("Second doc");
     expect(list.children[1].classList.contains("selected")).toBe(true);
+    expect(titleEl.textContent).toBe("Second doc");
     nextBtns[1].click();
     expect(container.innerHTML).toContain("First doc");
     expect(list.children[0].classList.contains("selected")).toBe(true);
+    expect(titleEl.textContent).toBe("First doc");
     prevBtns[1].click();
     expect(container.innerHTML).toContain("Second doc");
     expect(list.children[1].classList.contains("selected")).toBe(true);
+    expect(titleEl.textContent).toBe("Second doc");
   });
 
   it("selects documents via sidebar", async () => {
@@ -48,6 +55,8 @@ describe("prdReaderPage", () => {
     const parser = (md) => `<h1>${md}</h1>`;
 
     document.body.innerHTML = `
+      <div id="prd-title"></div>
+      <div id="task-summary"></div>
       <ul id="prd-list"></ul>
       <div id="prd-content"></div>
       <button data-nav="prev">Prev</button>
@@ -62,12 +71,15 @@ describe("prdReaderPage", () => {
     const list = document.getElementById("prd-list");
     const items = list.querySelectorAll("li");
     const container = document.getElementById("prd-content");
+    const titleEl = document.getElementById("prd-title");
 
     expect(items.length).toBe(2);
     items[1].click();
     expect(container.innerHTML).toContain("Two");
+    expect(titleEl.textContent).toBe("Two");
     items[0].dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
     expect(container.innerHTML).toContain("One");
+    expect(titleEl.textContent).toBe("One");
     expect(items[0].classList.contains("selected")).toBe(true);
   });
 
@@ -79,6 +91,8 @@ describe("prdReaderPage", () => {
     const parser = (md) => `<h1>${md}</h1>`;
 
     document.body.innerHTML = `
+      <div id="prd-title"></div>
+      <div id="task-summary"></div>
       <ul id="prd-list"></ul>
       <div id="prd-content"></div>
     `;
@@ -90,10 +104,13 @@ describe("prdReaderPage", () => {
 
     const items = document.querySelectorAll("#prd-list li");
     const container = document.getElementById("prd-content");
+    const titleEl = document.getElementById("prd-title");
 
     expect(container.innerHTML).toContain("Alpha");
+    expect(titleEl.textContent).toBe("Alpha");
     items[1].click();
     expect(container.innerHTML).toContain("Beta");
+    expect(titleEl.textContent).toBe("Beta");
   });
 
   it("displays task summary when element exists", async () => {
@@ -103,8 +120,9 @@ describe("prdReaderPage", () => {
     const parser = (md) => `<h1>${md}</h1>`;
 
     document.body.innerHTML = `
-      <ul id="prd-list"></ul>
+      <div id="prd-title"></div>
       <div id="task-summary"></div>
+      <ul id="prd-list"></ul>
       <div id="prd-content"></div>
       <button data-nav="prev">Prev</button>
       <button data-nav="next">Next</button>


### PR DESCRIPTION
## Summary
- show PRD titles and task summary in the header
- style new header elements
- extract document titles in `setupPrdReaderPage`
- update PRD viewer docs and README
- test header title updates

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688d0c2110ac8326bf8d3b80a3068579