### PR TITLE
Add settings button to Random Judoka header

### DIFF
--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -18,6 +18,10 @@ test.describe("View Judoka screen", () => {
     await battleLink.click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
+  test("settings button navigates to settings page", async ({ page }) => {
+    await page.getByTestId("settings-button").click();
+    await expect(page).toHaveURL(/settings\.html/);
+  });
 
   test("logo has alt text", async ({ page }) => {
     const logo = page.getByRole("img", { name: "JU-DO-KON! Logo" });

--- a/src/components/PlayerInfo.js
+++ b/src/components/PlayerInfo.js
@@ -1,0 +1,17 @@
+/**
+ * Define the `<player-info>` custom element for displaying player details.
+ *
+ * @pseudocode
+ * 1. Create a class extending `HTMLElement`.
+ * 2. In `connectedCallback`, set default text to "Player" if none provided.
+ * 3. Register the element as `player-info`.
+ */
+export class PlayerInfo extends HTMLElement {
+  connectedCallback() {
+    if (!this.textContent.trim()) {
+      this.textContent = "Player";
+    }
+  }
+}
+
+customElements.define("player-info", PlayerInfo);

--- a/src/helpers/setupSettingsButton.js
+++ b/src/helpers/setupSettingsButton.js
@@ -1,0 +1,19 @@
+/**
+ * Attach navigation behavior to the settings button.
+ *
+ * @pseudocode
+ * 1. Locate the `#settings-button` element.
+ * 2. Guard: exit if the element is missing.
+ * 3. Add a click listener that navigates to `settings.html`.
+ */
+import { onDomReady } from "./domReady.js";
+
+function init() {
+  const button = document.getElementById("settings-button");
+  if (!button) return;
+  button.addEventListener("click", () => {
+    window.location.href = "settings.html";
+  });
+}
+
+onDomReady(init);

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -30,13 +30,32 @@
   <body>
     <div class="home-screen">
       <header class="header">
-        <div class="header-spacer left"></div>
+        <player-info data-testid="player-info"></player-info>
         <div class="logo-container">
           <a href="../../index.html" data-testid="home-link">
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
-        <div class="header-spacer right"></div>
+        <button
+          id="settings-button"
+          class="settings-button"
+          type="button"
+          aria-label="Open settings"
+          data-testid="settings-button"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 -960 960 960"
+            width="64"
+            height="64"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              d="M480-280q83 0 141.5-58.5T680-480q0-83-58.5-141.5T480-680q-83 0-141.5 58.5T280-480q0 83 58.5 141.5T480-280Zm0 80q-116 0-198-82t-82-198q0-116 82-198t198-82q116 0 198 82t82 198q0 116-82 198t-198 82Zm352-40-56-96q12-27 18-55t6-57q0-29-6-57t-18-55l56-96-113-113-96 56q-27-12-55-18t-57-6q-29 0-57 6t-55 18l-96-56-113 113 56 96q-12 27-18 55t-6 57q0 29 6 57t18 55l-56 96 113 113 96-56q27 12 55 18t57 6q29 0 57-6t55-18l96 56 113-113Z"
+            />
+          </svg>
+        </button>
       </header>
 
       <div class="card-section">
@@ -62,6 +81,8 @@
       <footer>
         <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
       </footer>
+      <script type="module" src="../components/PlayerInfo.js"></script>
+      <script type="module" src="../helpers/setupSettingsButton.js"></script>
       <script type="module" src="../helpers/setupBottomNavbar.js"></script>
       <script type="module" src="../helpers/setupDisplaySettings.js"></script>
       <script type="module" src="../helpers/randomJudokaPage.js"></script>

--- a/src/styles/randomJudoka.css
+++ b/src/styles/randomJudoka.css
@@ -1,3 +1,26 @@
+player-info {
+  justify-self: start;
+  padding-left: var(--space-sm);
+}
+
+.settings-button {
+  justify-self: end;
+  background: none;
+  border: none;
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: var(--color-secondary);
+}
+
+.settings-button svg {
+  width: 64px;
+  height: 64px;
+}
+
 .card-section {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add `<player-info>` component to Random Judoka header
- include 64px settings button and navigation script
- test settings navigation with Playwright

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch for randomJudoka)*
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688e64bd9ba483269b2848a21f81a8dc