### PR TITLE
Remove remote score sync from classic battle

### DIFF
--- a/tests/helpers/classicBattle/syncFailures.test.js
+++ b/tests/helpers/classicBattle/syncFailures.test.js
@@ -46,27 +46,6 @@ describe("classicBattle backend sync failures", () => {
     expect(startRound).toHaveBeenCalledTimes(2);
     vi.useRealTimers();
   });
-
-  it("shows waiting message when score sync fails", async () => {
-    const showMessage = vi.fn();
-    const updateScore = vi.fn();
-    vi.doMock("../../../src/helpers/setupBattleInfoBar.js", () => ({
-      showMessage,
-      updateScore
-    }));
-    vi.doMock("../../../src/helpers/battleEngine.js", () => ({
-      handleStatSelection: vi.fn(),
-      quitMatch: vi.fn(),
-      getScores: () => {
-        throw new Error("fail");
-      },
-      _resetForTest: vi.fn()
-    }));
-    const { _syncScoreDisplay } = await import("../../../src/helpers/classicBattle.js");
-    _syncScoreDisplay();
-    expect(showMessage).toHaveBeenCalledWith("Waiting…");
-    expect(updateScore).not.toHaveBeenCalled();
-  });
 });
 
 describe("classicBattle timer messages", () => {


### PR DESCRIPTION
## Summary
- drop websocket/polling logic from classic battle helper
- simplify score display to use local engine scores
- trim obsolete test for backend score sync failures

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle Judoka page screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fa90d1ed0832683e324e5e8144556