### PR TITLE
Add ripple feedback for browsing carousel

### DIFF
--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -6,6 +6,7 @@ import { DATA_DIR } from "./constants.js";
 import { createButton } from "../components/Button.js";
 import { onDomReady } from "./domReady.js";
 import { initTooltips } from "./tooltip.js";
+import { setupButtonEffects } from "./buttonEffects.js";
 
 function handleKeyboardNavigation(event, container, buttonClass) {
   const buttons = Array.from(container.querySelectorAll(`button.${buttonClass}`));
@@ -139,6 +140,7 @@ export async function setupBrowseJudokaPage() {
    * 1. Clear the existing carousel container.
    * 2. Use `buildCardCarousel` to create carousel markup.
    * 3. Append the carousel to the container and add scroll markers.
+   * 4. Apply button ripple effects.
    *
    * @param {Judoka[]} list - Judoka to display.
    * @returns {Promise<void>} Resolves when rendering completes.
@@ -154,6 +156,8 @@ export async function setupBrowseJudokaPage() {
         addScrollMarkers(containerEl, carousel);
       }
     });
+
+    setupButtonEffects();
   }
 
   async function init() {

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -210,6 +210,21 @@
   outline-offset: 2px;
 }
 
+/* Disable ripple animations when motion is reduced */
+@media (prefers-reduced-motion: reduce) {
+  .top-navbar button .ripple,
+  .top-navbar .primary-button .ripple,
+  .filter-bar button .ripple {
+    animation: none;
+  }
+}
+
+.reduce-motion .top-navbar button .ripple,
+.reduce-motion .top-navbar .primary-button .ripple,
+.reduce-motion .filter-bar button .ripple {
+  animation: none;
+}
+
 /* Reduce motion for the country panel */
 @media (prefers-reduced-motion: reduce) {
   .country-panel[hidden],


### PR DESCRIPTION
## Summary
- apply ripple effects on browse page buttons and carousel arrows
- disable ripple animations when reduced-motion is preferred

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688e64d567588326a85b007a6a5c7911