### PR TITLE
Improve PRD viewer keyboard focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,12 @@ npx pa11y --config pa11y.config.cjs http://localhost:5000/src/pages/prdViewer.ht
 
 Open the PRD Viewer from the main menu or visit
 `http://localhost:5000/src/pages/prdViewer.html` in a running development
-server. The sidebar lists every PRD; select a title, press the left and right
-arrow keys, or swipe on touch devices to move between documents. Click the
-JU-DO-KON! logo to return to the homepage.
+server. The sidebar lists every PRD; select a title and press **Enter** to move
+focus to the document. Use **Arrow Up/Down** inside the sidebar to move between
+items without leaving the list. When the document content is focused,
+**Arrow Left/Right** move between PRDs, and **Tab** order flows: logo link →
+sidebar items → document content → footer links. Swipe on touch devices or
+click the JU-DO-KON! logo to return to the homepage.
 
 ## Screenshot Tests (On-Demand)
 

--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -188,6 +188,8 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 ### Accessibility Audit Findings
 
 - Screen reader announces the sidebar as "PRD list" and the footer as "Footer navigation".
-- Keyboard focus order: logo link → sidebar items → footer links.
+- Keyboard focus order: logo link → sidebar items → document content → footer links.
+- Arrow Up/Down move through the sidebar while keeping focus on the list. Enter or a mouse click moves focus to the document content.
+- Left/Right arrow navigation is available when the document content has focus and keeps focus on that region.
 - After navigating, focus moves to the document content and the active sidebar item sets `aria-current="page"` for assistive technologies.
 - `pa11y` scan of `src/pages/prdViewer.html` reported no accessibility issues.

--- a/playwright/prd-reader.spec.js
+++ b/playwright/prd-reader.spec.js
@@ -35,4 +35,34 @@ test.describe("PRD Reader page", () => {
     const afterPrev = await page.locator("#prd-content").innerHTML();
     expect(afterPrev).toBe(original);
   });
+
+  test("tab and arrow key traversal", async ({ page }) => {
+    const items = page.locator(".sidebar-list li");
+    const container = page.locator("#prd-content");
+    const initial = await container.innerHTML();
+
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await expect(items.first()).toBeFocused();
+
+    await page.keyboard.press("ArrowRight");
+    await expect(items.first()).toBeFocused();
+    expect(await container.innerHTML()).toBe(initial);
+
+    await page.keyboard.press("ArrowDown");
+    await expect(items.nth(1)).toBeFocused();
+    const afterArrow = await container.innerHTML();
+    expect(afterArrow).not.toBe(initial);
+
+    await page.keyboard.press("Enter");
+    await expect(container).toBeFocused();
+
+    await page.keyboard.press("ArrowRight");
+    await expect(container).toBeFocused();
+    const afterNext = await container.innerHTML();
+    expect(afterNext).not.toBe(afterArrow);
+
+    await page.keyboard.press("Tab");
+    await expect(container).not.toBeFocused();
+  });
 });

--- a/src/components/SidebarList.js
+++ b/src/components/SidebarList.js
@@ -3,17 +3,19 @@
  *
  * @pseudocode
  * 1. Build a `<ul>` element with class `sidebar-list`.
- * 2. For each provided item create an `<li>` with text and optional
- *    dataset or className values.
+ * 2. For each item create an `<li>` with text and optional dataset or
+ *    className values. Make it tabbable and update the current index
+ *    on focus.
  * 3. Attach click and keyboard handlers so Enter/Space trigger
- *    selection using `select(index)` and Arrow Up/Down move the
- *    selection relative to the current item.
- * 4. Add `odd`/`even` classes for zebra striping starting with `odd`
+ *    `select(index)`.
+ * 4. On the list element handle Arrow Up/Down to move the selection
+ *    relative to the current item using `select(next, {fromListNav})`.
+ * 5. Add `odd`/`even` classes for zebra striping starting with `odd`
  *    for the first item and toggle the `selected` class inside
  *    `select()`.
- * 5. Inside `select()` update the highlight, focus the newly
- *    selected element, and call `onSelect`.
- * 6. Return `{ element, select }` so callers can programmatically
+ * 6. Inside `select()` update the highlight, focus the newly selected
+ *    element, and call `onSelect` with any options.
+ * 7. Return `{ element, select }` so callers can programmatically
  *    change the highlighted item.
  *
  * @param {Array<string|object>} items - Labels or config objects.
@@ -46,6 +48,9 @@ export function createSidebarList(items, onSelect = () => {}) {
         select(i);
       }
     });
+    li.addEventListener("focus", () => {
+      current = i;
+    });
     list.appendChild(li);
     return li;
   });
@@ -57,11 +62,11 @@ export function createSidebarList(items, onSelect = () => {}) {
       e.preventDefault();
       const delta = e.key === "ArrowDown" ? 1 : -1;
       const next = current === -1 ? (delta === 1 ? 0 : elements.length - 1) : current + delta;
-      select(next);
+      select(next, { fromListNav: true });
     }
   });
 
-  function select(index) {
+  function select(index, opts = {}) {
     current = ((index % elements.length) + elements.length) % elements.length;
     elements.forEach((el, idx) => {
       const isCurrent = idx === current;
@@ -73,7 +78,7 @@ export function createSidebarList(items, onSelect = () => {}) {
       }
     });
     elements[current].focus();
-    onSelect(current, elements[current]);
+    onSelect(current, elements[current], opts);
   }
 
   return { element: list, select };

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -31,7 +31,7 @@
           <ul id="prd-list" class="sidebar-list"></ul>
         </aside>
         <section class="preview">
-          <div id="prd-content" tabindex="-1"></div>
+          <div id="prd-content" tabindex="0"></div>
           <div class="loading-spinner" id="prd-spinner" aria-hidden="true"></div>
         </section>
       </main>

--- a/tests/components/SidebarList.test.js
+++ b/tests/components/SidebarList.test.js
@@ -18,7 +18,7 @@ describe("createSidebarList", () => {
     select(1);
     expect(items[1].classList.contains("selected")).toBe(true);
     expect(items[1].getAttribute("aria-current")).toBe("page");
-    expect(cb).toHaveBeenCalledWith(1, items[1]);
+    expect(cb).toHaveBeenCalledWith(1, items[1], {});
     select(-1);
     expect(items[1].classList.contains("selected")).toBe(true);
     expect(items[1].getAttribute("aria-current")).toBe("page");
@@ -34,18 +34,18 @@ describe("createSidebarList", () => {
 
     items[0].focus();
     items[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
-    expect(items[0].classList.contains("selected")).toBe(true);
-    expect(items[0].getAttribute("aria-current")).toBe("page");
-    expect(document.activeElement).toBe(items[0]);
-
-    items[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
     expect(items[1].classList.contains("selected")).toBe(true);
     expect(items[1].getAttribute("aria-current")).toBe("page");
     expect(document.activeElement).toBe(items[1]);
 
-    items[1].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
-    expect(items[0].classList.contains("selected")).toBe(true);
-    expect(items[0].getAttribute("aria-current")).toBe("page");
-    expect(document.activeElement).toBe(items[0]);
+    items[1].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(items[2].classList.contains("selected")).toBe(true);
+    expect(items[2].getAttribute("aria-current")).toBe("page");
+    expect(document.activeElement).toBe(items[2]);
+
+    items[2].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+    expect(items[1].classList.contains("selected")).toBe(true);
+    expect(items[1].getAttribute("aria-current")).toBe("page");
+    expect(document.activeElement).toBe(items[1]);
   });
 });

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -15,7 +15,7 @@ describe("prdReaderPage", () => {
       <div id="prd-title"></div>
       <div id="task-summary"></div>
       <ul id="prd-list"></ul>
-      <div id="prd-content" tabindex="-1"></div>
+      <div id="prd-content" tabindex="0"></div>
       <button data-nav="prev">Prev</button>
       <button data-nav="next">Next</button>
       <button data-nav="prev">Prev bottom</button>
@@ -275,12 +275,12 @@ describe("prdReaderPage", () => {
     list.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }));
     expect(container.innerHTML).toContain("First doc");
     expect(items[0].getAttribute("aria-current")).toBe("page");
-    expect(document.activeElement).toBe(container);
+    expect(document.activeElement).toBe(items[0]);
 
     list.focus();
     list.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
     expect(container.innerHTML).toContain("Second doc");
     expect(items[1].getAttribute("aria-current")).toBe("page");
-    expect(document.activeElement).toBe(container);
+    expect(document.activeElement).toBe(items[1]);
   });
 });


### PR DESCRIPTION
## Summary
- include PRD content in keyboard tab order
- keep sidebar navigation focused while arrowing through items
- document PRD viewer keyboard flow and test focus traversal

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings: err unused variable, currentDesc unused, _opts unused, battleMod unused, judokaData unused)
- `npx vitest run`
- `npx playwright test` (failed: `playwright/battleJudoka.spec.js:25:3 › Battle Judoka page › narrow viewport screenshot and status aria attributes`)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f62439b08832696c35ad9771c2b2a