### PR TITLE
Reset modules before mocking in gameRandom test

### DIFF
--- a/tests/helpers/gameRandom.test.js
+++ b/tests/helpers/gameRandom.test.js
@@ -23,13 +23,18 @@ function setupDom() {
 describe("game.js", () => {
   it("passes motion preference to generateRandomCard", async () => {
     setupDom();
+    vi.resetModules();
     const generateRandomCard = vi.fn();
     const shouldReduceMotionSync = vi.fn(() => true);
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ shouldReduceMotionSync }));
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      loadSettings: vi.fn().mockResolvedValue({ featureFlags: {} })
+    }));
 
     await import("../../src/game.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
+    await Promise.resolve();
     showRandom.dispatchEvent(new Event("click"));
 
     expect(generateRandomCard).toHaveBeenCalledWith(null, null, gameArea, true, undefined, {


### PR DESCRIPTION
## Summary
- reset modules before mocking dependencies in `gameRandom.test.js`
- mock settings and wait a microtask to ensure `generateRandomCard` runs

## Testing
- `npx vitest run tests/helpers/gameRandom.test.js`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 5 failed, 19 failed tests)*
- `npx playwright test` *(fails: 4 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890effe017c8326bf4f00ec6a1dcf43