### PR TITLE
Remove unused catch variable in importJsonModule

### DIFF
--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -178,7 +178,7 @@ export async function validateWithSchema(data, schema) {
 export async function importJsonModule(spec) {
   try {
     return (await import(spec, { with: { type: "json" } })).default;
-  } catch (err) {
+  } catch {
     return (await import(spec, { assert: { type: "json" } })).default;
   }
 }


### PR DESCRIPTION
## Summary
- avoid creating unused error variable in `importJsonModule`

## Testing
- `npx prettier src/helpers/dataUtils.js --write`
- `npx eslint src/helpers/dataUtils.js`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 2 failed, 1 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890e7e7b8148326b35abcb705ad7f93