### PR TITLE
Reuse schema validator in tests and fix profile URL

### DIFF
--- a/src/data/judoka.json
+++ b/src/data/judoka.json
@@ -124,7 +124,7 @@
     },
     "signatureMoveId": 3,
     "lastUpdated": "2025-04-28T15:30:00Z",
-    "profileUrl": "https://en.wikipedia.org/wiki/Shōzō_Fujii",
+    "profileUrl": "https://en.wikipedia.org/wiki/Sh%C5%8Dz%C5%8D_Fujii",
     "bio": "More info to come...",
     "gender": "male",
     "isHidden": false,

--- a/tests/data/schemaValidation.test.js
+++ b/tests/data/schemaValidation.test.js
@@ -62,8 +62,7 @@ describe("data files conform to schemas", () => {
   it("fails validation for intentionally broken data", async () => {
     // Use a known-bad object for negative test
     const schema = JSON.parse(await readFile(path.join(schemaDir, "judoka.schema.json"), "utf8"));
-    const ajv = await getAjv();
-    const validate = ajv.compile(schema);
+    const validate = ajv.getSchema(schema.$id) || ajv.compile(schema);
     const bad = { foo: "bar" };
     expect(validate(bad)).toBe(false);
   });


### PR DESCRIPTION
## Summary
- reuse existing Ajv schema validator for negative test
- encode Shōzō Fujii profile URL to satisfy URI format

## Testing
- `npx prettier tests/data/schemaValidation.test.js --check`
- `npx eslint tests/data/schemaValidation.test.js`
- `npx prettier src/data/judoka.json --check`
- `npx eslint src/data/judoka.json`
- `npx vitest run tests/data/schemaValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688fea6b3e2c8326848e61693d1c1944