### PR TITLE
Defer initial random draw until user action

### DIFF
--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -9,10 +9,11 @@
  * 5. Define `displayCard` that disables the Draw button, updates its text and `aria-busy` state while loading, calls
  *    `generateRandomCard` with the loaded data and the user's motion preference, updates the history list, then restores
  *    the button once the animation completes.
- * 6. Create the "Draw Card!" button (min 64px height, 300px width, pill shape, ARIA attributes) and Animation/Sound toggles.
- * 7. Attach event listeners to persist toggle changes, update motion classes, and handle accessibility.
- * 8. If data fails to load, disable the Draw button and show an error message or fallback card.
- * 9. Use `onDomReady` to execute setup when the DOM content is loaded.
+ * 6. Render a placeholder card in the card container.
+ * 7. Create the "Draw Card!" button (min 64px height, 300px width, pill shape, ARIA attributes) and Animation/Sound toggles.
+ * 8. Attach event listeners to persist toggle changes, update motion classes, and handle accessibility.
+ * 9. If data fails to load, disable the Draw button and show an error message or fallback card.
+ * 10. Use `onDomReady` to execute setup when the DOM content is loaded.
  *
  * @returns {Promise<void>} Resolves when the page is fully initialized.
  * @see design/productRequirementsDocuments/prdRandomJudoka.md
@@ -163,6 +164,12 @@ export async function setupRandomJudokaPage() {
     );
   }
 
+  const cardContainer = document.getElementById("card-container");
+  const placeholderTemplate = document.getElementById("card-placeholder-template");
+  if (placeholderTemplate && cardContainer) {
+    cardContainer.appendChild(placeholderTemplate.content.cloneNode(true));
+  }
+
   await preloadData();
   const cardSection = document.querySelector(".card-section");
   toggleHistoryBtn = createButton("History", {
@@ -260,10 +267,8 @@ export async function setupRandomJudokaPage() {
     });
   });
 
-  // Initial state: show card if data loaded, else show error
-  if (dataLoaded) {
-    displayCard();
-  } else {
+  // Initial state: placeholder shown; disable draw button only if data failed to load
+  if (!dataLoaded) {
     showError("Unable to load judoka data. Please try again later.");
     drawButton.disabled = true;
     drawButton.setAttribute("aria-disabled", "true");

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -41,6 +41,11 @@
 
       <div class="card-section">
         <div id="card-container" data-testid="card-container" class="card-container"></div>
+        <template id="card-placeholder-template">
+          <div class="card placeholder-card" data-testid="placeholder-card">
+            <p>Tap "Draw Card!" to begin.</p>
+          </div>
+        </template>
         <!-- PRD: Draw Card button and toggles per prdRandomJudoka.md & prdDrawRandomCard.md -->
         <div id="draw-controls" class="draw-controls" aria-label="Draw controls">
           <!-- Button and toggles are injected by randomJudokaPage.js -->

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -53,8 +53,8 @@ describe("randomJudokaPage module", () => {
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings, updateSetting }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
 
-    const { section, container } = createRandomCardDom();
-    document.body.append(section, container);
+    const { section, container, placeholderTemplate } = createRandomCardDom();
+    document.body.append(section, container, placeholderTemplate);
 
     const { setupRandomJudokaPage } = await import("../../src/helpers/randomJudokaPage.js");
 
@@ -64,9 +64,13 @@ describe("randomJudokaPage module", () => {
     expect(loadSettings).toHaveBeenCalled();
     expect(createToggleSwitch).toHaveBeenCalledTimes(2);
     expect(applyMotionPreference).toHaveBeenCalledWith(baseSettings.motionEffects);
+    expect(generateRandomCard).not.toHaveBeenCalled();
+    const drawBtn = document.getElementById("draw-card-btn");
+    drawBtn.click();
+    await vi.runAllTimersAsync();
     expect(generateRandomCard.mock.calls[0][3]).toBe(false);
     expect(typeof setupRandomJudokaPage).toBe("function");
-    expect(document.getElementById("draw-card-btn").dataset.tooltipId).toBe("ui.drawCard");
+    expect(drawBtn.dataset.tooltipId).toBe("ui.drawCard");
   });
 
   it("renders card text with sufficient color contrast", async () => {
@@ -85,7 +89,11 @@ describe("randomJudokaPage module", () => {
     }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
     vi.doMock("../../src/components/Button.js", () => ({
-      createButton: () => document.createElement("button")
+      createButton: (_, opts = {}) => {
+        const btn = document.createElement("button");
+        if (opts.id) btn.id = opts.id;
+        return btn;
+      }
     }));
     vi.doMock("../../src/components/ToggleSwitch.js", () => ({
       createToggleSwitch: () => document.createElement("div")
@@ -104,8 +112,8 @@ describe("randomJudokaPage module", () => {
     }));
     vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
 
-    const { section, container } = createRandomCardDom();
-    document.body.append(section, container);
+    const { section, container, placeholderTemplate } = createRandomCardDom();
+    document.body.append(section, container, placeholderTemplate);
 
     const vars = parseCssVariables(readFileSync(resolve("src/styles/base.css"), "utf8"));
     const cardCss = readFileSync(resolve("src/styles/card.css"), "utf8");
@@ -120,6 +128,8 @@ describe("randomJudokaPage module", () => {
     await import("../../src/helpers/randomJudokaPage.js");
 
     document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+    document.getElementById("draw-card-btn").click();
     await vi.runAllTimersAsync();
 
     const cardEl = container.querySelector(".judoka-card");
@@ -159,8 +169,8 @@ describe("randomJudokaPage module", () => {
     }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
 
-    const { section, container } = createRandomCardDom();
-    document.body.append(section, container);
+    const { section, container, placeholderTemplate } = createRandomCardDom();
+    document.body.append(section, container, placeholderTemplate);
 
     const navbarCss = readFileSync(resolve("src/styles/navbar.css"), "utf8");
     const style = document.createElement("style");
@@ -204,8 +214,8 @@ describe("randomJudokaPage module", () => {
     }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
 
-    const { section, container } = createRandomCardDom();
-    document.body.append(section, container);
+    const { section, container, placeholderTemplate } = createRandomCardDom();
+    document.body.append(section, container, placeholderTemplate);
 
     await import("../../src/helpers/randomJudokaPage.js");
 
@@ -252,8 +262,8 @@ describe("randomJudokaPage module", () => {
     }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
 
-    const { section, container } = createRandomCardDom();
-    document.body.append(section, container);
+    const { section, container, placeholderTemplate } = createRandomCardDom();
+    document.body.append(section, container, placeholderTemplate);
 
     const settingsCss = readFileSync(resolve("src/styles/settings.css"), "utf8");
     const style = document.createElement("style");
@@ -316,8 +326,8 @@ describe("randomJudokaPage module", () => {
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings, updateSetting }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
 
-    const { section, container } = createRandomCardDom();
-    document.body.append(section, container);
+    const { section, container, placeholderTemplate } = createRandomCardDom();
+    document.body.append(section, container, placeholderTemplate);
 
     await import("../../src/helpers/randomJudokaPage.js");
 
@@ -325,7 +335,7 @@ describe("randomJudokaPage module", () => {
     await vi.runOnlyPendingTimersAsync();
 
     const drawBtn = document.getElementById("draw-card-btn");
-    for (let i = 1; i < judokaSeq.length; i++) {
+    for (let i = 0; i < judokaSeq.length; i++) {
       drawBtn.click();
       await Promise.resolve();
       await vi.runOnlyPendingTimersAsync();
@@ -369,12 +379,16 @@ describe("randomJudokaPage module", () => {
     }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
 
-    const { section, container } = createRandomCardDom();
-    document.body.append(section, container);
+    const { section, container, placeholderTemplate } = createRandomCardDom();
+    document.body.append(section, container, placeholderTemplate);
 
     await import("../../src/helpers/randomJudokaPage.js");
 
     document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const drawBtn = document.getElementById("draw-card-btn");
+    drawBtn.click();
     await vi.runAllTimersAsync();
 
     expect(container.querySelector(".debug-panel")).toBeNull();

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -30,7 +30,11 @@ export function createRandomCardDom() {
   section.className = "card-section";
   const container = document.createElement("div");
   container.id = "card-container";
-  return { section, container };
+  const placeholderTemplate = document.createElement("template");
+  placeholderTemplate.id = "card-placeholder-template";
+  placeholderTemplate.innerHTML =
+    '<div class="card placeholder-card" data-testid="placeholder-card"><p>Tap "Draw Card!" to begin.</p></div>';
+  return { section, container, placeholderTemplate };
 }
 
 export function createBattleCardContainers() {


### PR DESCRIPTION
## Summary
- add placeholder card template to randomJudoka page
- render placeholder on page setup and only draw after user clicks
- adjust Random Judoka tests for click-driven draws

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run --silent`
- `npx playwright test` *(fails: Screenshot suite / Signature move screenshots)*
- `npm run check:contrast` *(fails: Timeout in scripts/runPa11y.js)*

------
https://chatgpt.com/codex/tasks/task_e_688e5831bad083268c507b4fba4a3db9