### PR TITLE
List wait steps for computer card

### DIFF
--- a/design/productRequirementsDocuments/prdRandomStatMode.md
+++ b/design/productRequirementsDocuments/prdRandomStatMode.md
@@ -88,21 +88,25 @@ _(Visuals to be attached)_
 ## Tasks
 
 - [ ] 1.0 Implement Stat Selection Timer
+
   - [ ] 1.1 Add countdown timer to stat selection screen
   - [ ] 1.2 Configure default timer value (30 seconds)
   - [ ] 1.3 Integrate timer with `timerControl.js`
 
 - [ ] 2.0 Develop Auto-Select Random Stat Logic
+
   - [ ] 2.1 Trigger random stat selection on timer expiry
   - [ ] 2.2 Display auto-select message to player
   - [ ] 2.3 Ensure stat is logged and used in battle logic
 
 - [ ] 3.0 Create Settings Page Toggle
+
   - [ ] 3.1 Add toggle to Settings UI
   - [ ] 3.2 Link toggle state to game logic
   - [ ] 3.3 Persist toggle state across sessions
 
 - [ ] 4.0 Build Visual Timer Feedback
+
   - [ ] 4.1 Display visible countdown on stat selection screen
   - [ ] 4.2 Update style for clarity and accessibility
 

--- a/src/helpers/battleJudokaPage.js
+++ b/src/helpers/battleJudokaPage.js
@@ -4,8 +4,9 @@
  * @returns {Promise<void>}
  *
  * @pseudocode
- * Export `waitForComputerCard` which resolves once a `.judoka-card` element
- * appears inside `#computer-card`.
+ * 1. Fetch the `#computer-card` container.
+ * 2. Resolve immediately if missing or a `.judoka-card` is already present.
+ * 3. Otherwise observe mutations and resolve once a `.judoka-card` appears.
  */
 export function waitForComputerCard() {
   const container = document.getElementById("computer-card");


### PR DESCRIPTION
## Summary
- list wait steps for computer card

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npm run check:contrast`
- `npx playwright test` *(fails: settings light expanded screenshot mismatch and battle orientation, battleJudoka page)*

------
https://chatgpt.com/codex/tasks/task_e_688f95a741808326ac8795268238764b