### PR TITLE
Update battle debug panel docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,9 +450,9 @@ settings.layoutDebugPanel
 settings.navCacheResetButton
 ```
 
-Feature flags allow temporary or advanced tools without code changes:
+-Feature flags allow temporary or advanced tools without code changes:
 
-- **Battle Debug Panel** – shows a collapsible `<pre>` beside the opponent's card with live match data.
+- **Battle Debug Panel** – shows a collapsible `<pre>` beside the opponent's card that persists across rounds with live match data.
 - **Full Navigation Map** – overlays a map linking to every page for quick testing.
 - **Test Mode** – replaces all random calls with a seeded generator. Enable it from the Settings page to make matches reproducible and display a "Test Mode Active" banner. The seed resets on each new page load.
 - **Card Inspector** – adds a collapsible panel on each card displaying its raw JSON.

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -124,6 +124,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - AC-2.8 The panel displays real-time match state inside a `<pre>` element.
 - AC-2.9 The panel is keyboard accessible and hidden by default.
 - AC-2.10 The panel appears beside the opponent's card rather than at the page bottom.
+- The panel stays visible for the whole match once enabled.
 
 ### Card Inspector Feature Flag
 


### PR DESCRIPTION
## Summary
- clarify that the Battle Debug Panel remains across rounds
- note persistent panel behavior in PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688d2f55252883269a35524b27841d3b