### PR TITLE
Use container width for carousel scroll

### DIFF
--- a/src/helpers/carousel/navigation.js
+++ b/src/helpers/carousel/navigation.js
@@ -1,4 +1,4 @@
-import { CAROUSEL_SCROLL_DISTANCE, CAROUSEL_SWIPE_THRESHOLD } from "../constants.js";
+import { CAROUSEL_SWIPE_THRESHOLD } from "../constants.js";
 /**
  * Sets up keyboard navigation for the carousel container.
  *
@@ -14,14 +14,15 @@ export function setupKeyboardNavigation(container) {
   container.tabIndex = 0;
   const cards = container.querySelectorAll(".judoka-card");
   container.addEventListener("keydown", (event) => {
+    const scrollAmount = container.clientWidth;
     const active = document.activeElement;
     const index = Array.from(cards).indexOf(active);
     if (event.key === "ArrowLeft") {
-      container.scrollBy({ left: -CAROUSEL_SCROLL_DISTANCE, behavior: "smooth" });
+      container.scrollBy({ left: -scrollAmount, behavior: "smooth" });
       const prevIndex = index > 0 ? index - 1 : 0;
       cards[prevIndex]?.focus();
     } else if (event.key === "ArrowRight") {
-      container.scrollBy({ left: CAROUSEL_SCROLL_DISTANCE, behavior: "smooth" });
+      container.scrollBy({ left: scrollAmount, behavior: "smooth" });
       const nextIndex = index >= 0 ? Math.min(cards.length - 1, index + 1) : 0;
       cards[nextIndex]?.focus();
     }
@@ -48,10 +49,11 @@ export function setupSwipeNavigation(container) {
   container.addEventListener("touchend", (event) => {
     const touchEndX = event.changedTouches[0].clientX;
     const swipeDistance = touchEndX - touchStartX;
+    const scrollAmount = container.clientWidth;
     if (swipeDistance > CAROUSEL_SWIPE_THRESHOLD) {
-      container.scrollBy({ left: -CAROUSEL_SCROLL_DISTANCE, behavior: "smooth" });
+      container.scrollBy({ left: -scrollAmount, behavior: "smooth" });
     } else if (swipeDistance < -CAROUSEL_SWIPE_THRESHOLD) {
-      container.scrollBy({ left: CAROUSEL_SCROLL_DISTANCE, behavior: "smooth" });
+      container.scrollBy({ left: scrollAmount, behavior: "smooth" });
     }
   });
 }

--- a/src/helpers/carousel/scroll.js
+++ b/src/helpers/carousel/scroll.js
@@ -14,21 +14,16 @@
  *    - Add an accessible label (`aria-label`) matching the visible text.
  *
  * 3. Add a click event listener to the button:
- *    - Scroll the `container` by the specified `scrollAmount`.
+ *    - Scroll the `container` by its current `clientWidth` in the given direction.
  *    - Use smooth scrolling for better user experience.
  *
  * 4. Return the created button element.
  *
  * @param {String} direction - Either "left" or "right".
  * @param {HTMLElement} container - The carousel container to scroll.
- * @param {Number} scrollAmount - The amount to scroll in pixels.
  * @returns {HTMLElement} The scroll button element.
- *
- * Note: The function assumes `scrollAmount` is a number and does not
- * perform validation. Invalid values will simply be passed to
- * `scrollBy` without throwing an error.
  */
-export function createScrollButton(direction, container, scrollAmount) {
+export function createScrollButton(direction, container) {
   if (direction !== "left" && direction !== "right") {
     throw new Error("Invalid direction: must be 'left' or 'right'");
   }
@@ -52,6 +47,7 @@ export function createScrollButton(direction, container, scrollAmount) {
   button.setAttribute("aria-label", labelText);
 
   button.addEventListener("click", () => {
+    const scrollAmount = container.clientWidth;
     container.scrollBy({
       left: direction === "left" ? -scrollAmount : scrollAmount,
       behavior: "smooth"

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -11,7 +11,7 @@ import {
   appendCards,
   setupFocusHandlers
 } from "./carousel/index.js";
-import { CAROUSEL_SCROLL_DISTANCE, SPINNER_DELAY_MS } from "./constants.js";
+import { SPINNER_DELAY_MS } from "./constants.js";
 
 /**
  * Adds scroll markers to indicate the user's position in the carousel.
@@ -206,8 +206,8 @@ export async function buildCardCarousel(judokaList, gokyoData) {
 
   // Responsive sizing handled by helper
 
-  const leftButton = createScrollButton("left", container, CAROUSEL_SCROLL_DISTANCE);
-  const rightButton = createScrollButton("right", container, CAROUSEL_SCROLL_DISTANCE);
+  const leftButton = createScrollButton("left", container);
+  const rightButton = createScrollButton("right", container);
 
   wrapper.appendChild(leftButton);
   wrapper.appendChild(container);

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -7,7 +7,7 @@
  *
  * @pseudocode
  * 1. Resolve the helpers directory URL and derive the base path to JSON data files.
- * 2. Define carousel scroll distance, swipe threshold, and spinner delay.
+ * 2. Define carousel swipe threshold and spinner delay.
  * 3. Set fade and removal durations for settings error popups.
  * 4. Establish Classic Battle win conditions and maximum rounds.
  */
@@ -33,14 +33,6 @@ const HELPERS_DIR = new URL(/* @vite-ignore */ ".", import.meta.url);
  * @constant {string}
  */
 export const DATA_DIR = new URL("../data/", HELPERS_DIR).href;
-
-/**
- * Distance in pixels that the carousel scrolls when using keyboard
- * navigation or scroll buttons.
- *
- * @constant {number}
- */
-export const CAROUSEL_SCROLL_DISTANCE = 300;
 
 /**
  * Minimum swipe distance in pixels required to trigger carousel

--- a/tests/card/cardBuilder.test.js
+++ b/tests/card/cardBuilder.test.js
@@ -24,6 +24,7 @@ describe("createScrollButton", () => {
     container.style.overflow = "hidden";
     container.style.width = "200px";
     container.innerHTML = '<div style="width: 1000px;">Content</div>';
+    Object.defineProperty(container, "clientWidth", { value: 100, configurable: true });
     container.scrollLeft = 0;
 
     container.scrollBy = vi.fn(({ left }) => {
@@ -32,7 +33,7 @@ describe("createScrollButton", () => {
   });
 
   it("should create a scroll button with the correct class and inner HTML when direction is left", () => {
-    const button = createScrollButton("left", container, 100);
+    const button = createScrollButton("left", container);
     expect(button.className).toBe("scroll-button left");
     expect(button.innerHTML).toContain("<svg");
     expect(button.innerHTML).toContain("Prev.</span>");
@@ -40,7 +41,7 @@ describe("createScrollButton", () => {
   });
 
   it("should create a scroll button with the correct class and inner HTML when direction is right", () => {
-    const button = createScrollButton("right", container, 100);
+    const button = createScrollButton("right", container);
     expect(button.className).toBe("scroll-button right");
     expect(button.innerHTML).toContain("<svg");
     expect(button.innerHTML).toContain("Next</span>");
@@ -48,38 +49,28 @@ describe("createScrollButton", () => {
   });
 
   it("should throw an error when the direction is invalid", () => {
-    expect(() => createScrollButton("up", container, 100)).toThrowError("Invalid direction");
+    expect(() => createScrollButton("up", container)).toThrowError("Invalid direction");
   });
 
   it("should scroll the container to the left when clicked", () => {
-    const button = createScrollButton("left", container, 100);
+    const button = createScrollButton("left", container);
     button.click();
     expect(container.scrollLeft).toBe(-100);
   });
 
   it("should scroll the container to the right when clicked", () => {
-    const button = createScrollButton("right", container, 100);
+    const button = createScrollButton("right", container);
     button.click();
     expect(container.scrollLeft).toBe(100);
   });
 
   it("should throw an error if container is null", () => {
-    expect(() => createScrollButton("left", null, 100)).toThrowError("Container is required");
+    expect(() => createScrollButton("left", null)).toThrowError("Container is required");
   });
 
   it("should not throw if scrollBy is not defined on container", () => {
     const div = document.createElement("div");
-    expect(() => createScrollButton("left", div, 100)).not.toThrow();
-  });
-
-  it("should return a button even if scroll amount is invalid", () => {
-    const div = document.createElement("div");
-    expect(() => createScrollButton("left", div, null)).not.toThrow();
-    expect(createScrollButton("left", div, null)).toBeInstanceOf(HTMLButtonElement);
-    expect(() => createScrollButton("left", div, undefined)).not.toThrow();
-    expect(createScrollButton("left", div, undefined)).toBeInstanceOf(HTMLButtonElement);
-    expect(() => createScrollButton("left", div, "100")).not.toThrow();
-    expect(createScrollButton("left", div, "100")).toBeInstanceOf(HTMLButtonElement);
+    expect(() => createScrollButton("left", div)).not.toThrow();
   });
 });
 

--- a/tests/helpers/keyboardNavigation.test.js
+++ b/tests/helpers/keyboardNavigation.test.js
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { setupKeyboardNavigation } from "../../src/helpers/carousel/navigation.js";
-import { CAROUSEL_SCROLL_DISTANCE } from "../../src/helpers/constants.js";
 
 describe("setupKeyboardNavigation", () => {
   it("scrolls container and updates focus on arrow keys", () => {
     const container = document.createElement("div");
+    Object.defineProperty(container, "clientWidth", { value: 300, configurable: true });
     container.scrollLeft = 0;
     container.scrollBy = ({ left }) => {
       container.scrollLeft += left;
@@ -27,7 +27,7 @@ describe("setupKeyboardNavigation", () => {
 
     first.focus();
     container.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
-    expect(container.scrollLeft).toBe(CAROUSEL_SCROLL_DISTANCE);
+    expect(container.scrollLeft).toBe(container.clientWidth);
     expect(document.activeElement).toBe(second);
 
     container.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));


### PR DESCRIPTION
## Summary
- use container width for keyboard and swipe navigation
- scroll buttons compute width dynamically instead of using a constant
- remove unused `CAROUSEL_SCROLL_DISTANCE` constant and update tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Browse Judoka navigation tests and others)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68907a67e20083268cd748b861364555