### PR TITLE
Remove unused layout toggle

### DIFF
--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -119,7 +119,6 @@ export async function setupBrowseJudokaPage() {
   const carouselContainer = document.getElementById("carousel-container");
   const countryListContainer = document.getElementById("country-list");
   const toggleBtn = document.getElementById("country-toggle");
-  const layoutToggle = document.getElementById("layout-toggle");
   const countryPanel = document.getElementById("country-panel");
 
   toggleCountryPanelMode(countryPanel, false);


### PR DESCRIPTION
## Summary
- remove unused grid layout toggle on browse judoka page

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f419075d4832695b326868ef4a6ba