### PR TITLE
Handle missing tooltip file

### DIFF
--- a/design/productRequirementsDocuments/prdTooltipViewer.md
+++ b/design/productRequirementsDocuments/prdTooltipViewer.md
@@ -115,6 +115,7 @@ During v0.7, a typo in `stat.focus` persisted through 3 releases due to lack of 
 - Sidebar scrolls independently from the preview so the list remains visible while browsing.
 - Elements expose `data-key`, `data-body`, and `data-valid` for QA.
 - Viewer operates offline as a static HTML file.
+- When `tooltips.json` is missing, the preview panel displays "File not found".
 - Styling matches JU-DO-KON! brand (typography, colors, spacing).
 - **Sidebar supports keyboard navigation and category highlighting**
 - **Visual indicators (icon/tooltip) for invalid/empty/malformed entries are present**

--- a/src/helpers/tooltipViewerPage.js
+++ b/src/helpers/tooltipViewerPage.js
@@ -8,6 +8,8 @@ import { showSnackbar } from "./showSnackbar.js";
 const INVALID_TOOLTIP_MSG = "Empty or whitespace-only content";
 const MALFORMED_TOOLTIP_MSG = "Unbalanced markup detected";
 const INVALID_KEY_MSG = "Invalid key format (prefix.name)";
+const FILE_NOT_FOUND_MSG = "File not found";
+const LOAD_ERROR_MSG = "Error loading tooltips.";
 const KEY_PATTERN = /^[a-z]+\.[\w-]+$/;
 
 /**
@@ -15,6 +17,8 @@ const KEY_PATTERN = /^[a-z]+\.[\w-]+$/;
  *
  * @pseudocode
  * 1. Load and flatten `tooltips.json` using `fetchJson` and `flattenTooltips`.
+ *    When the file is missing, show "File not found"; otherwise display a
+ *    generic loading error.
  * 2. Render a clickable list of keys filtered by the search box (300ms debounce),
  *    tagging items with a class based on their prefix (e.g. `stat`, `ui`) and
  *    flagging empty bodies, malformed markup, or invalid key names with a warning icon.
@@ -77,7 +81,12 @@ export async function setupTooltipViewerPage() {
     data = flattenTooltips(json);
   } catch (err) {
     console.error("Failed to load tooltips", err);
-    previewEl.textContent = "Error loading tooltips.";
+    const status = err?.status ?? err?.response?.status;
+    if (err?.code === "ENOENT" || status === 404) {
+      previewEl.textContent = FILE_NOT_FOUND_MSG;
+    } else {
+      previewEl.textContent = LOAD_ERROR_MSG;
+    }
     return;
   }
 

--- a/tests/helpers/tooltipViewerPage.test.js
+++ b/tests/helpers/tooltipViewerPage.test.js
@@ -179,6 +179,24 @@ describe("setupTooltipViewerPage", () => {
     expect(btn.classList.contains("copied")).toBe(true);
   });
 
+  it("shows 'File not found' when tooltips.json is missing", async () => {
+    Object.defineProperty(document, "readyState", { value: "loading", configurable: true });
+
+    const error = Object.assign(new Error("missing"), { code: "ENOENT" });
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockRejectedValue(error),
+      importJsonModule: vi.fn().mockResolvedValue({})
+    }));
+
+    await import("../../src/helpers/tooltipViewerPage.js");
+
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+
+    await Promise.resolve();
+
+    expect(document.getElementById("tooltip-preview").textContent).toBe("File not found");
+  });
+
   it("adds warning icon to invalid key names", async () => {
     Object.defineProperty(document, "readyState", { value: "loading", configurable: true });
 


### PR DESCRIPTION
## Summary
- Show a clear "File not found" message when tooltips.json is missing in the viewer
- Document explicit missing-file message in tooltip viewer PRD
- Test tooltip viewer error handling for missing files

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings)
- `npx vitest run` (fail: network and resource errors)
- `npx playwright test` (fail: some tests failed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f861602508326a6f9398267887094