### PR TITLE
Show JSON parse errors in tooltip viewer

### DIFF
--- a/design/productRequirementsDocuments/prdTooltipViewer.md
+++ b/design/productRequirementsDocuments/prdTooltipViewer.md
@@ -116,6 +116,7 @@ During v0.7, a typo in `stat.focus` persisted through 3 releases due to lack of 
 - Elements expose `data-key`, `data-body`, and `data-valid` for QA.
 - Viewer operates offline as a static HTML file.
 - When `tooltips.json` is missing, the preview panel displays "File not found".
+- When `tooltips.json` contains invalid JSON, the preview shows `Line X, Column Y`.
 - Styling matches JU-DO-KON! brand (typography, colors, spacing).
 - **Sidebar supports keyboard navigation and category highlighting**
 - **Visual indicators (icon/tooltip) for invalid/empty/malformed entries are present**
@@ -128,14 +129,14 @@ During v0.7, a typo in `stat.focus` persisted through 3 releases due to lack of 
 
 ## Edge Cases & Failures
 
-| Case                    | Handling Behavior                                                                                  |
-| ----------------------- | -------------------------------------------------------------------------------------------------- |
-| File missing            | Show "File not found" message in viewer panel                                                      |
-| Corrupted JSON          | Render structured parse error (line, column) in preview area                                       |
-| Malformed markdown      | Render best-effort version and flag preview with warning icon                                      |
-| Missing/empty strings   | Highlight key with red icon and tooltip: "Empty or whitespace-only content"                        |
-| Unrecognized key format | Warn if keys deviate from pattern `prefix.name` (`/^[a-z]+\.[\w-]+$/`); show red icon with tooltip |
-| Long values             | Truncate preview after 300px height; add “Show more” toggle                                        |
+| Case                    | Handling Behavior                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| File missing            | Show "File not found" message in viewer panel                                                          |
+| Corrupted JSON          | Render structured parse error with line and column numbers (e.g., "Line 4, Column 10") in preview area |
+| Malformed markdown      | Render best-effort version and flag preview with warning icon                                          |
+| Missing/empty strings   | Highlight key with red icon and tooltip: "Empty or whitespace-only content"                            |
+| Unrecognized key format | Warn if keys deviate from pattern `prefix.name` (`/^[a-z]+\.[\w-]+$/`); show red icon with tooltip     |
+| Long values             | Truncate preview after 300px height; add “Show more” toggle                                            |
 
 ---
 
@@ -146,6 +147,7 @@ During v0.7, a typo in `stat.focus` persisted through 3 releases due to lack of 
   - [x] 1.1 Load `tooltips.json` from `src/data/tooltips.json`
   - [x] 1.2 Handle loading failures with user-friendly error display
   - [x] 1.3 Parse JSON and extract key-value pairs
+  - [x] 1.4 Display line and column numbers on JSON parse errors
 
 - [x] 2.0 Implement Sidebar Key List
 

--- a/src/helpers/tooltipViewerPage.js
+++ b/src/helpers/tooltipViewerPage.js
@@ -24,9 +24,27 @@ const KEY_PATTERN = /^[a-z]+\.[\w-]+$/;
  * @returns {{ line: number, column: number } | null} Parsed line/column or `null`.
  */
 function extractLineAndColumn(error) {
-  const match = /line (\d+) column (\d+)/i.exec(error?.message ?? "");
+  const message = error?.message ?? "";
+  // Try several common error message formats
+  // 1. "line X column Y"
+  let match = /line (\d+)[^\d]+column (\d+)/i.exec(message);
   if (match) {
     return { line: Number(match[1]), column: Number(match[2]) };
+  }
+  // 2. "at line X column Y"
+  match = /at line (\d+)[^\d]+column (\d+)/i.exec(message);
+  if (match) {
+    return { line: Number(match[1]), column: Number(match[2]) };
+  }
+  // 3. "at position Z" (return as column, line unknown)
+  match = /at position (\d+)/i.exec(message);
+  if (match) {
+    return { line: null, column: Number(match[1]) };
+  }
+  // 4. "Unexpected token ... in JSON at position Z"
+  match = /in JSON at position (\d+)/i.exec(message);
+  if (match) {
+    return { line: null, column: Number(match[1]) };
   }
   return null;
 }

--- a/tests/helpers/tooltipViewerPage.test.js
+++ b/tests/helpers/tooltipViewerPage.test.js
@@ -197,6 +197,24 @@ describe("setupTooltipViewerPage", () => {
     expect(document.getElementById("tooltip-preview").textContent).toBe("File not found");
   });
 
+  it("shows parse error details when JSON is invalid", async () => {
+    Object.defineProperty(document, "readyState", { value: "loading", configurable: true });
+
+    const error = new SyntaxError("Unexpected token } in JSON at line 3 column 15");
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockRejectedValue(error),
+      importJsonModule: vi.fn().mockResolvedValue({})
+    }));
+
+    await import("../../src/helpers/tooltipViewerPage.js");
+
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+
+    await Promise.resolve();
+
+    expect(document.getElementById("tooltip-preview").textContent).toBe("Line 3, Column 15");
+  });
+
   it("adds warning icon to invalid key names", async () => {
     Object.defineProperty(document, "readyState", { value: "loading", configurable: true });
 


### PR DESCRIPTION
## Summary
- Parse JSON errors in `setupTooltipViewerPage` and surface line/column to the user
- Test tooltip viewer's parse error message
- Document parse-error behavior in Tooltip Viewer PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fa96c03d88326824e39c76b9598c9