### PR TITLE
Add landscape layout media queries

### DIFF
--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -46,6 +46,25 @@ test.describe("View Judoka screen", () => {
     await expect(flag).toHaveAttribute("alt", /(Portugal|USA|Japan) flag/i);
   });
 
+  test("portrait and landscape layouts", async ({ page }) => {
+    const section = page.locator(".card-section");
+    const controls = page.locator(".draw-controls");
+
+    // Portrait
+    await page.setViewportSize({ width: 600, height: 900 });
+    let flexDir = await section.evaluate((el) => getComputedStyle(el).flexDirection);
+    let marginTop = await controls.evaluate((el) => getComputedStyle(el).marginTop);
+    expect(flexDir).toBe("column");
+    expect(marginTop).toBe("24px");
+
+    // Landscape
+    await page.setViewportSize({ width: 900, height: 600 });
+    flexDir = await section.evaluate((el) => getComputedStyle(el).flexDirection);
+    marginTop = await controls.evaluate((el) => getComputedStyle(el).marginTop);
+    expect(flexDir).toBe("row");
+    expect(marginTop).toBe("0px");
+  });
+
   test("draw button uses design tokens", async ({ page }) => {
     const btn = page.getByTestId("draw-button");
     await btn.waitFor();

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" href="../styles/layout.css" />
     <link rel="stylesheet" href="../styles/components.css" />
     <link rel="stylesheet" href="../styles/utilities.css" />
+    <link rel="stylesheet" href="../styles/randomJudoka.css" />
     <link rel="icon" type="image/png" href="../assets/images/favicon.ico" />
   </head>
 
@@ -41,12 +42,7 @@
       <div class="card-section">
         <div id="card-container" data-testid="card-container" class="card-container"></div>
         <!-- PRD: Draw Card button and toggles per prdRandomJudoka.md & prdDrawRandomCard.md -->
-        <div
-          id="draw-controls"
-          class="draw-controls"
-          aria-label="Draw controls"
-          style="display: flex; flex-direction: column; align-items: center; margin-top: 24px"
-        >
+        <div id="draw-controls" class="draw-controls" aria-label="Draw controls">
           <!-- Button and toggles are injected by randomJudokaPage.js -->
           <!-- Error message container for accessibility -->
           <div

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -238,17 +238,3 @@ body {
     grid-column: 1;
   }
 }
-
-/* Landscape layout for Random Judoka page */
-@media (orientation: landscape) and (min-width: 600px) {
-  .card-section {
-    flex-direction: row;
-    justify-content: center;
-    align-items: flex-start;
-    gap: var(--space-lg);
-  }
-
-  .card-section .draw-card-btn {
-    margin: var(--space-large) 0;
-  }
-}

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -118,17 +118,6 @@
   height: 24px;
 }
 
-.card-section {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding-bottom: calc(var(--footer-height) + env(safe-area-inset-bottom));
-}
-
-.card-section .draw-card-btn {
-  align-self: center;
-}
-
 .country-panel {
   position: fixed;
   top: var(--header-height);

--- a/src/styles/randomJudoka.css
+++ b/src/styles/randomJudoka.css
@@ -1,0 +1,34 @@
+.card-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: calc(var(--footer-height) + env(safe-area-inset-bottom));
+}
+
+.draw-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: var(--space-lg);
+}
+
+.card-section .draw-card-btn {
+  align-self: center;
+}
+
+@media (orientation: landscape) {
+  .card-section {
+    flex-direction: row;
+    justify-content: center;
+    align-items: flex-start;
+    gap: var(--space-lg);
+  }
+
+  .draw-controls {
+    margin-top: 0;
+  }
+
+  .card-section .draw-card-btn {
+    margin: var(--space-large) 0;
+  }
+}


### PR DESCRIPTION
## Summary
- move random judoka layout styles into dedicated stylesheet and add landscape media query
- load new stylesheet on random judoka page
- test portrait vs landscape layout with Playwright

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot spec snapshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688e45543f848326b96e6bd5aec2d900