### PR TITLE
Ensure PRD reader test handles focus traversal

### DIFF
--- a/playwright/prd-reader.spec.js
+++ b/playwright/prd-reader.spec.js
@@ -40,9 +40,20 @@ test.describe("PRD Reader page", () => {
     const items = page.locator(".sidebar-list li");
     const container = page.locator("#prd-content");
     const initial = await container.innerHTML();
-
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Tab");
+    const isFirstFocused = async () =>
+      await items.first().evaluate((el) => el === document.activeElement);
+    let attempts = 0;
+    while (!(await isFirstFocused()) && attempts < 10) {
+      await page.keyboard.press("Tab");
+      attempts += 1;
+    }
+    if (!(await isFirstFocused())) {
+      attempts = 0;
+      while (!(await isFirstFocused()) && attempts < 10) {
+        await page.keyboard.press("Shift+Tab");
+        attempts += 1;
+      }
+    }
     await expect(items.first()).toBeFocused();
 
     await page.keyboard.press("ArrowRight");


### PR DESCRIPTION
## Summary
- Refine PRD Reader Playwright test to tab or shift-tab until the sidebar item is focused instead of assuming a fixed number of Tab presses

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/prd-reader.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f77f4dd3c8326be086d8f37c68ab3