### PR TITLE
Add loading spinner to judoka browser

### DIFF
--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -116,7 +116,7 @@ function validateGokyoData(gokyoData) {
  * @param {HTMLElement} wrapper - The wrapper element to append the spinner to.
  * @returns {Object} An object containing the spinner element and timeout ID.
  */
-function createLoadingSpinner(wrapper) {
+export function createLoadingSpinner(wrapper) {
   const spinner = document.createElement("div");
   spinner.className = "loading-spinner";
   wrapper.appendChild(spinner);


### PR DESCRIPTION
## Summary
- show a loading spinner while the judoka browser fetches data and builds the carousel
- export `createLoadingSpinner` for reuse
- test that the spinner appears during load and disappears after render

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: 9)*
- `npx vitest run`
- `npx playwright test` *(fails: Settings screenshots › mode dark expanded)*

------
https://chatgpt.com/codex/tasks/task_e_688e8122da8c832694fda3f7eb2633f4