### PR TITLE
Clarify Safari stat button highlight handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ Safari may expand flex items if `min-width` isn't explicitly set. Set
 Safari 18.5 positions `.signature-move-container` text at the bottom edge unless the container uses standard flex alignment. The container now applies `line-height: max(10%, var(--touch-target-size))` along with `align-items: center` and `justify-content: center`. Setting `width: 100%` on the child spans prevents stretching so the label and value remain vertically centered.
 
 Safari 18.5 sometimes shrinks judoka cards, causing text overlap. The width rule now uses `clamp(200px, 60vw, 260px)` so cards occupy about 60% of the viewport on mobile. This applies to both the random card view and the browse carousel.
-Safari 18.5 may keep a stat button highlighted between rounds. The rule `#stat-buttons button { -webkit-tap-highlight-color: transparent; }` works with the reset logic to force a reflow and blur the element so the red overlay disappears.
+Safari 18.5 may keep a stat button highlighted between rounds. The battle stylesheet's rule `#stat-buttons button { -webkit-tap-highlight-color: transparent; }` works with the reset logic to force a reflow and blur the element so the red overlay disappears.
 
 - The carousel sets the `--card-width` CSS variable via JavaScript so each card maintains consistent sizing across browsers and devices.
 

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -122,7 +122,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - After confirming the quit action, the player is returned to the main menu (index.html).
 - If AI difficulty affects stat selection, AI uses correct logic per difficulty setting.
 - Animation flow: transitions between card reveal, stat selection, and result screens complete smoothly without stalling (**each ≤400 ms at ≥60 fps**).
-- Stat buttons reset between rounds so no previous selection remains highlighted. The CSS rule `#stat-buttons button { -webkit-tap-highlight-color: transparent; }` combined with a reflow ensures Safari clears the red touch overlay.
+- Stat buttons reset between rounds so no previous selection remains highlighted. The `battle.css` rule `#stat-buttons button { -webkit-tap-highlight-color: transparent; }` combined with a reflow ensures Safari clears the red touch overlay.
 - If the Judoka dataset fails to load, an error message appears with option to reload.
 - **All Info Bar content (messages, timer, score) must meet accessibility and responsiveness requirements as described in prdBattleInfoBar.md.**
 

--- a/src/helpers/battle/battleUI.js
+++ b/src/helpers/battle/battleUI.js
@@ -34,7 +34,7 @@ export function getRoundMessageEl() {
  * 1. Loop over buttons returned by `getStatButtons`.
  * 2. Remove the `selected` class and any inline background color.
  * 3. Disable the button to clear active/tap highlight.
- * 4. Force reflow and set `-webkit-tap-highlight-color` to transparent.
+ * 4. Force reflow so Safari clears the overlay.
  * 5. In the next animation frame re-enable, clear styles, and blur.
  */
 export function resetStatButtons() {
@@ -43,10 +43,8 @@ export function resetStatButtons() {
     btn.style.removeProperty("background-color");
     btn.disabled = true;
     void btn.offsetWidth;
-    btn.style.setProperty("-webkit-tap-highlight-color", "transparent");
     requestAnimationFrame(() => {
       btn.disabled = false;
-      btn.style.removeProperty("-webkit-tap-highlight-color");
       btn.style.backgroundColor = "";
       btn.blur();
     });

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -92,3 +92,8 @@
 #battle-area .judoka-card:focus-visible {
   transform: none;
 }
+
+/* Prevent Safari's red overlay from persisting */
+#stat-buttons button {
+  -webkit-tap-highlight-color: transparent;
+}


### PR DESCRIPTION
## Summary
- prevent persistent red overlay on stat buttons via `-webkit-tap-highlight-color`
- simplify `resetStatButtons` by relying on stylesheet rule
- document Safari quirk in README and PRD

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings)
- `npx vitest run`
- `npx playwright test` (1 failed screenshot)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f863a03388326b77ce88a3f39d72d