### PR TITLE
Query layout toggle in browse judoka setup

### DIFF
--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -121,6 +121,7 @@ export async function setupBrowseJudokaPage() {
   const toggleBtn = document.getElementById("country-toggle");
   const countryPanel = document.getElementById("country-panel");
   const layoutToggle = document.getElementById("layout-toggle");
+  setupLayoutToggle(layoutToggle);
 
   toggleCountryPanelMode(countryPanel, false);
 

--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -109,10 +109,10 @@ export function setupCountryFilter(
  * Initialize the Browse Judoka page.
  *
  * @pseudocode
- * 1. Grab DOM elements for the carousel and country filters.
+ * 1. Grab DOM elements for the carousel, layout toggle, and country filters.
  * 2. Show a loading spinner and load judoka and gokyo data from JSON files.
  * 3. Render the card carousel and hide the spinner once complete.
- * 4. Attach event listeners for filtering and panel controls.
+ * 4. Attach event listeners for filtering, layout toggle, and panel controls.
  * 5. Handle errors by showing a retry button when loading fails.
  */
 export async function setupBrowseJudokaPage() {
@@ -120,6 +120,7 @@ export async function setupBrowseJudokaPage() {
   const countryListContainer = document.getElementById("country-list");
   const toggleBtn = document.getElementById("country-toggle");
   const countryPanel = document.getElementById("country-panel");
+  const layoutToggle = document.getElementById("layout-toggle");
 
   toggleCountryPanelMode(countryPanel, false);
 


### PR DESCRIPTION
## Summary
- collect layout toggle button along with other DOM elements
- wire layout toggle through to setupLayoutToggle
- document layout toggle in setup pseudocode

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed to resolve flag URL: TypeError: Failed to parse URL from countryCodeMapping.json)*
- `npx playwright test` *(1 interrupted, 1 skipped, 77 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f56f986308326894847552699f38f