### PR TITLE
Add high contrast display mode and battle banner contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 
 ## Display Modes
 
-Light, dark and gray themes are supported. Changing modes uses a slide-over transition implemented with the View Transitions API when supported; otherwise the colors update immediately. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode switch applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running. The `--link-color` token controls anchor colors and is overridden to `#3399ff` in dark mode (along with `--color-primary: #ff4530`). In dark mode the tooltip viewer also uses this bright link color to highlight the selected sidebar key for better contrast.
+Light, dark, gray and high-contrast themes are supported. Changing modes uses a slide-over transition implemented with the View Transitions API when supported; otherwise the colors update immediately. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode switch applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running. The `--link-color` token controls anchor colors and is overridden to `#3399ff` in dark mode (along with `--color-primary: #ff4530`). In dark mode the tooltip viewer also uses this bright link color to highlight the selected sidebar key for better contrast.
 
 ## Settings & Feature Flags
 

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -144,7 +144,8 @@ test.describe("Settings page", () => {
         "label[for='tooltips-toggle']",
         "label[for='display-mode-light']",
         "label[for='display-mode-dark']",
-        "label[for='display-mode-gray']"
+        "label[for='display-mode-gray']",
+        "label[for='display-mode-high-contrast']"
       ].join(", "),
       (els) =>
         els.map((el) => {
@@ -175,7 +176,8 @@ test.describe("Settings page", () => {
       "#tooltips-toggle",
       "#display-mode-light",
       "#display-mode-dark",
-      "#display-mode-gray"
+      "#display-mode-gray",
+      "#display-mode-high-contrast"
     ];
 
     for (const sel of selectors) {

--- a/src/helpers/displayMode.js
+++ b/src/helpers/displayMode.js
@@ -2,17 +2,17 @@
  * Apply the chosen display mode by setting a theme data attribute on the body.
  *
  * @pseudocode
- * 1. Verify that `mode` is one of "light", "dark", or "gray".
+ * 1. Verify that `mode` is one of "light", "dark", "gray", or "high-contrast".
  *    - If the value is invalid, log a warning and exit early.
  *
  * 2. Set `document.body.dataset.theme` to the provided mode value.
  * 3. Remove any existing `*-mode` classes from `document.body` and add the
  *    class corresponding to the new mode (e.g. `dark-mode`).
  *
- * @param {"light"|"dark"|"gray"} mode - Desired display mode.
+ * @param {"light"|"dark"|"gray"|"high-contrast"} mode - Desired display mode.
  */
 export function applyDisplayMode(mode) {
-  const validModes = ["light", "dark", "gray"];
+  const validModes = ["light", "dark", "gray", "high-contrast"];
   if (!validModes.includes(mode)) {
     console.warn(`Invalid display mode: "${mode}". Valid modes are: ${validModes.join(", ")}.`);
     return;

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -184,7 +184,7 @@ export function resetSettings() {
  * @property {boolean} typewriterEffect
  * @property {boolean} tooltips
  * @property {boolean} showCardOfTheDay
- * @property {"light"|"dark"|"gray"} displayMode
+ * @property {"light"|"dark"|"gray"|"high-contrast"} displayMode
  * @property {boolean} fullNavigationMap
  * @property {Record<string, string>} [tooltipIds]
  * @property {Record<string, boolean>} [gameModes]

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -99,6 +99,16 @@
                   />
                   <label for="display-mode-gray">Gray</label>
                 </div>
+                <div class="display-mode-option">
+                  <input
+                    type="radio"
+                    id="display-mode-high-contrast"
+                    name="display-mode"
+                    value="high-contrast"
+                    tabindex="-1"
+                  />
+                  <label for="display-mode-high-contrast">High Contrast</label>
+                </div>
               </div>
             </div>
           </fieldset>

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -27,7 +27,7 @@
     },
     "displayMode": {
       "type": "string",
-      "enum": ["light", "dark", "gray"],
+      "enum": ["light", "dark", "gray", "high-contrast"],
       "description": "Visual display mode."
     },
     "fullNavigationMap": {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -91,6 +91,24 @@
   --color-text-inverted: #ffffff;
 }
 
+/* High contrast mode variable overrides */
+[data-theme="high-contrast"] {
+  --color-surface: #000000;
+  --color-background: #000000;
+  --color-tertiary: #000000;
+  --color-text: #ffffff;
+  --color-text-inverted: #000000;
+  --color-primary: #ffff00;
+  --color-secondary: #ffff00;
+  --link-color: #ffff00;
+  --button-bg: #ffff00;
+  --button-hover-bg: #e5e500;
+  --button-active-bg: #ffff00;
+  --button-text-color: #000000;
+  --color-slider-dot: #ffffff;
+  --color-slider-active: #ffff00;
+}
+
 *,
 *::before,
 *::after {

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -82,8 +82,8 @@
 /* Collapsible debug panel */
 
 .test-mode-banner {
-  background-color: var(--color-tertiary);
-  color: var(--color-text);
+  background-color: var(--color-secondary);
+  color: var(--color-text-inverted);
   text-align: center;
   padding: var(--space-sm) var(--space-md);
   font-weight: bold;

--- a/tests/helpers/displayMode.test.js
+++ b/tests/helpers/displayMode.test.js
@@ -12,6 +12,7 @@ describe("applyDisplayMode", () => {
       body.light-mode { background-color: rgb(255, 255, 255); }
       body.dark-mode { background-color: rgb(0, 0, 0); }
       body.gray-mode { background-color: rgb(205, 205, 205); }
+      body.high-contrast-mode { background-color: rgb(0, 0, 0); }
     `;
     document.head.appendChild(style);
   });
@@ -20,11 +21,14 @@ describe("applyDisplayMode", () => {
     style.remove();
   });
 
-  it.each(["dark", "gray", "light"])("sets data-theme and class for %s mode", (mode) => {
-    applyDisplayMode(mode);
-    expect(document.body.dataset.theme).toBe(mode);
-    expect(document.body.classList.contains(`${mode}-mode`)).toBe(true);
-  });
+  it.each(["dark", "gray", "light", "high-contrast"])(
+    "sets data-theme and class for %s mode",
+    (mode) => {
+      applyDisplayMode(mode);
+      expect(document.body.dataset.theme).toBe(mode);
+      expect(document.body.classList.contains(`${mode}-mode`)).toBe(true);
+    }
+  );
 
   it("warns when an invalid mode is provided", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -80,6 +80,11 @@ export function createSettingsDom() {
   displayGray.type = "radio";
   displayGray.name = "display-mode";
   displayGray.value = "gray";
+  const displayHighContrast = document.createElement("input");
+  displayHighContrast.id = "display-mode-high-contrast";
+  displayHighContrast.type = "radio";
+  displayHighContrast.name = "display-mode";
+  displayHighContrast.value = "high-contrast";
   const gameModeToggleContainer = document.createElement("section");
   gameModeToggleContainer.id = "game-mode-toggle-container";
 
@@ -116,6 +121,7 @@ export function createSettingsDom() {
     displayLight,
     displayDark,
     displayGray,
+    displayHighContrast,
     gameModeToggleContainer,
     advancedSection,
     resetButton


### PR DESCRIPTION
## Summary
- improve battle screen test-mode banner contrast
- add high-contrast display mode with CSS variable overrides and settings toggle
- document new theme in README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle orientation screenshots, battle Judoka page, settings screenshots - light/dark/gray collapsed/expanded, screenshot suite)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f8e56f1188326931efdc6d2b5e5e8