### PR TITLE
Add status roles to round indicators

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -29,16 +29,16 @@ The round message, timer, and score now sit directly inside the page header rath
 
 ## Functional Requirements
 
-| Priority | Feature                | Description                                                                                                                       |
-| -------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| **P1**   | Match Score Display    | Real-time, fast update of player vs opponent score per round                                                                      |
-| **P1**   | Round Status Messaging | Show clear win/loss messages post-round                                                                                           |
-| **P1**   | Stat Selection Timer   | Display 30s countdown for stat selection; auto-select if expired; timer pauses/resumes on tab inactivity (see Classic Battle PRD) |
-| **P2**   | Countdown Timer        | Display countdown to next round with fallback for server sync                                                                     |
-| **P2**   | User Action Prompt     | Prompt player for input and hide after interaction                                                                                |
-| **P3**   | Responsive Layout      | Adapt layout for small screens and collapse content as needed                                                                     |
-| **P3**   | Accessibility Features | Ensure text contrast, screen reader compatibility, minimum touch target size, and keyboard navigation (see Classic Battle PRD)    |
-| **P2**   | Edge Case Handling     | Fallback messages for backend sync failure and display issues                                                                     |
+| Priority | Feature                | Description                                                                                                                                                                 |
+| -------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **P1**   | Match Score Display    | Real-time, fast update of player vs opponent score per round                                                                                                                |
+| **P1**   | Round Status Messaging | Show clear win/loss messages post-round                                                                                                                                     |
+| **P1**   | Stat Selection Timer   | Display 30s countdown for stat selection; auto-select if expired; timer pauses/resumes on tab inactivity (see Classic Battle PRD)                                           |
+| **P2**   | Countdown Timer        | Display countdown to next round with fallback for server sync                                                                                                               |
+| **P2**   | User Action Prompt     | Prompt player for input and hide after interaction                                                                                                                          |
+| **P3**   | Responsive Layout      | Adapt layout for small screens and collapse content as needed                                                                                                               |
+| **P3**   | Accessibility Features | Ensure text contrast, screen reader compatibility (via `role="status"` on messages and timers), minimum touch target size, and keyboard navigation (see Classic Battle PRD) |
+| **P2**   | Edge Case Handling     | Fallback messages for backend sync failure and display issues                                                                                                               |
 
 ---
 
@@ -50,7 +50,7 @@ The round message, timer, and score now sit directly inside the page header rath
 - Action prompt appears during user input phases and disappears after interaction. <!-- Implemented: see showMessage and stat selection logic -->
 - **Stat selection timer (30s) is displayed during stat selection phase; if timer expires, a random stat is auto-selected. Timer pauses/resumes on tab inactivity.** <!-- Implemented: see startRound in battleEngine.js -->
 - Top bar content adapts responsively to different screen sizes and orientations. <!-- Partially implemented: stacking/truncation CSS present, but some edge cases pending -->
-- All messages meet minimum contrast ratio of **4.5:1** and are screen reader compatible. Run `npm run check:contrast` to audit these colors. <!-- Contrast via CSS variables; screen reader labels not yet implemented -->
+- All messages meet minimum contrast ratio of **4.5:1** and are screen reader compatible. Run `npm run check:contrast` to audit these colors. <!-- Contrast via CSS variables; screen reader labels implemented with `role="status"` -->
 - **All interactive elements meet minimum touch target size (≥44px) and support keyboard navigation.** <!-- Implemented: see CSS min-width/min-height and stat button logic -->
 
 ---
@@ -77,14 +77,14 @@ The round message, timer, and score now sit directly inside the page header rath
   - Stacked layout on narrow screens (<375px width). <!-- Implemented: see battle.css @media (max-width: 374px) -->
 - **Accessibility**
   - All text meets **WCAG 2.1 AA** standards. <!-- Contrast: mostly via CSS, but not programmatically checked -->
-  - Screen reader labels for dynamic messages. <!-- Not yet implemented: aria-live and labels missing in InfoBar.js markup -->
+  - Screen reader labels for dynamic messages using `aria-live="polite"` and `role="status"`.
 
 ---
 
 **Implementation status summary:**
 
 - **Score, round messages, timers, stat selection auto-select, pause/resume, and fallback "Waiting..." logic are implemented as described.**
-- **Responsive stacking/truncation and minimum touch target size are implemented in CSS, but some edge cases and accessibility (screen reader labels, explicit contrast checks) are not yet fully implemented.**
+- **Responsive stacking/truncation and minimum touch target size are implemented in CSS, but some edge cases and explicit contrast checks are not yet fully implemented.**
 - **See InfoBar.js, battleEngine.js, battleUI.js, and battle.css for current logic.**
 
 ---
@@ -114,7 +114,7 @@ The round message, timer, and score now sit directly inside the page header rath
 - [ ] 4.0 Implement Accessibility Features
 
   - [ ] 4.1 Ensure text contrast meets 4.5:1 ratio. Verify with `npm run check:contrast`.
-  - [ ] 4.2 Add screen reader labels for dynamic messages (aria-live, etc. not yet implemented)
+  - [x] 4.2 Add screen reader labels for dynamic messages (`aria-live="polite"` and `role="status"`)
   - [x] 4.3 Ensure all interactive elements have minimum 44px touch targets (CSS min-width/min-height present)
   - [ ] 4.4 Ensure all interactive elements support keyboard navigation (stat buttons: basic support, but needs explicit review/test)
 

--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -3,9 +3,9 @@
  *
  * @pseudocode
  * 1. Create three `<p>` elements:
- *    - `#round-message` with `aria-live="polite"` for result text.
- *    - `#next-round-timer` with `aria-live="polite"` for countdown updates.
- *    - `#score-display` with `aria-live="off"` for the match score.
+ *    - `#round-message` with `aria-live="polite"`, `aria-atomic="true"`, and `role="status"` for result text.
+ *    - `#next-round-timer` with `aria-live="polite"`, `aria-atomic="true"`, and `role="status"` for countdown updates.
+ *    - `#score-display` with `aria-live="off"` and `aria-atomic="true"` for the match score.
  * 2. Append them to the provided container (typically the page header).
  * 3. Store references to these elements for later updates.
  * 4. Return the container element.
@@ -21,14 +21,19 @@ export function createInfoBar(container = document.createElement("div")) {
   messageEl = document.createElement("p");
   messageEl.id = "round-message";
   messageEl.setAttribute("aria-live", "polite");
+  messageEl.setAttribute("aria-atomic", "true");
+  messageEl.setAttribute("role", "status");
 
   timerEl = document.createElement("p");
   timerEl.id = "next-round-timer";
   timerEl.setAttribute("aria-live", "polite");
+  timerEl.setAttribute("aria-atomic", "true");
+  timerEl.setAttribute("role", "status");
 
   scoreEl = document.createElement("p");
   scoreEl.id = "score-display";
   scoreEl.setAttribute("aria-live", "off");
+  scoreEl.setAttribute("aria-atomic", "true");
 
   container.append(messageEl, timerEl, scoreEl);
   return container;

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -30,8 +30,8 @@
     <div class="home-screen">
       <header class="header battle-header" role="banner">
         <div class="info-left" id="info-bar-left">
-          <p id="round-message" aria-live="polite" aria-atomic="true"></p>
-          <p id="next-round-timer" aria-live="polite" aria-atomic="true"></p>
+          <p id="round-message" aria-live="polite" aria-atomic="true" role="status"></p>
+          <p id="next-round-timer" aria-live="polite" aria-atomic="true" role="status"></p>
         </div>
         <div class="logo-container">
           <a href="../../index.html" data-testid="home-link" aria-label="Return to home">

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -22,8 +22,13 @@ describe("InfoBar component", () => {
     const timer = header.querySelector("#next-round-timer");
     const score = header.querySelector("#score-display");
     expect(msg).toHaveAttribute("aria-live", "polite");
+    expect(msg).toHaveAttribute("role", "status");
+    expect(msg).toHaveAttribute("aria-atomic", "true");
     expect(timer).toHaveAttribute("aria-live", "polite");
+    expect(timer).toHaveAttribute("role", "status");
+    expect(timer).toHaveAttribute("aria-atomic", "true");
     expect(score).toHaveAttribute("aria-live", "off");
+    expect(score).toHaveAttribute("aria-atomic", "true");
   });
 
   it("updates message and score", () => {

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -8,9 +8,9 @@ const gokyoFixture = JSON.parse(readFileSync(path.join(__dirname, "../fixtures/g
 export function createInfoBarHeader() {
   const header = document.createElement("header");
   header.innerHTML = `
-    <p id="round-message"></p>
-    <p id="next-round-timer"></p>
-    <p id="score-display"></p>
+    <p id="round-message" aria-live="polite" aria-atomic="true" role="status"></p>
+    <p id="next-round-timer" aria-live="polite" aria-atomic="true" role="status"></p>
+    <p id="score-display" aria-live="off" aria-atomic="true"></p>
   `;
   return header;
 }
@@ -18,9 +18,9 @@ export function createInfoBarHeader() {
 export function createBattleHeader() {
   const header = document.createElement("header");
   header.innerHTML = `
-    <p id="round-message"></p>
-    <p id="next-round-timer"></p>
-    <p id="score-display"></p>
+    <p id="round-message" aria-live="polite" aria-atomic="true" role="status"></p>
+    <p id="next-round-timer" aria-live="polite" aria-atomic="true" role="status"></p>
+    <p id="score-display" aria-live="off" aria-atomic="true"></p>
   `;
   return header;
 }


### PR DESCRIPTION
## Summary
- ensure round message and countdown timer have `role="status"`
- set matching accessibility attributes when the Info Bar is generated dynamically
- document screen reader requirements in the Battle Info Bar PRD

## Testing
- `npx prettier . --check` *(fails: Code style issues found in design/productRequirementsDocuments/prdDrawRandomCard.md, prdResetNavigation.md)*
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688e9d3c3ca48326af66749c6ea8548d