### PR TITLE
Add Playwright check for narrow viewport status ARIA attributes

### DIFF
--- a/playwright/battleJudoka.spec.js
+++ b/playwright/battleJudoka.spec.js
@@ -21,4 +21,24 @@ test.describe("Battle Judoka page", () => {
     await page.getByTestId(NAV_CLASSIC_BATTLE).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
+
+  test("narrow viewport screenshot and status aria attributes", async ({ page }) => {
+    await page.setViewportSize({ width: 280, height: 800 });
+
+    const axTree = await page.accessibility.snapshot({ interestingOnly: false });
+
+    const collectStatusNodes = (node) => {
+      if (!node) return [];
+      const matches = node.role === "status" ? [node] : [];
+      return node.children ? matches.concat(node.children.flatMap(collectStatusNodes)) : matches;
+    };
+
+    const statusNodes = collectStatusNodes(axTree);
+    expect(statusNodes.length).toBeGreaterThan(0);
+
+    const ariaLiveCount = await page.locator('[role="status"][aria-live]').count();
+    expect(ariaLiveCount).toBeGreaterThan(0);
+
+    await expect(page).toHaveScreenshot("battleJudoka-narrow.png");
+  });
 });


### PR DESCRIPTION
## Summary
- add Playwright test that narrows viewport, checks aria-live and status roles via accessibility snapshot, and captures a screenshot for regressions

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test --update-snapshots`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f40edb1708326ab41a28ad1783cdf