### PR TITLE
Remove random judoka toggles

### DIFF
--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -44,7 +44,12 @@ export async function setupRandomJudokaPage() {
     console.error("Error loading settings:", err);
     // Fallback to system motion preference
     settings = {
-      motionEffects: !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      motionEffects: !window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+      featureFlags: {
+        viewportSimulation: { enabled: false },
+        enableCardInspector: { enabled: false },
+        tooltipOverlayDebug: { enabled: false }
+      }
     };
   }
 

--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -1,6 +1,8 @@
 /**
  * Initialize the Random Judoka page once the DOM is ready.
  *
+ * Relies on global settings to respect motion preferences.
+ *
  * @pseudocode
  * 1. Load persisted settings and fall back to the system motion preference.
  * 2. Preload judoka and gokyo data using `fetchJson`.
@@ -10,10 +12,9 @@
  *    `generateRandomCard` with the loaded data and the user's motion preference, updates the history list, then restores
  *    the button once the animation completes.
  * 6. Render a placeholder card in the card container.
- * 7. Create the "Draw Card!" button (min 64px height, 300px width, pill shape, ARIA attributes) and Animation/Sound toggles.
- * 8. Attach event listeners to persist toggle changes, update motion classes, and handle accessibility.
- * 9. If data fails to load, disable the Draw button and show an error message or fallback card.
- * 10. Use `onDomReady` to execute setup when the DOM content is loaded.
+ * 7. Create the "Draw Card!" button (min 64px height, 300px width, pill shape, ARIA attributes) and attach its event listener.
+ * 8. If data fails to load, disable the Draw button and show an error message or fallback card.
+ * 9. Use `onDomReady` to execute setup when the DOM content is loaded.
  *
  * @returns {Promise<void>} Resolves when the page is fully initialized.
  * @see design/productRequirementsDocuments/prdRandomJudoka.md
@@ -24,8 +25,7 @@ import { generateRandomCard } from "./randomCard.js";
 import { toggleInspectorPanels } from "./cardUtils.js";
 import { DATA_DIR } from "./constants.js";
 import { createButton } from "../components/Button.js";
-import { createToggleSwitch } from "../components/ToggleSwitch.js";
-import { loadSettings, updateSetting } from "./settingsUtils.js";
+import { loadSettings } from "./settingsUtils.js";
 import { applyMotionPreference } from "./motionUtils.js";
 import { onDomReady } from "./domReady.js";
 import { initTooltips } from "./tooltip.js";
@@ -42,12 +42,13 @@ export async function setupRandomJudokaPage() {
     settings = await loadSettings();
   } catch (err) {
     console.error("Error loading settings:", err);
+    // Fallback to system motion preference
     settings = {
-      sound: false,
       motionEffects: !window.matchMedia("(prefers-reduced-motion: reduce)").matches
     };
   }
 
+  // Apply global motion preference
   applyMotionPreference(settings.motionEffects);
   toggleViewportSimulation(Boolean(settings.featureFlags.viewportSimulation?.enabled));
   toggleInspectorPanels(Boolean(settings.featureFlags?.enableCardInspector?.enabled));
@@ -225,21 +226,6 @@ export async function setupRandomJudokaPage() {
   cardSection.appendChild(drawButton);
   drawButton.addEventListener("click", displayCard);
 
-  // Animation and Sound toggles
-  const animationToggle = createToggleSwitch("Animation", {
-    id: "animation-toggle",
-    checked: settings.motionEffects,
-    ariaLabel: "Animation"
-  });
-  const soundToggle = createToggleSwitch("Sound", {
-    id: "sound-toggle",
-    checked: settings.sound,
-    ariaLabel: "Sound"
-  });
-  animationToggle.style.marginTop = "24px";
-  soundToggle.style.marginLeft = "16px";
-  cardSection.append(animationToggle, soundToggle);
-
   window.addEventListener("storage", (e) => {
     if (e.key === "settings" && e.newValue) {
       try {
@@ -249,22 +235,6 @@ export async function setupRandomJudokaPage() {
         toggleTooltipOverlayDebug(Boolean(s.featureFlags?.tooltipOverlayDebug?.enabled));
       } catch {}
     }
-  });
-
-  animationToggle.querySelector("input")?.addEventListener("change", (e) => {
-    const value = e.currentTarget.checked;
-    applyMotionPreference(value);
-    updateSetting("motionEffects", value).catch(() => {
-      e.currentTarget.checked = !value;
-      applyMotionPreference(!value);
-    });
-  });
-
-  soundToggle.querySelector("input")?.addEventListener("change", (e) => {
-    const value = e.currentTarget.checked;
-    updateSetting("sound", value).catch(() => {
-      e.currentTarget.checked = !value;
-    });
   });
 
   // Initial state: placeholder shown; disable draw button only if data failed to load

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -6,7 +6,6 @@ import { parseCssVariables } from "../../src/helpers/cssVariableParser.js";
 import { hex } from "wcag-contrast";
 
 const baseSettings = {
-  sound: false,
   motionEffects: true,
   typewriterEffect: true,
   tooltips: true,
@@ -32,25 +31,14 @@ describe("randomJudokaPage module", () => {
       if (opts.id) btn.id = opts.id;
       return btn;
     });
-    const createToggleSwitch = vi.fn((_, opts) => {
-      const wrapper = document.createElement("div");
-      const input = document.createElement("input");
-      input.type = "checkbox";
-      input.id = opts.id;
-      input.checked = opts.checked;
-      wrapper.appendChild(input);
-      return wrapper;
-    });
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
-    const updateSetting = vi.fn().mockResolvedValue(baseSettings);
     const applyMotionPreference = vi.fn();
 
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
     vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
     vi.doMock("../../src/components/Button.js", () => ({ createButton }));
-    vi.doMock("../../src/components/ToggleSwitch.js", () => ({ createToggleSwitch }));
-    vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings, updateSetting }));
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
 
     const { section, container, placeholderTemplate } = createRandomCardDom();
@@ -62,7 +50,8 @@ describe("randomJudokaPage module", () => {
     await vi.runAllTimersAsync();
 
     expect(loadSettings).toHaveBeenCalled();
-    expect(createToggleSwitch).toHaveBeenCalledTimes(2);
+    expect(document.getElementById("animation-toggle")).toBeNull();
+    expect(document.getElementById("sound-toggle")).toBeNull();
     expect(applyMotionPreference).toHaveBeenCalledWith(baseSettings.motionEffects);
     expect(generateRandomCard).not.toHaveBeenCalled();
     const drawBtn = document.getElementById("draw-card-btn");
@@ -80,12 +69,10 @@ describe("randomJudokaPage module", () => {
     const judoka = getJudokaFixture()[0];
 
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
-    const updateSetting = vi.fn();
     const applyMotionPreference = vi.fn();
 
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
-      loadSettings,
-      updateSetting
+      loadSettings
     }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
     vi.doMock("../../src/components/Button.js", () => ({
@@ -94,9 +81,6 @@ describe("randomJudokaPage module", () => {
         if (opts.id) btn.id = opts.id;
         return btn;
       }
-    }));
-    vi.doMock("../../src/components/ToggleSwitch.js", () => ({
-      createToggleSwitch: () => document.createElement("div")
     }));
     vi.doMock("../../src/helpers/randomCard.js", async () => {
       const { generateJudokaCardHTML } = await import("../../src/helpers/cardBuilder.js");
@@ -150,22 +134,17 @@ describe("randomJudokaPage module", () => {
     vi.doMock("../../src/components/Button.js", async () => {
       return await vi.importActual("../../src/components/Button.js");
     });
-    vi.doMock("../../src/components/ToggleSwitch.js", async () => {
-      return await vi.importActual("../../src/components/ToggleSwitch.js");
-    });
 
     const generateRandomCard = vi.fn();
     const fetchJson = vi.fn().mockResolvedValue([]);
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
-    const updateSetting = vi.fn();
     const applyMotionPreference = vi.fn();
 
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
     vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
-      loadSettings,
-      updateSetting
+      loadSettings
     }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
 
@@ -195,22 +174,17 @@ describe("randomJudokaPage module", () => {
     vi.doMock("../../src/components/Button.js", async () => {
       return await vi.importActual("../../src/components/Button.js");
     });
-    vi.doMock("../../src/components/ToggleSwitch.js", async () => {
-      return await vi.importActual("../../src/components/ToggleSwitch.js");
-    });
 
     const generateRandomCard = vi.fn().mockResolvedValue();
     const fetchJson = vi.fn().mockResolvedValue([]);
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
-    const updateSetting = vi.fn();
     const applyMotionPreference = vi.fn();
 
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
     vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
-      loadSettings,
-      updateSetting
+      loadSettings
     }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
 
@@ -236,55 +210,6 @@ describe("randomJudokaPage module", () => {
     expect(button).not.toHaveAttribute("aria-busy");
   });
 
-  it("animation and sound toggles meet minimum size requirements", async () => {
-    vi.useFakeTimers();
-    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
-
-    vi.doMock("../../src/components/Button.js", async () => {
-      return await vi.importActual("../../src/components/Button.js");
-    });
-    vi.doMock("../../src/components/ToggleSwitch.js", async () => {
-      return await vi.importActual("../../src/components/ToggleSwitch.js");
-    });
-
-    const generateRandomCard = vi.fn();
-    const fetchJson = vi.fn().mockResolvedValue([]);
-    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
-    const updateSetting = vi.fn();
-    const applyMotionPreference = vi.fn();
-
-    vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
-    vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
-    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
-    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
-      loadSettings,
-      updateSetting
-    }));
-    vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
-
-    const { section, container, placeholderTemplate } = createRandomCardDom();
-    document.body.append(section, container, placeholderTemplate);
-
-    const settingsCss = readFileSync(resolve("src/styles/settings.css"), "utf8");
-    const style = document.createElement("style");
-    style.textContent = settingsCss;
-    document.head.appendChild(style);
-
-    await import("../../src/helpers/randomJudokaPage.js");
-
-    document.dispatchEvent(new Event("DOMContentLoaded"));
-    await vi.runAllTimersAsync();
-
-    const animationInput = document.getElementById("animation-toggle");
-    const soundInput = document.getElementById("sound-toggle");
-    const animStyle = getComputedStyle(animationInput);
-    const soundStyle = getComputedStyle(soundInput);
-    expect(parseInt(animStyle.width)).toBeGreaterThanOrEqual(44);
-    expect(parseInt(animStyle.height)).toBeGreaterThanOrEqual(44);
-    expect(parseInt(soundStyle.width)).toBeGreaterThanOrEqual(44);
-    expect(parseInt(soundStyle.height)).toBeGreaterThanOrEqual(44);
-  });
-
   it("stores last draws in a slide-out history panel", async () => {
     vi.useFakeTimers();
     window.matchMedia = vi.fn().mockReturnValue({ matches: false });
@@ -307,23 +232,14 @@ describe("randomJudokaPage module", () => {
       if (opts.id) btn.id = opts.id;
       return btn;
     });
-    const createToggleSwitch = vi.fn(() => {
-      const wrapper = document.createElement("div");
-      const input = document.createElement("input");
-      input.type = "checkbox";
-      wrapper.appendChild(input);
-      return wrapper;
-    });
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
-    const updateSetting = vi.fn();
     const applyMotionPreference = vi.fn();
 
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
     vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
     vi.doMock("../../src/components/Button.js", () => ({ createButton }));
-    vi.doMock("../../src/components/ToggleSwitch.js", () => ({ createToggleSwitch }));
-    vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings, updateSetting }));
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
 
     const { section, container, placeholderTemplate } = createRandomCardDom();
@@ -367,15 +283,13 @@ describe("randomJudokaPage module", () => {
     });
     const fetchJson = vi.fn().mockResolvedValue([]);
     const loadSettings = vi.fn().mockResolvedValue(baseSettings);
-    const updateSetting = vi.fn();
     const applyMotionPreference = vi.fn();
 
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
     vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
-      loadSettings,
-      updateSetting
+      loadSettings
     }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
 


### PR DESCRIPTION
## Summary
- remove animation and sound toggles from random judoka page
- respect only global motion preference when loading settings
- drop toggle expectations from random judoka page tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: settings button navigation, screenshot suite, signature move screenshot)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f6a26e44c8326a0553c89725a89eb