### PR TITLE
Fix keyboard carousel navigation

### DIFF
--- a/src/helpers/carousel/navigation.js
+++ b/src/helpers/carousel/navigation.js
@@ -18,11 +18,11 @@ export function setupKeyboardNavigation(container) {
     const active = document.activeElement;
     const index = Array.from(cards).indexOf(active);
     if (event.key === "ArrowLeft") {
-      container.scrollBy({ left: -scrollAmount, behavior: "smooth" });
+      container.scrollLeft -= scrollAmount;
       const prevIndex = index > 0 ? index - 1 : 0;
       cards[prevIndex]?.focus();
     } else if (event.key === "ArrowRight") {
-      container.scrollBy({ left: scrollAmount, behavior: "smooth" });
+      container.scrollLeft += scrollAmount;
       const nextIndex = index >= 0 ? Math.min(cards.length - 1, index + 1) : 0;
       cards[nextIndex]?.focus();
     }
@@ -47,9 +47,9 @@ export function setupSwipeNavigation(container) {
   const scrollFromDelta = (delta) => {
     const scrollAmount = container.clientWidth;
     if (delta > CAROUSEL_SWIPE_THRESHOLD) {
-      container.scrollBy({ left: -scrollAmount, behavior: "smooth" });
+      container.scrollLeft -= scrollAmount;
     } else if (delta < -CAROUSEL_SWIPE_THRESHOLD) {
-      container.scrollBy({ left: scrollAmount, behavior: "smooth" });
+      container.scrollLeft += scrollAmount;
     }
   };
 


### PR DESCRIPTION
## Summary
- adjust carousel navigation to move using `scrollLeft`
- keep swipe interactions consistent across input methods

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden fetching package)*
- `npx playwright test` *(fails: 403 Forbidden fetching package)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6890991e37ec832685c9b31e416e567d