### PR TITLE
Fix prev button locator

### DIFF
--- a/playwright/browse-judoka-navigation.spec.js
+++ b/playwright/browse-judoka-navigation.spec.js
@@ -15,7 +15,7 @@ test.describe("Browse Judoka navigation", () => {
     await page.waitForSelector('[data-testid="carousel"] .judoka-card');
 
     const container = page.locator('[data-testid="carousel"]');
-    const left = page.getByRole("button", { name: /prev\./i });
+    const left = page.getByRole("button", { name: /prev\.?/i });
     const right = page.getByRole("button", { name: /next/i });
     const counter = page.locator(".page-counter");
 
@@ -51,7 +51,7 @@ test.describe("Browse Judoka navigation", () => {
     const container = page.locator(".card-carousel");
     await page.waitForSelector('[data-testid="carousel"] .judoka-card');
 
-    const left = page.getByRole("button", { name: /prev\./i });
+    const left = page.getByRole("button", { name: /prev\.?/i });
     const right = page.getByRole("button", { name: /next/i });
     const counter = page.locator(".page-counter");
 


### PR DESCRIPTION
## Summary
- allow `getByRole` lookup for Prev button to match label with or without period

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: navigation scenario and screenshot tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fd7b5e6f88326bd98b667d60d09db