### PR TITLE
Adjust card styles for ultra-narrow screens

### DIFF
--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -77,6 +77,24 @@ svg {
   aspect-ratio: 1 / 1;
   object-fit: contain;
 }
+
+@media (max-width: 320px) {
+  .card {
+    padding: var(--space-md);
+    box-sizing: border-box;
+    max-width: 100%;
+  }
+
+  .tile-content h2 {
+    padding: var(--space-sm) var(--space-md);
+    font-size: var(--font-medium);
+  }
+
+  .card svg {
+    width: clamp(24px, 10vw, 48px);
+    height: clamp(24px, 10vw, 48px);
+  }
+}
 /* Card styles */
 .card-container {
   display: flex;


### PR DESCRIPTION
## Summary
- Tweak card padding and heading sizing for viewports ≤320px
- Clamp icon size on small cards to avoid overflow

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle orientation and screenshot expectations)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890851cd2e083268028ff2f9e54d1bb