### PR TITLE
Use BASE_URL for PRD directory

### DIFF
--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -22,8 +22,8 @@ import { getPrdTaskStats } from "./prdTaskStats.js";
  * @param {Function} [parserFn=markdownToHtml] Parser used to convert Markdown to HTML.
  */
 export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
-  const prdDir = ["..", "..", "design", "productRequirementsDocuments"].join("/") + "/";
-  const PRD_DIR = new URL(prdDir, import.meta.url).href;
+  const base = (import.meta?.env?.BASE_URL ?? "/").replace(/\/?$/, "/");
+  const PRD_DIR = `${base}design/productRequirementsDocuments/`;
 
   let FILES = [];
   if (docsMap) {


### PR DESCRIPTION
## Summary
- build PRD directory from `import.meta.env.BASE_URL`
- drop `new URL` directory resolution

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings)
- `npx vitest run` (fails: unhandled errors)
- `npx playwright test` (fails: 7 failed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68906e15a114832690ae217c038f9ca4