### PR TITLE
Remove obsolete random judoka tests

### DIFF
--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -18,11 +18,6 @@ test.describe("View Judoka screen", () => {
     await battleLink.click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
-  test("settings button navigates to settings page", async ({ page }) => {
-    await page.getByTestId("settings-button").click();
-    await expect(page).toHaveURL(/settings\.html/);
-  });
-
   test("logo has alt text", async ({ page }) => {
     const logo = page.getByRole("img", { name: "JU-DO-KON! Logo" });
     await expect(logo).toHaveAttribute("alt", "JU-DO-KON! Logo");

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -21,47 +21,6 @@ const baseSettings = {
 };
 
 describe("randomJudokaPage module", () => {
-  it("initializes controls and passes motion flag", async () => {
-    vi.useFakeTimers();
-    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
-    const generateRandomCard = vi.fn();
-    const fetchJson = vi.fn().mockResolvedValue([]);
-    const createButton = vi.fn((_, opts = {}) => {
-      const btn = document.createElement("button");
-      if (opts.id) btn.id = opts.id;
-      return btn;
-    });
-    const loadSettings = vi.fn().mockResolvedValue(baseSettings);
-    const applyMotionPreference = vi.fn();
-
-    vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
-    vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
-    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
-    vi.doMock("../../src/components/Button.js", () => ({ createButton }));
-    vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
-    vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
-
-    const { section, container, placeholderTemplate } = createRandomCardDom();
-    document.body.append(section, container, placeholderTemplate);
-
-    const { setupRandomJudokaPage } = await import("../../src/helpers/randomJudokaPage.js");
-
-    document.dispatchEvent(new Event("DOMContentLoaded"));
-    await vi.runAllTimersAsync();
-
-    expect(loadSettings).toHaveBeenCalled();
-    expect(document.getElementById("animation-toggle")).toBeNull();
-    expect(document.getElementById("sound-toggle")).toBeNull();
-    expect(applyMotionPreference).toHaveBeenCalledWith(baseSettings.motionEffects);
-    expect(generateRandomCard).not.toHaveBeenCalled();
-    const drawBtn = document.getElementById("draw-card-btn");
-    drawBtn.click();
-    await vi.runAllTimersAsync();
-    expect(generateRandomCard.mock.calls[0][3]).toBe(false);
-    expect(typeof setupRandomJudokaPage).toBe("function");
-    expect(drawBtn.dataset.tooltipId).toBe("ui.drawCard");
-  });
-
   it("renders card text with sufficient color contrast", async () => {
     vi.useFakeTimers();
     window.matchMedia = vi.fn().mockReturnValue({ matches: false });


### PR DESCRIPTION
## Summary
- drop animation/sound toggle unit test for random judoka page
- remove header settings button Playwright check

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 3 screenshot tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f6e6431c083269aaa93fe109f26a5