### PR TITLE
Add contrast audit to pre-commit and fix info bar colors

### DIFF
--- a/.github/workflows/runUnitTests.yml
+++ b/.github/workflows/runUnitTests.yml
@@ -44,3 +44,5 @@ jobs:
         run: npm install
       - name: Run Vitest
         run: npm run test
+      - name: Run contrast audit
+        run: npm run check:contrast

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname "$0")/_/h"
 
-npm run lint && npm test
+npm run lint && npm test && npm run check:contrast

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,10 @@ npx prettier . --check       # verify formatting
 npx eslint .                 # lint the codebase
 npx vitest run                # run unit tests
 npx playwright test          # run Playwright UI tests
+npm run check:contrast       # Pa11y contrast audit (runs server automatically)
 ```
 
-**For UI-related changes** (styles, components, layouts), also run:
-
-```bash
-npm run check:contrast       # run Pa11y accessibility audit on http://localhost:5000 (start a dev server first)
-```
+The pre-commit hook runs linting, tests, and the contrast audit automatically.
 
 Common fixes:
 

--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -50,7 +50,7 @@ The round message, timer, and score now sit directly inside the page header rath
 - Action prompt appears during user input phases and disappears after interaction. <!-- Implemented: see showMessage and stat selection logic -->
 - **Stat selection timer (30s) is displayed during stat selection phase; if timer expires, a random stat is auto-selected. Timer pauses/resumes on tab inactivity.** <!-- Implemented: see startRound in battleEngine.js -->
 - Top bar content adapts responsively to different screen sizes and orientations. <!-- Partially implemented: stacking/truncation CSS present, but some edge cases pending -->
-- All messages meet minimum contrast ratio of **4.5:1** and are screen reader compatible. <!-- Contrast: mostly via CSS variables, but explicit checks not enforced; screen reader labels not yet implemented -->
+- All messages meet minimum contrast ratio of **4.5:1** and are screen reader compatible. Run `npm run check:contrast` to audit these colors. <!-- Contrast via CSS variables; screen reader labels not yet implemented -->
 - **All interactive elements meet minimum touch target size (≥44px) and support keyboard navigation.** <!-- Implemented: see CSS min-width/min-height and stat button logic -->
 
 ---
@@ -113,7 +113,7 @@ The round message, timer, and score now sit directly inside the page header rath
 
 - [ ] 4.0 Implement Accessibility Features
 
-  - [ ] 4.1 Ensure text contrast meets 4.5:1 ratio (CSS variables used, but not programmatically checked)
+  - [ ] 4.1 Ensure text contrast meets 4.5:1 ratio. Verify with `npm run check:contrast`.
   - [ ] 4.2 Add screen reader labels for dynamic messages (aria-live, etc. not yet implemented)
   - [x] 4.3 Ensure all interactive elements have minimum 44px touch targets (CSS min-width/min-height present)
   - [ ] 4.4 Ensure all interactive elements support keyboard navigation (stat buttons: basic support, but needs explicit review/test)

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -27,7 +27,7 @@
   margin: 0;
   font-size: clamp(16px, 4vw, 24px);
   font-weight: bold;
-  color: var(--link-color);
+  color: var(--color-text);
 }
 
 .battle-header #score-display {


### PR DESCRIPTION
## Summary
- ensure battle info bar text uses theme text color for WCAG AA contrast
- run contrast audit during pre-commit and CI
- document contrast audit requirement in AGENTS and PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: settings-screenshot.spec.js mode dark expanded)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688e87709a608326b7d99663f0618380