### PR TITLE
Document InfoBar temporary notices

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -66,7 +66,7 @@ decoupled from engine logic.
 
 `InfoBar.showTemporaryMessage(text)` displays a transient notice and returns a
 clear function that only removes the message if the same text is still shown.
-`classicBattle.handleStatSelection` uses this helper to show **"Waiting…"** while
+`classicBattle.js.handleStatSelection` uses this helper to show **"Waiting…"** while
 the opponent's move is computed.
 
 `classicBattle.js` now simulates the opponent entirely on the client. After a

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -64,10 +64,17 @@ the returned values to `InfoBar.updateScore`. The helper module
 `setupBattleInfoBar.js` exposes this method for pages, keeping UI updates
 decoupled from engine logic.
 
+`InfoBar.showTemporaryMessage(text)` displays a transient notice and returns a
+clear function that only removes the message if the same text is still shown.
+`classicBattle.handleStatSelection` uses this helper to show **"Waiting…"** while
+the opponent's move is computed.
+
 `classicBattle.js` now simulates the opponent entirely on the client. After a
-player selects a stat, the opponent’s choice is computed locally and revealed
-after a brief artificial delay. This client-side approach mimics turn-taking
-without any WebSocket or polling endpoints.
+player selects a stat, the module introduces a 300–700 ms delay and clears the
+temporary message once the opponent’s card is revealed. Tests and gameplay
+should expect the brief **"Waiting…"** notice during this pause. This
+client-side approach mimics turn-taking without any WebSocket or polling
+endpoints.
 
 ```javascript
 import { createCard } from "./src/components/Card.js";


### PR DESCRIPTION
## Summary
- Document `InfoBar.showTemporaryMessage` behavior and the brief opponent-selection delay that shows a temporary "Waiting…" notice

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings: no-unused-vars)
- `npx vitest run`
- `npx playwright test` *(fails: 4 tests, see log for screenshot diffs)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fcbf73d688326982a46a30b3522ca