### PR TITLE
Refine carousel keyboard navigation

### DIFF
--- a/src/helpers/carousel/navigation.js
+++ b/src/helpers/carousel/navigation.js
@@ -5,36 +5,36 @@ import { CAROUSEL_SWIPE_THRESHOLD } from "../constants.js";
  * @pseudocode
  * 1. Make the container focusable by setting `tabIndex` to 0.
  * 2. Add a `keydown` event listener to the container.
- *    - When the container is focused and "ArrowLeft" is pressed:
+ *    - Ignore events that do not originate from the container or are not
+ *      "ArrowLeft"/"ArrowRight".
+ *    - When "ArrowLeft" is pressed:
  *      - Prevent the default behavior.
- *      - Scroll left by one container width and dispatch a `scroll` event.
- *    - When the container is focused and "ArrowRight" is pressed:
+ *      - Scroll left by one container width.
+ *    - When "ArrowRight" is pressed:
  *      - Prevent the default behavior.
- *      - Scroll right by one container width and dispatch a `scroll` event.
+ *      - Scroll right by one container width.
  *
  * @param {HTMLElement} container - The carousel container element.
  */
 export function setupKeyboardNavigation(container) {
   container.tabIndex = 0;
   container.addEventListener("keydown", (event) => {
-    if (document.activeElement !== container) return;
+    if (event.target !== event.currentTarget) return;
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
     const scrollAmount = container.clientWidth;
     if (event.key === "ArrowLeft") {
-      event.preventDefault();
       if (typeof container.scrollBy === "function") {
         container.scrollBy({ left: -scrollAmount });
       } else {
         container.scrollLeft -= scrollAmount;
       }
-      container.dispatchEvent(new Event("scroll"));
     } else if (event.key === "ArrowRight") {
-      event.preventDefault();
       if (typeof container.scrollBy === "function") {
         container.scrollBy({ left: scrollAmount });
       } else {
         container.scrollLeft += scrollAmount;
       }
-      container.dispatchEvent(new Event("scroll"));
     }
   });
 }

--- a/tests/helpers/keyboardNavigation.test.js
+++ b/tests/helpers/keyboardNavigation.test.js
@@ -6,6 +6,11 @@ describe("setupKeyboardNavigation", () => {
     const container = document.createElement("div");
     Object.defineProperty(container, "clientWidth", { value: 300, configurable: true });
     container.scrollLeft = 0;
+    container.scrollBy = ({ left }) => {
+      container.scrollLeft += left;
+      container.dispatchEvent(new Event("scroll"));
+    };
+
     const scrollEvents = [];
     container.addEventListener("scroll", () => scrollEvents.push(true));
     document.body.append(container);
@@ -17,12 +22,10 @@ describe("setupKeyboardNavigation", () => {
     container.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
     expect(container.scrollLeft).toBe(container.clientWidth);
     expect(scrollEvents.length).toBe(1);
-    expect(document.activeElement).toBe(container);
 
     container.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
     expect(container.scrollLeft).toBe(0);
     expect(scrollEvents.length).toBe(2);
-    expect(document.activeElement).toBe(container);
   });
 
   it("ignores arrow keys when a card has focus", () => {


### PR DESCRIPTION
## Summary
- use event target checks to handle carousel arrow keys
- stop dispatching synthetic scroll events
- test keyboard navigation against native scroll behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890c4ba50f08326bee76d5da7090422