### PR TITLE
Document Card Inspector gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ General settings provide basic customization for all players:
 
 - **Battle Debug Panel** – shows a collapsible `<pre>` beside the opponent's card that persists across rounds with live match data.
 - **Test Mode** – replaces all random calls with a seeded generator. Enable it from the Settings page to make matches reproducible and display a "Test Mode Active" banner. The seed resets on each new page load.
-- **Card Inspector** – adds a collapsible panel on each card displaying its raw JSON.
+- **Card Inspector** – when `devMode` (or a QA override) is active, enabling the `enableCardInspector` flag under Advanced Settings adds a collapsible panel on each card displaying its raw JSON.
 - **Layout Debug Outlines** – highlights all visible containers on every page whenever the flag is enabled.
 
 Advanced or debug-oriented flags live under a collapsible **Advanced Settings** section. This keeps experimental options out of sight for younger players while remaining accessible to testers.

--- a/design/productRequirementsDocuments/prdCardInspector.md
+++ b/design/productRequirementsDocuments/prdCardInspector.md
@@ -2,7 +2,7 @@
 
 ## Overview (TL;DR)
 
-The **Card Inspector** is a developer/debugging utility in JU-DO-KON! that lets users view the raw JSON data behind each judoka card, directly within the game UI. It’s toggled from the Settings page and is meant for QA, developers, and advanced users to inspect card data in real-time, without interrupting the core gameplay experience.
+The **Card Inspector** is a developer/debugging utility in JU-DO-KON! that lets users view the raw JSON data behind each judoka card, directly within the game UI. It’s exposed via the `enableCardInspector` feature flag on the Settings page and is meant for QA, developers, and advanced users to inspect card data in real time. Production builds hide the flag unless a QA or `devMode` override is active.
 
 ---
 
@@ -42,11 +42,12 @@ This problem is urgent because:
 
 ### Player Actions
 
-1. **Toggle ON** Card Inspector from the Settings page (defaults to OFF).
+1. Enable **Card Inspector** from the Settings page (Advanced → Feature Flags). The switch defaults to OFF and only appears in `devMode` or with a QA override.
 2. **Judoka cards** will now show a collapsible JSON panel.
 3. Each panel starts **collapsed** and can be expanded via a disclosure triangle (`<details>`).
 4. Clicking outside a panel does not close it (explicit collapse required).
-5. Disabling the toggle **immediately hides** all JSON panels without reloading.
+5. Opening the panel sets `data-inspector="true"` on the card container for styling.
+6. Disabling the toggle **immediately hides** all JSON panels and removes the data attribute without reloading.
 
 ### Cancel/Exit Options
 
@@ -63,10 +64,11 @@ This problem is urgent because:
 
 ## Acceptance Criteria
 
-- The toggle switch appears in Settings, labeled “Card Inspector”, with the default state set to OFF.
+- The `enableCardInspector` switch appears in Settings when `devMode` or a QA override is active. It defaults to OFF.
 - Toggle state persists between sessions and updates the UI without a full reload.
-- JSON panel appears collapsed by default under each judoka card.
-- JSON output is valid, formatted, and reflects the current state of card data.
+- Enabling the flag injects a `<details>` element labeled “Card Inspector” under each visible judoka card.
+- JSON panel appears collapsed by default and pretty-prints only the card’s JSON (markup preview removed).
+- Opening the panel sets `data-inspector="true"` on the card container; closing removes the attribute.
 - Disclosure control is keyboard-accessible and screen-reader-friendly.
 - The panel never overlaps gameplay UI elements or interferes with interactions.
 - In cases of errors (e.g., invalid JSON, null card), a fallback message (“Invalid card data”) is shown.
@@ -87,7 +89,7 @@ This problem is urgent because:
 
 - Must support keyboard tabbing and screen reader hints (e.g., “Card Data: collapsed”).
 - Error handling for malformed card data (`try/catch` around render).
-- No inspector content rendered on production builds unless QA override is active.
+- In production builds the feature flag is hidden and the inspector never renders unless a QA or `devMode` override is explicitly enabled.
 
 ---
 
@@ -113,14 +115,16 @@ This problem is urgent because:
 
   - [ ] 1.1 Add "Card Inspector" toggle switch to `settings.html`
   - [ ] 1.2 Set default state to OFF
-  - [ ] 1.3 Persist toggle in user settings
-  - [ ] 1.4 Reflect toggle state in UI immediately
+  - [ ] 1.3 Gated by `devMode`/QA override so the switch is hidden in production
+  - [ ] 1.4 Persist toggle in user settings
+  - [ ] 1.5 Reflect toggle state in UI immediately
 
 - [ ] 2.0 Render JSON Panel in Cards
 
   - [ ] 2.1 Check for `toggle=true` in `cardBuilder.js`
   - [ ] 2.2 Inject formatted JSON into each card
   - [ ] 2.3 Use `<details>` for collapsibility with proper labeling
+  - [ ] 2.4 Set `data-inspector="true"` on open; remove on close
 
 - [ ] 3.0 Visual and Responsive Styling
 


### PR DESCRIPTION
## Summary
- describe Card Inspector feature flag and devMode gating in PRD
- note devMode/QA requirements for Card Inspector in README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fb6d441f483268b4cf60c8aaea24d