### PR TITLE
Route six-card dataset for carousel tests

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -94,6 +94,10 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("carousel responds to arrow keys", async ({ page }) => {
+    await page.unroute("**/src/data/judoka.json");
+    await page.route("**/src/data/judoka.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/judoka-carousel.json" })
+    );
     await page.setViewportSize({ width: 320, height: 800 });
     await page.reload();
     const container = page.locator('[data-testid="carousel"]');
@@ -113,6 +117,10 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("carousel responds to swipe gestures", async ({ page }) => {
+    await page.unroute("**/src/data/judoka.json");
+    await page.route("**/src/data/judoka.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/judoka-carousel.json" })
+    );
     await page.setViewportSize({ width: 320, height: 800 });
     await page.reload();
     const container = page.locator(".card-carousel");


### PR DESCRIPTION
## Summary
- Add routing to six-card dataset for mobile carousel tests
- Ensure carousel arrow key and swipe tests load consistent data

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: screenshot/expectation mismatches)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890a0c7fa2883269d258a67ee3384fc