### PR TITLE
Clarify random card settings

### DIFF
--- a/design/productRequirementsDocuments/prdDrawRandomCard.md
+++ b/design/productRequirementsDocuments/prdDrawRandomCard.md
@@ -31,7 +31,7 @@ Without this feature, players would be forced to pre-select cards, leading to pr
 ## User Stories
 
 - As a player who loves surprises, I want each card draw to feel random so battles stay exciting.
-- As a player sensitive to motion, I want to disable animations so I can play comfortably.
+- As a player sensitive to motion, I want animations to respect my settings so I can play comfortably.
 - As a parent watching my child play, I want the draw button to be large and responsive so they can use it easily.
 
 ---
@@ -43,7 +43,7 @@ Without this feature, players would be forced to pre-select cards, leading to pr
 - The system:
   - Selects a random Judoka card from the active card set (isActive = True).
   - Visually reveals the card with a slide animation.
-  - Future Enhancement: Plays a short celebratory sound (e.g., swoosh or chime)
+  - Future Enhancement: Plays a short celebratory sound (e.g., swoosh or chime) when sound is enabled in `settings.html`
   - Ensures animation smoothness for devices .
 - **Active card set**: The current pool of cards available in the player’s deck, dynamically updated based on the game state.
 
@@ -91,8 +91,8 @@ instantly without movement.
 - **Random Pick Failure**: If random draw fails (e.g., due to a code error), show a fallback card (judoka id=0, from `judoka.json`) via `getFallbackJudoka()`
 - **Empty Card Set**: Display a predefined error card (judoka id=0, from judoka.json) if no cards are available.
 - **Accessibility**:
-  - Respect system Reduced Motion settings — disable animations if active.
-  - Default: Animations ON, but respect system/user preferences.
+  - Respect system Reduced Motion and global motion settings — disable animations if either is active.
+  - Default: Animations OFF unless enabled in `settings.html`.
   - Provide an `aria-label` on the Draw button so the accessible name stays
     "Draw a random judoka card" even when the visible text is updated.
 
@@ -111,7 +111,7 @@ instantly without movement.
 ### User Goals
 
 - Provide an exciting, quick card reveal to keep players engaged.
-- Allow players sensitive to motion to control animation settings for comfort.
+- Ensure animations honor global motion settings so players sensitive to motion can play comfortably.
 
 ---
 
@@ -141,7 +141,7 @@ instantly without movement.
 - If the random function fails, a fallback card is shown (judoka id=0, from judoka.json).
 - If the active card set is empty, a fallback card is shown (judoka id=0, from judoka.json).
   Both cases rely on the shared `getFallbackJudoka()` helper.
-- Animation is disabled if the user has enabled Reduced Motion settings.
+- Animation is disabled if the user has enabled Reduced Motion or disabled motion in `settings.html`.
 
 ---
 
@@ -153,23 +153,22 @@ instantly without movement.
 | P1       | Display Selected Card          | Visually reveal the selected card with animation and sound feedback.         |
 | P2       | Fallback on Failure            | Show fallback card if draw fails or active set is empty.                     |
 | P2       | Reusable Random Draw Module    | Make the random draw callable from multiple game states or screens.          |
-| P3       | Accessibility Support          | Support Reduced Motion settings and maintain color contrast and readability. |
+| P3       | Accessibility Support          | Honor Reduced Motion and sound settings from `settings.html` and maintain color contrast and readability. |
 | P3       | UX Enhancements                | Optimize for animation, sound effect, and large tap targets.                 |
-| P3       | Sound & Animation User Toggles | Allow users to manually mute sounds and disable animations if desired.       |
 
 ---
 
 ## Design and User Experience Considerations
 
 - **Animation Style**: Fade or slide only — no flips or excessive transitions to keep visuals polished.
-- **Sound Effect**: Short celebratory chime or swoosh (<1 second) - future enhancement
+- **Sound Effect**: Short celebratory chime or swoosh (<1 second) when sound is enabled in `settings.html` – future enhancement
 - **Responsiveness**:
   - Smooth transitions.
   - Degrade to static reveal if hardware performance is low.
 - **Accessibility**:
-  - Respect system Reduced Motion settings (disable animations automatically).
+  - Respect system Reduced Motion and global motion settings (disable animations automatically).
   - Ensure color contrast and text readability on cards (WCAG AA compliance; validate with `npm run check:contrast`).
-- **Default Setting**: Animations and sound OFF unless user/system preferences state otherwise.
+  - Animations and sound follow global preferences from `settings.html` (default OFF).
 - **Fallback Visuals**:
   - If card loading fails, show a placeholder card (judoka id=0, from judoka.json).
 - **Tap Target Size**:
@@ -186,10 +185,9 @@ instantly without movement.
 **Contents:**
 
 - **Player Info Module**: “You” + small avatar + status (e.g., “Your Turn” indicator).
-- **Settings Button**: Bigger tappable area (44px+), slight margin from edge, no tiny icons.
 - **Optional Timer** (future feature): If there’s a time limit per draw.
 
-**Why**: Clear identification + quick settings access without hunting for small buttons.
+**Why**: Clear identification of player status.
 
 ---
 
@@ -217,7 +215,7 @@ instantly without movement.
 - **Fallback**:
   - If fail → fallback card (judoka id=0, from judoka.json) slides in with reduced animation.
 - **Accessibility Setting Check**:
-  - Automatically downgrade if Reduced Motion is detected — immediately snap card reveal, no slide.
+  - Automatically downgrade if Reduced Motion is detected or motion is disabled in `settings.html` — immediately snap card reveal, no slide.
 
 **Why**: Players should _feel_ the result without being confused or left staring at nothing.
 
@@ -226,7 +224,6 @@ instantly without movement.
 ### 4. Modular Expandability
 
 - Add a “Card History” mini panel (expandable from side or bottom).
-- Add mute toggle for sound (little speaker icon on card corner or header).
 - Pre-wire zones for device scaling:
   - Flexbox/grid layout so the card & button center stack on small screens, side-by-side on tablets.
 
@@ -245,23 +242,21 @@ instantly without movement.
   - [x] 1.2 Integrate card draw with UI trigger ("Draw Card" button).
 - [x] 2.0 Develop Card Reveal Animation
   - [x] 2.1 Implement `.animate-card` class for fade/slide card reveal.
-  - [x] 2.3 Respect Reduced Motion settings and disable animation when active.
+  - [x] 2.3 Respect Reduced Motion and global motion settings and disable animation when active.
 - [x] 3.0 Error and Fallback Handling
   - [x] 3.1 Display fallback card (judoka id=0, from judoka.json) if random draw fails.
   - [x] 3.2 Show predefined error card (judoka id=0, from judoka.json) if active card set is empty.
 - [ ] 4.0 Accessibility and UX Enhancements
-- [x] 4.1 Support Reduced Motion settings.
+- [x] 4.1 Support Reduced Motion and global motion settings.
   - [x] 4.2 Ensure color contrast on cards meets WCAG AA standards. Verified in [`tests/helpers/randomJudokaPage.test.js`](../../tests/helpers/randomJudokaPage.test.js).
   - [ ] 4.3 Set all tap targets to ≥44px, recommended 64px for better kid usability (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness)). **[Button styled, but no runtime check]**
-  - [ ] 4.4 Implement animation and sound toggle controls with settings persistence. **[Toggles present, but sound logic not implemented]**
-  - [ ] 4.5 Play card-draw audio when sound is enabled and provide a mute option. **[Not implemented]**
-  - [x] 4.6 Disable the “Draw Card” button while loading or animating a card.
-  - [ ] 4.7 Add orientation-based layout rules for portrait vs. landscape. **[Not implemented]**
-  - [x] 4.8 Write automated tests verifying color contrast and tap target sizes. See [`tests/helpers/randomJudokaPage.test.js`](../../tests/helpers/randomJudokaPage.test.js).
+  - [ ] 4.4 Play card-draw audio when sound is enabled in `settings.html`. **[Not implemented]**
+  - [x] 4.5 Disable the “Draw Card” button while loading or animating a card.
+  - [ ] 4.6 Add orientation-based layout rules for portrait vs. landscape. **[Not implemented]**
+  - [x] 4.7 Write automated tests verifying color contrast and tap target sizes. See [`tests/helpers/randomJudokaPage.test.js`](../../tests/helpers/randomJudokaPage.test.js).
 - [ ] 5.0 Additional Features
   - [ ] 5.1 Implement "Card History" panel. **[Not implemented]**
-  - [ ] 5.2 Add celebratory sound effect on card draw. **[Not implemented]**
-  - [ ] 5.3 Provide visual or ARIA feedback for loading state. **[Only button disables, no spinner/text]**
+  - [ ] 5.2 Provide visual or ARIA feedback for loading state. **[Only button disables, no spinner/text]**
 
 ---
 

--- a/design/productRequirementsDocuments/prdDrawRandomCard.md
+++ b/design/productRequirementsDocuments/prdDrawRandomCard.md
@@ -168,7 +168,7 @@ instantly without movement.
 - **Accessibility**:
   - Respect system Reduced Motion and global motion settings (disable animations automatically).
   - Ensure color contrast and text readability on cards (WCAG AA compliance; validate with `npm run check:contrast`).
-  - Animations and sound follow global preferences from `settings.html` (default OFF).
+  - Animations and sound follow global preferences from `settings.html` (default ON).
 - **Fallback Visuals**:
   - If card loading fails, show a placeholder card (judoka id=0, from judoka.json).
 - **Tap Target Size**:

--- a/design/productRequirementsDocuments/prdDrawRandomCard.md
+++ b/design/productRequirementsDocuments/prdDrawRandomCard.md
@@ -92,7 +92,7 @@ instantly without movement.
 - **Empty Card Set**: Display a predefined error card (judoka id=0, from judoka.json) if no cards are available.
 - **Accessibility**:
   - Respect system Reduced Motion and global motion settings — disable animations if either is active.
-  - Default: Animations OFF unless enabled in `settings.html`.
+  - Default: Animations ON for device smoothness, unless disabled by system Reduced Motion or in `settings.html`.
   - Provide an `aria-label` on the Draw button so the accessible name stays
     "Draw a random judoka card" even when the visible text is updated.
 

--- a/design/productRequirementsDocuments/prdRandomJudoka.md
+++ b/design/productRequirementsDocuments/prdRandomJudoka.md
@@ -36,7 +36,6 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 - As a player who wants to try new team combinations, I want to draw a random judoka so that I can discover picks I might not have considered.
 - As a young player with limited patience, I want the random card to appear instantly so that I stay engaged and don’t get bored waiting.
 - As a parent or accessibility user, I want the card reveal to respect Reduced Motion settings so that animations do not cause discomfort.
-- As a player who likes sound effects, I want to enable or disable draw sounds so that I can control my experience.
 - As a player who sometimes loses internet or has device issues, I want to see a fallback card if something goes wrong so that the screen never feels broken.
 
 ---
@@ -58,7 +57,6 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 |  **P1**  | Animation Timing                | Card reveal animation completes within 500ms and respects Reduced Motion settings.     |
 |  **P2**  | Fallback Card                   | If the judoka list is empty or fails to load, show a default placeholder card.         |
 |  **P2**  | Disable Interaction During Draw | Prevent repeated taps while a new card is loading.                                     |
-|  **P3**  | Optional Sound Toggle           | Play a short draw sound when enabled; default off.                                     |
 
 ---
 
@@ -69,7 +67,6 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 - Draw button reliably refreshes card on tap (≥99% tap success).
 - Show fallback card if judoka list is empty (displays in 99% of cases).
 - Respect OS-level Reduced Motion settings (disable animations when active).
-- Sound is off by default.
 
 ---
 
@@ -77,6 +74,7 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 
 - Access to the full judoka list
 - Uses `generateRandomCard` as described in [prdDrawRandomCard.md](prdDrawRandomCard.md)
+- Reads global sound and motion preferences from `settings.html`
 
 ---
 
@@ -111,7 +109,7 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 - **Draw Flow:**
   1. Player loads the screen → random judoka card appears automatically
   2. Player taps “Draw Card!” button → new random card slides or fades in
-  3. If Reduced Motion or manual animation toggle is active, card changes instantly without animation
+  3. If Reduced Motion is active or the player disables motion in `settings.html`, the card changes instantly without animation
 - **Button Size:**
   - Minimum: 64px height × 300px width for easy tapping, especially for kids
   - Style: Capsule shape using `--radius-pill` for consistent branding
@@ -129,7 +127,7 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 #### Accessibility
 
 - Detect OS-level Reduced Motion; disable animations if active
-- Provide manual animation toggle (default ON)
+- Sound and motion preferences are configured via `settings.html` (no on-screen toggles)
 - Tap targets ≥44px × 44px (64px recommended for kid-friendly design). See [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness)
 - Text must meet WCAG 2.1 AA 4.5:1 contrast ratio (verify with automated tools)
 - All buttons and states require clear text labels
@@ -142,17 +140,17 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
 - **Tablet/Desktop (>600px):** card ~40% of viewport; centered draw button with spacing
 - **Landscape Support:** components reposition vertically or side-by-side
 - Card container uses `min-height: 50dvh` to keep the Draw button visible on small screens
-- The Draw button and its toggles must remain fully visible within the viewport even with the fixed footer navigation present
+- The Draw button must remain fully visible within the viewport even with the fixed footer navigation present
 - `.card-section` uses `padding-bottom: calc(var(--footer-height) + env(safe-area-inset-bottom))` so buttons stay visible above the footer
 
 #### Audio Feedback (Optional Enhancement)
 
 - Chime/swoosh sound <1 second, volume at 60% of system volume
-- Mute option via toggle icon near the draw button (default: sound off)
+- Sound effect plays only when enabled in `settings.html`
 
 #### Visual Mockup Description
 
-- **Draw Button Area:** prominent pill-shaped “Draw Card!” button prefixed with a draw icon, with mute and animation toggles ~24px below the card
+- **Draw Button Area:** prominent pill-shaped “Draw Card!” button prefixed with a draw icon; sound and motion settings live in `settings.html`
 
 ---
 
@@ -167,12 +165,12 @@ Players currently experience predictable, repetitive gameplay when they pre-sele
   - [ ] 3.1 Verify WCAG contrast and tap target sizes (manual/automated check needed)
   - [x] 3.2 Display fallback card on error using the module
 - [ ] **4.0 Reduced Motion & Animation**
-  - [ ] 4.1 Animation toggle is a global setting in Settings page (not on Random Judoka page)
-  - [x] 4.2 Respect OS-level Reduced Motion setting for animation toggle (logic present)
-  - [ ] 4.3 Ensure all card reveal animations are fully disabled when Reduced Motion is active (verify in UI and CSS)
+  - [ ] 4.1 Honor animation preference from `settings.html`
+  - [x] 4.2 Respect OS-level Reduced Motion setting (logic present)
+  - [ ] 4.3 Ensure all card reveal animations are fully disabled when Reduced Motion or the global preference is active (verify in UI and CSS)
 - [ ] **5.0 Audio Feedback**
-  - [ ] 5.1 Play draw sound effect when enabled (sound toggle is a global setting in Settings page)
-  - [ ] 5.2 Ensure sound is off by default in global settings
+  - [ ] 5.1 Play draw sound effect when global sound setting in `settings.html` is enabled
+  - [ ] 5.2 Confirm sound is off by default in `settings.html`
 - [ ] **6.0 Button Interaction**
   - [x] 6.1 Disable Draw button during card animation/loading
   - [ ] 6.2 Add visual feedback for button press (scale-in effect)


### PR DESCRIPTION
## Summary
- Remove page-level sound/animation toggles from Random Judoka PRD
- Point Draw Random Card PRD at global settings and drop toggle task
- Strip obsolete header settings references across docs

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: no-unused-vars)*
- `npx vitest run`
- `npx playwright test` *(fails: battleJudoka screenshot, settings screenshot diff)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f85fe61888326ae59bf500ebfa455