### PR TITLE
Fix tooltip viewer selection

### DIFF
--- a/src/helpers/tooltipViewerPage.js
+++ b/src/helpers/tooltipViewerPage.js
@@ -50,8 +50,8 @@ export async function setupTooltipViewerPage() {
         });
       }
     });
-    const result = createSidebarList(items, (i) => {
-      select(items[i].dataset.key);
+    const result = createSidebarList(items, (_, el) => {
+      select(el.dataset.key);
     });
     listSelect = result.select;
     result.element.id = "tooltip-list";
@@ -61,6 +61,7 @@ export async function setupTooltipViewerPage() {
 
   let selectedKey;
   function select(key) {
+    if (selectedKey === key) return;
     selectedKey = key;
     const body = data[key] ?? "";
     if (listSelect) {

--- a/tests/helpers/tooltipViewerPage.test.js
+++ b/tests/helpers/tooltipViewerPage.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalReadyState = Object.getOwnPropertyDescriptor(document, "readyState");
+
+beforeEach(() => {
+  vi.resetModules();
+  document.body.innerHTML = `
+    <input id="tooltip-search" />
+    <ul id="tooltip-list"></ul>
+    <div id="tooltip-preview"></div>
+    <pre id="tooltip-raw"></pre>
+    <button id="copy-key-btn"></button>
+    <button id="copy-body-btn"></button>
+  `;
+});
+
+afterEach(() => {
+  if (originalReadyState) {
+    Object.defineProperty(document, "readyState", originalReadyState);
+  }
+});
+
+describe("setupTooltipViewerPage", () => {
+  it("updates preview when a list item is clicked", async () => {
+    Object.defineProperty(document, "readyState", { value: "loading", configurable: true });
+
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ tipA: "**Bold**", tipB: "Raw" }),
+      importJsonModule: vi.fn().mockResolvedValue({})
+    }));
+
+    await import("../../src/helpers/tooltipViewerPage.js");
+
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+
+    await Promise.resolve();
+
+    const item = document.querySelector("#tooltip-list li");
+    expect(item).toBeTruthy();
+    item.click();
+
+    expect(document.getElementById("tooltip-preview").innerHTML).toBe("<strong>Bold</strong>");
+    expect(document.getElementById("tooltip-raw").textContent).toBe("**Bold**");
+  });
+});


### PR DESCRIPTION
## Summary
- fix sidebar item selection to prevent recursion
- avoid redundant highlight when same tooltip is selected
- test tooltip viewer preview updates when clicking a list item

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688d2f69dd9c832695b0808f79c1f822