### PR TITLE
Fix carousel page calculation

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -102,8 +102,8 @@ test.describe("Browse Judoka screen", () => {
     await container.focus();
     const markers = page.locator(".scroll-marker");
     const counter = page.locator(".page-counter");
-    await expect(markers).toHaveCount(2);
-    await expect(counter).toHaveText("Page 1 of 2");
+    await expect(markers).toHaveCount(3);
+    await expect(counter).toHaveText("Page 1 of 3");
 
     await container.evaluate((el) => {
       el.scrollTo({ left: 600, behavior: "auto" });
@@ -121,8 +121,8 @@ test.describe("Browse Judoka screen", () => {
 
     const markers = page.locator(".scroll-marker");
     const counter = page.locator(".page-counter");
-    await expect(markers).toHaveCount(2);
-    await expect(counter).toHaveText("Page 1 of 2");
+    await expect(markers).toHaveCount(3);
+    await expect(counter).toHaveText("Page 1 of 3");
 
     const box = await container.boundingBox();
     const startX = box.x + box.width * 0.9;

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -19,7 +19,9 @@ import { SPINNER_DELAY_MS } from "./constants.js";
  * @pseudocode
  * 1. Validate inputs and exit early if `container` or `wrapper` is missing.
  * 2. Create a `<div>` element with the class `scroll-markers`.
- * 3. Determine how many cards fit within one page of the carousel.
+ * 3. Determine how many cards fit within one page of the carousel,
+ *    accounting for the gap between cards and ensuring at least one
+ *    card per page. Calculate the total page count.
  * 4. Add a marker for each page and an accompanying page counter.
  *    - Highlight the marker for the current page.
  * 5. Update the active marker and counter text on scroll events.
@@ -37,7 +39,10 @@ function addScrollMarkers(container, wrapper) {
   const cards = container.querySelectorAll(".judoka-card");
   const firstCard = cards[0];
   const cardWidth = firstCard ? firstCard.offsetWidth : 0;
-  const cardsPerPage = cardWidth ? Math.max(1, Math.round(container.clientWidth / cardWidth)) : 1;
+  const gap = parseFloat(getComputedStyle(container).columnGap) || 0;
+  const cardsPerPage = cardWidth
+    ? Math.max(1, Math.floor((container.clientWidth + gap) / (cardWidth + gap)))
+    : 1;
   const pageCount = Math.ceil(cards.length / cardsPerPage);
 
   for (let i = 0; i < pageCount; i++) {


### PR DESCRIPTION
## Summary
- account for gaps when calculating carousel pages
- expect three pages in browse judoka carousel tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689084e5897483268fb156d2c13dcca3