### PR TITLE
Refine battle header text for narrow viewports

### DIFF
--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -23,7 +23,7 @@
 
 .battle-header #round-message {
   margin: 0;
-  font-size: clamp(18px, 4vw, 30px);
+  font-size: clamp(14px, 4vw, 30px);
   font-weight: bold;
   color: var(--link-color);
 }
@@ -37,13 +37,13 @@
 
 .battle-header #score-display {
   margin: 0;
-  font-size: clamp(18px, 3.5vw, 26px);
+  font-size: clamp(14px, 3.5vw, 26px);
   font-weight: bold;
   color: var(--link-color);
   text-align: right;
 }
 
-@media (max-width: 374px) {
+@media (max-width: 375px) {
   .battle-header {
     grid-template-columns: 1fr;
     grid-template-rows: auto auto auto;
@@ -60,6 +60,11 @@
     grid-row: 3;
     justify-self: center;
     align-items: center;
+  }
+  .battle-header #round-message,
+  .battle-header #score-display {
+    font-size: clamp(14px, 5vw, 18px);
+    overflow-wrap: anywhere;
   }
 }
 

--- a/tests/helpers/battleHeaderEllipsis.test.js
+++ b/tests/helpers/battleHeaderEllipsis.test.js
@@ -22,9 +22,32 @@ function hasEllipsisRule(css) {
   return found;
 }
 
+function hasWrapRule(css) {
+  const root = postcss.parse(css);
+  let found = false;
+  root.walkAtRules("media", (at) => {
+    if (/max-width:\s*375px/.test(at.params)) {
+      at.walkRules((rule) => {
+        if (rule.selector.includes("#round-message") || rule.selector.includes("#score-display")) {
+          const wrap = rule.nodes.find((n) => n.prop === "overflow-wrap");
+          const fontSize = rule.nodes.find((n) => n.prop === "font-size");
+          if (wrap && /anywhere/.test(wrap.value) && fontSize && /clamp/.test(fontSize.value)) {
+            found = true;
+          }
+        }
+      });
+    }
+  });
+  return found;
+}
+
 describe("battle.css responsive truncation", () => {
   it("applies ellipsis to message and score on tiny screens", () => {
     const css = readFileSync("src/styles/battle.css", "utf8");
     expect(hasEllipsisRule(css)).toBe(true);
+  });
+  it("wraps and scales message and score on small screens", () => {
+    const css = readFileSync("src/styles/battle.css", "utf8");
+    expect(hasWrapRule(css)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Scale battle round and score text responsively
- Ensure battle header text wraps on narrow screens
- Test battle header styling helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688e759174dc832680af504704a8d602