### PR TITLE
Remove gray display mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 
 ## Display Modes
 
-Light, dark, gray and high-contrast themes are supported. Changing modes uses a slide-over transition implemented with the View Transitions API when supported; otherwise the colors update immediately. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode switch applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running. The `--link-color` token controls anchor colors and is overridden to `#3399ff` in dark mode (along with `--color-primary: #ff4530`). In dark mode the tooltip viewer also uses this bright link color to highlight the selected sidebar key for better contrast.
+Light, dark, and high-contrast themes are supported. Changing modes uses a slide-over transition implemented with the View Transitions API when supported; otherwise the colors update immediately. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode switch applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running. The `--link-color` token controls anchor colors and is overridden to `#3399ff` in dark mode (along with `--color-primary: #ff4530`). In dark mode the tooltip viewer also uses this bright link color to highlight the selected sidebar key for better contrast.
 
 ## Settings & Feature Flags
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -77,8 +77,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - **Motion effects (binary):** ON/OFF (default: ON) – Disable animations for a calmer interface.
 - **Typewriter effect (binary):** ON/OFF (default: ON, not currently used on the meditation screen) – Toggle the quote typing animation.
 - **Tooltips (binary):** ON/OFF (default: ON) – Show or hide helpful tooltips.
-- **Display mode (three options):** Light, Dark, Gray (default: Light)
-  - _Gray mode_ provides a grayscale display to reduce visual noise for neurodivergent users.
+- **Display mode (three options):** Light, Dark, High Contrast (default: Light)
 - **Game modes list:** Pulled from `gameModes.json` and cross-referenced with `navigationItems.json` to determine order and visibility; each mode has a binary toggle.
 - **View Change Log:** Link opens `changeLog.html` with the latest 20 judoka updates.
 - **View PRD Documents:** Link opens `prdViewer.html` for browsing product documents.
@@ -156,7 +155,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 
 ### Display Mode Switch
 
-- AC-5.1 Selecting a new display mode (light/dark/gray) applies changes instantly across all relevant UI components.
+- AC-5.1 Selecting a new display mode (light/dark/high-contrast) applies changes instantly across all relevant UI components.
 - AC-4.2 Selected mode persists through a page refresh within the same session.
 - AC-4.3 Current display mode is correctly pulled from `settings.json` on page load.
 - AC-4.4 Transition to new display mode completes without visible flickering or rendering artifacts.

--- a/playwright/settings-screenshot.spec.js
+++ b/playwright/settings-screenshot.spec.js
@@ -9,7 +9,7 @@ test.describe.parallel(
     test.use({ viewport: { width: 1280, height: 720 } });
     test.skip(!runScreenshots);
 
-    const modes = ["light", "dark", "gray"];
+    const modes = ["light", "dark"];
 
     for (const mode of modes) {
       test(`mode ${mode} collapsed`, async ({ page }) => {

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -144,7 +144,6 @@ test.describe("Settings page", () => {
         "label[for='tooltips-toggle']",
         "label[for='display-mode-light']",
         "label[for='display-mode-dark']",
-        "label[for='display-mode-gray']",
         "label[for='display-mode-high-contrast']"
       ].join(", "),
       (els) =>
@@ -176,7 +175,6 @@ test.describe("Settings page", () => {
       "#tooltips-toggle",
       "#display-mode-light",
       "#display-mode-dark",
-      "#display-mode-gray",
       "#display-mode-high-contrast"
     ];
 

--- a/src/helpers/displayMode.js
+++ b/src/helpers/displayMode.js
@@ -2,17 +2,17 @@
  * Apply the chosen display mode by setting a theme data attribute on the body.
  *
  * @pseudocode
- * 1. Verify that `mode` is one of "light", "dark", "gray", or "high-contrast".
+ * 1. Verify that `mode` is one of "light", "dark", or "high-contrast".
  *    - If the value is invalid, log a warning and exit early.
  *
  * 2. Set `document.body.dataset.theme` to the provided mode value.
  * 3. Remove any existing `*-mode` classes from `document.body` and add the
  *    class corresponding to the new mode (e.g. `dark-mode`).
  *
- * @param {"light"|"dark"|"gray"|"high-contrast"} mode - Desired display mode.
+ * @param {"light"|"dark"|"high-contrast"} mode - Desired display mode.
  */
 export function applyDisplayMode(mode) {
-  const validModes = ["light", "dark", "gray", "high-contrast"];
+  const validModes = ["light", "dark", "high-contrast"];
   if (!validModes.includes(mode)) {
     console.warn(`Invalid display mode: "${mode}". Valid modes are: ${validModes.join(", ")}.`);
     return;

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -184,7 +184,7 @@ export function resetSettings() {
  * @property {boolean} typewriterEffect
  * @property {boolean} tooltips
  * @property {boolean} showCardOfTheDay
- * @property {"light"|"dark"|"gray"|"high-contrast"} displayMode
+ * @property {"light"|"dark"|"high-contrast"} displayMode
  * @property {boolean} fullNavigationMap
  * @property {Record<string, string>} [tooltipIds]
  * @property {Record<string, boolean>} [gameModes]

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -92,16 +92,6 @@
                 <div class="display-mode-option">
                   <input
                     type="radio"
-                    id="display-mode-gray"
-                    name="display-mode"
-                    value="gray"
-                    tabindex="-1"
-                  />
-                  <label for="display-mode-gray">Gray</label>
-                </div>
-                <div class="display-mode-option">
-                  <input
-                    type="radio"
                     id="display-mode-high-contrast"
                     name="display-mode"
                     value="high-contrast"

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -27,7 +27,7 @@
     },
     "displayMode": {
       "type": "string",
-      "enum": ["light", "dark", "gray", "high-contrast"],
+      "enum": ["light", "dark", "high-contrast"],
       "description": "Visual display mode."
     },
     "fullNavigationMap": {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -83,14 +83,6 @@
   --button-disabled-pattern: none;
 }
 
-/* Gray mode variable overrides */
-[data-theme="gray"] {
-  --color-surface: #f0f0f0;
-  --color-background: #cdcdcd;
-  --color-text: #000000;
-  --color-text-inverted: #ffffff;
-}
-
 /* High contrast mode variable overrides */
 [data-theme="high-contrast"] {
   --color-surface: #000000;

--- a/tests/helpers/displayMode.test.js
+++ b/tests/helpers/displayMode.test.js
@@ -11,7 +11,6 @@ describe("applyDisplayMode", () => {
     style.textContent = `
       body.light-mode { background-color: rgb(255, 255, 255); }
       body.dark-mode { background-color: rgb(0, 0, 0); }
-      body.gray-mode { background-color: rgb(205, 205, 205); }
       body.high-contrast-mode { background-color: rgb(0, 0, 0); }
     `;
     document.head.appendChild(style);
@@ -21,14 +20,11 @@ describe("applyDisplayMode", () => {
     style.remove();
   });
 
-  it.each(["dark", "gray", "light", "high-contrast"])(
-    "sets data-theme and class for %s mode",
-    (mode) => {
-      applyDisplayMode(mode);
-      expect(document.body.dataset.theme).toBe(mode);
-      expect(document.body.classList.contains(`${mode}-mode`)).toBe(true);
-    }
-  );
+  it.each(["dark", "light", "high-contrast"])("sets data-theme and class for %s mode", (mode) => {
+    applyDisplayMode(mode);
+    expect(document.body.dataset.theme).toBe(mode);
+    expect(document.body.classList.contains(`${mode}-mode`)).toBe(true);
+  });
 
   it("warns when an invalid mode is provided", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -75,11 +75,6 @@ export function createSettingsDom() {
   displayDark.type = "radio";
   displayDark.name = "display-mode";
   displayDark.value = "dark";
-  const displayGray = document.createElement("input");
-  displayGray.id = "display-mode-gray";
-  displayGray.type = "radio";
-  displayGray.name = "display-mode";
-  displayGray.value = "gray";
   const displayHighContrast = document.createElement("input");
   displayHighContrast.id = "display-mode-high-contrast";
   displayHighContrast.type = "radio";
@@ -120,7 +115,6 @@ export function createSettingsDom() {
     fullNavigationMapToggle,
     displayLight,
     displayDark,
-    displayGray,
     displayHighContrast,
     gameModeToggleContainer,
     advancedSection,


### PR DESCRIPTION
## Summary
- drop gray mode from theme handling and settings schema
- align tests, styles, and docs with remaining light/dark/high-contrast options

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot baseline mismatches)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fbede95cc8326ae66a7f730d576b6