### PR TITLE
Improve inspector panel accessibility

### DIFF
--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -164,8 +164,30 @@ async function createTopBar(judoka, flagUrl) {
 function createInspectorPanel(container, judoka, sections) {
   const panel = document.createElement("details");
   panel.className = "debug-panel";
+  panel.setAttribute("aria-label", "Inspector panel");
+
   const summary = document.createElement("summary");
   summary.textContent = "Card Inspector";
+  summary.tabIndex = 0;
+  summary.style.minHeight = "44px";
+  summary.style.minWidth = "44px";
+  summary.style.display = "flex";
+  summary.style.alignItems = "center";
+  summary.style.outline = "2px solid transparent";
+  summary.style.outlineOffset = "2px";
+  summary.addEventListener("focus", () => {
+    summary.style.outlineColor = "#000";
+  });
+  summary.addEventListener("blur", () => {
+    summary.style.outlineColor = "transparent";
+  });
+  summary.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      panel.open = !panel.open;
+      panel.dispatchEvent(new Event("toggle"));
+    }
+  });
   panel.appendChild(summary);
 
   const jsonPre = document.createElement("pre");

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -175,16 +175,16 @@ export async function handleStatSelection(stat) {
   const delay = 300 + Math.floor(Math.random() * 401);
   return new Promise((resolve) => {
     setTimeout(async () => {
-        await revealComputerCard();
-        infoBar.showMessage("");
-        const result = evaluateRound(stat);
-        resetStatButtons();
-        scheduleNextRound(result, getStartRound());
-        if (result.matchEnded) {
-            showSummary(result);
-        }
-        updateDebugPanel();
-        resolve(result);
+      await revealComputerCard();
+      infoBar.showMessage("");
+      const result = evaluateRound(stat);
+      resetStatButtons();
+      scheduleNextRound(result, getStartRound());
+      if (result.matchEnded) {
+        showSummary(result);
+      }
+      updateDebugPanel();
+      resolve(result);
     }, delay);
   });
 }

--- a/tests/helpers/createInspectorPanel.test.js
+++ b/tests/helpers/createInspectorPanel.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { createInspectorPanel } from "../../src/helpers/cardBuilder.js";
+
+const judoka = {};
+
+/** @test {createInspectorPanel} */
+describe("createInspectorPanel accessibility", () => {
+  it("adds label, focus styles, and keyboard support", () => {
+    const container = document.createElement("div");
+    const panel = createInspectorPanel(container, judoka, {});
+    const summary = panel.querySelector("summary");
+
+    expect(panel.getAttribute("aria-label")).toBe("Inspector panel");
+    expect(parseInt(summary.style.minHeight)).toBeGreaterThanOrEqual(44);
+    expect(parseInt(summary.style.minWidth)).toBeGreaterThanOrEqual(44);
+    expect(summary.tabIndex).toBe(0);
+
+    summary.dispatchEvent(new Event("focus"));
+    expect(summary.style.outlineColor).toBe("rgb(0, 0, 0)");
+
+    expect(panel.open).toBe(false);
+    summary.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(panel.open).toBe(true);
+    summary.dispatchEvent(new KeyboardEvent("keydown", { key: " " }));
+    expect(panel.open).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- label inspector panel details and enlarge summary's hit area for easier activation
- add keyboard handling, focus styles and tests for inspector panel accessiblity

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle Judoka page › narrow viewport screenshot and status aria attributes)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fb121ef2c8326a310a78ee2eb3d2e