### PR TITLE
Test Card of the Day toggle settings

### DIFF
--- a/design/productRequirementsDocuments/prdTestMode.md
+++ b/design/productRequirementsDocuments/prdTestMode.md
@@ -1,33 +1,38 @@
 ## Test Mode PRD
 
 ### Overview
+
 Test Mode is a deterministic mode for JU-DO-KON! that enables predictable, repeatable game behavior for testing and debugging. When enabled, all randomization (e.g., card draws, stat selection) uses a seeded pseudo-random number generator, ensuring the same sequence of outcomes for a given seed. Test Mode is toggled via the Settings page and is visually indicated in the UI.
 
 ### Problem Statement
+
 Developers and testers need a way to reproduce game scenarios reliably, especially for debugging, automated testing, and visual regression checks. Without deterministic behavior, it is difficult to verify that changes do not introduce regressions or to reproduce specific bugs.
 
 ### Goals / Success Metrics
+
 - Enable deterministic, repeatable game sessions for debugging and automated tests
 - Allow toggling Test Mode via the Settings UI
 - Clearly indicate when Test Mode is active
 - Ensure all randomization in supported game modes is controlled by the seeded generator
 
 ### User Stories
+
 - As a developer, I want to enable Test Mode so that I can reproduce the same game flow for debugging.
 - As a QA engineer, I want to run automated tests with predictable outcomes.
 - As a user, I want to know when Test Mode is active so I am not confused by non-random behavior.
 
 ### Prioritized Functional Requirements
 
-| Priority | Feature                        | Description                                                                 |
-|----------|--------------------------------|-----------------------------------------------------------------------------|
-| P1       | Test Mode Toggle in Settings   | Add a switch in the Settings page to enable/disable Test Mode.              |
-| P1       | Deterministic Random Generator | When Test Mode is enabled, all randomization uses a seeded generator.       |
-| P1       | Test Mode Banner               | Display a visible banner or indicator when Test Mode is active.             |
-| P2       | Seed Management                | Allow setting or displaying the current seed value for reproducibility.     |
-| P2       | Storage/Sync                   | Persist Test Mode state in settings and update UI on storage changes.       |
+| Priority | Feature                        | Description                                                             |
+| -------- | ------------------------------ | ----------------------------------------------------------------------- |
+| P1       | Test Mode Toggle in Settings   | Add a switch in the Settings page to enable/disable Test Mode.          |
+| P1       | Deterministic Random Generator | When Test Mode is enabled, all randomization uses a seeded generator.   |
+| P1       | Test Mode Banner               | Display a visible banner or indicator when Test Mode is active.         |
+| P2       | Seed Management                | Allow setting or displaying the current seed value for reproducibility. |
+| P2       | Storage/Sync                   | Persist Test Mode state in settings and update UI on storage changes.   |
 
 ### Acceptance Criteria
+
 - Test Mode can be enabled/disabled via the Settings page toggle.
 - When enabled, all randomization in Classic Battle uses the seeded generator.
 - A visible banner or indicator appears when Test Mode is active.
@@ -36,12 +41,14 @@ Developers and testers need a way to reproduce game scenarios reliably, especial
 - Disabling Test Mode restores normal randomization.
 
 ### Non-Functional Requirements / Design Considerations
+
 - Test Mode must not affect normal gameplay when disabled.
 - Banner/indicator must be accessible and clearly visible.
 - All code must be covered by unit and UI tests.
 - No performance degradation in normal or test mode.
 
 ### Dependencies and Open Questions
+
 - Depends on settings storage and feature flag infrastructure.
 - Relies on all randomization in supported modes being routed through the seeded generator.
 - (Open) UI for setting custom seed value is not yet implemented.

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -253,6 +253,37 @@ describe("settingsPage module", () => {
     expect(showSnackbar).toHaveBeenCalledWith("Full navigation map disabled");
   });
 
+  it("toggling showCardOfTheDay updates setting", async () => {
+    vi.useFakeTimers();
+    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
+    const updated = { ...baseSettings, showCardOfTheDay: true };
+    const updateSetting = vi.fn().mockResolvedValue(updated);
+    const loadNavigationItems = vi.fn().mockResolvedValue([]);
+    const showSnackbar = vi.fn();
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings,
+      updateSetting
+    }));
+    vi.doMock("../../src/helpers/gameModeUtils.js", () => ({
+      loadNavigationItems,
+      loadGameModes: loadNavigationItems,
+      updateNavigationItemHidden: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar }));
+
+    await import("../../src/helpers/settingsPage.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await vi.runAllTimersAsync();
+
+    const input = document.getElementById("card-of-the-day-toggle");
+    expect(input).toBeTruthy();
+    input.checked = true;
+    input.dispatchEvent(new Event("change"));
+    expect(updateSetting).toHaveBeenCalledWith("showCardOfTheDay", true);
+    await vi.runAllTimersAsync();
+    expect(showSnackbar).toHaveBeenCalledWith("Card of the Day enabled");
+  });
+
   it("renders feature flag switches", async () => {
     vi.useFakeTimers();
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -59,6 +59,9 @@ export function createSettingsDom() {
   const tooltipsToggle = document.createElement("input");
   tooltipsToggle.id = "tooltips-toggle";
   tooltipsToggle.type = "checkbox";
+  const cardOfTheDayToggle = document.createElement("input");
+  cardOfTheDayToggle.id = "card-of-the-day-toggle";
+  cardOfTheDayToggle.type = "checkbox";
   const fullNavigationMapToggle = document.createElement("input");
   fullNavigationMapToggle.id = "full-navigation-map-toggle";
   fullNavigationMapToggle.type = "checkbox";
@@ -108,6 +111,7 @@ export function createSettingsDom() {
     motionToggle,
     typewriterToggle,
     tooltipsToggle,
+    cardOfTheDayToggle,
     fullNavigationMapToggle,
     displayLight,
     displayDark,


### PR DESCRIPTION
## Summary
- Format Test Mode PRD for consistent style.
- Add Card of the Day toggle DOM fixture.
- Cover showCardOfTheDay toggle in settings page tests.

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: country filter updates carousel; changelog screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688e93ab48448326b8ff7dd85255e386