### PR TITLE
Add expandable preview for tooltip viewer

### DIFF
--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -146,7 +146,7 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
   - [x] 2.1 Integrate `marked` library for parsing markdown
   - [x] 2.2 Apply consistent styles to headings, tables, lists, code blocks
-  - [x] 2.3 Benchmark and optimize rendering to complete quickly on devices 
+  - [x] 2.3 Benchmark and optimize rendering to complete quickly on devices
 
 - [x] 3.0 Build Navigation System
 

--- a/src/styles/tooltipViewer.css
+++ b/src/styles/tooltipViewer.css
@@ -27,6 +27,19 @@
   margin-bottom: var(--space-sm);
 }
 
+.preview-container {
+  max-height: 300px;
+  overflow: hidden;
+}
+
+.preview-container.expanded {
+  max-height: none;
+}
+
+.preview-toggle {
+  margin-top: var(--space-sm);
+}
+
 .preview-warning {
   color: #c62828;
   margin-top: var(--space-sm);

--- a/tests/helpers/tooltipViewerPage.test.js
+++ b/tests/helpers/tooltipViewerPage.test.js
@@ -90,4 +90,33 @@ describe("setupTooltipViewerPage", () => {
     expect(warnEl.hidden).toBe(false);
     expect(warnEl.textContent).toBe("Unbalanced markup detected");
   });
+
+  it("toggles preview expansion for long content", async () => {
+    Object.defineProperty(document, "readyState", { value: "loading", configurable: true });
+
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ tip: "long" }),
+      importJsonModule: vi.fn().mockResolvedValue({})
+    }));
+
+    await import("../../src/helpers/tooltipViewerPage.js");
+
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+
+    await Promise.resolve();
+
+    const preview = document.getElementById("tooltip-preview");
+    Object.defineProperty(preview, "scrollHeight", { value: 400, configurable: true });
+
+    const item = document.querySelector("#tooltip-list li");
+    item.click();
+
+    const toggle = document.getElementById("toggle-preview-btn");
+    const container = preview.parentElement;
+    expect(toggle.hidden).toBe(false);
+    expect(container.classList.contains("expanded")).toBe(false);
+    toggle.click();
+    expect(container.classList.contains("expanded")).toBe(true);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+  });
 });


### PR DESCRIPTION
## Summary
- limit tooltip preview height to 300px and allow expansion via toggle button
- style preview container and toggle
- test expanding/collapsing long tooltips

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f168feb608326944c03eb1d52a5ba