### PR TITLE
Disable country panel motion for reduced motion settings

### DIFF
--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -233,12 +233,16 @@
 
 /* Reduce motion for the country panel */
 @media (prefers-reduced-motion: reduce) {
+  .country-panel,
+  .country-panel.open,
   .country-panel[hidden],
   .country-panel.grid {
     transition: none;
   }
 }
 
+.reduce-motion .country-panel,
+.reduce-motion .country-panel.open,
 .reduce-motion .country-panel[hidden],
 .reduce-motion .country-panel.grid {
   transition: none;


### PR DESCRIPTION
## Summary
- stop country panel transitions when reduced motion is requested or `.reduce-motion` is set

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed to parse URL from countryCodeMapping.json, fetch errors)*
- `npx playwright test` *(some tests interrupted: settings screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f0f60ffa883268cd2441df0543eba