### PR TITLE
Use 'Prev.' for carousel left button

### DIFF
--- a/design/productRequirementsDocuments/prdCardCarousel.md
+++ b/design/productRequirementsDocuments/prdCardCarousel.md
@@ -46,21 +46,21 @@ Failure to provide an efficient browsing experience may impact core gameplay —
 
 ## Functional Requirements
 
-| Priority | Requirement                                                            |
-| -------- | ---------------------------------------------------------------------- |
-| **P1**   | Display judoka in a carousel.                                          |
-| **P1**   | Scroll left/right using large arrow buttons labeled "Prev" and "Next". |
-| **P2**   | Swipe or scroll navigation on mobile devices.                          |
-| **P2**   | Cards scale to **1.05** on hover; center card scales to **1.1**.       |
-| **P3**   | Page markers show "current page of total" with active highlight.       |
-| **P3**   | Keyboard arrow key navigation for accessibility.                       |
+| Priority | Requirement                                                             |
+| -------- | ----------------------------------------------------------------------- |
+| **P1**   | Display judoka in a carousel.                                           |
+| **P1**   | Scroll left/right using large arrow buttons labeled "Prev." and "Next". |
+| **P2**   | Swipe or scroll navigation on mobile devices.                           |
+| **P2**   | Cards scale to **1.05** on hover; center card scales to **1.1**.        |
+| **P3**   | Page markers show "current page of total" with active highlight.        |
+| **P3**   | Keyboard arrow key navigation for accessibility.                        |
 
 ---
 
 ## Acceptance Criteria
 
 - Carousel loads quickly for up to 150 cards.
-- User can scroll left/right via large "Prev" and "Next" arrow buttons.
+- User can scroll left/right via large "Prev." and "Next" arrow buttons.
 - Arrow buttons disable when the carousel reaches either end so players cannot scroll past the available cards.
 - User can see page markers showing "current page of total" with the active page highlighted and announced via `aria-live`.
 - Hovering over a card scales it to **1.05**, verified via bounding box. The card nearest the center scales to **1.1** when focused.
@@ -100,7 +100,7 @@ Failure to provide an efficient browsing experience may impact core gameplay —
 2. The returned element is mounted into the page (for example, `browseJudoka.html` inserts it into `#carousel-container`).
 3. Carousel loads cards quickly; a loading spinner appears if delayed.
 4. Player uses:
-   - Large "Prev" and "Next" arrow buttons to move left or right,
+   - Large "Prev." and "Next" arrow buttons to move left or right,
    - Swipe or scroll gestures on mobile,
    - Or keyboard arrows for navigation.
 5. Hovering scales cards to **1.05** on desktop.
@@ -162,7 +162,7 @@ generated carousel so each card's real portrait loads once it becomes visible.
 
 ### Conceptual Layout
 
-- **Desktop**: 3 cards in view — center card scales to **1.1**; large "Prev" and "Next" arrows at the sides; page markers at the bottom.
+- **Desktop**: 3 cards in view — center card scales to **1.1**; large "Prev." and "Next" arrows at the sides; page markers at the bottom.
 - **Mobile**: 1.5 cards visible (peek of next card); swipe or scroll enabled; arrows optional.
 - **Hover Effect**: On desktop, cards scale to **1.05** on hover; the focused center card scales to **1.1**.
 - **Touch Interaction**: On mobile, swipe left/right; smooth snap after swipe.
@@ -180,7 +180,7 @@ generated carousel so each card's real portrait loads once it becomes visible.
   - [x] 1.2 Implement dynamic loading for up to 100 cards.
   - [x] 1.3 Ensure responsive resizing for mobile and desktop.
 - [x] 2.0 Integrate Navigation Methods (P1)
-  - [x] 2.1 Add large "Prev" and "Next" arrow buttons for scrolling.
+- [x] 2.1 Add large "Prev." and "Next" arrow buttons for scrolling.
   - [x] 2.2 Add swipe or scroll support for mobile.
   - [x] 2.3 Add keyboard arrow navigation support.
 - [x] 3.0 Add UI Enhancements (P2)

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -28,7 +28,7 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("scroll buttons have labels", async ({ page }) => {
-    const left = page.getByRole("button", { name: /previous/i });
+    const left = page.getByRole("button", { name: /prev\./i });
     const right = page.getByRole("button", { name: /next/i });
     await expect(left).toBeVisible();
     await expect(right).toBeVisible();

--- a/src/helpers/carousel/scroll.js
+++ b/src/helpers/carousel/scroll.js
@@ -10,7 +10,7 @@
  * 2. Create a button element:
  *    - Assign a class based on the `direction` (e.g., "scroll-button left" or "scroll-button right").
  *    - Set the inner HTML to display an inline SVG chevron pointing left or right.
- *    - Include a visible `<span class="label">` with "Previous" or "Next" text.
+ *    - Include a visible `<span class="label">` with "Prev." or "Next" text.
  *    - Add an accessible label (`aria-label`) matching the visible text.
  *
  * 3. Add a click event listener to the button:
@@ -41,7 +41,7 @@ export function createScrollButton(direction, container, scrollAmount) {
 
   button.className = `scroll-button ${direction}`;
 
-  const labelText = direction === "left" ? "Previous" : "Next";
+  const labelText = direction === "left" ? "Prev." : "Next";
 
   button.innerHTML =
     (direction === "left"

--- a/tests/card/cardBuilder.test.js
+++ b/tests/card/cardBuilder.test.js
@@ -35,8 +35,8 @@ describe("createScrollButton", () => {
     const button = createScrollButton("left", container, 100);
     expect(button.className).toBe("scroll-button left");
     expect(button.innerHTML).toContain("<svg");
-    expect(button.innerHTML).toContain("Previous</span>");
-    expect(button).toHaveAttribute("aria-label", "Previous");
+    expect(button.innerHTML).toContain("Prev.</span>");
+    expect(button).toHaveAttribute("aria-label", "Prev.");
   });
 
   it("should create a scroll button with the correct class and inner HTML when direction is right", () => {


### PR DESCRIPTION
## Summary
- Rename carousel's left scroll label to "Prev." and keep `aria-label` in sync
- Update UI and unit tests for the new button text
- Document "Prev." terminology in the card carousel PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle orientation screenshots; Battle Judoka narrow viewport screenshot and status aria attributes; Screenshot suite screenshot /src/pages/browseJudoka.html; Settings screenshots mode high-contrast expanded)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fcdf352208326bcb3f4e4eb102ee2