### PR TITLE
Handle sync failures in classic battle

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -26,6 +26,32 @@ export function getStartRound() {
 
 let quitModal = null;
 
+/**
+ * Update the info bar with current scores and show a waiting message when
+ * synchronizing with the backend fails.
+ *
+ * @pseudocode
+ * 1. Attempt to read scores via `getScores()`.
+ * 2. When scores are not numbers or an error occurs, display
+ *    `"Waiting…"` using `infoBar.showMessage` and return false.
+ * 3. Otherwise, update the score display and return true.
+ *
+ * @returns {boolean} True when scores were updated, false on failure.
+ */
+function syncScoreDisplay() {
+  try {
+    const { playerScore, computerScore } = getScores();
+    if (typeof playerScore === "number" && typeof computerScore === "number") {
+      infoBar.updateScore(playerScore, computerScore);
+      return true;
+    }
+  } catch {
+    // ignore error and fall through to waiting message
+  }
+  infoBar.showMessage("Waiting…");
+  return false;
+}
+
 function createQuitConfirmation(onConfirm) {
   const title = document.createElement("h2");
   title.id = "quit-modal-title";
@@ -64,8 +90,7 @@ export async function startRound() {
   disableNextRoundButton();
   await drawCards();
   showSelectionPrompt();
-  const { playerScore, computerScore } = getScores();
-  infoBar.updateScore(playerScore, computerScore);
+  syncScoreDisplay();
   await startTimer(handleStatSelection);
   updateDebugPanel();
 }
@@ -79,8 +104,7 @@ export function evaluateRound(stat) {
   if (result.message) {
     showResult(result.message);
   }
-  const { playerScore, computerScore } = getScores();
-  infoBar.updateScore(playerScore, computerScore);
+  syncScoreDisplay();
   updateDebugPanel();
   return result;
 }
@@ -128,8 +152,7 @@ export function _resetForTest() {
     quitModal.element.remove();
     quitModal = null;
   }
-  const { playerScore, computerScore } = getScores();
-  infoBar.updateScore(playerScore, computerScore);
+  syncScoreDisplay();
   updateDebugPanel();
 }
 
@@ -141,6 +164,7 @@ export {
 } from "./classicBattle/uiHelpers.js";
 export { getComputerJudoka } from "./classicBattle/cardSelection.js";
 export { scheduleNextRound } from "./classicBattle/timerControl.js";
+export { syncScoreDisplay as _syncScoreDisplay };
 
 const quitButton = document.getElementById("quit-match-button");
 if (quitButton) {

--- a/src/helpers/classicBattle/timerControl.js
+++ b/src/helpers/classicBattle/timerControl.js
@@ -9,6 +9,7 @@ import { enableNextRoundButton, disableNextRoundButton, updateDebugPanel } from 
  *
  * @pseudocode
  * 1. Determine timer duration using `getDefaultTimer('roundTimer')`.
+ *    - On error, show "Waiting…" and fallback to 30 seconds.
  * 2. Call `engineStartRound` to update the countdown each second.
  * 3. When expired, auto-select a random stat via `onExpired`.
  *
@@ -17,13 +18,21 @@ import { enableNextRoundButton, disableNextRoundButton, updateDebugPanel } from 
  */
 export async function startTimer(onExpiredSelect) {
   const timerEl = document.getElementById("next-round-timer");
-  let duration;
+  let duration = 30;
+  let synced = true;
   try {
-    duration = await getDefaultTimer("roundTimer");
+    const val = await getDefaultTimer("roundTimer");
+    if (typeof val === "number") {
+      duration = val;
+    } else {
+      synced = false;
+    }
   } catch {
-    duration = 30;
+    synced = false;
   }
-  if (typeof duration !== "number") duration = 30;
+  if (!synced) {
+    infoBar.showMessage("Waiting…");
+  }
   engineStartRound(
     (remaining) => {
       if (timerEl) timerEl.textContent = `Time Left: ${remaining}s`;

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -32,7 +32,12 @@ describe("classicBattle match flow", () => {
     const header = createBattleHeader();
     document.body.append(playerCard, computerCard, header);
     timerSpy = vi.useFakeTimers();
-    fetchJsonMock = vi.fn(async () => []);
+    fetchJsonMock = vi.fn(async (url) => {
+      if (String(url).includes("gameTimers.json")) {
+        return [{ id: 1, value: 30, default: true, category: "roundTimer" }];
+      }
+      return [];
+    });
     generateRandomCardMock = vi.fn(async (_d, _g, container, _pm, cb) => {
       container.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
       if (cb) cb({ id: 1 });

--- a/tests/helpers/classicBattle/syncFailures.test.js
+++ b/tests/helpers/classicBattle/syncFailures.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+  document.body.innerHTML = "";
+});
+
+describe("classicBattle backend sync failures", () => {
+  it("shows waiting message when timer sync fails", async () => {
+    document.body.innerHTML = '<p id="next-round-timer"></p>';
+    const showMessage = vi.fn();
+    vi.doMock("../../../src/helpers/setupBattleInfoBar.js", () => ({ showMessage }));
+    vi.doMock("../../../src/helpers/timerUtils.js", () => ({
+      getDefaultTimer: vi.fn().mockRejectedValue(new Error("fail"))
+    }));
+    vi.doMock("../../../src/helpers/battleEngine.js", () => ({
+      startRound: vi.fn(),
+      startCoolDown: vi.fn(),
+      STATS: ["power"]
+    }));
+    const { startTimer } = await import("../../../src/helpers/classicBattle/timerControl.js");
+    await startTimer(() => {});
+    expect(showMessage).toHaveBeenCalledWith("Waiting…");
+  });
+
+  it("shows waiting message when score sync fails", async () => {
+    const showMessage = vi.fn();
+    const updateScore = vi.fn();
+    vi.doMock("../../../src/helpers/setupBattleInfoBar.js", () => ({
+      showMessage,
+      updateScore
+    }));
+    vi.doMock("../../../src/helpers/battleEngine.js", () => ({
+      handleStatSelection: vi.fn(),
+      quitMatch: vi.fn(),
+      getScores: () => {
+        throw new Error("fail");
+      },
+      _resetForTest: vi.fn()
+    }));
+    const { _syncScoreDisplay } = await import("../../../src/helpers/classicBattle.js");
+    _syncScoreDisplay();
+    expect(showMessage).toHaveBeenCalledWith("Waiting…");
+    expect(updateScore).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- display waiting message when score sync fails in classic battle
- show waiting message and fallback when round timer cannot sync
- cover score and timer sync failure cases with dedicated tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_688e64ee0d488326b0d704b8cedd361e