### PR TITLE
Update layout debug panel defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ settings.navCacheResetButton
 - **Full Navigation Map** – overlays a map linking to every page for quick testing.
 - **Test Mode** – replaces all random calls with a seeded generator. Enable it from the Settings page to make matches reproducible and display a "Test Mode Active" banner. The seed resets on each new page load.
 - **Card Inspector** – adds a collapsible panel on each card displaying its raw JSON.
-- **Layout Debug Outlines** – highlights key elements for debugging layout whenever the flag is enabled.
+- **Layout Debug Outlines** – highlights all visible containers on every page whenever the flag is enabled.
 
 Advanced or debug-oriented flags live under a collapsible **Advanced Settings** section. This keeps experimental options out of sight for younger players while remaining accessible to testers.
 

--- a/src/helpers/layoutDebugPanel.js
+++ b/src/helpers/layoutDebugPanel.js
@@ -1,11 +1,5 @@
 let enabledState = false;
-const DEFAULT_SELECTORS = [
-  ".judoka-card",
-  ".card-container",
-  ".card-carousel",
-  ".home-screen",
-  ".kodokan-screen"
-];
+const DEFAULT_SELECTORS = ["body *:not(script):not(style)"];
 
 /**
  * Toggle the global layout debug panel.
@@ -13,8 +7,9 @@ const DEFAULT_SELECTORS = [
  * @pseudocode
  * 1. Exit early if `document.body` is unavailable.
  * 2. Remove any existing `.layout-debug-outline` classes.
- * 3. When `enabled` is true, add `.layout-debug-outline` to all matching
- *    elements so their boxes are visible.
+ * 3. When `enabled` is true, add `.layout-debug-outline` to all visible
+ *    elements matching the provided selectors. The default selector highlights
+ *    all visible containers across the page.
  *
  * @param {boolean} enabled - Whether to show the outlines.
  * @param {string[]} [selectors] - Optional custom selectors.
@@ -28,7 +23,9 @@ export function toggleLayoutDebugPanel(enabled, selectors = DEFAULT_SELECTORS) {
   if (enabledState) {
     selectors.forEach((sel) => {
       document.querySelectorAll(sel).forEach((el) => {
-        el.classList.add("layout-debug-outline");
+        if (el.offsetParent !== null) {
+          el.classList.add("layout-debug-outline");
+        }
       });
     });
   }

--- a/tests/helpers/layoutDebugPanel.test.js
+++ b/tests/helpers/layoutDebugPanel.test.js
@@ -7,9 +7,21 @@ beforeEach(() => {
 describe("toggleLayoutDebugPanel", () => {
   it("adds outlines when enabled and cleans up when disabled", async () => {
     const { toggleLayoutDebugPanel } = await import("../../src/helpers/layoutDebugPanel.js");
-    toggleLayoutDebugPanel(true, ["body"]);
-    expect(document.body.classList.contains("layout-debug-outline")).toBe(true);
-    toggleLayoutDebugPanel(false, ["body"]);
-    expect(document.body.classList.contains("layout-debug-outline")).toBe(false);
+    document.body.innerHTML = '<div id="custom"></div>';
+    const el = document.getElementById("custom");
+    Object.defineProperty(el, "offsetParent", { get: () => document.body });
+    toggleLayoutDebugPanel(true, ["#custom"]);
+    expect(el.classList.contains("layout-debug-outline")).toBe(true);
+    toggleLayoutDebugPanel(false, ["#custom"]);
+    expect(el.classList.contains("layout-debug-outline")).toBe(false);
+  });
+
+  it("adds outlines to visible elements with default selector", async () => {
+    const { toggleLayoutDebugPanel } = await import("../../src/helpers/layoutDebugPanel.js");
+    document.body.innerHTML = '<div id="sample"></div>';
+    const el = document.getElementById("sample");
+    Object.defineProperty(el, "offsetParent", { get: () => document.body });
+    toggleLayoutDebugPanel(true);
+    expect(el.classList.contains("layout-debug-outline")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- debug outlines now highlight all visible containers by default
- verify toggleLayoutDebugPanel works without arguments
- clarify README entry about Layout Debug Outlines

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Error fetching / network issues)*
- `npx playwright test` *(fails: Error fetching / network issues)*

------
https://chatgpt.com/codex/tasks/task_e_688d45bedc148326a30bdfc8fdcd46d6