### PR TITLE
Add timer drift monitoring

### DIFF
--- a/src/helpers/battleEngine.js
+++ b/src/helpers/battleEngine.js
@@ -235,9 +235,9 @@ export function watchForDrift(duration, onDrift) {
   const interval = setInterval(() => {
     const elapsed = Math.floor((Date.now() - start) / 1000);
     const expected = duration - elapsed;
-    if (Math.abs(remaining - expected) > DRIFT_THRESHOLD) {
+    if (Math.abs(getTimerState().remaining - expected) > DRIFT_THRESHOLD) {
       clearInterval(interval);
-      if (typeof onDrift === "function") onDrift(remaining);
+      if (typeof onDrift === "function") onDrift(getTimerState().remaining);
     }
   }, 1000);
   return () => clearInterval(interval);


### PR DESCRIPTION
## Summary
- detect timer drift in battle engine
- restart round and cooldown timers on drift with consistent messaging

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: screenshot mismatch)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fc77171288326bc019adbbd4e9090