### PR TITLE
Retain debug panel during card rerender

### DIFF
--- a/src/helpers/cardUtils.js
+++ b/src/helpers/cardUtils.js
@@ -111,8 +111,11 @@ export async function displayJudokaCard(judoka, gokyo, gameArea) {
  * 3. When `useObscuredStats` is true, clone `judoka` and replace name and stats
  *    with "?".
  * 4. Generate the card element using `generateJudokaCardHTML`.
- * 5. Replace the container contents with the generated card.
- * 6. When `animate` is true, add the `animate-card` class on the next frame.
+ * 5. Keep an existing `#debug-panel` element:
+ *    - Store it before clearing the container.
+ *    - Prepend it back after clearing.
+ * 6. Replace the container contents with the generated card.
+ * 7. When `animate` is true, add the `animate-card` class on the next frame.
  *
  * @param {Judoka} judoka - Judoka data to render.
  * @param {Object<string, GokyoEntry>} gokyoLookup - Lookup of gokyo moves.
@@ -151,7 +154,9 @@ export async function renderJudokaCard(
       enableInspector
     });
     if (!card) return null;
+    const debugEl = container.querySelector("#debug-panel");
     container.innerHTML = "";
+    if (debugEl) container.prepend(debugEl);
     container.appendChild(card);
     setupLazyPortraits(card);
     if (animate) {

--- a/tests/helpers/renderJudokaCard.test.js
+++ b/tests/helpers/renderJudokaCard.test.js
@@ -96,4 +96,16 @@ describe("renderJudokaCard", () => {
     toggleInspectorPanels(false);
     expect(container.querySelector(".debug-panel")).toBeNull();
   });
+
+  it("retains existing debug panel when rendering", async () => {
+    generateMock = vi.fn(async () => document.createElement("div"));
+    setupLazyPortraitsMock = vi.fn();
+    const { renderJudokaCard } = await import("../../src/helpers/cardUtils.js");
+    const container = document.createElement("div");
+    const debugPanel = document.createElement("div");
+    debugPanel.id = "debug-panel";
+    container.appendChild(debugPanel);
+    await renderJudokaCard(judoka, {}, container);
+    expect(container.querySelector("#debug-panel")).toBe(debugPanel);
+  });
 });


### PR DESCRIPTION
## Summary
- preserve #debug-panel element when updating judoka card
- document debug panel retention in card utils pseudocode
- test that renderJudokaCard keeps the debug panel intact

## Testing
- `npx vitest run`
- `npx playwright test`
- `npx prettier . --check`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_688d2f4713c0832681289fdc7a702b76