### PR TITLE
Use carousel fixture in navigation tests

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -94,7 +94,6 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("carousel responds to arrow keys", async ({ page }) => {
-    await page.unroute("**/src/data/judoka.json");
     await page.route("**/src/data/judoka.json", (route) =>
       route.fulfill({ path: "tests/fixtures/judoka-carousel.json" })
     );
@@ -117,7 +116,6 @@ test.describe("Browse Judoka screen", () => {
   });
 
   test("carousel responds to swipe gestures", async ({ page }) => {
-    await page.unroute("**/src/data/judoka.json");
     await page.route("**/src/data/judoka.json", (route) =>
       route.fulfill({ path: "tests/fixtures/judoka-carousel.json" })
     );


### PR DESCRIPTION
## Summary
- load six-card judoka fixture in arrow key and swipe gesture carousel tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/browse-judoka.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890a9632fa8832687aa30d0ae180cdb