### PR TITLE
Use expect.poll for waitFor

### DIFF
--- a/tests/helpers/quoteBuilder.test.js
+++ b/tests/helpers/quoteBuilder.test.js
@@ -1,9 +1,14 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { waitFor } from "../waitFor.js";
 
 const originalFetch = global.fetch;
 
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
 afterEach(() => {
+  vi.useRealTimers();
   global.fetch = originalFetch;
 });
 

--- a/tests/waitFor.js
+++ b/tests/waitFor.js
@@ -14,5 +14,5 @@ import { expect } from "vitest";
  * @returns {Promise<void>} Resolves when the predicate is satisfied.
  */
 export async function waitFor(predicate, { timeout = 500, interval = 10 } = {}) {
-  await expect.poll(predicate, { timeout, interval }).toBe(true);
+  await expect.poll(() => predicate() === true, { timeout, interval }).toBe(true);
 }

--- a/tests/waitFor.js
+++ b/tests/waitFor.js
@@ -1,8 +1,18 @@
+import { expect } from "vitest";
+
+/**
+ * Waits until the provided predicate returns `true`.
+ *
+ * Uses `expect.poll` so callers can rely on fake timers instead of real
+ * delays. The returned promise rejects if the predicate never returns `true`
+ * within the timeout.
+ *
+ * @param {() => boolean} predicate - Condition to repeatedly evaluate.
+ * @param {object} [options] - Configuration options.
+ * @param {number} [options.timeout=500] - Maximum time to wait in milliseconds.
+ * @param {number} [options.interval=10] - Polling interval in milliseconds.
+ * @returns {Promise<void>} Resolves when the predicate is satisfied.
+ */
 export async function waitFor(predicate, { timeout = 500, interval = 10 } = {}) {
-  const endTime = Date.now() + timeout;
-  while (Date.now() < endTime) {
-    if (predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, interval));
-  }
-  throw new Error("waitFor timeout");
+  await expect.poll(predicate, { timeout, interval }).toBe(true);
 }


### PR DESCRIPTION
## Summary
- replace manual polling with `expect.poll` in `waitFor`
- run quoteBuilder tests with fake timers to avoid real delays

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-orientation screenshots, battle Judoka narrow viewport screenshot and settings dark expanded screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890e84ca89c8326ab3fd32a28fe19d2