### PR TITLE
Add card of the day setting toggle

### DIFF
--- a/design/productRequirementsDocuments/prdLayoutDebugPanel.md
+++ b/design/productRequirementsDocuments/prdLayoutDebugPanel.md
@@ -1,29 +1,35 @@
 # PRD: Layout Debug Panel
 
 ## Overview
+
 The Layout Debug Panel is a developer-facing feature that visually outlines all visible elements on the page. It is toggled via a switch in the Settings page and is intended to assist with UI layout debugging and accessibility checks during development.
 
 ## Problem Statement
+
 Developers and designers need a quick way to visually inspect the structure and boundaries of all visible elements in the application. Without such a tool, diagnosing layout issues or verifying UI consistency is time-consuming and error-prone.
 
 ## Goals
+
 - Enable developers to toggle a visual outline on all visible elements for layout inspection.
 - Ensure the feature is easily accessible from the Settings page.
 - Do not impact end-user experience when disabled.
 
 ## User Stories
+
 - As a developer, I want to toggle a layout debug mode so that I can see the outlines of all visible elements for easier UI debugging.
 - As a designer, I want to verify that all containers and components are aligned and sized as intended.
 
 ## Prioritized Functional Requirements
-| Priority | Feature                        | Description                                                                 |
-|----------|-------------------------------|-----------------------------------------------------------------------------|
-| P1       | Toggle Layout Debug Panel     | Add a switch in the Settings page to enable/disable the layout debug panel. |
-| P1       | Visual Outlines               | When enabled, all visible elements matching the selector are outlined.      |
-| P2       | Custom Selector Support        | Allow specifying custom selectors for outlining (default: all visible).     |
-| P3       | Remove Outlines on Disable     | All outlines are removed when the panel is disabled.                        |
+
+| Priority | Feature                    | Description                                                                 |
+| -------- | -------------------------- | --------------------------------------------------------------------------- |
+| P1       | Toggle Layout Debug Panel  | Add a switch in the Settings page to enable/disable the layout debug panel. |
+| P1       | Visual Outlines            | When enabled, all visible elements matching the selector are outlined.      |
+| P2       | Custom Selector Support    | Allow specifying custom selectors for outlining (default: all visible).     |
+| P3       | Remove Outlines on Disable | All outlines are removed when the panel is disabled.                        |
 
 ## Acceptance Criteria
+
 - Toggling the switch in Settings immediately adds or removes outlines on all visible elements.
 - Outlines are only visible when the debug panel is enabled.
 - No outlines remain after disabling the panel.
@@ -31,11 +37,13 @@ Developers and designers need a quick way to visually inspect the structure and 
 - (P2) If custom selectors are provided, only those elements are outlined.
 
 ## Non-Functional Requirements
+
 - No performance degradation when toggling the panel on/off.
 - Outlines must be visually distinct and not interfere with element content.
 - Feature is only visible to users with access to the Settings page.
 
 ## Dependencies and Open Questions
+
 - Relies on the Settings page and layoutDebugPanel.js helper.
 - Should this feature be hidden or restricted in production builds?
 - Should keyboard shortcuts be supported for toggling?

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -39,7 +39,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 ## Functional Requirements
 
 | Priority | Feature                             | Description                                                                                            |
-| -------- | ----------------------------------- | ---------------------------------------------------------------------------------------------- |
+| -------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | P1       | Sound Toggle                        | Binary toggle updating `settings.json` live on change.                                                 |
 | P1       | Full Navigation Map Toggle          | Enable or disable the full navigation map via general setting; updates `settings.json` live on change. |
 | P3       | Test Mode Feature Flag              | Enables deterministic battles for automated testing.                                                   |

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -61,6 +61,7 @@ test.describe("Settings page", () => {
       "Motion Effects",
       "Typewriter Effect",
       "Tooltips",
+      "Card of the Day",
       ...sortedNames,
       ...flagLabels
     ];

--- a/src/helpers/settings/applyInitialValues.js
+++ b/src/helpers/settings/applyInitialValues.js
@@ -76,6 +76,16 @@ export function applyInitialControlValues(controls, settings, tooltipMap = {}) {
   const tipsDescEl = document.getElementById("tooltips-desc");
   if (tipsLabel && tipsLabelEl) tipsLabelEl.textContent = tipsLabel;
   if (tipsDesc && tipsDescEl) tipsDescEl.textContent = tipsDesc;
+  applyInputState(controls.cardOfTheDayToggle, settings.showCardOfTheDay);
+  if (controls.cardOfTheDayToggle && settings.tooltipIds?.showCardOfTheDay) {
+    controls.cardOfTheDayToggle.dataset.tooltipId = settings.tooltipIds.showCardOfTheDay;
+  }
+  const cardLabel = tooltipMap["settings.showCardOfTheDay.label"];
+  const cardDesc = tooltipMap["settings.showCardOfTheDay.description"];
+  const cardLabelEl = controls.cardOfTheDayToggle?.closest("label")?.querySelector("span");
+  const cardDescEl = document.getElementById("card-of-the-day-desc");
+  if (cardLabel && cardLabelEl) cardLabelEl.textContent = cardLabel;
+  if (cardDesc && cardDescEl) cardDescEl.textContent = cardDesc;
   applyInputState(controls.fullNavigationMapToggle, settings.fullNavigationMap);
   if (controls.fullNavigationMapToggle && settings.tooltipIds?.fullNavigationMap) {
     controls.fullNavigationMapToggle.dataset.tooltipId = settings.tooltipIds.fullNavigationMap;

--- a/src/helpers/settings/listenerUtils.js
+++ b/src/helpers/settings/listenerUtils.js
@@ -24,6 +24,7 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
     displayRadios,
     typewriterToggle,
     tooltipsToggle,
+    cardOfTheDayToggle,
     fullNavigationMapToggle
   } = controls;
   soundToggle?.addEventListener("change", () => {
@@ -96,6 +97,16 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
       })
     ).then(() => {
       showSnackbar(`Tooltips ${tooltipsToggle.checked ? "enabled" : "disabled"}`);
+    });
+  });
+  cardOfTheDayToggle?.addEventListener("change", () => {
+    const prev = !cardOfTheDayToggle.checked;
+    Promise.resolve(
+      handleUpdate("showCardOfTheDay", cardOfTheDayToggle.checked, () => {
+        cardOfTheDayToggle.checked = prev;
+      })
+    ).then(() => {
+      showSnackbar(`Card of the Day ${cardOfTheDayToggle.checked ? "enabled" : "disabled"}`);
     });
   });
   fullNavigationMapToggle?.addEventListener("change", () => {

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -99,6 +99,7 @@ function initializeControls(settings, gameModes, tooltipMap) {
     displayRadios: document.querySelectorAll('input[name="display-mode"]'),
     typewriterToggle: document.getElementById("typewriter-toggle"),
     tooltipsToggle: document.getElementById("tooltips-toggle"),
+    cardOfTheDayToggle: document.getElementById("card-of-the-day-toggle"),
     fullNavigationMapToggle: document.getElementById("full-navigation-map-toggle")
   };
   const modesContainer = document.getElementById("game-mode-toggle-container");

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -189,6 +189,22 @@
                   </p>
                 </div>
                 <div class="settings-item">
+                  <label for="card-of-the-day-toggle" class="switch">
+                    <input
+                      type="checkbox"
+                      id="card-of-the-day-toggle"
+                      name="cardOfTheDay"
+                      aria-label="Card of the Day"
+                      aria-describedby="card-of-the-day-desc"
+                    />
+                    <div class="slider round"></div>
+                    <span>Card of the Day</span>
+                  </label>
+                  <p id="card-of-the-day-desc" class="settings-description">
+                    Display a rotating featured card on the landing screen.
+                  </p>
+                </div>
+                <div class="settings-item">
                   <label for="full-navigation-map-toggle" class="switch">
                     <input
                       type="checkbox"


### PR DESCRIPTION
## Summary
- add Card of the Day toggle to settings page and wire into settings controls
- initialize and persist Card of the Day preference with tooltips
- update settings Playwright test for the new toggle

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diffs, missing label)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688e9090774c832692605bc864ab019e