### PR TITLE
Handle pointer swipe events in carousel navigation

### DIFF
--- a/src/helpers/carousel/navigation.js
+++ b/src/helpers/carousel/navigation.js
@@ -30,30 +30,50 @@ export function setupKeyboardNavigation(container) {
 }
 
 /**
- * Sets up swipe navigation for the carousel container.
+ * Sets up swipe navigation for the carousel container, supporting touch and pointer events.
  *
  * @pseudocode
- * 1. Track the starting X position of a touch event (`touchstart`).
- * 2. Track the ending X position of a touch event (`touchend`).
- * 3. Calculate the swipe distance and direction.
- *    - Scroll left if the swipe distance is greater than 50 pixels.
- *    - Scroll right if the swipe distance is less than -50 pixels.
+ * 1. Track the starting X position of a touch or pointer press (`touchstart` or `pointerdown`).
+ * 2. On `touchend` or `pointerup`, calculate the swipe distance.
+ *    - Scroll left if the swipe distance is greater than the carousel swipe threshold.
+ *    - Scroll right if the swipe distance is less than the negative carousel swipe threshold.
  *
  * @param {HTMLElement} container - The carousel container element.
  */
 export function setupSwipeNavigation(container) {
   let touchStartX = 0;
+  let pointerStartX = 0;
+
+  const scrollFromDelta = (delta) => {
+    const scrollAmount = container.clientWidth;
+    if (delta > CAROUSEL_SWIPE_THRESHOLD) {
+      container.scrollBy({ left: -scrollAmount, behavior: "smooth" });
+    } else if (delta < -CAROUSEL_SWIPE_THRESHOLD) {
+      container.scrollBy({ left: scrollAmount, behavior: "smooth" });
+    }
+  };
+
   container.addEventListener("touchstart", (event) => {
     touchStartX = event.touches[0].clientX;
   });
+
   container.addEventListener("touchend", (event) => {
     const touchEndX = event.changedTouches[0].clientX;
     const swipeDistance = touchEndX - touchStartX;
-    const scrollAmount = container.clientWidth;
-    if (swipeDistance > CAROUSEL_SWIPE_THRESHOLD) {
-      container.scrollBy({ left: -scrollAmount, behavior: "smooth" });
-    } else if (swipeDistance < -CAROUSEL_SWIPE_THRESHOLD) {
-      container.scrollBy({ left: scrollAmount, behavior: "smooth" });
+    scrollFromDelta(swipeDistance);
+  });
+
+  container.addEventListener("pointerdown", (event) => {
+    if (event.pointerType !== "touch") {
+      pointerStartX = event.clientX;
+    }
+  });
+
+  container.addEventListener("pointerup", (event) => {
+    if (event.pointerType !== "touch") {
+      const pointerEndX = event.clientX;
+      const swipeDistance = pointerEndX - pointerStartX;
+      scrollFromDelta(swipeDistance);
     }
   });
 }

--- a/tests/helpers/swipeNavigation.test.js
+++ b/tests/helpers/swipeNavigation.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { setupSwipeNavigation } from "../../src/helpers/carousel/navigation.js";
+import { CAROUSEL_SWIPE_THRESHOLD } from "../../src/helpers/constants.js";
+
+if (typeof PointerEvent === "undefined") {
+  globalThis.PointerEvent = class extends MouseEvent {
+    constructor(type, params = {}) {
+      super(type, params);
+      this.pointerType = params.pointerType ?? "";
+    }
+  };
+}
+
+describe("setupSwipeNavigation", () => {
+  it("scrolls container based on pointer swipe distance", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "clientWidth", { value: 300, configurable: true });
+    container.scrollBy = vi.fn();
+
+    setupSwipeNavigation(container);
+
+    container.dispatchEvent(
+      new PointerEvent("pointerdown", { clientX: 100, pointerType: "mouse" })
+    );
+    container.dispatchEvent(new PointerEvent("pointerup", { clientX: 0, pointerType: "mouse" }));
+    expect(container.scrollBy).toHaveBeenCalledWith({
+      left: container.clientWidth,
+      behavior: "smooth"
+    });
+
+    container.scrollBy.mockClear();
+
+    const endX = CAROUSEL_SWIPE_THRESHOLD + 60;
+    container.dispatchEvent(new PointerEvent("pointerdown", { clientX: 0, pointerType: "mouse" }));
+    container.dispatchEvent(new PointerEvent("pointerup", { clientX: endX, pointerType: "mouse" }));
+    expect(container.scrollBy).toHaveBeenCalledWith({
+      left: -container.clientWidth,
+      behavior: "smooth"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- support pointer and touch swipe gestures for carousel navigation
- test pointer-based swipe scrolling

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings)
- `npx vitest run`
- `npx playwright test` (fails: screenshot and interaction differences)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890854109d48326bd666a8be1f5c457