### PR TITLE
Update carousel page counts

### DIFF
--- a/playwright/browse-judoka-navigation.spec.js
+++ b/playwright/browse-judoka-navigation.spec.js
@@ -47,11 +47,12 @@ test.describe("Browse Judoka navigation", () => {
     const right = page.getByRole("button", { name: /next/i });
     const counter = page.locator(".page-counter");
 
-    await expect(counter).toHaveText("Page 1 of 3");
+    await expect(counter).toHaveText("Page 1 of 6");
     await expect(left).toBeDisabled();
 
     const box = await container.boundingBox();
     const startX = box.x + box.width * 0.9;
+    const endX = box.x + box.width * 0.1;
     const y = box.y + box.height / 2;
     const swipe = (from, to) =>
       page.evaluate(
@@ -77,12 +78,18 @@ test.describe("Browse Judoka navigation", () => {
 
     await swipe(startX, startX - 600);
     await swipe(startX, startX - 600);
-    await expect.poll(() => counter.textContent()).not.toBe("Page 1 of 3");
+    await swipe(startX, startX - 600);
+    await swipe(startX, startX - 600);
+    await swipe(startX, startX - 600);
+    await expect(counter).toHaveText("Page 6 of 6");
     await expect(right).toBeDisabled();
 
-    await swipe(box.x + box.width * 0.1, box.x + box.width * 0.1 + 600);
-    await swipe(box.x + box.width * 0.1, box.x + box.width * 0.1 + 600);
-    await expect.poll(() => counter.textContent()).toBe("Page 1 of 3");
+    await swipe(endX, endX + 600);
+    await swipe(endX, endX + 600);
+    await swipe(endX, endX + 600);
+    await swipe(endX, endX + 600);
+    await swipe(endX, endX + 600);
+    await expect(counter).toHaveText("Page 1 of 6");
     await expect(left).toBeDisabled();
   });
 });

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -151,11 +151,9 @@ test.describe("Browse Judoka screen", () => {
 
     const before = await container.evaluate((el) => el.scrollLeft);
 
-    await swipe(startX, startX - 600);
-    await swipe(startX, startX - 600);
-    await swipe(startX, startX - 600);
-    await swipe(startX, startX - 600);
-    await swipe(startX, startX - 600);
+    for (let i = 0; i < 5; i++) {
+      await swipe(startX, startX - 600);
+    }
 
     await expect.poll(() => container.evaluate((el) => el.scrollLeft)).toBeGreaterThan(before);
     await expect.poll(() => counter.textContent()).toBe("Page 6 of 6");

--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -102,14 +102,14 @@ test.describe("Browse Judoka screen", () => {
     await container.focus();
     const markers = page.locator(".scroll-marker");
     const counter = page.locator(".page-counter");
-    await expect(markers).toHaveCount(3);
-    await expect(counter).toHaveText("Page 1 of 3");
+    await expect(markers).toHaveCount(6);
+    await expect(counter).toHaveText("Page 1 of 6");
 
     await container.evaluate((el) => {
-      el.scrollTo({ left: 600, behavior: "auto" });
+      el.scrollTo({ left: el.scrollWidth, behavior: "auto" });
     });
 
-    await expect.poll(() => counter.textContent()).not.toBe("Page 1 of 3");
+    await expect.poll(() => counter.textContent()).toBe("Page 6 of 6");
   });
 
   test("carousel responds to swipe gestures", async ({ page }) => {
@@ -121,41 +121,44 @@ test.describe("Browse Judoka screen", () => {
 
     const markers = page.locator(".scroll-marker");
     const counter = page.locator(".page-counter");
-    await expect(markers).toHaveCount(3);
-    await expect(counter).toHaveText("Page 1 of 3");
+    await expect(markers).toHaveCount(6);
+    await expect(counter).toHaveText("Page 1 of 6");
 
     const box = await container.boundingBox();
     const startX = box.x + box.width * 0.9;
     const y = box.y + box.height / 2;
+    const swipe = (from, to) =>
+      page.evaluate(
+        ({ from, to, y }) => {
+          const el = document.querySelector(".card-carousel");
+          el.dispatchEvent(
+            new TouchEvent("touchstart", {
+              bubbles: true,
+              cancelable: true,
+              touches: [new Touch({ identifier: 1, target: el, clientX: from, clientY: y })]
+            })
+          );
+          el.dispatchEvent(
+            new TouchEvent("touchend", {
+              bubbles: true,
+              cancelable: true,
+              changedTouches: [new Touch({ identifier: 1, target: el, clientX: to, clientY: y })]
+            })
+          );
+        },
+        { from, to, y }
+      );
 
     const before = await container.evaluate((el) => el.scrollLeft);
 
-    await page.evaluate(
-      ({ startX, y }) => {
-        const el = document.querySelector(".card-carousel");
-        el.dispatchEvent(
-          new TouchEvent("touchstart", {
-            bubbles: true,
-            cancelable: true,
-            touches: [new Touch({ identifier: 1, target: el, clientX: startX, clientY: y })]
-          })
-        );
-        el.dispatchEvent(
-          new TouchEvent("touchend", {
-            bubbles: true,
-            cancelable: true,
-            changedTouches: [
-              new Touch({ identifier: 1, target: el, clientX: startX - 600, clientY: y })
-            ]
-          })
-        );
-      },
-      { startX, y }
-    );
+    await swipe(startX, startX - 600);
+    await swipe(startX, startX - 600);
+    await swipe(startX, startX - 600);
+    await swipe(startX, startX - 600);
+    await swipe(startX, startX - 600);
 
     await expect.poll(() => container.evaluate((el) => el.scrollLeft)).toBeGreaterThan(before);
-
-    await expect.poll(() => counter.textContent()).not.toBe("Page 1 of 3");
+    await expect.poll(() => counter.textContent()).toBe("Page 6 of 6");
   });
 
   test.skip("shows loading spinner on slow network", async ({ page }) => {


### PR DESCRIPTION
## Summary
- update navigation carousel tests for 6 page workflow
- extend browse judoka carousel tests to check full range

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68908e8df0888326841a2aa55091b1c0