### PR TITLE
Add timer resume tests and responsive UI scenarios

### DIFF
--- a/playwright/responsive-contrast.spec.js
+++ b/playwright/responsive-contrast.spec.js
@@ -1,0 +1,29 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+
+test.describe("Responsive scenarios", () => {
+  test("renders ultra-narrow layout without horizontal scroll", async ({ page }) => {
+    await page.goto("/index.html");
+    await page.setViewportSize({ width: 260, height: 800 });
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(260);
+  });
+
+  test("updates orientation on viewport rotation", async ({ page }) => {
+    await page.goto("/src/pages/battleJudoka.html");
+    await page.setViewportSize({ width: 320, height: 480 });
+    await page.waitForFunction(
+      () => document.querySelector(".battle-header")?.dataset.orientation === "portrait"
+    );
+    await page.setViewportSize({ width: 480, height: 320 });
+    await page.waitForFunction(
+      () => document.querySelector(".battle-header")?.dataset.orientation === "landscape"
+    );
+  });
+
+  test("toggles high-contrast display mode", async ({ page }) => {
+    await page.goto("/src/pages/settings.html");
+    await page.check("#display-mode-high-contrast");
+    const theme = await page.evaluate(() => document.body.dataset.theme);
+    expect(theme).toBe("high-contrast");
+  });
+});

--- a/tests/helpers/battleEngine/pauseResumeTimer.test.js
+++ b/tests/helpers/battleEngine/pauseResumeTimer.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let timerApi;
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.doMock("../../../src/helpers/timerUtils.js", async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+      ...actual,
+      createCountdownTimer: (duration, { onTick }) => {
+        let remaining = duration;
+        let paused = false;
+        timerApi = {
+          start() {},
+          stop() {},
+          pause() {
+            paused = true;
+          },
+          resume() {
+            paused = false;
+          },
+          tick() {
+            if (paused) return;
+            remaining -= 1;
+            onTick(remaining);
+          }
+        };
+        return timerApi;
+      }
+    };
+  });
+});
+
+describe("pauseTimer/resumeTimer", () => {
+  it("resumes countdown from paused remaining time", async () => {
+    const { startRound, pauseTimer, resumeTimer, getTimerState, _resetForTest } = await import(
+      "../../../src/helpers/battleEngine.js"
+    );
+    _resetForTest();
+
+    await startRound(
+      () => {},
+      () => {},
+      5
+    );
+    timerApi.tick();
+    timerApi.tick();
+    pauseTimer();
+    expect(getTimerState()).toEqual({ remaining: 3, paused: true });
+
+    timerApi.tick();
+    expect(getTimerState()).toEqual({ remaining: 3, paused: true });
+
+    resumeTimer();
+    timerApi.tick();
+    expect(getTimerState()).toEqual({ remaining: 2, paused: false });
+  });
+});


### PR DESCRIPTION
## Summary
- test battleEngine timer resume via pauseTimer/resumeTimer
- check ultra-narrow layout, orientation change, and high-contrast toggle in Playwright

## Testing
- `npx prettier . --check`
- `npx eslint .` (with warnings)
- `npx vitest run`
- `npx playwright test` (fails: missing screenshots and other failures)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fd7e0978483268d67f55d59a2e02b