### PR TITLE
Ensure isNodeEnvironment returns boolean

### DIFF
--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -10,14 +10,13 @@ import { getMissingJudokaFields } from "./judokaValidation.js";
  * Determine if the code is running in a Node environment.
  *
  * @pseudocode
- * 1. Verify that `process` is defined.
- * 2. Confirm `process.versions.node` exists.
- * 3. Return `true` when both checks succeed.
+ * 1. Check if `process.versions.node` exists using optional chaining.
+ * 2. Return `true` when it exists; otherwise, return `false`.
  *
  * @returns {boolean} `true` if running under Node.
  */
 function isNodeEnvironment() {
-  return typeof process !== "undefined" && process.versions && process.versions.node;
+  return Boolean(process?.versions?.node);
 }
 
 export async function getAjv() {

--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -16,7 +16,7 @@ import { getMissingJudokaFields } from "./judokaValidation.js";
  * @returns {boolean} `true` if running under Node.
  */
 function isNodeEnvironment() {
-  return Boolean(process?.versions?.node);
+  return Boolean(typeof process !== "undefined" && process?.versions?.node);
 }
 
 export async function getAjv() {


### PR DESCRIPTION
## Summary
- Simplify Node environment detection with optional chaining and explicit boolean return
- Clarify pseudocode to note that the function returns true or false

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f8e0dc1048326b581d58ca1612e54