### PR TITLE
Ensure toggles meet touch target size

### DIFF
--- a/design/productRequirementsDocuments/prdDrawRandomCard.md
+++ b/design/productRequirementsDocuments/prdDrawRandomCard.md
@@ -101,8 +101,8 @@ Motion** enabled, ensuring the card appears instantly without movement.
 
 | Goal             | Metric                                                                                    |
 | ---------------- | ----------------------------------------------------------------------------------------- |
-| Fast Response    | Card draw completes quickly.                                                       |
-| Smooth Animation | Reveal animation plays with no visual glitches.                                 |
+| Fast Response    | Card draw completes quickly.                                                              |
+| Smooth Animation | Reveal animation plays with no visual glitches.                                           |
 | Fair Randomness  | Random selection passes chi-square testing for uniformity, 95% confidence over 100 draws. |
 | Low Failure Rate | No more than 1% draw failures.                                                            |
 | Accessibility    | Automatically disable animations if system Reduced Motion is active.                      |
@@ -150,10 +150,10 @@ Motion** enabled, ensuring the card appears instantly without movement.
 | -------- | ------------------------------ | ---------------------------------------------------------------------------- |
 | P1       | Random Card Selection          | Select a random card from the active card set dynamically.                   |
 | P1       | Display Selected Card          | Visually reveal the selected card with animation and sound feedback.         |
-| P2       | Fallback on Failure            | Show fallback card if draw fails or active set is empty.   |
+| P2       | Fallback on Failure            | Show fallback card if draw fails or active set is empty.                     |
 | P2       | Reusable Random Draw Module    | Make the random draw callable from multiple game states or screens.          |
 | P3       | Accessibility Support          | Support Reduced Motion settings and maintain color contrast and readability. |
-| P3       | UX Enhancements                | Optimize for animation, sound effect, and large tap targets.           |
+| P3       | UX Enhancements                | Optimize for animation, sound effect, and large tap targets.                 |
 | P3       | Sound & Animation User Toggles | Allow users to manually mute sounds and disable animations if desired.       |
 
 ---

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -97,8 +97,10 @@
 .switch input {
   position: absolute;
   opacity: 0;
-  width: 0;
-  height: 0;
+  width: 44px;
+  height: 44px;
+  margin: 0;
+  cursor: pointer;
 }
 
 .switch input:focus-visible + .slider {
@@ -108,8 +110,8 @@
 .slider {
   position: relative;
   display: inline-block;
-  width: 60px;
-  height: 34px;
+  width: 80px;
+  height: 44px;
   background-color: var(--switch-off-bg);
   border-radius: var(--radius-pill);
   transition: var(--transition-fast);
@@ -118,8 +120,8 @@
 .slider::before {
   content: "";
   position: absolute;
-  height: 26px;
-  width: 26px;
+  height: 36px;
+  width: 36px;
   left: 4px;
   top: 4px;
   background-color: var(--color-surface);
@@ -132,7 +134,7 @@
 }
 
 .switch input:checked + .slider::before {
-  transform: translateX(26px);
+  transform: translateX(36px);
 }
 
 .slider.round {

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -178,6 +178,55 @@ describe("randomJudokaPage module", () => {
     expect(parseInt(computed.width)).toBeGreaterThanOrEqual(300);
   });
 
+  it("animation and sound toggles meet minimum size requirements", async () => {
+    vi.useFakeTimers();
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    vi.doMock("../../src/components/Button.js", async () => {
+      return await vi.importActual("../../src/components/Button.js");
+    });
+    vi.doMock("../../src/components/ToggleSwitch.js", async () => {
+      return await vi.importActual("../../src/components/ToggleSwitch.js");
+    });
+
+    const generateRandomCard = vi.fn();
+    const fetchJson = vi.fn().mockResolvedValue([]);
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updateSetting = vi.fn();
+    const applyMotionPreference = vi.fn();
+
+    vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
+    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
+
+    const { section, container } = createRandomCardDom();
+    document.body.append(section, container);
+
+    const settingsCss = readFileSync(resolve("src/styles/settings.css"), "utf8");
+    const style = document.createElement("style");
+    style.textContent = settingsCss;
+    document.head.appendChild(style);
+
+    await import("../../src/helpers/randomJudokaPage.js");
+
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const animationInput = document.getElementById("animation-toggle");
+    const soundInput = document.getElementById("sound-toggle");
+    const animStyle = getComputedStyle(animationInput);
+    const soundStyle = getComputedStyle(soundInput);
+    expect(parseInt(animStyle.width)).toBeGreaterThanOrEqual(44);
+    expect(parseInt(animStyle.height)).toBeGreaterThanOrEqual(44);
+    expect(parseInt(soundStyle.width)).toBeGreaterThanOrEqual(44);
+    expect(parseInt(soundStyle.height)).toBeGreaterThanOrEqual(44);
+  });
+
   it("storage event toggles card inspector", async () => {
     vi.useFakeTimers();
     window.matchMedia = vi.fn().mockReturnValue({ matches: false });


### PR DESCRIPTION
## Summary
- enlarge toggle switch hit areas to at least 44px and expand slider/knob dimensions
- add unit test verifying animation and sound toggles meet minimum touch target size
- format PRD document with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Screenshot suite › screenshot /src/pages/randomJudoka.html)*
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688e433c84a48326ae72fd97a24b4d80