### PR TITLE
Resync battle timer on drift

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -73,6 +73,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Classic Battle logic must reuse shared random card draw module (`generateRandomCard`).
 - Card reveal and result animations should use hardware-accelerated CSS for smooth performance on low-end devices (**≥60 fps**).
 - **Stat selection timer (30s) must be displayed in the Info Bar; if timer expires, a random stat is auto-selected. Timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see prdBattleInfoBar.md).**
+- Detect timer drift by comparing engine state with real time; if drift exceeds 2s, display "Waiting…" and restart the countdown.
 - Backend must send real-time stat updates via WebSocket or polling for smooth live updates (**<200 ms latency**).
 - The debug panel is available when the `battleDebugPanel` feature flag is enabled and appears beside the opponent's card.
 

--- a/src/helpers/classicBattle/timerControl.js
+++ b/src/helpers/classicBattle/timerControl.js
@@ -65,6 +65,13 @@ export async function startTimer(onExpiredSelect) {
       const elapsed = Math.floor((Date.now() - startTime) / 1000);
       const expected = duration - elapsed;
       if (Math.abs(remaining - expected) > DRIFT_THRESHOLD) {
+        driftRetries += 1;
+        if (driftRetries > MAX_DRIFT_RETRIES) {
+          clearInterval(driftInterval);
+          infoBar.showMessage("Timer error. Auto-selecting stat.");
+          onExpired();
+          return;
+        }
         infoBar.showMessage("Waiting…");
         runTimer(remaining);
       }

--- a/src/helpers/classicBattle/timerControl.js
+++ b/src/helpers/classicBattle/timerControl.js
@@ -1,6 +1,11 @@
 import { seededRandom } from "../testModeUtils.js";
 import { getDefaultTimer } from "../timerUtils.js";
-import { startRound as engineStartRound, startCoolDown, STATS } from "../battleEngine.js";
+import {
+  startRound as engineStartRound,
+  startCoolDown,
+  STATS,
+  getTimerState
+} from "../battleEngine.js";
 import * as infoBar from "../setupBattleInfoBar.js";
 import { enableNextRoundButton, disableNextRoundButton, updateDebugPanel } from "./uiHelpers.js";
 
@@ -11,7 +16,8 @@ import { enableNextRoundButton, disableNextRoundButton, updateDebugPanel } from 
  * 1. Determine timer duration using `getDefaultTimer('roundTimer')`.
  *    - On error, show "Waiting…" and fallback to 30 seconds.
  * 2. Call `engineStartRound` to update the countdown each second.
- * 3. When expired, auto-select a random stat via `onExpired`.
+ * 3. Compare real elapsed time with `getTimerState()` and restart the timer on drift.
+ * 4. When expired, auto-select a random stat via `onExpired`.
  *
  * @param {function(string): void} onExpiredSelect - Callback to handle stat auto-selection.
  * @returns {Promise<void>} Resolves when the timer begins.
@@ -33,17 +39,39 @@ export async function startTimer(onExpiredSelect) {
   if (!synced) {
     infoBar.showMessage("Waiting…");
   }
-  engineStartRound(
-    (remaining) => {
-      if (timerEl) timerEl.textContent = `Time Left: ${remaining}s`;
-    },
-    () => {
-      const randomStat = STATS[Math.floor(seededRandom() * STATS.length)];
-      infoBar.showMessage(`Time's up! Auto-selecting ${randomStat}`);
-      onExpiredSelect(randomStat);
-    },
-    duration
-  );
+
+  const onTick = (remaining) => {
+    if (timerEl) timerEl.textContent = `Time Left: ${remaining}s`;
+  };
+
+  const onExpired = () => {
+    clearInterval(driftInterval);
+    const randomStat = STATS[Math.floor(seededRandom() * STATS.length)];
+    infoBar.showMessage(`Time's up! Auto-selecting ${randomStat}`);
+    onExpiredSelect(randomStat);
+  };
+
+  const DRIFT_THRESHOLD = 2;
+  let driftInterval;
+  let startTime = Date.now();
+
+  const runTimer = (dur) => {
+    startTime = Date.now();
+    duration = dur;
+    engineStartRound(onTick, onExpired, dur);
+    clearInterval(driftInterval);
+    driftInterval = setInterval(() => {
+      const { remaining } = getTimerState();
+      const elapsed = Math.floor((Date.now() - startTime) / 1000);
+      const expected = duration - elapsed;
+      if (Math.abs(remaining - expected) > DRIFT_THRESHOLD) {
+        infoBar.showMessage("Waiting…");
+        runTimer(remaining);
+      }
+    }, 1000);
+  };
+
+  runTimer(duration);
 }
 
 /**

--- a/tests/helpers/classicBattle/syncFailures.test.js
+++ b/tests/helpers/classicBattle/syncFailures.test.js
@@ -23,6 +23,30 @@ describe("classicBattle backend sync failures", () => {
     expect(showMessage).toHaveBeenCalledWith("Waiting…");
   });
 
+  it("restarts timer when drift exceeds threshold", async () => {
+    document.body.innerHTML = '<p id="next-round-timer"></p>';
+    vi.useFakeTimers();
+    const showMessage = vi.fn();
+    const startRound = vi.fn();
+    const getTimerState = vi.fn().mockReturnValue({ remaining: 30, paused: false });
+    vi.doMock("../../../src/helpers/setupBattleInfoBar.js", () => ({ showMessage }));
+    vi.doMock("../../../src/helpers/timerUtils.js", () => ({
+      getDefaultTimer: vi.fn().mockResolvedValue(30)
+    }));
+    vi.doMock("../../../src/helpers/battleEngine.js", () => ({
+      startRound,
+      startCoolDown: vi.fn(),
+      STATS: ["power"],
+      getTimerState
+    }));
+    const { startTimer } = await import("../../../src/helpers/classicBattle/timerControl.js");
+    await startTimer(() => {});
+    vi.advanceTimersByTime(5000);
+    expect(showMessage).toHaveBeenCalledWith("Waiting…");
+    expect(startRound).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
   it("shows waiting message when score sync fails", async () => {
     const showMessage = vi.fn();
     const updateScore = vi.fn();


### PR DESCRIPTION
## Summary
- detect battle timer drift and resync via `startRound`
- document timer drift handling in Classic Battle PRD
- test timer restart when drift exceeds threshold

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f23699010832698d59401c64d44be