### PR TITLE
Load PRDs dynamically in PRD viewer

### DIFF
--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -18,7 +18,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
 ## Goals
 
-- Enable in-browser reading of all PRDs in the `design/productRequirementsDocuments` directory. **(Implemented: Loads a fixed list of PRDs, not a dynamic directory scan)**
+- Enable in-browser reading of all PRDs in the `design/productRequirementsDocuments` directory. **(Implemented)**
 - Support intuitive navigation (buttons, keyboard, swipe) between documents. **(Implemented: Keyboard and swipe; navigation buttons not present in UI)**
 - Render markdown PRDs as readable, styled HTML with tables, code blocks, and headings. **(Implemented)**
 - Ensure accessibility and responsive design for all users. **(Partially implemented: ARIA roles and responsive CSS present; full accessibility testing not yet done)**
@@ -37,7 +37,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 ## Defined Player Actions and Game Flow
 
 - The player opens the PRD Viewer from the JU-DO-KON! main menu.
-- The viewer loads all markdown files from the `design/productRequirementsDocuments` directory. **(Implemented: Loads a static list of files)**
+- The viewer loads all markdown files from the `design/productRequirementsDocuments` directory. **(Implemented)**
 - The player views the first PRD rendered as styled HTML.
 - The player navigates between PRDs by:
   - Selecting a document from the sidebar list,
@@ -55,7 +55,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
 | Priority | Feature                    | Description                                                          | Status      |
 | -------- | -------------------------- | -------------------------------------------------------------------- | ----------- |
-| P1       | Markdown PRD Loading       | Load all markdown files from the PRD directory and display them.     | Static list |
+| P1       | Markdown PRD Loading       | Load all markdown files from the PRD directory and display them.     | Implemented |
 | P1       | Markdown-to-HTML Rendering | Convert markdown to styled HTML with accurate formatting.            | Implemented |
 | P1       | Keyboard Navigation        | Allow navigation via arrow keys with focus management.               | Implemented |
 | P1       | Touch/Swipe Navigation     | Support swipe gestures with gesture threshold to avoid misfires.     | Implemented |
@@ -68,7 +68,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
 ## Acceptance Criteria
 
-- Given the PRD Viewer is opened, when loading the markdown files in `design/productRequirementsDocuments/`, then all files are loaded and displayed in sequence. **(Implemented with static file list)**
+- Given the PRD Viewer is opened, when loading the markdown files in `design/productRequirementsDocuments/`, then all files are loaded and displayed in sequence. **(Implemented)**
 - Given a markdown file is rendered, then headings, tables, lists, and code blocks appear styled as readable HTML. **(Implemented)**
 - Given the player presses the right or left arrow keys, then navigation moves accordingly between PRDs. **(Implemented)**
 - Given the player selects a document from the sidebar list, then that PRD is displayed in the viewer. **(Implemented)**
@@ -105,7 +105,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 ## Dependencies and Open Questions
 
 - Depends on the `markdownToHtml` helper for markdown parsing (uses the `marked` library).
-- Requires an up-to-date file list from the `design/productRequirementsDocuments` directory. **(Currently hardcoded)**
+- Requires an up-to-date file list from the `design/productRequirementsDocuments` directory.
 - **Open:** Should the viewer support deep-linking to specific PRDs via URL hash or query parameters? This affects navigation and state restoration.
 
 ---
@@ -127,7 +127,6 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
 **Note:**
 
-- The PRD Viewer currently uses a static list of markdown files. Dynamic directory scanning is not implemented.
 - There are no navigation buttons in the UI; navigation is via sidebar, keyboard, or swipe.
 - Warning badges for malformed markdown and loading spinners are not implemented.
 - Accessibility is partially implemented; further testing and improvements may be needed.
@@ -138,7 +137,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
 - [x] 1.0 Set Up Markdown File Loader
 
-  - [x] 1.1 Create function to scan `design/productRequirementsDocuments` directory **(Implemented as static list)**
+  - [x] 1.1 Create function to scan `design/productRequirementsDocuments` directory
   - [x] 1.2 Load markdown content of each file asynchronously
   - [x] 1.3 Implement error handling and fallback display for file load failures
 

--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -25,31 +25,9 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
 
   const FILES = docsMap
     ? Object.keys(docsMap)
-    : [
-        "prdBattleInfoBar.md",
-        "prdBrowseJudoka.md",
-        "prdCardCarousel.md",
-        "prdCardCodeGeneration.md",
-        "prdClassicBattle.md",
-        "prdCountryPickerFilter.md",
-        "prdDrawRandomCard.md",
-        "prdGameModes.md",
-        "prdHomePageNavigation.md",
-        "prdJudokaCard.md",
-        "prdMeditationScreen.md",
-        "prdNavigationBar.md",
-        "prdNavigationMap.md",
-        "prdPseudoJapanese.md",
-        "prdRandomJudoka.md",
-        "prdSettingsMenu.md",
-        "prdTeamBattleFemale.md",
-        "prdTeamBattleMale.md",
-        "prdTeamBattleMixed.md",
-        "prdTeamBattleRules.md",
-        "prdTeamBattleSelection.md",
-        "prdUpdateJudoka.md",
-        "prdChangeLog.md"
-      ];
+    : Object.keys(import.meta.glob("../../design/productRequirementsDocuments/*.md")).map((p) =>
+        p.split("/").pop()
+      );
 
   FILES.sort((a, b) => a.localeCompare(b));
 

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -3,8 +3,8 @@ import { describe, it, expect } from "vitest";
 describe("prdReaderPage", () => {
   it("navigates documents with wrap-around", async () => {
     const docs = {
-      "file1.md": "# First doc",
-      "file2.md": "# Second doc"
+      "b.md": "# Second doc",
+      "a.md": "# First doc"
     };
     const parser = (md) => `<h1>${md}</h1>`;
 
@@ -49,8 +49,8 @@ describe("prdReaderPage", () => {
 
   it("selects documents via sidebar", async () => {
     const docs = {
-      "doc1.md": "# One",
-      "doc2.md": "# Two"
+      "docB.md": "# Two",
+      "docA.md": "# One"
     };
     const parser = (md) => `<h1>${md}</h1>`;
 
@@ -85,8 +85,8 @@ describe("prdReaderPage", () => {
 
   it("updates #prd-content when a list item is clicked", async () => {
     const docs = {
-      "alpha.md": "# Alpha",
-      "beta.md": "# Beta"
+      "beta.md": "# Beta",
+      "alpha.md": "# Alpha"
     };
     const parser = (md) => `<h1>${md}</h1>`;
 


### PR DESCRIPTION
## Summary
- Discover PRD markdown files automatically using `import.meta.glob`
- Adjust PRD reader tests to verify alphabetical sorting of dynamically loaded docs
- Remove static-file references from PRD viewer design notes

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: PRD Reader page › forward and back navigation)*

------
https://chatgpt.com/codex/tasks/task_e_688e75b0815c832689b78b5a2b997c01