### PR TITLE
Add InfoBar message helpers

### DIFF
--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -74,6 +74,35 @@ export function showMessage(text) {
 }
 
 /**
+ * Clear the round message.
+ *
+ * @pseudocode
+ * 1. If the message element exists, set its text content to an empty string.
+ *
+ * @returns {void}
+ */
+export function clearMessage() {
+  if (messageEl) {
+    messageEl.textContent = "";
+  }
+}
+
+/**
+ * Display a temporary message and return a function to clear it later.
+ *
+ * @pseudocode
+ * 1. Call `showMessage(text)` to update the round message.
+ * 2. Return `clearMessage` so callers can remove the message when finished.
+ *
+ * @param {string} text - Message to display temporarily.
+ * @returns {() => void} Function that clears the message.
+ */
+export function showTemporaryMessage(text) {
+  showMessage(text);
+  return clearMessage;
+}
+
+/**
  * Start a countdown timer that updates once per second.
  *
  * @pseudocode

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -75,8 +75,7 @@ async function handleReplay() {
   engineReset();
   const panel = document.getElementById("summary-panel");
   if (panel) panel.classList.add("hidden");
-  const msgEl = document.getElementById("round-message");
-  if (msgEl) msgEl.textContent = "";
+  infoBar.clearMessage();
   const startRoundFn = getStartRound();
   await startRoundFn();
 }
@@ -171,20 +170,20 @@ export function evaluateRound(stat) {
 export async function handleStatSelection(stat) {
   clearTimeout(statTimeoutId);
   clearTimeout(autoSelectId);
-  infoBar.showMessage("Waiting…");
+  const clearWaitingMessage = infoBar.showTemporaryMessage("Waiting…");
   const delay = 300 + Math.floor(Math.random() * 401);
   return new Promise((resolve) => {
     setTimeout(async () => {
-        await revealComputerCard();
-        infoBar.showMessage("");
-        const result = evaluateRound(stat);
-        resetStatButtons();
-        scheduleNextRound(result, getStartRound());
-        if (result.matchEnded) {
-            showSummary(result);
-        }
-        updateDebugPanel();
-        resolve(result);
+      await revealComputerCard();
+      clearWaitingMessage();
+      const result = evaluateRound(stat);
+      resetStatButtons();
+      scheduleNextRound(result, getStartRound());
+      if (result.matchEnded) {
+        showSummary(result);
+      }
+      updateDebugPanel();
+      resolve(result);
     }, delay);
   });
 }
@@ -212,8 +211,7 @@ export function _resetForTest() {
   autoSelectId = null;
   const timerEl = document.getElementById("next-round-timer");
   if (timerEl) timerEl.textContent = "";
-  const resultEl = document.getElementById("round-message");
-  if (resultEl) resultEl.textContent = "";
+  infoBar.clearMessage();
   const nextBtn = document.getElementById("next-round-button");
   if (nextBtn) {
     const clone = nextBtn.cloneNode(true);

--- a/src/helpers/setupBattleInfoBar.js
+++ b/src/helpers/setupBattleInfoBar.js
@@ -1,4 +1,11 @@
-import { initInfoBar, showMessage, updateScore, startCountdown } from "../components/InfoBar.js";
+import {
+  initInfoBar,
+  showMessage,
+  updateScore,
+  startCountdown,
+  clearMessage,
+  showTemporaryMessage
+} from "../components/InfoBar.js";
 import { onDomReady } from "./domReady.js";
 
 /**
@@ -16,4 +23,4 @@ function setupBattleInfoBar() {
 
 onDomReady(setupBattleInfoBar);
 
-export { showMessage, updateScore, startCountdown };
+export { showMessage, updateScore, startCountdown, clearMessage, showTemporaryMessage };

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -3,6 +3,8 @@ import {
   createInfoBar,
   initInfoBar,
   showMessage,
+  clearMessage,
+  showTemporaryMessage,
   startCountdown,
   updateScore
 } from "../../src/components/InfoBar.js";
@@ -37,6 +39,17 @@ describe("InfoBar component", () => {
 
     updateScore(1, 2);
     expect(document.getElementById("score-display").textContent).toBe("You: 1\nOpponent: 2");
+  });
+
+  it("clears and temporarily shows messages", () => {
+    showMessage("Persist");
+    clearMessage();
+    expect(document.getElementById("round-message").textContent).toBe("");
+
+    const clear = showTemporaryMessage("Temp");
+    expect(document.getElementById("round-message").textContent).toBe("Temp");
+    clear();
+    expect(document.getElementById("round-message").textContent).toBe("");
   });
 
   it("startCountdown updates timer each second", () => {

--- a/tests/helpers/setupBattleInfoBar.test.js
+++ b/tests/helpers/setupBattleInfoBar.test.js
@@ -26,6 +26,15 @@ describe("setupBattleInfoBar", () => {
     mod.showMessage("Hi");
     expect(document.getElementById("round-message").textContent).toBe("Hi");
 
+    const reset = mod.showTemporaryMessage("Temp");
+    expect(document.getElementById("round-message").textContent).toBe("Temp");
+    reset();
+    expect(document.getElementById("round-message").textContent).toBe("");
+
+    mod.showMessage("Hi");
+    mod.clearMessage();
+    expect(document.getElementById("round-message").textContent).toBe("");
+
     mod.updateScore(1, 2);
     expect(document.getElementById("score-display").textContent).toBe("You: 1\nOpponent: 2");
 
@@ -53,6 +62,8 @@ describe("setupBattleInfoBar", () => {
     const mod = await import("../../src/helpers/setupBattleInfoBar.js");
     mod.showMessage("Hello");
     expect(document.getElementById("round-message").textContent).toBe("Hello");
+    mod.clearMessage();
+    expect(document.getElementById("round-message").textContent).toBe("");
     mod.updateScore(3, 4);
     expect(document.getElementById("score-display").textContent).toBe("You: 3\nOpponent: 4");
     vi.useFakeTimers();


### PR DESCRIPTION
## Summary
- add `clearMessage` and `showTemporaryMessage` to InfoBar and re-export through `setupBattleInfoBar`
- use helpers in classic battle flow and tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle orientation screenshots, Battle Judoka page screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fb0eb8df48326839a3ba580d53ab4