### PR TITLE
Verify carousel page counter updates via arrow keys

### DIFF
--- a/playwright/browse-judoka-navigation.spec.js
+++ b/playwright/browse-judoka-navigation.spec.js
@@ -23,15 +23,17 @@ test.describe("Browse Judoka navigation", () => {
     await expect(left).toBeDisabled();
 
     await container.focus();
+
     await container.press("ArrowRight");
-    await container.press("ArrowRight");
+    await expect(counter).toHaveText("Page 2 of 3");
+
     await container.press("ArrowRight");
     await expect(counter).toHaveText("Page 3 of 3");
     await expect(right).toBeDisabled();
 
-    await container.focus();
     await container.press("ArrowLeft");
-    await container.press("ArrowLeft");
+    await expect(counter).toHaveText("Page 2 of 3");
+
     await container.press("ArrowLeft");
     await expect(counter).toHaveText("Page 1 of 3");
     await expect(left).toBeDisabled();


### PR DESCRIPTION
## Summary
- strengthen desktop carousel navigation test to assert page counter updates when pressing ArrowRight and ArrowLeft without refocusing
- ensure test covers traveling to last and first pages and checks button disabled states

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890c96660008326bec93ee42a3346a5