### PR TITLE
Use static mockup base path

### DIFF
--- a/src/helpers/mockupViewerPage.js
+++ b/src/helpers/mockupViewerPage.js
@@ -8,7 +8,7 @@ import { createSidebarList } from "../components/SidebarList.js";
  *
  * @pseudocode
  * 1. Select the image, filename display, sidebar list, and navigation buttons.
- * 2. Define an array of mockup filenames and compute their base URL.
+ * 2. Define an array of mockup filenames and set a base path.
  * 3. Build sidebar list items that call `showImage(index)` when activated.
  * 4. Implement `showImage(index)` to update the image, alt text, filename, and sidebar highlight.
  * 5. Attach click handlers and keyboard events to cycle images with wraparound.
@@ -27,7 +27,7 @@ export function setupMockupViewerPage() {
     return;
   }
 
-  const basePath = new URL("../../design/mockups/", import.meta.url).href;
+  const basePath = "/design/mockups/";
 
   const files = [
     "mockupBattleInfoBar1.png",


### PR DESCRIPTION
## Summary
- avoid Vite directory resolution by switching to a static mockup path

## Testing
- `npx prettier . --check` *(fails: Code style issues found in 13 files)*
- `npx eslint .`
- `npx vitest run` *(fails: 10 tests failed, unresolved imports and fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fea7f01008326953914bd72325843