### PR TITLE
Use runtime base path for mockup viewer images

### DIFF
--- a/src/helpers/mockupViewerPage.js
+++ b/src/helpers/mockupViewerPage.js
@@ -27,7 +27,7 @@ export function setupMockupViewerPage() {
     return;
   }
 
-  const basePath = new URL("../../design/mockups/", import.meta.url).href;
+  const basePath = new URL("/design/mockups/", document.baseURI).href;
 
   const files = [
     "mockupBattleInfoBar1.png",


### PR DESCRIPTION
## Summary
- use `document.baseURI` to compute mockup image base path at runtime

## Testing
- `npx prettier . --check` *(fails: code style issues found in 13 files)*
- `npx eslint .`
- `npx vitest run` *(fails: 10 tests failed)*
- `npx playwright test` *(fails: 7 failed, 80 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fea50d4b083268d512ebccf186453