### PR TITLE
Use grid for settings page links

### DIFF
--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -163,6 +163,7 @@ Reuse the following markup for general settings, game modes, and feature flags:
   - Group supplemental pages under a `Links` heading using a simple `<fieldset>`.
   - Include links to `changeLog.html`, `prdViewer.html`, `mockupViewer.html`, `tooltipViewer.html`, and `vectorSearch.html`.
   - Style each as a `.settings-item` and assign sequential `tabindex` values (e.g., 99, 100, 101).
+  - Arrange the links in a responsive three-column grid using `.settings-links-list`; collapse to a single column below 768px.
   - Position this fieldset after all setting controls and before the error popup container.
 
 - **Error Message Container & ARIA**

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -85,6 +85,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - **View Design Mockups:** Link opens `mockupViewer.html` for viewing design mockups.
 - **View Tooltip Descriptions:** Link opens `tooltipViewer.html` for exploring tooltip text.
 - **Vector Search for RAG:** Link opens `vectorSearch.html` to explore the vector database.
+- Links in this fieldset are arranged in a responsive three-column grid, collapsing to a single column below 768px.
 - **Restore Defaults:** Button opens a confirmation modal to clear stored settings and reapply defaults.
 
 ---

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -288,7 +288,7 @@
           </div>
           <fieldset id="links-container" class="settings-form">
             <legend>Links</legend>
-            <ul class="settings-links-list">
+            <ul class="settings-links-list settings-links-grid">
               <li class="settings-item">
                 <a href="../pages/changeLog.html" id="changelog-link" tabindex="99"
                   >View Change Log</a

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -195,6 +195,25 @@
   color: var(--color-text);
 }
 
+.settings-links-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-lg);
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.settings-links-list .settings-item {
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .settings-links-list {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Simulated viewport for screenshot testing */
 body.simulate-viewport {
   width: 375px;


### PR DESCRIPTION
## Summary
- Make Links list a grid so items arrange in three columns on wide screens and collapse to one column on small screens
- Document the responsive three-column Links layout in settings design guidelines and PRD

## Testing
- `npx prettier . --check`
- `npx eslint src/pages/settings.html src/styles/settings.css`
- `npx vitest run`
- `npx playwright test` *(fails: 10 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fbeae45688326b7a188119dec570e