### PR TITLE
Fix tooltip viewer sidebar scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,9 @@ left side of the header with a task completion summary on the right.
 key used by the game. The sidebar on the left lists all keys. Clicking a key
 updates the preview pane to show the rendered tooltip text along with the raw
 string. A search box filters the list on each keystroke, and **Copy Key** and
-**Copy Body** buttons make it easy to copy either value to your clipboard.
+**Copy Body** buttons make it easy to copy either value to your clipboard. The
+sidebar scrolls independently from the preview so the list stays visible while
+browsing.
 
 ### CSS Organization
 

--- a/design/productRequirementsDocuments/prdTooltipViewer.md
+++ b/design/productRequirementsDocuments/prdTooltipViewer.md
@@ -97,6 +97,7 @@ During v0.7, a typo in `stat.focus` persisted through 3 releases due to lack of 
 - Viewer accepts URL hash (`#key`) and selects/scrolls accordingly.
 - Copy buttons work for both key and body text.
 - Layout adapts responsively to screen size.
+- Sidebar scrolls independently from the preview so the list remains visible while browsing.
 - Elements expose `data-key`, `data-body`, and `data-valid` for QA.
 - Viewer operates offline as a static HTML file.
 - Styling matches JU-DO-KON! brand (typography, colors, spacing).
@@ -119,19 +120,16 @@ During v0.7, a typo in `stat.focus` persisted through 3 releases due to lack of 
 ## Tasks
 
 - [ ] 1.0 Load and Parse Tooltip Data
-
   - [ ] 1.1 Load `tooltips.json` from `src/data/tooltips.json`
   - [ ] 1.2 Handle loading failures with user-friendly error display
   - [ ] 1.3 Parse JSON and extract key-value pairs
 
 - [ ] 2.0 Implement Sidebar Key List
-
   - [ ] 2.1 Render scrollable list of tooltip keys
   - [ ] 2.2 Enable click interaction to select a tooltip
   - [ ] 2.3 Add real-time search/filter functionality (300ms debounce)
 
 - [ ] 3.0 Build Preview Panel
-
   - [ ] 3.1 Render raw tooltip text
   - [ ] 3.2 Parse and render markdown-styled preview
   - [ ] 3.3 Animate panel on update (fade-in, 100ms)
@@ -139,7 +137,6 @@ During v0.7, a typo in `stat.focus` persisted through 3 releases due to lack of 
   - [ ] 3.5 Include copy-to-clipboard buttons for key and body
 
 - [ ] 4.0 URL Fragment Support
-
   - [ ] 4.1 Read and parse URL hash on page load
   - [ ] 4.2 Scroll to and pre-select corresponding tooltip key
 

--- a/src/pages/tooltipViewer.html
+++ b/src/pages/tooltipViewer.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="../styles/base.css" />
     <link rel="stylesheet" href="../styles/layout.css" />
     <link rel="stylesheet" href="../styles/components.css" />
+    <link rel="stylesheet" href="../styles/sidebar.css" />
     <link rel="stylesheet" href="../styles/tooltipViewer.css" />
     <link rel="stylesheet" href="../styles/utilities.css" />
     <link rel="icon" type="image/png" href="../assets/images/favicon.ico" />

--- a/src/styles/tooltipViewer.css
+++ b/src/styles/tooltipViewer.css
@@ -1,7 +1,13 @@
 .tooltip-viewer {
   display: flex;
-  height: 100%;
+  height: calc(100dvh - var(--header-height) - var(--footer-height));
   width: 100%;
+  overflow: hidden;
+}
+
+.tooltip-viewer .sidebar,
+.tooltip-viewer .preview {
+  height: 100%;
 }
 
 .tooltip-viewer .sidebar input {


### PR DESCRIPTION
## Summary
- import sidebar styles in tooltip viewer page
- size tooltip viewer like PRD viewer so panes scroll separately
- document independent scrolling in Tooltip Viewer PRD
- note sidebar scrolling in README

## Testing
- `npx prettier src/pages/tooltipViewer.html src/styles/tooltipViewer.css design/productRequirementsDocuments/prdTooltipViewer.md README.md --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npx playwright test` *(fails: 403 Forbidden fetching playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_688d3d3101f48326807b4f4f49ee81bb