### PR TITLE
Remove settings button styles

### DIFF
--- a/src/styles/randomJudoka.css
+++ b/src/styles/randomJudoka.css
@@ -3,24 +3,6 @@ player-info {
   padding-left: var(--space-sm);
 }
 
-.settings-button {
-  justify-self: end;
-  background: none;
-  border: none;
-  width: 64px;
-  height: 64px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  color: var(--color-secondary);
-}
-
-.settings-button svg {
-  width: 64px;
-  height: 64px;
-}
-
 .card-section {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- drop unused settings button styles from random judoka stylesheet

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings)*
- `npx vitest run` *(fails: Failed to resolve flag URL: TypeError: Failed to parse URL from countryCodeMapping.json, etc.)*
- `npx playwright test` *(fails: 4 failed, 75 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f6d5a4e088326b07d44e2c5465170