### PR TITLE
Show fallback card when judoka data fails

### DIFF
--- a/src/helpers/carousel/cards.js
+++ b/src/helpers/carousel/cards.js
@@ -10,6 +10,7 @@ import { getMissingJudokaFields, hasRequiredJudokaFields } from "../judokaValida
  *    a. Validate required fields and log errors for missing data.
  *    b. Generate a card or fall back to a default judoka.
  *    c. Apply accessibility attributes and append to the container.
+ *    d. Replace cards with the fallback judoka when the portrait fails to load.
  *
  * @param {HTMLElement} container - Carousel container element.
  * @param {Judoka[]} judokaList - Array of judoka objects.
@@ -34,9 +35,20 @@ export async function appendCards(container, judokaList, gokyoLookup) {
     if (card) {
       const img = card.querySelector("img");
       if (img) {
-        img.onerror = () => {
-          img.src = "./assets/cardBacks/cardBack-2.png";
-        };
+        img.addEventListener("error", async () => {
+          const fallback = await getFallbackJudoka();
+          const temp = document.createElement("div");
+          const replacement = await generateJudokaCard(fallback, gokyoLookup, temp);
+          if (replacement) {
+            replacement.tabIndex = 0;
+            replacement.setAttribute("role", "listitem");
+            replacement.setAttribute(
+              "aria-label",
+              replacement.getAttribute("data-judoka-name") || "Judoka card"
+            );
+            container.replaceChild(replacement, card);
+          }
+        });
       }
       card.tabIndex = 0;
       card.setAttribute("role", "listitem");

--- a/tests/helpers/appendCards.test.js
+++ b/tests/helpers/appendCards.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+
+describe("appendCards", () => {
+  it("replaces broken images with fallback card", async () => {
+    const defaultJudoka = { id: 0, firstname: "Default", surname: "Card" };
+    const generateJudokaCard = vi.fn(async (judoka, _gokyo, container) => {
+      const card = document.createElement("div");
+      card.setAttribute("data-judoka-name", `${judoka.firstname} ${judoka.surname}`);
+      const img = document.createElement("img");
+      card.appendChild(img);
+      if (container) container.appendChild(card);
+      return card;
+    });
+    const getFallbackJudoka = vi.fn(async () => defaultJudoka);
+    vi.doMock("../../src/helpers/cardBuilder.js", () => ({ generateJudokaCard }));
+    vi.doMock("../../src/helpers/judokaUtils.js", () => ({ getFallbackJudoka }));
+    vi.doMock("../../src/helpers/judokaValidation.js", () => ({
+      getMissingJudokaFields: () => [],
+      hasRequiredJudokaFields: () => true
+    }));
+
+    const { appendCards } = await import("../../src/helpers/carousel/cards.js");
+
+    const container = document.createElement("div");
+    const judokaList = [{ id: 1, firstname: "Real", surname: "Judoka" }];
+    await appendCards(container, judokaList, {});
+
+    const initialCard = container.firstElementChild;
+    const img = initialCard.querySelector("img");
+    img.dispatchEvent(new Event("error"));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(getFallbackJudoka).toHaveBeenCalled();
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild.getAttribute("data-judoka-name")).toBe("Default Card");
+  });
+});


### PR DESCRIPTION
## Summary
- replace broken carousel images with the default judoka card
- render a default card on the Browse Judoka page when roster data fails to load
- test carousel image fallback and Browse Judoka page default behavior

## Testing
- `npx prettier . --check | tail -n 20`
- `npx eslint src/helpers/carousel/cards.js src/helpers/browseJudokaPage.js tests/helpers/appendCards.test.js tests/helpers/browseJudokaPage.test.js`
- `npx vitest run tests/helpers/appendCards.test.js tests/helpers/browseJudokaPage.test.js`
- `npx playwright test` *(fails: screenshot differences and interrupted tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fb6b92cf08326bc54a80899ccee7b