### PR TITLE
Improve PRD reader accessibility

### DIFF
--- a/design/productRequirementsDocuments/prdCountryPickerFilter.md
+++ b/design/productRequirementsDocuments/prdCountryPickerFilter.md
@@ -90,7 +90,7 @@ On in-scope screens (e.g., the Browse Judoka screen), there should be an option 
 | Priority | Feature                         | Description                                                                                                         |
 | -------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | **P1**   | Country selector toggle         | Allow users to toggle the country selector panel via a panel icon with an arrow and filter judoka cards by country. |
-| **P1**   | Filtering and responsive time   | Ensure filtering is completed quickly for 90% of sessions.                                                  |
+| **P1**   | Filtering and responsive time   | Ensure filtering is completed quickly for 90% of sessions.                                                          |
 | **P2**   | Three display modes             | Provide hidden, slide-in (default), and full-screen grid views for the selector.                                    |
 | **P2**   | Clear filter icon               | Provide an easy way to remove the current country filter.                                                           |
 | **P2**   | Accessibility compliance        | Ensure alt-text, aria-labels, color contrast, keyboard navigation, and touch target size are all accessible.        |

--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -191,4 +191,5 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 
 - Screen reader announces the sidebar as "PRD list" and the footer as "Footer navigation".
 - Keyboard focus order: logo link → sidebar items → footer links.
+- After navigating, focus moves to the document content and the active sidebar item sets `aria-current="page"` for assistive technologies.
 - `pa11y` scan of `src/pages/prdViewer.html` reported no accessibility issues.

--- a/src/components/SidebarList.js
+++ b/src/components/SidebarList.js
@@ -64,7 +64,13 @@ export function createSidebarList(items, onSelect = () => {}) {
   function select(index) {
     current = ((index % elements.length) + elements.length) % elements.length;
     elements.forEach((el, idx) => {
-      el.classList.toggle("selected", idx === current);
+      const isCurrent = idx === current;
+      el.classList.toggle("selected", isCurrent);
+      if (isCurrent) {
+        el.setAttribute("aria-current", "page");
+      } else {
+        el.removeAttribute("aria-current");
+      }
     });
     elements[current].focus();
     onSelect(current, elements[current]);

--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -116,6 +116,7 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
     index = (i + documents.length) % documents.length;
     if (!skipList) listSelect(index);
     renderDoc(index);
+    container.focus();
     if (updateHistory) {
       const url = new URL(window.location);
       url.searchParams.set("doc", baseNames[index]);

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -31,7 +31,7 @@
           <ul id="prd-list" class="sidebar-list"></ul>
         </aside>
         <section class="preview">
-          <div id="prd-content"></div>
+          <div id="prd-content" tabindex="-1"></div>
           <div class="loading-spinner" id="prd-spinner" aria-hidden="true"></div>
         </section>
       </main>

--- a/tests/components/SidebarList.test.js
+++ b/tests/components/SidebarList.test.js
@@ -17,11 +17,14 @@ describe("createSidebarList", () => {
     const items = element.querySelectorAll("li");
     select(1);
     expect(items[1].classList.contains("selected")).toBe(true);
+    expect(items[1].getAttribute("aria-current")).toBe("page");
     expect(cb).toHaveBeenCalledWith(1, items[1]);
     select(-1);
     expect(items[1].classList.contains("selected")).toBe(true);
+    expect(items[1].getAttribute("aria-current")).toBe("page");
     select(0);
     expect(items[0].classList.contains("selected")).toBe(true);
+    expect(items[0].getAttribute("aria-current")).toBe("page");
   });
 
   it("handles arrow key navigation and focus", () => {
@@ -32,14 +35,17 @@ describe("createSidebarList", () => {
     items[0].focus();
     items[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
     expect(items[0].classList.contains("selected")).toBe(true);
+    expect(items[0].getAttribute("aria-current")).toBe("page");
     expect(document.activeElement).toBe(items[0]);
 
     items[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
     expect(items[1].classList.contains("selected")).toBe(true);
+    expect(items[1].getAttribute("aria-current")).toBe("page");
     expect(document.activeElement).toBe(items[1]);
 
     items[1].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
     expect(items[0].classList.contains("selected")).toBe(true);
+    expect(items[0].getAttribute("aria-current")).toBe("page");
     expect(document.activeElement).toBe(items[0]);
   });
 });

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -15,7 +15,7 @@ describe("prdReaderPage", () => {
       <div id="prd-title"></div>
       <div id="task-summary"></div>
       <ul id="prd-list"></ul>
-      <div id="prd-content"></div>
+      <div id="prd-content" tabindex="-1"></div>
       <button data-nav="prev">Prev</button>
       <button data-nav="next">Next</button>
       <button data-nav="prev">Prev bottom</button>
@@ -35,18 +35,22 @@ describe("prdReaderPage", () => {
 
     expect(container.innerHTML).toContain("First doc");
     expect(list.children[0].classList.contains("selected")).toBe(true);
+    expect(list.children[0].getAttribute("aria-current")).toBe("page");
     expect(titleEl.textContent).toBe("First doc");
     nextBtns[0].click();
     expect(container.innerHTML).toContain("Second doc");
     expect(list.children[1].classList.contains("selected")).toBe(true);
+    expect(list.children[1].getAttribute("aria-current")).toBe("page");
     expect(titleEl.textContent).toBe("Second doc");
     nextBtns[1].click();
     expect(container.innerHTML).toContain("First doc");
     expect(list.children[0].classList.contains("selected")).toBe(true);
+    expect(list.children[0].getAttribute("aria-current")).toBe("page");
     expect(titleEl.textContent).toBe("First doc");
     prevBtns[1].click();
     expect(container.innerHTML).toContain("Second doc");
     expect(list.children[1].classList.contains("selected")).toBe(true);
+    expect(list.children[1].getAttribute("aria-current")).toBe("page");
     expect(titleEl.textContent).toBe("Second doc");
   });
 
@@ -61,7 +65,7 @@ describe("prdReaderPage", () => {
       <div id="prd-title"></div>
       <div id="task-summary"></div>
       <ul id="prd-list"></ul>
-      <div id="prd-content"></div>
+      <div id="prd-content" tabindex="-1"></div>
       <button data-nav="prev">Prev</button>
       <button data-nav="next">Next</button>
     `;
@@ -80,10 +84,12 @@ describe("prdReaderPage", () => {
     items[1].click();
     expect(container.innerHTML).toContain("Two");
     expect(titleEl.textContent).toBe("Two");
+    expect(items[1].getAttribute("aria-current")).toBe("page");
     items[0].dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
     expect(container.innerHTML).toContain("One");
     expect(titleEl.textContent).toBe("One");
     expect(items[0].classList.contains("selected")).toBe(true);
+    expect(items[0].getAttribute("aria-current")).toBe("page");
   });
 
   it("updates #prd-content when a list item is clicked", async () => {
@@ -97,7 +103,7 @@ describe("prdReaderPage", () => {
       <div id="prd-title"></div>
       <div id="task-summary"></div>
       <ul id="prd-list"></ul>
-      <div id="prd-content"></div>
+      <div id="prd-content" tabindex="-1"></div>
     `;
 
     globalThis.SKIP_PRD_AUTO_INIT = true;
@@ -111,9 +117,11 @@ describe("prdReaderPage", () => {
 
     expect(container.innerHTML).toContain("Alpha");
     expect(titleEl.textContent).toBe("Alpha");
+    expect(items[0].getAttribute("aria-current")).toBe("page");
     items[1].click();
     expect(container.innerHTML).toContain("Beta");
     expect(titleEl.textContent).toBe("Beta");
+    expect(items[1].getAttribute("aria-current")).toBe("page");
   });
 
   it("displays task summary when element exists", async () => {
@@ -126,7 +134,7 @@ describe("prdReaderPage", () => {
       <div id="prd-title"></div>
       <div id="task-summary"></div>
       <ul id="prd-list"></ul>
-      <div id="prd-content"></div>
+      <div id="prd-content" tabindex="-1"></div>
       <button data-nav="prev">Prev</button>
       <button data-nav="next">Next</button>
     `;
@@ -137,7 +145,9 @@ describe("prdReaderPage", () => {
     await setupPrdReaderPage(docs, parser);
 
     const summary = document.getElementById("task-summary");
+    const list = document.getElementById("prd-list");
     expect(summary.textContent).toContain("1/2");
+    expect(list.children[0].getAttribute("aria-current")).toBe("page");
   });
 
   it("loads document from query parameter", async () => {
@@ -153,7 +163,7 @@ describe("prdReaderPage", () => {
       <div id="prd-title"></div>
       <div id="task-summary"></div>
       <ul id="prd-list"></ul>
-      <div id="prd-content"></div>
+      <div id="prd-content" tabindex="-1"></div>
       <button data-nav="prev">Prev</button>
       <button data-nav="next">Next</button>
     `;
@@ -164,8 +174,10 @@ describe("prdReaderPage", () => {
     await setupPrdReaderPage(docs, parser);
 
     const container = document.getElementById("prd-content");
+    const list = document.getElementById("prd-list");
     expect(container.innerHTML).toContain("Second doc");
     expect(window.location.search).toBe("?doc=b");
+    expect(list.children[1].getAttribute("aria-current")).toBe("page");
   });
 
   it("updates URL when navigating", async () => {
@@ -179,7 +191,7 @@ describe("prdReaderPage", () => {
       <div id="prd-title"></div>
       <div id="task-summary"></div>
       <ul id="prd-list"></ul>
-      <div id="prd-content"></div>
+      <div id="prd-content" tabindex="-1"></div>
       <button data-nav="prev">Prev</button>
       <button data-nav="next">Next</button>
     `;
@@ -189,10 +201,13 @@ describe("prdReaderPage", () => {
 
     await setupPrdReaderPage(docs, parser);
 
+    const list = document.getElementById("prd-list");
     expect(window.location.search).toBe("?doc=a");
+    expect(list.children[0].getAttribute("aria-current")).toBe("page");
     const next = document.querySelector('[data-nav="next"]');
     next.click();
     expect(window.location.search).toBe("?doc=b");
+    expect(list.children[1].getAttribute("aria-current")).toBe("page");
   });
 
   it("shows warning badge when markdown parsing fails", async () => {
@@ -217,7 +232,55 @@ describe("prdReaderPage", () => {
     await setupPrdReaderPage(docs, parser);
 
     const warning = document.querySelector(".markdown-warning");
+    const list = document.getElementById("prd-list");
     expect(warning).toBeTruthy();
     expect(warning.getAttribute("aria-label")).toBe("Content could not be fully rendered");
+    expect(list.children[0].getAttribute("aria-current")).toBe("page");
+  });
+
+  it("supports keyboard-only navigation with focus management", async () => {
+    const docs = {
+      "b.md": "# Second doc",
+      "a.md": "# First doc"
+    };
+    const parser = (md) => `<h1>${md}</h1>`;
+
+    document.body.innerHTML = `
+      <div id="prd-title"></div>
+      <div id="task-summary"></div>
+      <ul id="prd-list"></ul>
+      <div id="prd-content" tabindex="-1"></div>
+      <button data-nav="prev">Prev</button>
+      <button data-nav="next">Next</button>
+    `;
+
+    globalThis.SKIP_PRD_AUTO_INIT = true;
+    const { setupPrdReaderPage } = await import("../../src/helpers/prdReaderPage.js");
+
+    await setupPrdReaderPage(docs, parser);
+
+    const container = document.getElementById("prd-content");
+    const list = document.getElementById("prd-list");
+    const items = list.querySelectorAll("li");
+
+    expect(document.activeElement).toBe(container);
+    expect(items[0].getAttribute("aria-current")).toBe("page");
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+    expect(container.innerHTML).toContain("Second doc");
+    expect(items[1].getAttribute("aria-current")).toBe("page");
+    expect(document.activeElement).toBe(container);
+
+    list.focus();
+    list.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }));
+    expect(container.innerHTML).toContain("First doc");
+    expect(items[0].getAttribute("aria-current")).toBe("page");
+    expect(document.activeElement).toBe(container);
+
+    list.focus();
+    list.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    expect(container.innerHTML).toContain("Second doc");
+    expect(items[1].getAttribute("aria-current")).toBe("page");
+    expect(document.activeElement).toBe(container);
   });
 });


### PR DESCRIPTION
## Summary
- Move keyboard focus to PRD content after navigation and mark selected sidebar items with `aria-current="page"`
- Make PRD content container programmatically focusable
- Document and test keyboard-only navigation behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f410e479483269f36498cba966933