### PR TITLE
Remove header settings button from random judoka page

### DIFF
--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -36,26 +36,6 @@
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
-        <button
-          id="settings-button"
-          class="settings-button"
-          type="button"
-          aria-label="Open settings"
-          data-testid="settings-button"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 -960 960 960"
-            width="64"
-            height="64"
-            fill="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              d="M480-280q83 0 141.5-58.5T680-480q0-83-58.5-141.5T480-680q-83 0-141.5 58.5T280-480q0 83 58.5 141.5T480-280Zm0 80q-116 0-198-82t-82-198q0-116 82-198t198-82q116 0 198 82t82 198q0 116-82 198t-198 82Zm352-40-56-96q12-27 18-55t6-57q0-29-6-57t-18-55l56-96-113-113-96 56q-27-12-55-18t-57-6q-29 0-57 6t-55 18l-96-56-113 113 56 96q-12 27-18 55t-6 57q0 29 6 57t18 55l-56 96 113 113 96-56q27 12 55 18t57 6q29 0 57-6t55-18l96 56 113-113Z"
-            />
-          </svg>
-        </button>
       </header>
 
       <div class="card-section">
@@ -65,9 +45,9 @@
             <p>Tap "Draw Card!" to begin.</p>
           </div>
         </template>
-        <!-- PRD: Draw Card button and toggles per prdRandomJudoka.md & prdDrawRandomCard.md -->
+        <!-- PRD: Draw Card button per prdRandomJudoka.md & prdDrawRandomCard.md -->
         <div id="draw-controls" class="draw-controls" aria-label="Draw controls">
-          <!-- Button and toggles are injected by randomJudokaPage.js -->
+          <!-- Draw button is injected by randomJudokaPage.js -->
           <!-- Error message container for accessibility -->
           <div
             id="draw-error-message"
@@ -82,7 +62,6 @@
         <nav class="bottom-navbar" data-testid="bottom-nav"></nav>
       </footer>
       <script type="module" src="../components/PlayerInfo.js"></script>
-      <script type="module" src="../helpers/setupSettingsButton.js"></script>
       <script type="module" src="../helpers/setupBottomNavbar.js"></script>
       <script type="module" src="../helpers/setupDisplaySettings.js"></script>
       <script type="module" src="../helpers/randomJudokaPage.js"></script>


### PR DESCRIPTION
## Summary
- remove standalone settings button from random judoka page
- drop unused setupSettingsButton script
- update draw controls comments to refer only to draw button

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle Judoka page narrow screenshot, View Judoka settings navigation, Screenshot suite)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f63a669008326af4696147c9c0937