### PR TITLE
Add touch-target feedback for PRD viewer sidebar

### DIFF
--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -89,8 +89,8 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 - The viewer must use the site’s base styles and support high-contrast mode for accessibility. **(Implemented)**
 - All navigation controls must be operable via keyboard with clear focus states. **(Implemented; verified with keyboard navigation and screen reader audit)**
 - The viewer must not expose internal file paths or repository URLs to end users. **(Implemented)**
-- Smooth transitions and interaction feedback (button press states, swipe animations) should be implemented. **(Fade-in animation implemented; button press states not present)**
-- Minimum tap/click target size of 44x44 pixels for all interactive elements. **(Sidebar items are large; no explicit check for all elements)**
+- Smooth transitions and interaction feedback (hover and active states, swipe animations) should be implemented. **(Fade-in animation and sidebar hover/active feedback implemented)**
+- Minimum tap/click target size of 44x44 pixels for all interactive elements with adequate padding. **(Implemented for sidebar items; full audit pending)**
 - Provide wireframes and mockups to visualize layout, navigation flow, and error states. (See attached visual reference.) **(Not present in code)**
 
 ---

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -25,9 +25,23 @@
 }
 
 .sidebar-list li {
-  padding: var(--space-xs) var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  min-height: var(--touch-target-size, 44px);
   cursor: pointer;
   border-left: 4px solid transparent;
+  display: flex;
+  align-items: center;
+}
+
+.sidebar-list li:hover:not(.selected),
+.sidebar-list li:active:not(.selected) {
+  background: var(--color-secondary);
+  color: var(--color-text-inverted);
+}
+
+[data-theme="dark"] .sidebar-list li:hover:not(.selected),
+[data-theme="dark"] .sidebar-list li:active:not(.selected) {
+  background: var(--link-color);
 }
 
 /* Highlight the item currently focused via keyboard */


### PR DESCRIPTION
## Summary
- add hover and active styles to PRD viewer sidebar items
- enforce 44px minimum touch targets
- document interaction feedback requirements in PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f3955f85c832695b6f92e2170ea1a