### PR TITLE
Document local opponent simulation for Classic Battle

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -64,11 +64,10 @@ the returned values to `InfoBar.updateScore`. The helper module
 `setupBattleInfoBar.js` exposes this method for pages, keeping UI updates
 decoupled from engine logic.
 
-`classicBattle.js` opens a WebSocket to `/classic-battle` so the backend can
-stream opponent stats and scores. If the connection drops or WebSockets are
-unavailable, it falls back to polling `/api/classic-battle/score` with
-exponential backoff. Latency or connection problems are surfaced via
-`InfoBar.showMessage` so players know when updates are delayed.
+`classicBattle.js` now simulates the opponent entirely on the client. After a
+player selects a stat, the opponent’s choice is computed locally and revealed
+after a brief artificial delay. This client-side approach mimics turn-taking
+without any WebSocket or polling endpoints.
 
 ```javascript
 import { createCard } from "./src/components/Card.js";

--- a/design/productRequirementsDocuments/prdCardCarousel.md
+++ b/design/productRequirementsDocuments/prdCardCarousel.md
@@ -51,7 +51,7 @@ Failure to provide an efficient browsing experience may impact core gameplay —
 | **P1**   | Display judoka in a carousel.                                          |
 | **P1**   | Scroll left/right using large arrow buttons labeled "Prev" and "Next". |
 | **P2**   | Swipe or scroll navigation on mobile devices.                          |
-| **P2**   | Cards slightly enlarge on hover.                                 |
+| **P2**   | Cards slightly enlarge on hover.                                       |
 | **P3**   | Page markers show "current page of total" with active highlight.       |
 | **P3**   | Keyboard arrow key navigation for accessibility.                       |
 

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -74,11 +74,9 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Card reveal and result animations should use hardware-accelerated CSS for smooth performance on low-end devices (**≥60 fps**).
 - **Stat selection timer (30s) must be displayed in the Info Bar; if timer expires, a random stat is auto-selected. Timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see prdBattleInfoBar.md).**
 - Detect timer drift by comparing engine state with real time; if drift exceeds 2s, display "Waiting…" and restart the countdown.
-- Backend must expose a WebSocket endpoint (`/classic-battle`) streaming opponent
-  scores and stat data. Clients fall back to polling `/api/classic-battle/score`
-  with exponential backoff when the socket is unavailable. Latency or dropped
-  connections trigger a `"Waiting…"` message in the Info Bar (**<200 ms
-  latency** when connected).
+- Opponent stat selection runs entirely on the client. After the player picks a
+  stat (or the timer auto-chooses), the opponent's choice is revealed after a
+  short artificial delay to mimic turn-taking.
 - The debug panel is available when the `battleDebugPanel` feature flag is enabled and appears beside the opponent's card.
 
 ---


### PR DESCRIPTION
## Summary
- describe client-side opponent simulation and delay in architecture overview
- remove WebSocket endpoint details from Classic Battle PRD and note local opponent selection delay
- format Card Carousel PRD for consistency

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings)*
- `npx vitest run` *(errors: fetch failures, navigation not implemented)*
- `npx playwright test` *(2 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fbfb62f1083269f52eab278b01fca