### PR TITLE
Handle invalid card data in inspector

### DIFF
--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -162,6 +162,15 @@ async function createTopBar(judoka, flagUrl) {
 }
 
 function createInspectorPanel(container, judoka, sections) {
+  let json;
+  try {
+    json = JSON.stringify(judoka, null, 2);
+  } catch {
+    const p = document.createElement("p");
+    p.textContent = "Invalid card data";
+    return p;
+  }
+
   const panel = document.createElement("details");
   panel.className = "debug-panel";
   panel.setAttribute("aria-label", "Inspector panel");
@@ -191,7 +200,7 @@ function createInspectorPanel(container, judoka, sections) {
   panel.appendChild(summary);
 
   const jsonPre = document.createElement("pre");
-  jsonPre.textContent = JSON.stringify(judoka, null, 2);
+  jsonPre.textContent = json;
   panel.appendChild(jsonPre);
 
   // Only show the card's JSON data. The markup preview was removed to
@@ -247,7 +256,11 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup, options = {}) 
 
   const cardContainer = document.createElement("div");
   cardContainer.className = "card-container";
-  cardContainer.dataset.cardJson = JSON.stringify(judoka);
+  try {
+    cardContainer.dataset.cardJson = JSON.stringify(judoka);
+  } catch {
+    // Ignore serialization errors; inspector will render a fallback
+  }
 
   const judokaCard = document.createElement("div");
   judokaCard.className = `judoka-card ${cardType}`;

--- a/tests/card/judokaCardInspectorInvalidData.test.js
+++ b/tests/card/judokaCardInspectorInvalidData.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { generateJudokaCardHTML } from "../../src/helpers/cardBuilder.js";
+
+const judoka = {
+  id: 1,
+  firstname: "John",
+  surname: "Doe",
+  country: "USA",
+  countryCode: "us",
+  stats: { power: 5, speed: 5, technique: 5, kumikata: 5, newaza: 5 },
+  weightClass: "-100kg",
+  signatureMoveId: 1,
+  rarity: "common",
+  gender: "male",
+  extra: 1n
+};
+
+const gokyoLookup = {
+  1: { id: 1, name: "Uchi-mata" }
+};
+
+describe("generateJudokaCardHTML invalid inspector data", () => {
+  it("renders fallback paragraph when card data cannot be stringified", async () => {
+    const container = await generateJudokaCardHTML(judoka, gokyoLookup, {
+      enableInspector: true
+    });
+    const panel = container.querySelector(".debug-panel");
+    expect(panel).toBeNull();
+    const fallback = container.querySelector("p");
+    expect(fallback).toBeTruthy();
+    expect(fallback.textContent).toBe("Invalid card data");
+  });
+});


### PR DESCRIPTION
## Summary
- Safely stringify judoka data for inspector panels; render `Invalid card data` when serialization fails
- Add regression test for malformed judoka objects

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings only)
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diff at browse-judoka.spec.js:83)*
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688fb6ad80308326a5c436fb99ac0fab