### PR TITLE
Flag malformed tooltips in viewer

### DIFF
--- a/design/productRequirementsDocuments/prdTooltipViewer.md
+++ b/design/productRequirementsDocuments/prdTooltipViewer.md
@@ -161,9 +161,9 @@ During v0.7, a typo in `stat.focus` persisted through 3 releases due to lack of 
   - [x] 3.1 Render raw tooltip text
   - [x] 3.2 Parse and render markdown-styled preview
   - [x] 3.3 Animate panel on update (fade-in)
-  - [ ] 3.4 Display visual indicators for blank/malformed tooltips (icon/tooltip)
+  - [x] 3.4 Display visual indicators for blank/malformed tooltips (icon/tooltip)
     - [x] Blank entries flagged with warning icon
-    - [ ] Malformed entries not yet flagged
+    - [x] Malformed entries flagged with warning icon
   - [x] 3.5 Include copy-to-clipboard buttons for key and body
   - [x] 3.6 Show warning for malformed markdown in preview
   - [x] 3.7 Truncate long values after 300px height; add “Show more” toggle

--- a/tests/helpers/tooltipViewerPage.test.js
+++ b/tests/helpers/tooltipViewerPage.test.js
@@ -71,6 +71,30 @@ describe("setupTooltipViewerPage", () => {
     expect(sr.textContent).toBe("Empty or whitespace-only content");
   });
 
+  it("adds warning icon to malformed entries", async () => {
+    Object.defineProperty(document, "readyState", { value: "loading", configurable: true });
+
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ ok: "text", warn: "**Bold" }),
+      importJsonModule: vi.fn().mockResolvedValue({})
+    }));
+
+    await import("../../src/helpers/tooltipViewerPage.js");
+
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+
+    await Promise.resolve();
+
+    const malformed = document.querySelector('#tooltip-list li[data-key="warn"]');
+    expect(malformed).toBeTruthy();
+    const icon = malformed.querySelector(".tooltip-invalid-icon");
+    expect(icon).toBeTruthy();
+    expect(icon.title).toBe("Unbalanced markup detected");
+    const sr = malformed.querySelector(".tooltip-invalid-text");
+    expect(sr).toBeTruthy();
+    expect(sr.textContent).toBe("Unbalanced markup detected");
+  });
+
   it("shows warning for unbalanced markup", async () => {
     Object.defineProperty(document, "readyState", { value: "loading", configurable: true });
 


### PR DESCRIPTION
## Summary
- flag malformed tooltip entries in viewer sidebar
- test malformed tooltip warnings
- update tooltip viewer PRD for completed task

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f5ff3d0508326bff3faeb4fb65aed