### PR TITLE
Add test for full navigation map toggle

### DIFF
--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -222,6 +222,37 @@ describe("settingsPage module", () => {
     expect(showSnackbar).toHaveBeenCalledWith("Tooltips disabled");
   });
 
+  it("renders full navigation map toggle and updates setting", async () => {
+    vi.useFakeTimers();
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updated = { ...baseSettings, fullNavigationMap: false };
+    const updateSetting = vi.fn().mockResolvedValue(updated);
+    const loadNavigationItems = vi.fn().mockResolvedValue([]);
+    const showSnackbar = vi.fn();
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
+      updateNavigationItemHidden: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar }));
+
+    await import("../../src/helpers/settingsPage.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const input = document.getElementById("full-navigation-map-toggle");
+    expect(input).toBeTruthy();
+    input.checked = false;
+    input.dispatchEvent(new Event("change"));
+    expect(updateSetting).toHaveBeenCalledWith("fullNavigationMap", false);
+    await vi.runAllTimersAsync();
+    expect(showSnackbar).toHaveBeenCalledWith("Full navigation map disabled");
+  });
+
   it("renders feature flag switches", async () => {
     vi.useFakeTimers();
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -59,6 +59,9 @@ export function createSettingsDom() {
   const tooltipsToggle = document.createElement("input");
   tooltipsToggle.id = "tooltips-toggle";
   tooltipsToggle.type = "checkbox";
+  const fullNavigationMapToggle = document.createElement("input");
+  fullNavigationMapToggle.id = "full-navigation-map-toggle";
+  fullNavigationMapToggle.type = "checkbox";
   const displayLight = document.createElement("input");
   displayLight.id = "display-mode-light";
   displayLight.type = "radio";
@@ -105,6 +108,7 @@ export function createSettingsDom() {
     motionToggle,
     typewriterToggle,
     tooltipsToggle,
+    fullNavigationMapToggle,
     displayLight,
     displayDark,
     displayGray,


### PR DESCRIPTION
## Summary
- add DOM support and tests for full navigation map setting toggle

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test --reporter=line` *(fails: 4 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688e8c6a67248326ac858b03418d4883