### PR TITLE
Remove gray display option

### DIFF
--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -92,16 +92,6 @@
                 <div class="display-mode-option">
                   <input
                     type="radio"
-                    id="display-mode-gray"
-                    name="display-mode"
-                    value="gray"
-                    tabindex="-1"
-                  />
-                  <label for="display-mode-gray">Gray</label>
-                </div>
-                <div class="display-mode-option">
-                  <input
-                    type="radio"
                     id="display-mode-high-contrast"
                     name="display-mode"
                     value="high-contrast"

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -83,14 +83,6 @@
   --button-disabled-pattern: none;
 }
 
-/* Gray mode variable overrides */
-[data-theme="gray"] {
-  --color-surface: #f0f0f0;
-  --color-background: #cdcdcd;
-  --color-text: #000000;
-  --color-text-inverted: #ffffff;
-}
-
 /* High contrast mode variable overrides */
 [data-theme="high-contrast"] {
   --color-surface: #000000;


### PR DESCRIPTION
## Summary
- remove Gray display mode option and tabindex
- drop unused gray theme overrides in base styling

## Testing
- `npx prettier . --write`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: 10 failed, 72 passed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fc2cbfe908326b8174e3cfca76390