### PR TITLE
Add random stat mode setting

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -12,6 +12,10 @@
   },
   "gameModes": {},
   "featureFlags": {
+    "randomStatMode": {
+      "enabled": true,
+      "tooltipId": "settings.randomStatMode"
+    },
     "battleDebugPanel": {
       "enabled": false,
       "tooltipId": "settings.battleDebugPanel"

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -56,6 +56,10 @@
       "label": "Tooltips",
       "description": "Show helpful pop-up hints when hovering controls."
     },
+    "randomStatMode": {
+      "label": "Random Stat Mode",
+      "description": "Auto-selects a random stat when timer expires"
+    },
     "battleDebugPanel": {
       "label": "Battle Debug Panel",
       "description": "Show a panel with live match data for debugging."

--- a/tests/fixtures/tooltips.json
+++ b/tests/fixtures/tooltips.json
@@ -17,6 +17,10 @@
       "label": "Tooltips",
       "description": "Show helpful pop-up hints when hovering controls."
     },
+    "randomStatMode": {
+      "label": "Random Stat Mode",
+      "description": "Auto-selects a random stat when timer expires"
+    },
     "battleDebugPanel": {
       "label": "Battle Debug Panel",
       "description": "Show a panel with live match data for debugging."

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -149,6 +149,7 @@ describe("populateNavbar", () => {
       displayMode: "light",
       gameModes: { 2: false },
       featureFlags: {
+        randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
         fullNavigationMap: { enabled: true },
         enableTestMode: { enabled: false },
@@ -213,6 +214,7 @@ describe("populateNavbar", () => {
       displayMode: "light",
       gameModes: {},
       featureFlags: {
+        randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
         fullNavigationMap: { enabled: true },
         enableTestMode: { enabled: false },
@@ -265,6 +267,7 @@ describe("populateNavbar", () => {
       displayMode: "light",
       gameModes: {},
       featureFlags: {
+        randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
         fullNavigationMap: { enabled: true },
         enableTestMode: { enabled: false },

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -10,7 +10,9 @@ describe("classicBattlePage stat help tooltip", () => {
     vi.useFakeTimers();
     const startRound = vi.fn();
     const waitForComputerCard = vi.fn();
-    const loadSettings = vi.fn().mockResolvedValue({ featureFlags: {} });
+    const loadSettings = vi.fn().mockResolvedValue({
+      featureFlags: { randomStatMode: { enabled: true } }
+    });
     const initTooltips = vi.fn().mockResolvedValue();
     const setTestMode = vi.fn();
 
@@ -50,6 +52,7 @@ describe("classicBattlePage test mode flag", () => {
     const waitForComputerCard = vi.fn();
     const loadSettings = vi.fn().mockResolvedValue({
       featureFlags: {
+        randomStatMode: { enabled: true },
         enableTestMode: {
           enabled: true,
           label: "Test Mode",
@@ -89,6 +92,7 @@ describe("classicBattlePage test mode flag", () => {
     const waitForComputerCard = vi.fn();
     const loadSettings = vi.fn().mockResolvedValue({
       featureFlags: {
+        randomStatMode: { enabled: true },
         enableTestMode: { enabled: false }
       }
     });

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -55,6 +55,7 @@ describe("settings utils", () => {
       displayMode: "dark",
       gameModes: {},
       featureFlags: {
+        randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
         fullNavigationMap: { enabled: false },
         enableTestMode: { enabled: false },
@@ -126,6 +127,7 @@ describe("settings utils", () => {
         displayMode: "light",
         gameModes: {},
         featureFlags: {
+          randomStatMode: { enabled: true },
           battleDebugPanel: { enabled: false },
           fullNavigationMap: { enabled: false },
           enableTestMode: { enabled: false },
@@ -164,6 +166,7 @@ describe("settings utils", () => {
       displayMode: "light",
       gameModes: {},
       featureFlags: {
+        randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
         fullNavigationMap: { enabled: false },
         enableTestMode: { enabled: false },
@@ -177,6 +180,7 @@ describe("settings utils", () => {
       displayMode: "dark",
       gameModes: {},
       featureFlags: {
+        randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
         fullNavigationMap: { enabled: false },
         enableTestMode: { enabled: false },


### PR DESCRIPTION
## Summary
- add `randomStatMode` flag enabled by default in settings
- document tooltip text for `randomStatMode`
- update tests and fixtures for new flag

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warns: 'err' is defined but never used, etc.)*
- `npx vitest run` *(fails: Error loading game modes: Error: fail)*
- `npx playwright test` *(fails to fetch tooltips: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_688e40471fc4832684e2b56381749879