### PR TITLE
Encode Fujii profile URL

### DIFF
--- a/src/data/judoka.json
+++ b/src/data/judoka.json
@@ -124,7 +124,7 @@
     },
     "signatureMoveId": 3,
     "lastUpdated": "2025-04-28T15:30:00Z",
-    "profileUrl": "https://en.wikipedia.org/wiki/Shōzō_Fujii",
+    "profileUrl": "https://en.wikipedia.org/wiki/Sh%C5%8Dz%C5%8D_Fujii",
     "bio": "More info to come...",
     "gender": "male",
     "isHidden": false,


### PR DESCRIPTION
## Summary
- encode Shozo Fujii Wikipedia profile URL so it conforms to JSON Schema `uri`

## Testing
- `npx eslint .`
- `npx vitest run tests/data/schemaValidation.test.js` *(fails: schema with id already exists)*
- `npx playwright test` *(fails: 8 tests failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_688fe9dea5848326bfec59eb98ab8f6d