### PR TITLE
Align battle info bar clamp ranges

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -71,7 +71,7 @@ The round message, timer, and score now sit directly inside the page header rath
   - Two-line score format appears on narrow screens (`Player: X` line break `Opponent: Y`)
   - Left side: rotating status messages (e.g., "You won!", "Next round in: 3s", "Select your move", **"Time left: 29s"**)
 - **Visuals**
-  - Font size: min 16sp, bold for win/loss messages.
+  - Font size: `clamp(16px, 4vw, 24px)`; on narrow screens (<375px) `clamp(14px, 5vw, 20px)`.
   - Color coding: green (win), red (loss), neutral grey (countdown).
 - **Responsiveness**
   - Stacked layout on narrow screens (<375px width). <!-- Implemented: see battle.css @media (max-width: 374px) -->

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -21,25 +21,16 @@
   align-items: flex-end;
 }
 
-.battle-header #round-message {
+.battle-header #round-message,
+.battle-header #next-round-timer,
+.battle-header #score-display {
   margin: 0;
-  font-size: clamp(14px, 4vw, 30px);
-  font-weight: bold;
-  color: var(--link-color);
-}
-
-.battle-header #next-round-timer {
-  margin: 0;
-  font-size: clamp(15px, 3vw, 18px);
+  font-size: clamp(16px, 4vw, 24px);
   font-weight: bold;
   color: var(--link-color);
 }
 
 .battle-header #score-display {
-  margin: 0;
-  font-size: clamp(14px, 3.5vw, 26px);
-  font-weight: bold;
-  color: var(--link-color);
   text-align: right;
 }
 
@@ -62,8 +53,9 @@
     align-items: center;
   }
   .battle-header #round-message,
+  .battle-header #next-round-timer,
   .battle-header #score-display {
-    font-size: clamp(14px, 5vw, 18px);
+    font-size: clamp(14px, 5vw, 20px);
     overflow-wrap: anywhere;
   }
 }


### PR DESCRIPTION
## Summary
- use shared clamp ranges for battle info bar text
- document clamp ranges in Battle Info Bar PRD

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings)
- `npx vitest run`
- `npx playwright test` (failure: settings-screenshot spec)
- `npm run check:contrast` (timeout)


------
https://chatgpt.com/codex/tasks/task_e_688e813c54988326b0a8ff1bae8c33bf