### PR TITLE
Style empty search result messages

### DIFF
--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -131,7 +131,7 @@ than an entire file.
 - Query text is expanded using `src/data/synonyms.json` so common phrases and near
   spellings map to canonical technique names.
 - Lower scoring results appear only when there are no strong matches.
-- Result messages such as "No strong matches found…" should use the `.search-result-empty` CSS class. Each result entry uses `.search-result-item` and is fully justified with spacing between items.
+- Result messages such as "No strong matches found…" now use the `.search-result-empty` CSS class. Each result entry uses `.search-result-item` and is fully justified with spacing between items.
 
 ### UI Mockup
 

--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -175,13 +175,19 @@ export async function handleSearch(event) {
   const selected =
     tagSelect && tagSelect.value && tagSelect.value !== "all" ? [tagSelect.value] : [];
   spinner.style.display = "block";
-  if (messageEl) messageEl.textContent = "Searching...";
+  if (messageEl) {
+    messageEl.textContent = "Searching...";
+    messageEl.classList.remove("search-result-empty");
+  }
   try {
     const model = await getExtractor();
     const result = await model(expandedQuery, { pooling: "mean" });
     const vector = Array.from(result.data ?? result);
     const matches = await findMatches(vector, 5, selected, expandedQuery);
-    if (messageEl) messageEl.textContent = "";
+    if (messageEl) {
+      messageEl.textContent = "";
+      messageEl.classList.remove("search-result-empty");
+    }
     spinner.style.display = "none";
     if (matches === null) {
       if (messageEl)
@@ -189,7 +195,10 @@ export async function handleSearch(event) {
       return;
     }
     if (matches.length === 0) {
-      if (messageEl) messageEl.textContent = "No close matches found — refine your query.";
+      if (messageEl) {
+        messageEl.textContent = "No close matches found — refine your query.";
+        messageEl.classList.add("search-result-empty");
+      }
       return;
     }
 
@@ -201,6 +210,7 @@ export async function handleSearch(event) {
     if (strongMatches.length === 0 && messageEl) {
       messageEl.textContent =
         "\u26A0\uFE0F No strong matches found, but here are the closest matches based on similarity.";
+      messageEl.classList.add("search-result-empty");
     }
 
     for (const [idx, match] of toRender.entries()) {

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -70,3 +70,9 @@
   margin-bottom: var(--space-md);
   text-align: justify;
 }
+
+.search-result-empty {
+  color: var(--color-text);
+  font-style: italic;
+  opacity: 0.65;
+}

--- a/tests/helpers/vectorSearchPage.test.js
+++ b/tests/helpers/vectorSearchPage.test.js
@@ -115,6 +115,139 @@ describe("vector search page integration", () => {
   });
 });
 
+describe("search result message styling", () => {
+  it("adds search-result-empty class when no matches", async () => {
+    const findMatches = vi.fn().mockResolvedValue([]);
+    vi.doMock("../../src/helpers/vectorSearch.js", () => ({
+      findMatches,
+      fetchContextById: vi.fn(),
+      loadEmbeddings: vi.fn().mockResolvedValue([])
+    }));
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ count: 0 })
+    }));
+    vi.doMock("../../src/helpers/constants.js", () => ({
+      DATA_DIR: "./"
+    }));
+
+    const { handleSearch, init, __setExtractor } = await import(
+      "../../src/helpers/vectorSearchPage.js"
+    );
+
+    __setExtractor(async () => ({ data: [0, 0, 0] }));
+
+    document.body.innerHTML = `
+      <div id="search-spinner"></div>
+      <form id="vector-search-form">
+        <input id="vector-search-input" />
+        <select id="tag-filter"><option value="all">all</option></select>
+      </form>
+      <table id="vector-results-table"><tbody></tbody></table>
+      <p id="search-results-message"></p>
+    `;
+
+    await init();
+
+    document.getElementById("vector-search-input").value = "query";
+    await handleSearch(new Event("submit"));
+
+    const messageEl = document.getElementById("search-results-message");
+    expect(messageEl.classList.contains("search-result-empty")).toBe(true);
+  });
+
+  it("adds search-result-empty class when only weak matches returned", async () => {
+    const match = {
+      id: "1",
+      score: 0.5,
+      text: "test",
+      source: "doc",
+      tags: []
+    };
+    const findMatches = vi.fn().mockResolvedValue([match]);
+    vi.doMock("../../src/helpers/vectorSearch.js", () => ({
+      findMatches,
+      fetchContextById: vi.fn(),
+      loadEmbeddings: vi.fn().mockResolvedValue([match])
+    }));
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ count: 1 })
+    }));
+    vi.doMock("../../src/helpers/constants.js", () => ({
+      DATA_DIR: "./"
+    }));
+
+    const { handleSearch, init, __setExtractor } = await import(
+      "../../src/helpers/vectorSearchPage.js"
+    );
+
+    __setExtractor(async () => ({ data: [0, 0, 0] }));
+
+    document.body.innerHTML = `
+      <div id="search-spinner"></div>
+      <form id="vector-search-form">
+        <input id="vector-search-input" />
+        <select id="tag-filter"><option value="all">all</option></select>
+      </form>
+      <table id="vector-results-table"><tbody></tbody></table>
+      <p id="search-results-message"></p>
+    `;
+
+    await init();
+
+    document.getElementById("vector-search-input").value = "query";
+    await handleSearch(new Event("submit"));
+
+    const messageEl = document.getElementById("search-results-message");
+    expect(messageEl.classList.contains("search-result-empty")).toBe(true);
+  });
+
+  it("removes search-result-empty class when strong matches exist", async () => {
+    const match = {
+      id: "1",
+      score: 0.8,
+      text: "test",
+      source: "doc",
+      tags: []
+    };
+    const findMatches = vi.fn().mockResolvedValue([match]);
+    vi.doMock("../../src/helpers/vectorSearch.js", () => ({
+      findMatches,
+      fetchContextById: vi.fn(),
+      loadEmbeddings: vi.fn().mockResolvedValue([match])
+    }));
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ count: 1 })
+    }));
+    vi.doMock("../../src/helpers/constants.js", () => ({
+      DATA_DIR: "./"
+    }));
+
+    const { handleSearch, init, __setExtractor } = await import(
+      "../../src/helpers/vectorSearchPage.js"
+    );
+
+    __setExtractor(async () => ({ data: [0, 0, 0] }));
+
+    document.body.innerHTML = `
+      <div id="search-spinner"></div>
+      <form id="vector-search-form">
+        <input id="vector-search-input" />
+        <select id="tag-filter"><option value="all">all</option></select>
+      </form>
+      <table id="vector-results-table"><tbody></tbody></table>
+      <p id="search-results-message" class="search-result-empty"></p>
+    `;
+
+    await init();
+
+    document.getElementById("vector-search-input").value = "query";
+    await handleSearch(new Event("submit"));
+
+    const messageEl = document.getElementById("search-results-message");
+    expect(messageEl.classList.contains("search-result-empty")).toBe(false);
+  });
+});
+
 describe("highlightTerms", () => {
   it("wraps query words in <mark>", async () => {
     const { highlightTerms } = await import("../../src/helpers/snippetFormatter.js");


### PR DESCRIPTION
## Summary
- style `.search-result-empty` utility class for empty vector search results
- toggle empty-result styling in vector search page and document class
- test search result message styling for empty and weak matches

## Testing
- `npx prettier . --check` (failed: code style issues in unrelated files)
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast` (failed: Server start timeout)


------
https://chatgpt.com/codex/tasks/task_e_688e3ac554e88326840c82d6af0bc5f1