### PR TITLE
Enable keyboard navigation for carousel

### DIFF
--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -4,6 +4,7 @@ import { setupLazyPortraits } from "./lazyPortrait.js";
 import {
   createScrollButton,
   updateScrollButtonState,
+  setupKeyboardNavigation,
   setupSwipeNavigation,
   applyAccessibilityImprovements,
   setupResponsiveSizing,
@@ -221,6 +222,7 @@ export async function buildCardCarousel(judokaList, gokyoData) {
   window.addEventListener("resize", updateButtons);
 
   setupFocusHandlers(container);
+  setupKeyboardNavigation(container);
   setupSwipeNavigation(container);
   applyAccessibilityImprovements(wrapper);
   setupLazyPortraits(container);

--- a/tests/helpers/keyboardNavigation.test.js
+++ b/tests/helpers/keyboardNavigation.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { setupKeyboardNavigation } from "../../src/helpers/carousel/navigation.js";
+import { CAROUSEL_SCROLL_DISTANCE } from "../../src/helpers/constants.js";
+
+describe("setupKeyboardNavigation", () => {
+  it("scrolls container and updates focus on arrow keys", () => {
+    const container = document.createElement("div");
+    container.scrollLeft = 0;
+    container.scrollBy = ({ left }) => {
+      container.scrollLeft += left;
+    };
+
+    const first = document.createElement("button");
+    first.className = "judoka-card";
+    first.tabIndex = 0;
+    const second = document.createElement("button");
+    second.className = "judoka-card";
+    second.tabIndex = 0;
+    const third = document.createElement("button");
+    third.className = "judoka-card";
+    third.tabIndex = 0;
+    container.append(first, second, third);
+    document.body.append(container);
+
+    setupKeyboardNavigation(container);
+    expect(container.tabIndex).toBe(0);
+
+    first.focus();
+    container.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+    expect(container.scrollLeft).toBe(CAROUSEL_SCROLL_DISTANCE);
+    expect(document.activeElement).toBe(second);
+
+    container.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
+    expect(container.scrollLeft).toBe(0);
+    expect(document.activeElement).toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary
- call `setupKeyboardNavigation` inside `buildCardCarousel` so users can tab to the carousel and scroll with arrow keys
- add tests ensuring arrow keys scroll the carousel and update focus

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Error loading game modes: Error: fail, Error fetching http://localhost:3000/src/dataclient_embeddings.meta.json: TypeError: fetch failed, and others)*
- `npx playwright test` *(1 failed, 2 interrupted, 1 skipped, 12 did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688faf583098832692bb21a50b90323a