### PR TITLE
docs: update display mode references

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Try the game live in your browser: [JU-DO-KON!](https://cyanautomation.github.io
 
 ## Display Modes
 
-Light, dark, and high-contrast themes are supported. Changing modes uses a slide-over transition implemented with the View Transitions API when supported; otherwise the colors update immediately. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode switch applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running. The `--link-color` token controls anchor colors and is overridden to `#3399ff` in dark mode (along with `--color-primary: #ff4530`). In dark mode the tooltip viewer also uses this bright link color to highlight the selected sidebar key for better contrast.
+Light, Dark, and High Contrast themes are supported. Changing modes uses a slide-over transition implemented with the View Transitions API when supported; otherwise the colors update immediately. See [prdSettingsMenu.md](design/productRequirementsDocuments/prdSettingsMenu.md) for how the Display Mode switch applies these themes and related accessibility checks. If you modify colors, run `npm run check:contrast` while the development server is running. The `--link-color` token controls anchor colors and is overridden to `#3399ff` in dark mode (along with `--color-primary: #ff4530`). In dark mode the tooltip viewer also uses this bright link color to highlight the selected sidebar key for better contrast.
 
 ## Settings & Feature Flags
 

--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -92,10 +92,10 @@ Reuse the following markup for general settings, game modes, and feature flags:
   - Use CSS variables: `--color-primary`, `--button-bg`, etc.
   - Do not hard-code color values.
 
-- Ensure all new elements work across Light, Dark, and Gray themes.
+- Ensure all new elements work across Light, Dark, and High Contrast themes.
 
-  - Snackbars should use `--color-tertiary` as the background to avoid
-    clashing with the bottom navigation bar.
+- Snackbars should use `--color-tertiary` as the background to avoid
+  clashing with the bottom navigation bar.
 
 - **Spacing and Sizing**
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -286,7 +286,7 @@ The page begins with an `h1` heading labeled "Settings". Two `fieldset` sections
 [ ON | OFF ] (default: ON)
 
 [ SELECTOR: DISPLAY MODE ]  
-[ Light | Dark | Gray ] (default: Light)
+[ Light | Dark | High Contrast ] (default: Light)
 
 ───────────────────────────────  
 | GAME MODES |  


### PR DESCRIPTION
## Summary
- remove gray theme references and clarify high contrast option
- document color theme coverage in settings guidelines
- adjust settings menu display mode selector to include High Contrast

## Testing
- `npx prettier . --write`
- `npx eslint .` *(fails: no-unused-vars warnings)*
- `npx vitest run`
- `npx playwright test` *(fails: Battle Judoka and Signature move tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fc7564094832683ab5c618923063f