### PR TITLE
Guard tooltip overlay for missing document

### DIFF
--- a/src/helpers/tooltipOverlayDebug.js
+++ b/src/helpers/tooltipOverlayDebug.js
@@ -2,13 +2,13 @@
  * Toggle the tooltip debug overlay class on the document body.
  *
  * @pseudocode
- * 1. If document.body is not available, return immediately.
+ * 1. If `document` is undefined or document.body is not available, return immediately.
  * 2. Toggle the "tooltip-overlay-debug" class on document.body based on `enabled`.
  *
  * @param {boolean} enabled - Whether the overlay should be enabled.
  * @returns {void}
  */
 export function toggleTooltipOverlayDebug(enabled) {
-  if (!document.body) return;
+  if (typeof document === "undefined" || !document.body) return;
   document.body.classList.toggle("tooltip-overlay-debug", Boolean(enabled));
 }

--- a/tests/helpers/tooltipOverlayDebug.test.js
+++ b/tests/helpers/tooltipOverlayDebug.test.js
@@ -12,4 +12,12 @@ describe("toggleTooltipOverlayDebug", () => {
     toggleTooltipOverlayDebug(false);
     expect(document.body.classList.contains("tooltip-overlay-debug")).toBe(false);
   });
+
+  it("does nothing when document is undefined", () => {
+    const originalDocument = global.document;
+    // @ts-ignore - simulate an environment without document
+    delete global.document;
+    expect(() => toggleTooltipOverlayDebug(true)).not.toThrow();
+    global.document = originalDocument;
+  });
 });


### PR DESCRIPTION
## Summary
- skip tooltip overlay debug toggling when `document` or `document.body` is unavailable
- test that no error is thrown when `document` is undefined

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 6 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68906e0860e883268d16554da2a7e2fc