### PR TITLE
Tag tooltip prefixes with category styles

### DIFF
--- a/src/helpers/tooltipViewerPage.js
+++ b/src/helpers/tooltipViewerPage.js
@@ -9,7 +9,8 @@ import { createSidebarList } from "../components/SidebarList.js";
  *
  * @pseudocode
  * 1. Load and flatten `tooltips.json` using `fetchJson` and `flattenTooltips`.
- * 2. Render a clickable list of keys filtered by the search box (300ms debounce).
+ * 2. Render a clickable list of keys filtered by the search box (300ms debounce),
+ *    tagging items with a class based on their prefix (e.g. `stat`, `ui`).
  * 3. When a key is selected, display its parsed HTML and raw text in the preview.
  * 4. Provide copy buttons for the key and body using `navigator.clipboard`.
  * 5. On page load, select the key from the URL hash when present and scroll to it.
@@ -43,9 +44,10 @@ export async function setupTooltipViewerPage() {
       const match = terms.every((t) => haystack.includes(t));
       if (match) {
         const valid = typeof body === "string" && body.trim().length > 0;
+        const prefix = key.split(".")[0];
         items.push({
           label: key,
-          className: valid ? undefined : "invalid",
+          className: prefix,
           dataset: { key, body, valid: String(valid) }
         });
       }

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -27,6 +27,7 @@
 .sidebar-list li {
   padding: var(--space-xs) var(--space-sm);
   cursor: pointer;
+  border-left: 4px solid transparent;
 }
 
 /* Highlight the item currently focused via keyboard */
@@ -53,6 +54,30 @@
   background: var(--link-color);
 }
 
-.sidebar-list li.invalid {
+.sidebar-list li[data-valid="false"] {
   color: #c62828;
+}
+
+.sidebar-list li.stat {
+  border-left-color: var(--color-primary);
+}
+
+.sidebar-list li.ui {
+  border-left-color: var(--color-secondary);
+}
+
+.sidebar-list li.mode {
+  border-left-color: #08a700;
+}
+
+.sidebar-list li.nav {
+  border-left-color: #ff9800;
+}
+
+.sidebar-list li.settings {
+  border-left-color: #9c27b0;
+}
+
+.sidebar-list li.card {
+  border-left-color: #795548;
 }


### PR DESCRIPTION
## Summary
- Tag tooltip entries with classes derived from their key prefixes
- Color-code sidebar items for stat, UI, mode, navigation, settings, and card categories

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings only)
- `npx vitest run`
- `npx playwright test` (1 failed)
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688e818712dc8326a369519af999ac38