### PR TITLE
Enable card inspector flag

### DIFF
--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -1,5 +1,6 @@
 import { generateRandomCard } from "../randomCard.js";
 import { getRandomJudoka, renderJudokaCard } from "../cardUtils.js";
+import { loadSettings } from "../settingsUtils.js";
 import { fetchJson } from "../dataUtils.js";
 import { createGokyoLookup } from "../utils.js";
 import { DATA_DIR } from "../constants.js";
@@ -87,6 +88,14 @@ export async function drawCards() {
   const playerContainer = document.getElementById("player-card");
   const computerContainer = document.getElementById("computer-card");
 
+  let settings;
+  try {
+    settings = await loadSettings();
+  } catch {
+    settings = { featureFlags: {} };
+  }
+  const enableInspector = Boolean(settings.featureFlags?.enableCardInspector?.enabled);
+
   let playerJudoka = null;
   await generateRandomCard(
     available,
@@ -96,7 +105,7 @@ export async function drawCards() {
     (j) => {
       playerJudoka = j;
     },
-    { enableInspector: false }
+    { enableInspector }
   );
 
   let compJudoka = getRandomJudoka(available);
@@ -114,7 +123,7 @@ export async function drawCards() {
   await renderJudokaCard(placeholder, gokyoLookup, computerContainer, {
     animate: false,
     useObscuredStats: true,
-    enableInspector: false
+    enableInspector
   });
 
   return { playerJudoka, computerJudoka };

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -1,5 +1,6 @@
 import { getComputerJudoka, getGokyoLookup, clearComputerJudoka } from "./cardSelection.js";
 import { renderJudokaCard } from "../cardUtils.js";
+import { loadSettings } from "../settingsUtils.js";
 import { getScores, getTimerState, isMatchEnded } from "../battleEngine.js";
 import { isTestModeEnabled, getCurrentSeed } from "../testModeUtils.js";
 
@@ -34,7 +35,17 @@ export async function revealComputerCard() {
   const judoka = getComputerJudoka();
   if (!judoka) return;
   const container = document.getElementById("computer-card");
-  await renderJudokaCard(judoka, getGokyoLookup(), container, { animate: false });
+  let settings;
+  try {
+    settings = await loadSettings();
+  } catch {
+    settings = { featureFlags: {} };
+  }
+  const enableInspector = Boolean(settings.featureFlags?.enableCardInspector?.enabled);
+  await renderJudokaCard(judoka, getGokyoLookup(), container, {
+    animate: false,
+    enableInspector
+  });
   clearComputerJudoka();
 }
 

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -38,6 +38,7 @@ import { setTestMode } from "./testModeUtils.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
 import { loadStatNames } from "./stats.js";
 import { STATS } from "./battleEngine.js";
+import { toggleInspectorPanels } from "./cardUtils.js";
 
 function enableStatButtons(enable = true) {
   document.querySelectorAll("#stat-buttons button").forEach((btn) => {
@@ -109,6 +110,8 @@ export async function setupClassicBattlePage() {
   } catch {
     settings = { featureFlags: {} };
   }
+  const inspectorEnabled = Boolean(settings.featureFlags?.enableCardInspector?.enabled);
+  toggleInspectorPanels(inspectorEnabled);
 
   simulatedOpponentMode = Boolean(settings.featureFlags.simulatedOpponentMode?.enabled);
   if (simulatedOpponentMode) {
@@ -161,6 +164,7 @@ export async function setupClassicBattlePage() {
           banner.classList.toggle("hidden", !s.featureFlags?.enableTestMode?.enabled);
         }
         setTestMode(Boolean(s.featureFlags?.enableTestMode?.enabled));
+        toggleInspectorPanels(Boolean(s.featureFlags?.enableCardInspector?.enabled));
       } catch {}
     }
   });


### PR DESCRIPTION
## Summary
- load feature flag settings to enable the card inspector on game and battle pages
- propagate the flag when rendering cards
- watch for settings changes to toggle inspector panels

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: no-importJsonModule mocked)*
- `npx vitest run` *(fails: importJsonModule mocks missing)*
- `npx playwright test` *(fails: screenshot comparisons)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890e88fa8408326b9217149c3054962