### PR TITLE
Add embedding version check

### DIFF
--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -87,6 +87,12 @@ scripts/generateEmbeddings.js`). This rebuilds `client_embeddings.json`, now
 pretty-printed for easier diffing, so agents search the latest content. Commit
 the regenerated JSON file along with your changes.
 
+The vector search page checks each embedding's `version` against the
+`CURRENT_EMBEDDING_VERSION` constant in `src/helpers/vectorSearch.js`.
+If a mismatch warning appears, bump the constant and rerun
+`npm run generate:embeddings` to refresh both
+`client_embeddings.json` and `client_embeddings.meta.json`.
+
 If the result would be larger than 6.8MB, the generator exits with
 `"Output exceeds 6.8MB"`. Increase the `CHUNK_SIZE` constant or omit large files to
 reduce the output size before running the script again.

--- a/src/helpers/vectorSearch.js
+++ b/src/helpers/vectorSearch.js
@@ -5,6 +5,14 @@ let embeddingsPromise;
 let cachedEmbeddings;
 
 /**
+ * Current version of the client embedding data.
+ *
+ * Increment this when regenerating embeddings to ensure the
+ * vector search page can detect outdated data.
+ */
+export const CURRENT_EMBEDDING_VERSION = 1;
+
+/**
  * Load vector embeddings from `client_embeddings.json`.
  *
  * @pseudocode

--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -310,7 +310,14 @@ export async function init() {
     );
   }
   if (versionMismatch && messageEl) {
-    messageEl.textContent = "⚠️ Embedding data is out of date. Run npm run generate:embeddings.";
+    // Use a dedicated warning element to avoid overwriting other messages
+    let warningEl = messageEl.querySelector('.embedding-warning');
+    if (!warningEl) {
+      warningEl = document.createElement('div');
+      warningEl.className = 'embedding-warning';
+      messageEl.appendChild(warningEl);
+    }
+    warningEl.textContent = "⚠️ Embedding data is out of date. Run npm run generate:embeddings.";
   }
 
   const tagSelect = document.getElementById("tag-filter");

--- a/tests/helpers/vectorSearchPage.test.js
+++ b/tests/helpers/vectorSearchPage.test.js
@@ -51,7 +51,8 @@ describe("vector search page integration", () => {
     vi.doMock("../../src/helpers/vectorSearch.js", () => ({
       findMatches,
       fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([{ tags: ["foo"] }])
+      loadEmbeddings: vi.fn().mockResolvedValue([{ tags: ["foo"], version: 1 }]),
+      CURRENT_EMBEDDING_VERSION: 1
     }));
 
     const { handleSearch, init, __setExtractor } = await import(
@@ -82,14 +83,18 @@ describe("vector search page integration", () => {
   });
 
   it("displays embedding count and tag options on init", async () => {
-    const embeddings = [{ tags: ["alpha"] }, { tags: ["beta"] }];
+    const embeddings = [
+      { tags: ["alpha"], version: 1 },
+      { tags: ["beta"], version: 1 }
+    ];
     vi.doMock("../../src/helpers/vectorSearch.js", () => ({
       findMatches: vi.fn(),
       fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue(embeddings)
+      loadEmbeddings: vi.fn().mockResolvedValue(embeddings),
+      CURRENT_EMBEDDING_VERSION: 1
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
-      fetchJson: vi.fn().mockResolvedValue({ count: 2 })
+      fetchJson: vi.fn().mockResolvedValue({ count: 2, version: 1 })
     }));
     vi.doMock("../../src/helpers/constants.js", () => ({
       DATA_DIR: "./"
@@ -121,10 +126,11 @@ describe("search result message styling", () => {
     vi.doMock("../../src/helpers/vectorSearch.js", () => ({
       findMatches,
       fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([])
+      loadEmbeddings: vi.fn().mockResolvedValue([]),
+      CURRENT_EMBEDDING_VERSION: 1
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
-      fetchJson: vi.fn().mockResolvedValue({ count: 0 })
+      fetchJson: vi.fn().mockResolvedValue({ count: 0, version: 1 })
     }));
     vi.doMock("../../src/helpers/constants.js", () => ({
       DATA_DIR: "./"
@@ -161,16 +167,18 @@ describe("search result message styling", () => {
       score: 0.5,
       text: "test",
       source: "doc",
-      tags: []
+      tags: [],
+      version: 1
     };
     const findMatches = vi.fn().mockResolvedValue([match]);
     vi.doMock("../../src/helpers/vectorSearch.js", () => ({
       findMatches,
       fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([match])
+      loadEmbeddings: vi.fn().mockResolvedValue([match]),
+      CURRENT_EMBEDDING_VERSION: 1
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
-      fetchJson: vi.fn().mockResolvedValue({ count: 1 })
+      fetchJson: vi.fn().mockResolvedValue({ count: 1, version: 1 })
     }));
     vi.doMock("../../src/helpers/constants.js", () => ({
       DATA_DIR: "./"
@@ -207,16 +215,18 @@ describe("search result message styling", () => {
       score: 0.8,
       text: "test",
       source: "doc",
-      tags: []
+      tags: [],
+      version: 1
     };
     const findMatches = vi.fn().mockResolvedValue([match]);
     vi.doMock("../../src/helpers/vectorSearch.js", () => ({
       findMatches,
       fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([match])
+      loadEmbeddings: vi.fn().mockResolvedValue([match]),
+      CURRENT_EMBEDDING_VERSION: 1
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
-      fetchJson: vi.fn().mockResolvedValue({ count: 1 })
+      fetchJson: vi.fn().mockResolvedValue({ count: 1, version: 1 })
     }));
     vi.doMock("../../src/helpers/constants.js", () => ({
       DATA_DIR: "./"
@@ -268,16 +278,18 @@ describe("snippet highlighting", () => {
       text: "lorem ipsum dolor",
       score: 1,
       source: "doc",
-      tags: []
+      tags: [],
+      version: 1
     };
     const findMatches = vi.fn().mockResolvedValue([match]);
     vi.doMock("../../src/helpers/vectorSearch.js", () => ({
       findMatches,
       fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([match])
+      loadEmbeddings: vi.fn().mockResolvedValue([match]),
+      CURRENT_EMBEDDING_VERSION: 1
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
-      fetchJson: vi.fn().mockResolvedValue({ count: 1 })
+      fetchJson: vi.fn().mockResolvedValue({ count: 1, version: 1 })
     }));
     vi.doMock("../../src/helpers/constants.js", () => ({
       DATA_DIR: "./"
@@ -314,7 +326,8 @@ describe("synonym expansion", () => {
     vi.doMock("../../src/helpers/vectorSearch.js", () => ({
       findMatches: vi.fn().mockResolvedValue([]),
       fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([])
+      loadEmbeddings: vi.fn().mockResolvedValue([]),
+      CURRENT_EMBEDDING_VERSION: 1
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue(synonyms)
@@ -335,7 +348,8 @@ describe("synonym expansion", () => {
     vi.doMock("../../src/helpers/vectorSearch.js", () => ({
       findMatches,
       fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([])
+      loadEmbeddings: vi.fn().mockResolvedValue([]),
+      CURRENT_EMBEDDING_VERSION: 1
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue(synonyms)


### PR DESCRIPTION
## Summary
- add CURRENT_EMBEDDING_VERSION constant for embedding data
- warn on vector search page when embedding or metadata versions differ
- document embedding version checks and regeneration steps

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot /src/pages/vectorSearch.html)*

------
https://chatgpt.com/codex/tasks/task_e_688e408a21e48326a69c76da774e4159