### PR TITLE
Add ajv-formats and apply formats to Ajv

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "agent-base": "^7.1.4",
     "ajv": "^8.17.1",
+    "ajv-formats": "^3.x",
     "assertion-error": "^2.0.1",
     "cac": "^6.7.14",
     "chai": "^5.2.1",

--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -18,14 +18,31 @@ import { getMissingJudokaFields } from "./judokaValidation.js";
 function isNodeEnvironment() {
   return Boolean(typeof process !== "undefined" && process?.versions?.node);
 }
-
+/**
+ * Lazily instantiate and return a singleton Ajv instance with format support.
+ *
+ * @pseudocode
+ * 1. Return `ajvInstance` when it already exists.
+ * 2. If running under Node:
+ *    - Import `Ajv` and `ajv-formats`.
+ *    - Create an Ajv instance and apply the formats.
+ * 3. If running in a browser window:
+ *    - Import the bundled Ajv v6 locally or from a CDN.
+ * 4. Otherwise:
+ *    - Import `Ajv` and `ajv-formats`, then apply the formats.
+ * 5. Return the Ajv instance.
+ *
+ * @returns {Promise<import("ajv").default>} Ajv instance.
+ */
 export async function getAjv() {
   if (ajvInstance) {
     return ajvInstance;
   }
   if (isNodeEnvironment()) {
     const Ajv = (await import("ajv")).default;
+    const addFormats = (await import("ajv-formats")).default;
     ajvInstance = new Ajv();
+    addFormats(ajvInstance);
   } else if (typeof window !== "undefined") {
     try {
       const module = await import("../vendor/ajv6.min.js");
@@ -37,7 +54,9 @@ export async function getAjv() {
     }
   } else {
     const Ajv = (await import("ajv")).default;
+    const addFormats = (await import("ajv-formats")).default;
     ajvInstance = new Ajv();
+    addFormats(ajvInstance);
   }
   return ajvInstance;
 }


### PR DESCRIPTION
## Summary
- add `ajv-formats` dependency
- load `ajv-formats` when creating Ajv in Node and non-window environments
- document Ajv singleton behavior with pseudocode

## Testing
- `npx prettier package.json src/helpers/dataUtils.js --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed to resolve import "ajv-formats" from "src/helpers/dataUtils.js")*
- `npx playwright test` *(fails: 8 failed, 79 passed)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_688fe2059e20832689e86aae7e8230b6