### PR TITLE
Handle battle header orientation

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -1,0 +1,59 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+
+const runScreenshots = process.env.SKIP_SCREENSHOTS !== "true";
+
+test.describe("Battle orientation behavior", () => {
+  test("updates orientation data attribute on rotation", async ({ page }) => {
+    await page.goto("/src/pages/battleJudoka.html");
+
+    await page.setViewportSize({ width: 320, height: 480 });
+    await page.waitForFunction(
+      () => document.querySelector(".battle-header")?.dataset.orientation === "portrait"
+    );
+
+    await page.setViewportSize({ width: 480, height: 320 });
+    await page.waitForFunction(
+      () => document.querySelector(".battle-header")?.dataset.orientation === "landscape"
+    );
+  });
+
+  test("truncates round message below 320px", async ({ page }) => {
+    await page.goto("/src/pages/battleJudoka.html");
+    await page.setViewportSize({ width: 300, height: 600 });
+    const msg = page.locator("#round-message");
+    await msg.evaluate(
+      (el) => (el.textContent = "A very long round message that should overflow on narrow screens")
+    );
+    const overflow = await msg.evaluate((el) => getComputedStyle(el).textOverflow);
+    expect(overflow).toBe("ellipsis");
+  });
+});
+
+test.describe(
+  runScreenshots ? "Battle orientation screenshots" : "Battle orientation screenshots (skipped)",
+  () => {
+    test.skip(!runScreenshots);
+
+    test("captures portrait and landscape headers", async ({ page }) => {
+      await page.goto("/src/pages/battleJudoka.html");
+
+      await page.setViewportSize({ width: 320, height: 480 });
+      await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-portrait.png");
+
+      await page.setViewportSize({ width: 480, height: 320 });
+      await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-landscape.png");
+    });
+
+    test("captures extra-narrow header", async ({ page }) => {
+      await page.goto("/src/pages/battleJudoka.html");
+      await page.setViewportSize({ width: 300, height: 600 });
+      await page
+        .locator("#round-message")
+        .evaluate(
+          (el) =>
+            (el.textContent = "A very long round message that should overflow on narrow screens")
+        );
+      await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-300.png");
+    });
+  }
+);

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -19,7 +19,9 @@
  *    d. Toggle the `.simulate-viewport` class based on the viewport flag.
  *    e. Invoke `startRoundWrapper` to begin the match.
  *    f. Initialize tooltips and show the stat help tooltip once for new users.
- *    g. Listen for `storage` events and update the Test Mode banner and
+ *    g. Watch for orientation changes and update the battle header's
+ *       `data-orientation` attribute.
+ *    h. Listen for `storage` events and update the Test Mode banner and
  *       `data-test-mode` attribute when settings change.
  * 5. Execute `setupClassicBattlePage` with `onDomReady`.
  */
@@ -62,6 +64,32 @@ async function applyStatLabels() {
       btn.setAttribute("aria-label", `Select ${n.name}`);
     }
   });
+}
+
+/**
+ * Apply orientation data attribute on the battle header and watch for changes.
+ *
+ * @pseudocode
+ * 1. Select the `.battle-header` element and exit if missing.
+ * 2. Define `updateOrientation` that sets `data-orientation` to `portrait` or
+ *    `landscape` based on `matchMedia`.
+ * 3. Invoke `updateOrientation` immediately.
+ * 4. Listen for `orientationchange` and `resize` events to call
+ *    `updateOrientation` on each change.
+ */
+function watchBattleOrientation() {
+  const header = document.querySelector(".battle-header");
+  if (!header) return;
+
+  const updateOrientation = () => {
+    header.dataset.orientation = window.matchMedia("(orientation: portrait)").matches
+      ? "portrait"
+      : "landscape";
+  };
+
+  updateOrientation();
+  window.addEventListener("orientationchange", updateOrientation);
+  window.addEventListener("resize", updateOrientation);
 }
 
 export async function setupClassicBattlePage() {
@@ -137,6 +165,7 @@ export async function setupClassicBattlePage() {
   window.startRoundOverride = startRoundWrapper;
   startRoundWrapper();
   await initTooltips();
+  watchBattleOrientation();
 
   try {
     if (typeof localStorage !== "undefined") {

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -34,33 +34,35 @@
   text-align: right;
 }
 
-@media (max-width: 375px) {
-  .battle-header {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto auto;
-    text-align: center;
-  }
-  .battle-header .info-left {
-    grid-row: 1;
-    align-items: center;
-  }
-  .battle-header .logo-container {
-    grid-row: 2;
-  }
-  .battle-header .info-right {
-    grid-row: 3;
-    justify-self: center;
-    align-items: center;
-  }
-  .battle-header #round-message,
-  .battle-header #next-round-timer,
-  .battle-header #score-display {
-    font-size: clamp(14px, 5vw, 20px);
-    overflow-wrap: anywhere;
-  }
+.battle-header[data-orientation="portrait"] {
+  grid-template-columns: 1fr;
+  grid-template-rows: auto auto auto;
+  text-align: center;
 }
 
-@media (max-width: 300px) {
+.battle-header[data-orientation="portrait"] .info-left {
+  grid-row: 1;
+  align-items: center;
+}
+
+.battle-header[data-orientation="portrait"] .logo-container {
+  grid-row: 2;
+}
+
+.battle-header[data-orientation="portrait"] .info-right {
+  grid-row: 3;
+  justify-self: center;
+  align-items: center;
+}
+
+.battle-header[data-orientation="portrait"] #round-message,
+.battle-header[data-orientation="portrait"] #next-round-timer,
+.battle-header[data-orientation="portrait"] #score-display {
+  font-size: clamp(14px, 5vw, 20px);
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 320px) {
   .battle-header #round-message,
   .battle-header #score-display {
     overflow: hidden;

--- a/tests/helpers/battleHeaderEllipsis.test.js
+++ b/tests/helpers/battleHeaderEllipsis.test.js
@@ -7,7 +7,7 @@ function hasEllipsisRule(css) {
   const root = postcss.parse(css);
   let found = false;
   root.walkAtRules("media", (at) => {
-    if (/max-width:\s*300px/.test(at.params)) {
+    if (/max-width:\s*320px/.test(at.params)) {
       at.walkRules((rule) => {
         if (rule.selector.includes("#round-message") || rule.selector.includes("#score-display")) {
           const overflow = rule.nodes.find((n) => n.prop === "text-overflow");
@@ -25,17 +25,16 @@ function hasEllipsisRule(css) {
 function hasWrapRule(css) {
   const root = postcss.parse(css);
   let found = false;
-  root.walkAtRules("media", (at) => {
-    if (/max-width:\s*375px/.test(at.params)) {
-      at.walkRules((rule) => {
-        if (rule.selector.includes("#round-message") || rule.selector.includes("#score-display")) {
-          const wrap = rule.nodes.find((n) => n.prop === "overflow-wrap");
-          const fontSize = rule.nodes.find((n) => n.prop === "font-size");
-          if (wrap && /anywhere/.test(wrap.value) && fontSize && /clamp/.test(fontSize.value)) {
-            found = true;
-          }
-        }
-      });
+  root.walkRules((rule) => {
+    if (
+      rule.selector.includes('.battle-header[data-orientation="portrait"] #round-message') ||
+      rule.selector.includes('.battle-header[data-orientation="portrait"] #score-display')
+    ) {
+      const wrap = rule.nodes.find((n) => n.prop === "overflow-wrap");
+      const fontSize = rule.nodes.find((n) => n.prop === "font-size");
+      if (wrap && /anywhere/.test(wrap.value) && fontSize && /clamp/.test(fontSize.value)) {
+        found = true;
+      }
     }
   });
   return found;


### PR DESCRIPTION
## Summary
- stack battle info bar vertically when device is in portrait orientation
- truncate round message and score when viewport is under 320px
- cover orientation and narrow widths in Playwright tests

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings)*
- `npx vitest run`
- `SKIP_SCREENSHOTS=true npx playwright test --reporter=list` *(fails: battleJudoka.spec.js screenshot)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_688f86221af4832697575be422a8c981