### PR TITLE
Handle empty country list

### DIFF
--- a/src/helpers/country/list.js
+++ b/src/helpers/country/list.js
@@ -9,10 +9,11 @@ const SCROLL_THRESHOLD_PX = 50;
  * @pseudocode
  * 1. Fetch `judoka.json` to determine which countries appear in the deck.
  * 2. Load the country code mapping and build a sorted list of active entries.
- * 3. Determine batch size based on network conditions.
- * 4. Render an "All" button followed by batches of country buttons with lazily loaded flags.
- * 5. Use `IntersectionObserver` and `loading="lazy"` to defer flag requests until visible.
- * 6. Log errors if data fails to load or individual flags cannot be retrieved.
+ * 3. If no active countries exist, show a message and exit.
+ * 4. Determine batch size based on network conditions.
+ * 5. Render an "All" button followed by batches of country buttons with lazily loaded flags.
+ * 6. Use `IntersectionObserver` and `loading="lazy"` to defer flag requests until visible.
+ * 7. Log errors if data fails to load or individual flags cannot be retrieved.
  *
  * @param {HTMLElement} container - Element where buttons will be appended.
  * @returns {Promise<void>} Resolves when the list is populated.
@@ -32,6 +33,13 @@ export async function populateCountryList(container) {
       .map((name) => countryData.find((entry) => entry.country === name && entry.active))
       .filter(Boolean)
       .sort((a, b) => a.country.localeCompare(b.country));
+
+    if (activeCountries.length === 0) {
+      const message = document.createElement("p");
+      message.textContent = "No countries available.";
+      container.replaceChildren(message);
+      return;
+    }
 
     const allButton = document.createElement("button");
     allButton.className = "flag-button slide";

--- a/tests/helpers/populateCountryList.test.js
+++ b/tests/helpers/populateCountryList.test.js
@@ -148,7 +148,7 @@ describe("populateCountryList", () => {
     expect(names).toEqual(["All", "Japan"]);
   });
 
-  it("renders 'All' even if no countries are found", async () => {
+  it("shows a message if no countries are found", async () => {
     global.fetch = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => [] })
@@ -156,8 +156,7 @@ describe("populateCountryList", () => {
     const { populateCountryList } = await import("../../src/helpers/country/index.js");
     const container = document.createElement("div");
     await populateCountryList(container);
-    const slides = container.querySelectorAll(".slide");
-    expect(slides.length).toBe(1);
-    expect(slides[0].querySelector("p").textContent).toBe("All");
+    expect(container.textContent).toBe("No countries available.");
+    expect(container.querySelectorAll(".slide").length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- show placeholder message if no country data
- add unit test for empty country list

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f23a4de588326a2f0720e5f86e754