### PR TITLE
Add full navigation map setting

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -4,11 +4,13 @@
   "typewriterEffect": false,
   "tooltips": true,
   "displayMode": "light",
+  "fullNavigationMap": false,
   "tooltipIds": {
     "sound": "settings.sound",
     "motionEffects": "settings.motionEffects",
     "typewriterEffect": "settings.typewriterEffect",
-    "tooltips": "settings.tooltips"
+    "tooltips": "settings.tooltips",
+    "fullNavigationMap": "settings.fullNavigationMap"
   },
   "gameModes": {},
   "featureFlags": {
@@ -19,10 +21,6 @@
     "battleDebugPanel": {
       "enabled": false,
       "tooltipId": "settings.battleDebugPanel"
-    },
-    "fullNavigationMap": {
-      "enabled": false,
-      "tooltipId": "settings.fullNavigationMap"
     },
     "enableTestMode": {
       "enabled": false,

--- a/src/helpers/settings/applyInitialValues.js
+++ b/src/helpers/settings/applyInitialValues.js
@@ -76,4 +76,14 @@ export function applyInitialControlValues(controls, settings, tooltipMap = {}) {
   const tipsDescEl = document.getElementById("tooltips-desc");
   if (tipsLabel && tipsLabelEl) tipsLabelEl.textContent = tipsLabel;
   if (tipsDesc && tipsDescEl) tipsDescEl.textContent = tipsDesc;
+  applyInputState(controls.fullNavigationMapToggle, settings.fullNavigationMap);
+  if (controls.fullNavigationMapToggle && settings.tooltipIds?.fullNavigationMap) {
+    controls.fullNavigationMapToggle.dataset.tooltipId = settings.tooltipIds.fullNavigationMap;
+  }
+  const mapLabel = tooltipMap["settings.fullNavigationMap.label"];
+  const mapDesc = tooltipMap["settings.fullNavigationMap.description"];
+  const mapLabelEl = controls.fullNavigationMapToggle?.closest("label")?.querySelector("span");
+  const mapDescEl = document.getElementById("full-navigation-map-desc");
+  if (mapLabel && mapLabelEl) mapLabelEl.textContent = mapLabel;
+  if (mapDesc && mapDescEl) mapDescEl.textContent = mapDesc;
 }

--- a/src/helpers/settings/listenerUtils.js
+++ b/src/helpers/settings/listenerUtils.js
@@ -18,7 +18,14 @@ import { showSnackbar } from "../showSnackbar.js";
  *   Persist function that returns a Promise.
  */
 export function attachToggleListeners(controls, getCurrentSettings, handleUpdate) {
-  const { soundToggle, motionToggle, displayRadios, typewriterToggle, tooltipsToggle } = controls;
+  const {
+    soundToggle,
+    motionToggle,
+    displayRadios,
+    typewriterToggle,
+    tooltipsToggle,
+    fullNavigationMapToggle
+  } = controls;
   soundToggle?.addEventListener("change", () => {
     const prev = !soundToggle.checked;
     Promise.resolve(
@@ -89,6 +96,18 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
       })
     ).then(() => {
       showSnackbar(`Tooltips ${tooltipsToggle.checked ? "enabled" : "disabled"}`);
+    });
+  });
+  fullNavigationMapToggle?.addEventListener("change", () => {
+    const prev = !fullNavigationMapToggle.checked;
+    Promise.resolve(
+      handleUpdate("fullNavigationMap", fullNavigationMapToggle.checked, () => {
+        fullNavigationMapToggle.checked = prev;
+      })
+    ).then(() => {
+      showSnackbar(
+        `Full navigation map ${fullNavigationMapToggle.checked ? "enabled" : "disabled"}`
+      );
     });
   });
 }

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -98,7 +98,8 @@ function initializeControls(settings, gameModes, tooltipMap) {
     motionToggle: document.getElementById("motion-toggle"),
     displayRadios: document.querySelectorAll('input[name="display-mode"]'),
     typewriterToggle: document.getElementById("typewriter-toggle"),
-    tooltipsToggle: document.getElementById("tooltips-toggle")
+    tooltipsToggle: document.getElementById("tooltips-toggle"),
+    fullNavigationMapToggle: document.getElementById("full-navigation-map-toggle")
   };
   const modesContainer = document.getElementById("game-mode-toggle-container");
   const flagsContainer = document.getElementById("feature-flags-container");

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -183,6 +183,7 @@ export function resetSettings() {
  * @property {boolean} motionEffects
  * @property {boolean} typewriterEffect
  * @property {"light"|"dark"|"gray"} displayMode
+ * @property {boolean} fullNavigationMap
  * @property {Record<string, string>} [tooltipIds]
  * @property {Record<string, boolean>} [gameModes]
  * @property {Record<string, {

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -188,6 +188,22 @@
                     Show or hide helpful tooltips.
                   </p>
                 </div>
+                <div class="settings-item">
+                  <label for="full-navigation-map-toggle" class="switch">
+                    <input
+                      type="checkbox"
+                      id="full-navigation-map-toggle"
+                      name="fullNavigationMap"
+                      aria-label="Full Navigation Map"
+                      aria-describedby="full-navigation-map-desc"
+                    />
+                    <div class="slider round"></div>
+                    <span>Full Navigation Map</span>
+                  </label>
+                  <p id="full-navigation-map-desc" class="settings-description">
+                    Display an overlay map linking to every page.
+                  </p>
+                </div>
               </fieldset>
             </div>
           </div>

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -25,6 +25,10 @@
       "enum": ["light", "dark", "gray"],
       "description": "Visual display mode."
     },
+    "fullNavigationMap": {
+      "type": "boolean",
+      "description": "Enable the full navigation map overlay."
+    },
     "tooltipIds": {
       "type": "object",
       "description": "Mapping of setting keys to tooltip identifiers.",
@@ -60,7 +64,8 @@
     "motionEffects",
     "typewriterEffect",
     "tooltips",
-    "displayMode"
+    "displayMode",
+    "fullNavigationMap"
   ],
   "additionalProperties": false
 }

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -147,11 +147,11 @@ describe("populateNavbar", () => {
       motionEffects: true,
       tooltips: true,
       displayMode: "light",
+      fullNavigationMap: true,
       gameModes: { 2: false },
       featureFlags: {
         randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
-        fullNavigationMap: { enabled: true },
         enableTestMode: { enabled: false },
         enableCardInspector: { enabled: false }
       }
@@ -212,11 +212,11 @@ describe("populateNavbar", () => {
       motionEffects: true,
       tooltips: true,
       displayMode: "light",
+      fullNavigationMap: true,
       gameModes: {},
       featureFlags: {
         randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
-        fullNavigationMap: { enabled: true },
         enableTestMode: { enabled: false },
         enableCardInspector: { enabled: false }
       }
@@ -265,11 +265,11 @@ describe("populateNavbar", () => {
       motionEffects: true,
       tooltips: true,
       displayMode: "light",
+      fullNavigationMap: true,
       gameModes: {},
       featureFlags: {
         randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
-        fullNavigationMap: { enabled: true },
         enableTestMode: { enabled: false },
         enableCardInspector: { enabled: false }
       }

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -11,11 +11,11 @@ const baseSettings = {
   typewriterEffect: true,
   tooltips: true,
   displayMode: "light",
+  fullNavigationMap: true,
   gameModes: {},
   featureFlags: {
     randomStatMode: { enabled: false },
     battleDebugPanel: { enabled: false },
-    fullNavigationMap: { enabled: true },
     enableTestMode: { enabled: false },
     enableCardInspector: { enabled: false }
   }

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -7,11 +7,11 @@ const baseSettings = {
   typewriterEffect: true,
   tooltips: true,
   displayMode: "light",
+  fullNavigationMap: true,
   gameModes: {},
   featureFlags: {
     randomStatMode: { enabled: true },
     battleDebugPanel: { enabled: false },
-    fullNavigationMap: { enabled: true },
     enableTestMode: { enabled: false },
     enableCardInspector: { enabled: false },
     showCardOfTheDay: { enabled: false },
@@ -356,7 +356,6 @@ describe("settingsPage module", () => {
         ...baseSettings.featureFlags.battleDebugPanel,
         enabled: true
       },
-      fullNavigationMap: baseSettings.featureFlags.fullNavigationMap,
       enableTestMode: baseSettings.featureFlags.enableTestMode,
       enableCardInspector: baseSettings.featureFlags.enableCardInspector,
       showCardOfTheDay: baseSettings.featureFlags.showCardOfTheDay,

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -53,11 +53,12 @@ describe("settings utils", () => {
       motionEffects: true,
       typewriterEffect: false,
       displayMode: "dark",
+      tooltips: true,
+      fullNavigationMap: false,
       gameModes: {},
       featureFlags: {
         randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
-        fullNavigationMap: { enabled: false },
         enableTestMode: { enabled: false },
         enableCardInspector: { enabled: false }
       }
@@ -125,11 +126,12 @@ describe("settings utils", () => {
         motionEffects: true,
         typewriterEffect: false,
         displayMode: "light",
+        tooltips: true,
+        fullNavigationMap: false,
         gameModes: {},
         featureFlags: {
           randomStatMode: { enabled: true },
           battleDebugPanel: { enabled: false },
-          fullNavigationMap: { enabled: false },
           enableTestMode: { enabled: false },
           enableCardInspector: { enabled: false }
         }
@@ -164,11 +166,12 @@ describe("settings utils", () => {
       motionEffects: true,
       typewriterEffect: false,
       displayMode: "light",
+      tooltips: true,
+      fullNavigationMap: false,
       gameModes: {},
       featureFlags: {
         randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
-        fullNavigationMap: { enabled: false },
         enableTestMode: { enabled: false },
         enableCardInspector: { enabled: false }
       }
@@ -178,11 +181,12 @@ describe("settings utils", () => {
       motionEffects: false,
       typewriterEffect: false,
       displayMode: "dark",
+      tooltips: true,
+      fullNavigationMap: false,
       gameModes: {},
       featureFlags: {
         randomStatMode: { enabled: true },
         battleDebugPanel: { enabled: false },
-        fullNavigationMap: { enabled: false },
         enableTestMode: { enabled: false },
         enableCardInspector: { enabled: false }
       }


### PR DESCRIPTION
## Summary
- promote fullNavigationMap from feature flag to top-level setting
- expose Full Navigation Map toggle on Settings page
- wire up initialization and listeners for the new control

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: 9 warnings)*
- `npx vitest run`
- `npx playwright test` *(fails: 4 tests, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688e87c714048326b491d7d9c1204fca