### PR TITLE
Announce score updates with polite live region

### DIFF
--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -5,7 +5,7 @@
  * 1. Create three `<p>` elements:
  *    - `#round-message` with `aria-live="polite"`, `aria-atomic="true"`, and `role="status"` for result text.
  *    - `#next-round-timer` with `aria-live="polite"`, `aria-atomic="true"`, and `role="status"` for countdown updates.
- *    - `#score-display` with `aria-live="off"` and `aria-atomic="true"` for the match score.
+ *    - `#score-display` with `aria-live="polite"` and `aria-atomic="true"` for the match score.
  * 2. Append them to the provided container (typically the page header).
  * 3. Store references to these elements for later updates.
  * 4. Return the container element.
@@ -32,7 +32,8 @@ export function createInfoBar(container = document.createElement("div")) {
 
   scoreEl = document.createElement("p");
   scoreEl.id = "score-display";
-  scoreEl.setAttribute("aria-live", "off");
+  scoreEl.setAttribute("aria-live", "polite");
+  // Score announcements use a polite live region; consider throttling if updates are frequent.
   scoreEl.setAttribute("aria-atomic", "true");
 
   container.append(messageEl, timerEl, scoreEl);

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -39,7 +39,8 @@
           </a>
         </div>
         <div class="info-right" id="info-bar-right">
-          <p id="score-display" aria-live="off" aria-atomic="true">You: 0 Opponent: 0</p>
+          <p id="score-display" aria-live="polite" aria-atomic="true">You: 0 Opponent: 0</p>
+          <!-- Score updates announce politely; throttle updates if they become noisy. -->
         </div>
       </header>
 

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -27,7 +27,7 @@ describe("InfoBar component", () => {
     expect(timer).toHaveAttribute("aria-live", "polite");
     expect(timer).toHaveAttribute("role", "status");
     expect(timer).toHaveAttribute("aria-atomic", "true");
-    expect(score).toHaveAttribute("aria-live", "off");
+    expect(score).toHaveAttribute("aria-live", "polite");
     expect(score).toHaveAttribute("aria-atomic", "true");
   });
 


### PR DESCRIPTION
## Summary
- Announce score changes with a polite `aria-live` region and document need for throttling
- Mirror polite score updates in `battleJudoka.html`
- Update InfoBar tests for new live region behavior

## Testing
- `CI=true npx prettier . --check`
- `npx eslint .`
- `CI=true npx vitest run`
- `npx playwright test` *(fails: 1 failed - battleJudoka screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f625fd03c83269ba9c1a3f15a5ce1