### PR TITLE
Dispatch scroll event for carousel keyboard navigation

### DIFF
--- a/src/helpers/carousel/navigation.js
+++ b/src/helpers/carousel/navigation.js
@@ -5,8 +5,12 @@ import { CAROUSEL_SWIPE_THRESHOLD } from "../constants.js";
  * @pseudocode
  * 1. Make the container focusable by setting `tabIndex` to 0.
  * 2. Add a `keydown` event listener to the container.
- *    - When the container is focused, scroll left on "ArrowLeft".
- *    - When the container is focused, scroll right on "ArrowRight".
+ *    - When the container is focused and "ArrowLeft" is pressed:
+ *      - Prevent the default behavior.
+ *      - Scroll left by one container width and dispatch a `scroll` event.
+ *    - When the container is focused and "ArrowRight" is pressed:
+ *      - Prevent the default behavior.
+ *      - Scroll right by one container width and dispatch a `scroll` event.
  *
  * @param {HTMLElement} container - The carousel container element.
  */
@@ -16,9 +20,21 @@ export function setupKeyboardNavigation(container) {
     if (document.activeElement !== container) return;
     const scrollAmount = container.clientWidth;
     if (event.key === "ArrowLeft") {
-      container.scrollLeft -= scrollAmount;
+      event.preventDefault();
+      if (typeof container.scrollBy === "function") {
+        container.scrollBy({ left: -scrollAmount });
+      } else {
+        container.scrollLeft -= scrollAmount;
+      }
+      container.dispatchEvent(new Event("scroll"));
     } else if (event.key === "ArrowRight") {
-      container.scrollLeft += scrollAmount;
+      event.preventDefault();
+      if (typeof container.scrollBy === "function") {
+        container.scrollBy({ left: scrollAmount });
+      } else {
+        container.scrollLeft += scrollAmount;
+      }
+      container.dispatchEvent(new Event("scroll"));
     }
   });
 }

--- a/tests/helpers/keyboardNavigation.test.js
+++ b/tests/helpers/keyboardNavigation.test.js
@@ -6,6 +6,8 @@ describe("setupKeyboardNavigation", () => {
     const container = document.createElement("div");
     Object.defineProperty(container, "clientWidth", { value: 300, configurable: true });
     container.scrollLeft = 0;
+    const scrollEvents = [];
+    container.addEventListener("scroll", () => scrollEvents.push(true));
     document.body.append(container);
 
     setupKeyboardNavigation(container);
@@ -14,10 +16,12 @@ describe("setupKeyboardNavigation", () => {
     container.focus();
     container.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
     expect(container.scrollLeft).toBe(container.clientWidth);
+    expect(scrollEvents.length).toBe(1);
     expect(document.activeElement).toBe(container);
 
     container.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
     expect(container.scrollLeft).toBe(0);
+    expect(scrollEvents.length).toBe(2);
     expect(document.activeElement).toBe(container);
   });
 


### PR DESCRIPTION
## Summary
- Use `scrollBy` or manual `scrollLeft` updates for arrow key navigation, calling `preventDefault` and dispatching a `scroll` event
- Update keyboard navigation tests to ensure `scroll` events fire

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: 17 failed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890bb4b6b7083268e82b4c5f08e21e0