### PR TITLE
Gate carousel focus to active cards

### DIFF
--- a/src/helpers/carousel/focus.js
+++ b/src/helpers/carousel/focus.js
@@ -4,7 +4,8 @@
  * @pseudocode
  * 1. Highlight the card nearest the carousel center when focus changes and
  *    focus it only if the container itself is active.
- * 2. Move focus with arrow keys and keep the center card enlarged.
+ * 2. Move focus with arrow keys only when a card already has focus and keep
+ *    the center card enlarged.
  * 3. Update focus styles on mouse hover for desktop users.
  *
  * @param {HTMLElement} container - Carousel container element.
@@ -38,6 +39,7 @@ export function setupFocusHandlers(container) {
   }
 
   container.addEventListener("keydown", (e) => {
+    if (document.activeElement === container) return;
     if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
       const cards = Array.from(container.querySelectorAll(".judoka-card"));
       const current = document.activeElement;

--- a/src/helpers/carousel/navigation.js
+++ b/src/helpers/carousel/navigation.js
@@ -5,26 +5,20 @@ import { CAROUSEL_SWIPE_THRESHOLD } from "../constants.js";
  * @pseudocode
  * 1. Make the container focusable by setting `tabIndex` to 0.
  * 2. Add a `keydown` event listener to the container.
- *    - Scroll left when the "ArrowLeft" key is pressed and focus the previous card.
- *    - Scroll right when the "ArrowRight" key is pressed and focus the next card.
+ *    - When the container is focused, scroll left on "ArrowLeft".
+ *    - When the container is focused, scroll right on "ArrowRight".
  *
  * @param {HTMLElement} container - The carousel container element.
  */
 export function setupKeyboardNavigation(container) {
   container.tabIndex = 0;
-  const cards = container.querySelectorAll(".judoka-card");
   container.addEventListener("keydown", (event) => {
+    if (document.activeElement !== container) return;
     const scrollAmount = container.clientWidth;
-    const active = document.activeElement;
-    const index = Array.from(cards).indexOf(active);
     if (event.key === "ArrowLeft") {
       container.scrollLeft -= scrollAmount;
-      const prevIndex = index > 0 ? index - 1 : 0;
-      cards[prevIndex]?.focus();
     } else if (event.key === "ArrowRight") {
       container.scrollLeft += scrollAmount;
-      const nextIndex = index >= 0 ? Math.min(cards.length - 1, index + 1) : 0;
-      cards[nextIndex]?.focus();
     }
   });
 }

--- a/tests/helpers/focusHandlers.test.js
+++ b/tests/helpers/focusHandlers.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { setupFocusHandlers } from "../../src/helpers/carousel/focus.js";
+
+describe("setupFocusHandlers", () => {
+  it("does not move focus when container is active", () => {
+    const container = document.createElement("div");
+    container.tabIndex = 0;
+    document.body.append(container);
+
+    setupFocusHandlers(container);
+    container.focus();
+    container.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+    expect(document.activeElement).toBe(container);
+  });
+
+  it("moves focus between cards when one is focused", () => {
+    const container = document.createElement("div");
+    const first = document.createElement("button");
+    first.className = "judoka-card";
+    first.tabIndex = 0;
+    const second = document.createElement("button");
+    second.className = "judoka-card";
+    second.tabIndex = 0;
+    container.append(first, second);
+    document.body.append(container);
+
+    setupFocusHandlers(container);
+    first.focus();
+    first.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(document.activeElement).toBe(second);
+  });
+});

--- a/tests/helpers/keyboardNavigation.test.js
+++ b/tests/helpers/keyboardNavigation.test.js
@@ -2,36 +2,41 @@ import { describe, it, expect } from "vitest";
 import { setupKeyboardNavigation } from "../../src/helpers/carousel/navigation.js";
 
 describe("setupKeyboardNavigation", () => {
-  it("scrolls container and updates focus on arrow keys", () => {
+  it("scrolls container on arrow keys when container is focused", () => {
     const container = document.createElement("div");
     Object.defineProperty(container, "clientWidth", { value: 300, configurable: true });
     container.scrollLeft = 0;
-    container.scrollBy = ({ left }) => {
-      container.scrollLeft += left;
-    };
-
-    const first = document.createElement("button");
-    first.className = "judoka-card";
-    first.tabIndex = 0;
-    const second = document.createElement("button");
-    second.className = "judoka-card";
-    second.tabIndex = 0;
-    const third = document.createElement("button");
-    third.className = "judoka-card";
-    third.tabIndex = 0;
-    container.append(first, second, third);
     document.body.append(container);
 
     setupKeyboardNavigation(container);
     expect(container.tabIndex).toBe(0);
 
-    first.focus();
+    container.focus();
     container.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
     expect(container.scrollLeft).toBe(container.clientWidth);
-    expect(document.activeElement).toBe(second);
+    expect(document.activeElement).toBe(container);
 
     container.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
     expect(container.scrollLeft).toBe(0);
-    expect(document.activeElement).toBe(first);
+    expect(document.activeElement).toBe(container);
+  });
+
+  it("ignores arrow keys when a card has focus", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "clientWidth", { value: 300, configurable: true });
+    container.scrollLeft = 0;
+
+    const card = document.createElement("button");
+    card.className = "judoka-card";
+    card.tabIndex = 0;
+    container.append(card);
+    document.body.append(container);
+
+    setupKeyboardNavigation(container);
+
+    card.focus();
+    card.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(container.scrollLeft).toBe(0);
+    expect(document.activeElement).toBe(card);
   });
 });


### PR DESCRIPTION
## Summary
- avoid card focus changes when container has focus
- only scroll carousel when container is focused
- add tests for keyboard navigation and focus handlers

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/keyboardNavigation.test.js tests/helpers/focusHandlers.test.js`
- `npx vitest run` *(fails: Error fetching http://localhost:3000/data/client_embeddings.meta.json: TypeError: fetch failed)*
- `npx playwright test` *(fails: 3 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890ad51c7a8832693110dbdf4661417