### PR TITLE
Warn on unbalanced tooltip markup

### DIFF
--- a/src/helpers/tooltipViewerPage.js
+++ b/src/helpers/tooltipViewerPage.js
@@ -14,7 +14,8 @@ const INVALID_TOOLTIP_MSG = "Empty or whitespace-only content";
  * 2. Render a clickable list of keys filtered by the search box (300ms debounce),
  *    tagging items with a class based on their prefix (e.g. `stat`, `ui`) and
  *    flagging empty bodies with a warning icon.
- * 3. When a key is selected, display its parsed HTML and raw text in the preview.
+ * 3. When a key is selected, display its parsed HTML and raw text in the preview,
+ *    and show a warning when the markup is unbalanced.
  * 4. Provide copy buttons for the key and body using `navigator.clipboard`.
  * 5. On page load, select the key from the URL hash when present and scroll to it.
  * 6. Call `initTooltips()` so help icons inside the page gain tooltips.
@@ -24,6 +25,7 @@ export async function setupTooltipViewerPage() {
   let listPlaceholder = document.getElementById("tooltip-list");
   const previewEl = document.getElementById("tooltip-preview");
   const rawEl = document.getElementById("tooltip-raw");
+  const warningEl = document.getElementById("tooltip-warning");
   const keyCopyBtn = document.getElementById("copy-key-btn");
   const bodyCopyBtn = document.getElementById("copy-body-btn");
 
@@ -86,8 +88,16 @@ export async function setupTooltipViewerPage() {
       const index = Array.from(listPlaceholder.children).findIndex((el) => el.dataset.key === key);
       if (index !== -1) listSelect(index);
     }
-    previewEl.innerHTML = parseTooltipText(body);
+    const { html, warning } = parseTooltipText(body);
+    previewEl.innerHTML = html;
     rawEl.textContent = body;
+    if (warning) {
+      warningEl.textContent = "Unbalanced markup detected";
+      warningEl.hidden = false;
+    } else {
+      warningEl.textContent = "";
+      warningEl.hidden = true;
+    }
     keyCopyBtn.dataset.copy = key;
     bodyCopyBtn.dataset.copy = body;
     previewEl.classList.remove("fade-in");

--- a/src/pages/tooltipViewer.html
+++ b/src/pages/tooltipViewer.html
@@ -48,6 +48,7 @@
             </button>
           </div>
           <div id="tooltip-preview" class="preview-body"></div>
+          <div id="tooltip-warning" class="preview-warning" hidden></div>
           <pre id="tooltip-raw" class="raw-body"></pre>
         </section>
       </main>

--- a/src/styles/tooltipViewer.css
+++ b/src/styles/tooltipViewer.css
@@ -27,6 +27,11 @@
   margin-bottom: var(--space-sm);
 }
 
+.preview-warning {
+  color: #c62828;
+  margin-top: var(--space-sm);
+}
+
 .fade-in {
   animation: fadeIn 0.1s ease-in;
 }

--- a/tests/helpers/parseTooltipText.test.js
+++ b/tests/helpers/parseTooltipText.test.js
@@ -4,17 +4,24 @@ import { parseTooltipText } from "../../src/helpers/tooltip.js";
 
 describe("parseTooltipText", () => {
   it("parses bold, italic and newlines", () => {
-    const result = parseTooltipText("**Bold**\n_italic_");
-    expect(result).toBe("<strong>Bold</strong><br><em>italic</em>");
+    const { html, warning } = parseTooltipText("**Bold**\n_italic_");
+    expect(html).toBe("<strong>Bold</strong><br><em>italic</em>");
+    expect(warning).toBe(false);
   });
 
   it("escapes HTML before parsing", () => {
-    const result = parseTooltipText("<span>test</span> **ok**");
-    expect(result).toBe("&lt;span&gt;test&lt;/span&gt; <strong>ok</strong>");
+    const { html, warning } = parseTooltipText("<span>test</span> **ok**");
+    expect(html).toBe("&lt;span&gt;test&lt;/span&gt; <strong>ok</strong>");
+    expect(warning).toBe(false);
   });
 
   it("handles empty and null input", () => {
-    expect(parseTooltipText("")).toBe("");
-    expect(parseTooltipText(null)).toBe("");
+    expect(parseTooltipText("")).toEqual({ html: "", warning: false });
+    expect(parseTooltipText(null)).toEqual({ html: "", warning: false });
+  });
+
+  it("flags unbalanced markup", () => {
+    const { warning } = parseTooltipText("**Bold");
+    expect(warning).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Detect unmatched bold/italic markers in tooltips and log a warning when markup is unbalanced
- Display unbalanced markup warnings in tooltip viewer alongside preview content
- Add tooltip viewer warning styles and unit tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f0fd3f08c8326aa627b90c9464d3f