### PR TITLE
Update settings error pseudocode

### DIFF
--- a/src/helpers/showSettingsError.js
+++ b/src/helpers/showSettingsError.js
@@ -5,7 +5,9 @@
  * 1. Remove any existing `.settings-error-popup` element.
  * 2. Create a new div with that class containing an error message.
  * 3. Append the div to `document.body`.
- * 4. Remove the popup after 2 seconds.
+ * 4. Schedule removal:
+ *    - After `SETTINGS_FADE_MS`, remove the "show" class to start fading.
+ *    - After `SETTINGS_REMOVE_MS`, remove the popup element.
  */
 import { SETTINGS_FADE_MS, SETTINGS_REMOVE_MS } from "./constants.js";
 


### PR DESCRIPTION
## Summary
- clarify removal timing in settings error popup pseudocode

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings)
- `npx vitest run` (fails: 11)
- `npx playwright test` (fails: 3)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688f980662748326b6b5712d4b2d6abc