### PR TITLE
Sync Classic Battle scores with backend

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -64,6 +64,12 @@ the returned values to `InfoBar.updateScore`. The helper module
 `setupBattleInfoBar.js` exposes this method for pages, keeping UI updates
 decoupled from engine logic.
 
+`classicBattle.js` opens a WebSocket to `/classic-battle` so the backend can
+stream opponent stats and scores. If the connection drops or WebSockets are
+unavailable, it falls back to polling `/api/classic-battle/score` with
+exponential backoff. Latency or connection problems are surfaced via
+`InfoBar.showMessage` so players know when updates are delayed.
+
 ```javascript
 import { createCard } from "./src/components/Card.js";
 const card = createCard("<p>Hello</p>");

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -74,7 +74,11 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Card reveal and result animations should use hardware-accelerated CSS for smooth performance on low-end devices (**≥60 fps**).
 - **Stat selection timer (30s) must be displayed in the Info Bar; if timer expires, a random stat is auto-selected. Timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see prdBattleInfoBar.md).**
 - Detect timer drift by comparing engine state with real time; if drift exceeds 2s, display "Waiting…" and restart the countdown.
-- Backend must send real-time stat updates via WebSocket or polling for smooth live updates (**<200 ms latency**).
+- Backend must expose a WebSocket endpoint (`/classic-battle`) streaming opponent
+  scores and stat data. Clients fall back to polling `/api/classic-battle/score`
+  with exponential backoff when the socket is unavailable. Latency or dropped
+  connections trigger a `"Waiting…"` message in the Info Bar (**<200 ms
+  latency** when connected).
 - The debug panel is available when the `battleDebugPanel` feature flag is enabled and appears beside the opponent's card.
 
 ---

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -28,6 +28,12 @@ export function getStartRound() {
 let quitModal = null;
 let statTimeoutId = null;
 let autoSelectId = null;
+let latestScores = null;
+let lastScoreUpdate = 0;
+let scoreSocket = null;
+let pollIntervalId = null;
+let reconnectDelay = 1000;
+const MAX_RECONNECT_DELAY = 30000;
 
 /**
  * Display match summary with final message and scores.
@@ -86,6 +92,113 @@ function onStatSelectionTimeout() {
 }
 
 /**
+ * Parse score payloads and update the Info Bar.
+ *
+ * @pseudocode
+ * 1. Convert the input to an object.
+ * 2. When values are numbers, store and forward them to `infoBar.updateScore`.
+ * 3. On failure, show `"Waiting…"`.
+ */
+function handleScorePayload(data) {
+  try {
+    const parsed = typeof data === "string" ? JSON.parse(data) : data;
+    const { playerScore, computerScore } = parsed;
+    if (typeof playerScore === "number" && typeof computerScore === "number") {
+      latestScores = { playerScore, computerScore };
+      lastScoreUpdate = Date.now();
+      infoBar.updateScore(playerScore, computerScore);
+      return true;
+    }
+  } catch {
+    // ignore malformed payloads
+  }
+  infoBar.showMessage("Waiting…");
+  return false;
+}
+
+/**
+ * Poll the backend for updated scores with retry logic.
+ *
+ * @pseudocode
+ * 1. Fetch the score JSON from `url` with a 2s timeout.
+ * 2. On success, call `handleScorePayload` and reset the retry delay.
+ * 3. On failure, show `"Waiting…"` and retry with exponential backoff.
+ */
+function startPolling(url) {
+  clearInterval(pollIntervalId);
+  async function poll() {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 2000);
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      clearTimeout(timeoutId);
+      if (!res.ok) throw new Error("bad response");
+      const data = await res.json();
+      handleScorePayload(data);
+      reconnectDelay = 1000;
+    } catch {
+      clearTimeout(timeoutId);
+      infoBar.showMessage("Waiting…");
+      clearInterval(pollIntervalId);
+      setTimeout(() => startPolling(url), reconnectDelay);
+      reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY);
+    }
+  }
+  pollIntervalId = setInterval(poll, 5000);
+  poll();
+}
+
+/**
+ * Establish a WebSocket for score updates with polling fallback.
+ *
+ * @pseudocode
+ * 1. Try to open a WebSocket to `wsUrl`.
+ * 2. Forward `message` events to `handleScorePayload`.
+ * 3. On error or close, display an Info Bar message and retry or fall back to polling.
+ */
+function connectScoreSocket(wsUrl, pollUrl) {
+  if (scoreSocket) return;
+  try {
+    scoreSocket = new WebSocket(wsUrl);
+  } catch {
+    startPolling(pollUrl);
+    return;
+  }
+  scoreSocket.addEventListener("message", (e) => handleScorePayload(e.data));
+  scoreSocket.addEventListener("open", () => {
+    reconnectDelay = 1000;
+  });
+  scoreSocket.addEventListener("close", () => {
+    scoreSocket = null;
+    infoBar.showMessage("Connection lost. Retrying…");
+    setTimeout(() => connectScoreSocket(wsUrl, pollUrl), reconnectDelay);
+    reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY);
+  });
+  scoreSocket.addEventListener("error", () => {
+    infoBar.showMessage("Connection error. Switching to polling…");
+    scoreSocket?.close();
+    scoreSocket = null;
+    startPolling(pollUrl);
+  });
+}
+
+/**
+ * Begin real-time score synchronization if not already active.
+ *
+ * @pseudocode
+ * 1. Exit early on server-side renders.
+ * 2. Skip when a socket or poller already exists.
+ * 3. Connect to the backend via `connectScoreSocket`.
+ */
+function startScoreSync() {
+  if (typeof window === "undefined") return;
+  if (scoreSocket || pollIntervalId) return;
+  const wsUrl = "ws://localhost:3000/classic-battle";
+  const pollUrl = "/api/classic-battle/score";
+  connectScoreSocket(wsUrl, pollUrl);
+}
+
+/**
  * Update the info bar with current scores and show a waiting message when
  * synchronizing with the backend fails.
  *
@@ -98,6 +211,15 @@ function onStatSelectionTimeout() {
  * @returns {boolean} True when scores were updated, false on failure.
  */
 function syncScoreDisplay() {
+  if (latestScores) {
+    const stale = Date.now() - lastScoreUpdate > 5000;
+    infoBar.updateScore(latestScores.playerScore, latestScores.computerScore);
+    if (stale) {
+      infoBar.showMessage("Waiting…");
+      return false;
+    }
+    return true;
+  }
   try {
     const { playerScore, computerScore } = getScores();
     if (typeof playerScore === "number" && typeof computerScore === "number") {
@@ -105,7 +227,7 @@ function syncScoreDisplay() {
       return true;
     }
   } catch {
-    // ignore error and fall through to waiting message
+    // ignore and fall through
   }
   infoBar.showMessage("Waiting…");
   return false;
@@ -145,6 +267,7 @@ function createQuitConfirmation(onConfirm) {
 }
 
 export async function startRound() {
+  startScoreSync();
   resetStatButtons();
   disableNextRoundButton();
   await drawCards();

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -193,7 +193,10 @@ function connectScoreSocket(wsUrl, pollUrl) {
 function startScoreSync() {
   if (typeof window === "undefined") return;
   if (scoreSocket || pollIntervalId) return;
-  const wsUrl = "ws://localhost:3000/classic-battle";
+  // Dynamically construct the WebSocket URL based on the current location
+  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const wsHost = window.location.host;
+  const wsUrl = `${wsProtocol}//${wsHost}/classic-battle`;
   const pollUrl = "/api/classic-battle/score";
   connectScoreSocket(wsUrl, pollUrl);
 }


### PR DESCRIPTION
## Summary
- stream opponent scores via WebSocket with polling fallback and retry
- surface connection latency in classic battle Info Bar
- document backend WebSocket and polling requirements

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: `Battle orientation screenshots`, `Battle Judoka page`, `Settings screenshots`)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f8e62270083268c419e2e63f45b82