### PR TITLE
Add keyboard navigation to sidebar list

### DIFF
--- a/src/components/SidebarList.js
+++ b/src/components/SidebarList.js
@@ -5,12 +5,14 @@
  * 1. Build a `<ul>` element with class `sidebar-list`.
  * 2. For each provided item create an `<li>` with text and optional
  *    dataset or className values.
- * 3. Attach click and keyboard handlers so Enter or Space trigger
- *    selection using `select(index)`.
+ * 3. Attach click and keyboard handlers so Enter/Space trigger
+ *    selection using `select(index)` and Arrow Up/Down move the
+ *    selection relative to the current item.
  * 4. Add `odd`/`even` classes for zebra striping starting with `odd`
  *    for the first item and toggle the `selected` class inside
  *    `select()`.
- * 5. Call the `onSelect` callback whenever a new index is selected.
+ * 5. Inside `select()` update the highlight, focus the newly
+ *    selected element, and call `onSelect`.
  * 6. Return `{ element, select }` so callers can programmatically
  *    change the highlighted item.
  *
@@ -50,11 +52,21 @@ export function createSidebarList(items, onSelect = () => {}) {
 
   let current = -1;
 
+  list.addEventListener("keydown", (e) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      const delta = e.key === "ArrowDown" ? 1 : -1;
+      const next = current === -1 ? (delta === 1 ? 0 : elements.length - 1) : current + delta;
+      select(next);
+    }
+  });
+
   function select(index) {
     current = ((index % elements.length) + elements.length) % elements.length;
     elements.forEach((el, idx) => {
       el.classList.toggle("selected", idx === current);
     });
+    elements[current].focus();
     onSelect(current, elements[current]);
   }
 

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -29,6 +29,12 @@
   cursor: pointer;
 }
 
+/* Highlight the item currently focused via keyboard */
+.sidebar-list li:focus {
+  outline: 2px solid var(--link-color);
+  outline-offset: -2px;
+}
+
 .sidebar-list li:nth-child(odd),
 .sidebar-list li.odd {
   background-color: var(--color-surface);

--- a/tests/components/SidebarList.test.js
+++ b/tests/components/SidebarList.test.js
@@ -23,4 +23,23 @@ describe("createSidebarList", () => {
     select(0);
     expect(items[0].classList.contains("selected")).toBe(true);
   });
+
+  it("handles arrow key navigation and focus", () => {
+    const { element } = createSidebarList(["A", "B", "C"]);
+    document.body.appendChild(element);
+    const items = element.querySelectorAll("li");
+
+    items[0].focus();
+    items[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(items[0].classList.contains("selected")).toBe(true);
+    expect(document.activeElement).toBe(items[0]);
+
+    items[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(items[1].classList.contains("selected")).toBe(true);
+    expect(document.activeElement).toBe(items[1]);
+
+    items[1].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+    expect(items[0].classList.contains("selected")).toBe(true);
+    expect(document.activeElement).toBe(items[0]);
+  });
 });


### PR DESCRIPTION
## Summary
- allow moving sidebar selection with ArrowUp/ArrowDown and keep focus on the selected item
- document focus styles for sidebar list items
- test keyboard navigation in SidebarList

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688e75422f8c83269c4c8ee0aca5222e