### PR TITLE
Handle card load errors with retry

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -131,7 +131,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 ## Edge Cases / Failure States
 
 - **Player disconnects mid-match:** round is abandoned; player rejoins at main menu.
-- **Judoka dataset fails to load:** error message appears; player can retry loading.
+- **Judoka or Gokyo dataset fails to load:** error message surfaces in the Info Bar and an error dialog offers a "Retry" button to reload data or the page.
 - **Player does not make a stat selection within 30 seconds:** system randomly selects a stat automatically. **Info Bar must update accordingly.**
 - **AI fails to select a stat (if difficulty logic implemented):** fallback to random stat selection.
 

--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -3,10 +3,52 @@ import { getRandomJudoka, renderJudokaCard } from "../cardUtils.js";
 import { fetchJson } from "../dataUtils.js";
 import { createGokyoLookup } from "../utils.js";
 import { DATA_DIR } from "../constants.js";
+import { showMessage } from "../setupBattleInfoBar.js";
+import { createModal } from "../../components/Modal.js";
+import { createButton } from "../../components/Button.js";
 
 let judokaData = null;
 let gokyoLookup = null;
 let computerJudoka = null;
+let loadErrorModal = null;
+
+function showLoadError(error) {
+  const msg = error?.message || "Unable to load data.";
+  showMessage(msg);
+  if (!loadErrorModal) {
+    const title = document.createElement("h2");
+    title.id = "load-error-title";
+    title.textContent = "Load Error";
+
+    const desc = document.createElement("p");
+    desc.id = "load-error-desc";
+    desc.textContent = msg;
+
+    const actions = document.createElement("div");
+    actions.className = "modal-actions";
+
+    const retry = createButton("Retry", { id: "retry-draw-button" });
+    retry.addEventListener("click", async () => {
+      loadErrorModal.close();
+      try {
+        await drawCards();
+      } catch {
+        window.location.reload();
+      }
+    });
+    actions.append(retry);
+
+    const frag = document.createDocumentFragment();
+    frag.append(title, desc, actions);
+
+    loadErrorModal = createModal(frag, { labelledBy: title, describedBy: desc });
+    document.body.appendChild(loadErrorModal.element);
+  } else {
+    const descEl = loadErrorModal.element.querySelector("#load-error-desc");
+    if (descEl) descEl.textContent = msg;
+  }
+  loadErrorModal.open();
+}
 
 /**
  * Draw battle cards for the player and computer.
@@ -23,13 +65,23 @@ let computerJudoka = null;
  */
 export async function drawCards() {
   if (!judokaData) {
-    judokaData = await fetchJson(`${DATA_DIR}judoka.json`);
+    try {
+      judokaData = await fetchJson(`${DATA_DIR}judoka.json`);
+    } catch (error) {
+      showLoadError(error);
+      return { playerJudoka: null, computerJudoka: null };
+    }
   }
   const available = Array.isArray(judokaData) ? judokaData.filter((j) => !j.isHidden) : [];
 
   if (!gokyoLookup) {
-    const gokyoData = await fetchJson(`${DATA_DIR}gokyo.json`);
-    gokyoLookup = createGokyoLookup(gokyoData);
+    try {
+      const gokyoData = await fetchJson(`${DATA_DIR}gokyo.json`);
+      gokyoLookup = createGokyoLookup(gokyoData);
+    } catch (error) {
+      showLoadError(error);
+      return { playerJudoka: null, computerJudoka: null };
+    }
   }
 
   const playerContainer = document.getElementById("player-card");

--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -32,7 +32,7 @@ function showLoadError(error) {
       loadErrorModal.close();
       try {
         await drawCards();
-      } catch {
+      } catch (retryError) {
         window.location.reload();
       }
     });

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -106,4 +106,29 @@ describe("classicBattle card selection", () => {
       expect.objectContaining({ id: 2, isHidden: false })
     ]);
   });
+
+  it("shows retry dialog when data load fails", async () => {
+    fetchJsonMock
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const { drawCards, _resetForTest } = await import(
+      "../../../src/helpers/classicBattle/cardSelection.js"
+    );
+    _resetForTest();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload: vi.fn() }
+    });
+
+    await drawCards();
+
+    expect(document.getElementById("round-message").textContent).toBe("boom");
+    const retry = document.getElementById("retry-draw-button");
+    expect(retry).toBeTruthy();
+    await retry.click();
+    await Promise.resolve();
+    expect(fetchJsonMock).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
## Summary
- catch data load errors in `drawCards` and surface retry modal with info bar message
- document dataset failure handling in Classic Battle PRD
- test retry flow when card data fails to load

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f628f61588326a4ff956fa60c666a