### PR TITLE
Add AI stat selection difficulty options

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -91,7 +91,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 | **P1**   | Match End Condition     | End match on 10 points or after 25 rounds.                                                                                                                                       |
 | **P2**   | Tie Handling            | Show tie message; round ends without score change; continue to next round.                                                                                                       |
 | **P2**   | Player Quit Flow        | Allow player to exit match early with confirmation; counts as a loss.                                                                                                            |
-| **P3**   | AI Stat Selection Logic | Optional: vary AI stat selection by difficulty level; fallback to random if not specified.                                                                                       |
+| **P3**   | AI Stat Selection Logic | AI stat choice follows difficulty setting (`easy` random, `medium` picks stats ≥ average, `hard` selects highest stat). Difficulty can be set via Settings or `?difficulty=` URL param; defaults to `easy`. |
 
 **Additional Behavioral Requirements:**
 
@@ -100,15 +100,6 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Players have 30 seconds to select a stat; if no selection is made, the system randomly selects a stat from the drawn card. **The timer and prompt are displayed in the Info Bar.**
 - The opponent's card must always differ from the player's card for each round.
 - **Default:** 30-second timer is fixed (not adjustable by the player at launch), but can be reviewed for future difficulty settings.
-
----
-
-## Future Considerations
-
-- Add easy/medium/hard modes changing AI stat selection strategy:
-  - **Easy**: AI selects randomly.
-  - **Medium**: AI favors stats where it’s average or better.
-  - **Hard**: AI prefers its highest stat each round.
 
 ---
 
@@ -176,12 +167,6 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Uses the shared random card draw module (`generateRandomCard`) as detailed in [prdDrawRandomCard.md](prdDrawRandomCard.md) (see `src/helpers/randomCard.js`).
 - Uses the Mystery Card placeholder outlined in [prdMysteryCard.md](prdMysteryCard.md), which relies on the `useObscuredStats` flag added to `renderJudokaCard()`.
 - **Relies on Info Bar (see prdBattleInfoBar.md) for all round messages, timer, and score display.**
-
----
-
-## Open Questions
-
-_Resolved in [Future Considerations](#future-considerations):_ AI difficulty will control stat selection strategy.
 
 ---
 

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -6,6 +6,7 @@
   "showCardOfTheDay": false,
   "displayMode": "light",
   "fullNavigationMap": false,
+  "aiDifficulty": "easy",
   "tooltipIds": {
     "sound": "settings.sound",
     "motionEffects": "settings.motionEffects",

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -30,15 +30,44 @@ let statTimeoutId = null;
 let autoSelectId = null;
 
 /**
- * Return a random stat key for the opponent.
+ * Determine the opponent's stat choice based on difficulty.
  *
  * @pseudocode
- * 1. Pick a random index from `STATS`.
- * 2. Return the stat at that index.
+ * 1. When `difficulty` is `hard`:
+ *    a. Read all stat values from the opponent card.
+ *    b. Find the highest value and return one of the stats with that value.
+ * 2. When `difficulty` is `medium`:
+ *    a. Read all stat values from the opponent card.
+ *    b. Compute the average of those values.
+ *    c. Choose randomly among stats whose value is at least the average.
+ *    d. If none qualify, fallback to random.
+ * 3. Otherwise (`easy`): pick a random stat from `STATS`.
  *
+ * @param {"easy"|"medium"|"hard"} [difficulty="easy"] Difficulty setting.
  * @returns {string} One of the values from `STATS`.
  */
-export function simulateOpponentStat() {
+export function simulateOpponentStat(difficulty = "easy") {
+  if (difficulty !== "easy") {
+    const card = document.getElementById("computer-card");
+    if (card) {
+      const values = STATS.map((stat) => ({
+        stat,
+        value: getStatValue(card, stat)
+      }));
+      if (difficulty === "hard") {
+        const max = Math.max(...values.map((v) => v.value));
+        const best = values.filter((v) => v.value === max);
+        return best[Math.floor(Math.random() * best.length)].stat;
+      }
+      if (difficulty === "medium") {
+        const avg = values.reduce((sum, v) => sum + v.value, 0) / values.length;
+        const eligible = values.filter((v) => v.value >= avg);
+        if (eligible.length > 0) {
+          return eligible[Math.floor(Math.random() * eligible.length)].stat;
+        }
+      }
+    }
+  }
   return STATS[Math.floor(Math.random() * STATS.length)];
 }
 

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -48,13 +48,14 @@ function enableStatButtons(enable = true) {
 }
 
 let simulatedOpponentMode = false;
+let aiDifficulty = "easy";
 
 async function startRoundWrapper() {
   enableStatButtons(false);
   await classicStartRound();
   await waitForComputerCard();
   if (simulatedOpponentMode) {
-    const stat = simulateOpponentStat();
+    const stat = simulateOpponentStat(aiDifficulty);
     await handleStatSelection(stat);
   } else {
     enableStatButtons(true);
@@ -111,6 +112,13 @@ export async function setupClassicBattlePage() {
   }
 
   simulatedOpponentMode = Boolean(settings.featureFlags.simulatedOpponentMode?.enabled);
+  const params = new URLSearchParams(window.location.search);
+  const paramDifficulty = params.get("difficulty");
+  if (["easy", "medium", "hard"].includes(paramDifficulty)) {
+    aiDifficulty = paramDifficulty;
+  } else if (typeof settings.aiDifficulty === "string") {
+    aiDifficulty = settings.aiDifficulty;
+  }
   if (simulatedOpponentMode) {
     enableStatButtons(false);
   } else {
@@ -139,6 +147,7 @@ export async function setupClassicBattlePage() {
     battleArea.dataset.randomStat = String(Boolean(settings.featureFlags.randomStatMode));
     battleArea.dataset.testMode = String(Boolean(settings.featureFlags.enableTestMode?.enabled));
     battleArea.dataset.simulatedOpponent = String(simulatedOpponentMode);
+    battleArea.dataset.difficulty = aiDifficulty;
   }
 
   toggleViewportSimulation(Boolean(settings.featureFlags.viewportSimulation?.enabled));

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -34,6 +34,12 @@
       "type": "boolean",
       "description": "Enable the full navigation map overlay."
     },
+    "aiDifficulty": {
+      "type": "string",
+      "enum": ["easy", "medium", "hard"],
+      "description": "Difficulty level for AI stat selection.",
+      "default": "easy"
+    },
     "tooltipIds": {
       "type": "object",
       "description": "Mapping of setting keys to tooltip identifiers.",

--- a/tests/helpers/classicBattle/difficulty.test.js
+++ b/tests/helpers/classicBattle/difficulty.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createBattleCardContainers } from "../../utils/testUtils.js";
+import { STATS } from "../../../src/helpers/battleEngine.js";
+
+describe("simulateOpponentStat difficulty", () => {
+  let simulateOpponentStat;
+
+  beforeEach(async () => {
+    document.body.innerHTML = "";
+    const { computerCard } = createBattleCardContainers();
+    document.body.appendChild(computerCard);
+    computerCard.innerHTML = `
+      <ul>
+        <li class="stat"><strong>power</strong> <span>1</span></li>
+        <li class="stat"><strong>speed</strong> <span>2</span></li>
+        <li class="stat"><strong>technique</strong> <span>3</span></li>
+        <li class="stat"><strong>kumikata</strong> <span>4</span></li>
+        <li class="stat"><strong>newaza</strong> <span>5</span></li>
+      </ul>
+    `;
+    ({ simulateOpponentStat } = await import("../../../src/helpers/classicBattle.js"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a random stat on easy", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const stat = simulateOpponentStat("easy");
+    expect(STATS.includes(stat)).toBe(true);
+  });
+
+  it("chooses among stats at or above average on medium", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const stat = simulateOpponentStat("medium");
+    expect(["technique", "kumikata", "newaza"]).toContain(stat);
+  });
+
+  it("chooses the highest stat on hard", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const stat = simulateOpponentStat("hard");
+    expect(stat).toBe("newaza");
+  });
+});

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -146,6 +146,7 @@ describe("classicBattlePage simulated opponent mode", () => {
     const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
     await setupClassicBattlePage();
 
+    expect(simulateOpponentStat).toHaveBeenCalledWith("easy");
     expect(handleStatSelection).toHaveBeenCalledWith("power");
     const calls = handleStatSelection.mock.calls.length;
     btn.dispatchEvent(new Event("click", { bubbles: true }));


### PR DESCRIPTION
## Summary
- Extend `simulateOpponentStat` with easy/medium/hard difficulty strategies
- Allow Classic Battle to read difficulty from settings or `?difficulty=` param
- Document and test the new AI difficulty options

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 3 tests failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890e8785d048326a4bc4e99c6cd4830