### PR TITLE
Filter enabled settings flags

### DIFF
--- a/design/productRequirementsDocuments/prdRandomStatMode.md
+++ b/design/productRequirementsDocuments/prdRandomStatMode.md
@@ -1,32 +1,38 @@
 # PRD: Random Stat Mode
 
 ## Overview (TL;DR)
+
 Random Stat Mode is an optional game mode in JU-DO-KON! where, if the player does not select a stat within a set time limit, the system automatically selects a random stat for the round. This feature adds urgency and unpredictability to matches, and can be toggled via the Settings page.
 
 ## Problem Statement / Why It Matters
+
 Some players may hesitate or be indecisive when choosing a stat, slowing down gameplay. Others may want a faster-paced or more unpredictable experience. Random Stat Mode ensures rounds progress smoothly and adds variety, improving engagement and reducing waiting time.
 
 ## Goals / Success Metrics
+
 - Reduce average round selection time by 30% for players who enable Random Stat Mode
 - Increase match completion rate for casual players
 - Provide a seamless, accessible way to enable/disable the feature
 
 ## User Stories
+
 - As a new player, I want the game to pick a stat for me if I don't decide quickly, so I can keep playing without stress.
 - As a returning player, I want to enable Random Stat Mode for a more dynamic and fast-paced experience.
 - As a player, I want to toggle this feature in Settings so I can control my preferred play style.
 
 ## Prioritized Functional Requirements
-| Priority | Feature                        | Description                                                                                 |
-|----------|-------------------------------|---------------------------------------------------------------------------------------------|
-| P1       | Stat Selection Timer           | Start a countdown timer each round for stat selection.                                      |
-| P1       | Auto-Select Random Stat        | If timer expires, automatically select a random stat for the player.                        |
-| P1       | Settings Toggle                | Allow players to enable/disable Random Stat Mode via the Settings page.                     |
-| P2       | Visual Timer Feedback          | Display remaining time to the player during stat selection.                                 |
-| P2       | Info Message on Auto-Select    | Show a message indicating which stat was auto-selected when time runs out.                  |
-| P3       | Accessibility Compliance       | Ensure timer and auto-select messages are accessible (e.g., ARIA live regions).             |
+
+| Priority | Feature                     | Description                                                                     |
+| -------- | --------------------------- | ------------------------------------------------------------------------------- |
+| P1       | Stat Selection Timer        | Start a countdown timer each round for stat selection.                          |
+| P1       | Auto-Select Random Stat     | If timer expires, automatically select a random stat for the player.            |
+| P1       | Settings Toggle             | Allow players to enable/disable Random Stat Mode via the Settings page.         |
+| P2       | Visual Timer Feedback       | Display remaining time to the player during stat selection.                     |
+| P2       | Info Message on Auto-Select | Show a message indicating which stat was auto-selected when time runs out.      |
+| P3       | Accessibility Compliance    | Ensure timer and auto-select messages are accessible (e.g., ARIA live regions). |
 
 ## Acceptance Criteria
+
 - A visible timer appears during stat selection, counting down from the configured duration (default: 30s).
 - If the player does not select a stat before the timer expires, the system auto-selects a random stat and displays a message (e.g., "Time's up! Auto-selecting technique").
 - The Random Stat Mode can be enabled or disabled via a toggle in the Settings page.
@@ -36,11 +42,13 @@ Some players may hesitate or be indecisive when choosing a stat, slowing down ga
 - If timer configuration fails, a fallback duration is used and a waiting message is shown.
 
 ## Non-Functional Requirements / Design Considerations
+
 - Timer and messages must be accessible (ARIA live, clear contrast, keyboard focus not lost).
 - No significant performance impact on round transitions.
 - Settings toggle persists across sessions (if applicable).
 
 ## Dependencies and Open Questions
+
 - Depends on timer logic in `src/helpers/classicBattle/timerControl.js`.
 - UI elements in `src/pages/battleJudoka.html` and `src/pages/settings.html`.
 - Open: Should timer duration be user-configurable in future?

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -52,7 +52,8 @@ test.describe("Settings page", () => {
 
     const tooltips = JSON.parse(fs.readFileSync("src/data/tooltips.json", "utf8"));
     const flagLabels = Object.keys(DEFAULT_SETTINGS.featureFlags)
-      .map((f) => tooltips.settings?.[f]?.label)
+      .filter((flag) => DEFAULT_SETTINGS.featureFlags[flag].enabled)
+      .map((flag) => tooltips.settings?.[flag]?.label)
       .filter(Boolean);
 
     const expectedLabels = [
@@ -65,6 +66,10 @@ test.describe("Settings page", () => {
       ...sortedNames,
       ...flagLabels
     ];
+
+    const tabStopCount =
+      expectedLabels.length +
+      (Object.keys(DEFAULT_SETTINGS.featureFlags).length - flagLabels.length);
 
     await expect(page.locator("#sound-toggle")).toHaveAttribute("aria-label", "Sound");
     await expect(page.locator("#motion-toggle")).toHaveAttribute("aria-label", "Motion Effects");
@@ -91,7 +96,7 @@ test.describe("Settings page", () => {
     await page.focus("#display-mode-light");
 
     const activeLabels = [];
-    for (let i = 0; i < expectedLabels.length; i++) {
+    for (let i = 0; i < tabStopCount; i++) {
       const label = await page.evaluate(() => {
         const el = document.activeElement;
         if (!el) return "";


### PR DESCRIPTION
## Summary
- Only include labels for feature flags that are enabled in the tab-order test.
- Expand tab traversal to cover disabled flag controls when verifying focus order.
- Format PRD for Random Stat Mode to satisfy repository formatting rules.

## Testing
- `npx prettier playwright/settings.spec.js design/productRequirementsDocuments/prdRandomStatMode.md --check`
- `npx eslint playwright/settings.spec.js`
- `npx vitest run`
- `npx playwright test` (fails: screenshot comparison for Settings screenshots)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688e99715080832694c7ea1681ab3ea4