### PR TITLE
Add wait for settings initialization in responsive test

### DIFF
--- a/playwright/responsive-contrast.spec.js
+++ b/playwright/responsive-contrast.spec.js
@@ -2,14 +2,14 @@ import { test, expect } from "./fixtures/commonSetup.js";
 
 test.describe("Responsive scenarios", () => {
   test("renders ultra-narrow layout without horizontal scroll", async ({ page }) => {
-    await page.goto("/index.html");
+    await page.goto("/index.html", { waitUntil: "networkidle" });
     await page.setViewportSize({ width: 260, height: 800 });
     const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
     expect(scrollWidth).toBeLessThanOrEqual(260);
   });
 
   test("updates orientation on viewport rotation", async ({ page }) => {
-    await page.goto("/src/pages/battleJudoka.html");
+    await page.goto("/src/pages/battleJudoka.html", { waitUntil: "networkidle" });
     await page.setViewportSize({ width: 320, height: 480 });
     await page.waitForFunction(
       () => document.querySelector(".battle-header")?.dataset.orientation === "portrait"
@@ -22,8 +22,8 @@ test.describe("Responsive scenarios", () => {
 
   test("toggles high-contrast display mode", async ({ page }) => {
     await page.goto("/src/pages/settings.html");
+    await page.getByLabel(/Classic Battle/i).waitFor({ state: "attached" });
     await page.check("#display-mode-high-contrast");
-    const theme = await page.evaluate(() => document.body.dataset.theme);
-    expect(theme).toBe("high-contrast");
+    await expect(page.locator("body")).toHaveAttribute("data-theme", "high-contrast");
   });
 });


### PR DESCRIPTION
## Summary
- ensure pages settle before responsive checks by waiting for network idle
- verify high-contrast theme toggle after enabling display mode

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 6 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689078e5bbf88326991b8502ce02ab54