### PR TITLE
Warn when PRD markdown fails to parse

### DIFF
--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -46,7 +46,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 - Navigation loops around at the ends of the PRD list.
 - The player can click the JU-DO-KON! logo to exit the viewer at any time.
 - If loading a markdown file fails, an error message is shown for that document, and the player can continue navigating others. **(Implemented: Fallback message and error logging)**
-- If a markdown file is malformed, partial content is shown with a warning badge. **(Not implemented: No warning badge for malformed markdown)**
+- If a markdown file is malformed, partial content is shown with a warning badge. **(Implemented)**
 - The viewer is fully keyboard operable, supports screen readers, and adapts layout for desktop, tablet, and mobile screens. **(Partially implemented: Keyboard navigation and responsive layout present; screen reader support not fully verified)**
 
 ---
@@ -76,7 +76,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 - Given the player is on any screen size, then the layout adapts to desktop, tablet, or mobile formats responsively. **(Implemented)**
 - Given the player clicks the JU-DO-KON! logo or “Home” link, then the viewer exits to the main homepage. **(Implemented)**
 - Given a markdown file fails to load, then an error is logged to the console, a fallback message is shown, and other files remain navigable. **(Implemented)**
-- Given malformed markdown content, then partial content is rendered with a warning badge visually indicating an issue. **(Not implemented)**
+- Given malformed markdown content, then partial content is rendered with a warning badge visually indicating an issue. **(Implemented)**
 - Given a PRD includes a Tasks section, then the viewer displays the total number of tasks and completion percentage above the document content. **(Implemented)**
 
 ---
@@ -95,7 +95,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 ## Edge Cases / Failure States
 
 - **Markdown File Fails to Load:** Log error, show fallback message (“Content unavailable”), continue allowing navigation of others. **(Implemented)**
-- **Malformed Markdown Content:** Display partial content with warning icon and accessible tooltip. **(Not implemented)**
+- **Malformed Markdown Content:** Display partial content with warning icon and accessible tooltip. **(Implemented)**
 - **Slow Network or File Load Delay:** Show a loading spinner or status message while fetching files. **(Not implemented)**
 - **Swipe Misfires on Touch Devices:** Use minimum gesture thresholds and debounce timing to avoid accidental navigations. **(Implemented: 30px threshold)**
 - **Keyboard Navigation Blocked:** Ensure `tabindex`, role attributes, and focus management are correctly implemented. **(Partially implemented)**
@@ -121,14 +121,14 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
   `--color-tertiary` tokens for zebra striping. Odd/even classes start with
   `odd` for the first row.
 - Sidebar PRDs are listed alphabetically.
-- Warning badge in content area if markdown partially rendered. **(Not implemented)**
+- Warning badge in content area if markdown partially rendered. **(Implemented)**
 - Bottom footer with keyboard and swipe navigation instructions. **(Footer present, instructions may need to be added)**
 - Responsive layout for desktop, tablet, and mobile.
 
 **Note:**
 
 - There are no navigation buttons in the UI; navigation is via sidebar, keyboard, or swipe.
-- Warning badges for malformed markdown and loading spinners are not implemented.
+- Loading spinners are not implemented.
 - Accessibility is partially implemented; further testing and improvements may be needed.
 
 ---
@@ -177,7 +177,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
   - [x] 8.1 Show fade-in animation when switching documents
   - [ ] 8.2 Show loading spinner or status message while fetching files (not yet implemented)
-  - [ ] 8.3 Show warning badge for malformed markdown (not yet implemented)
+  - [x] 8.3 Show warning badge for malformed markdown
 
 - [x] 9.0 Footer Navigation Instructions
   - [x] 9.1 Footer present for navigation instructions (content may need to be added)

--- a/src/styles/prdViewer.css
+++ b/src/styles/prdViewer.css
@@ -62,3 +62,14 @@
   justify-self: end;
   text-align: right;
 }
+
+.markdown-warning {
+  display: inline-block;
+  background: #fff3cd;
+  color: #000;
+  border: 1px solid #ffeeba;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: 4px;
+  font-weight: 600;
+  margin-bottom: var(--space-sm);
+}

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -136,4 +136,30 @@ describe("prdReaderPage", () => {
     const summary = document.getElementById("task-summary");
     expect(summary.textContent).toContain("1/2");
   });
+
+  it("shows warning badge when markdown parsing fails", async () => {
+    const docs = {
+      "bad.md": "# Bad\\n[link](../missing.md)"
+    };
+    const parser = (md) => {
+      if (md.includes("../")) throw new Error("bad path");
+      return `<h1>${md}</h1>`;
+    };
+
+    document.body.innerHTML = `
+      <div id="prd-title"></div>
+      <div id="task-summary"></div>
+      <ul id="prd-list"></ul>
+      <div id="prd-content"></div>
+    `;
+
+    globalThis.SKIP_PRD_AUTO_INIT = true;
+    const { setupPrdReaderPage } = await import("../../src/helpers/prdReaderPage.js");
+
+    await setupPrdReaderPage(docs, parser);
+
+    const warning = document.querySelector(".markdown-warning");
+    expect(warning).toBeTruthy();
+    expect(warning.getAttribute("aria-label")).toBe("Content could not be fully rendered");
+  });
 });


### PR DESCRIPTION
## Summary
- show a warning badge when PRD markdown parsing fails and keep rendering
- style `.markdown-warning` badge and document the behavior
- test that malformed markdown paths trigger the warning

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(1 failing screenshot test: `Settings screenshots › mode dark expanded`)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688e816c05e083268ac306c95267b944