### PR TITLE
Add missing dataUtils mock for classicBattle tests

### DIFF
--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -17,7 +17,8 @@ vi.mock("../../../src/helpers/cardUtils.js", () => ({
 
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args)
+  fetchJson: (...args) => fetchJsonMock(...args),
+  importJsonModule: vi.fn()
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -16,7 +16,8 @@ vi.mock("../../../src/helpers/cardUtils.js", () => ({
 }));
 
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args)
+  fetchJson: (...args) => fetchJsonMock(...args),
+  importJsonModule: vi.fn()
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -17,7 +17,8 @@ vi.mock("../../../src/helpers/cardUtils.js", () => ({
 
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args)
+  fetchJson: (...args) => fetchJsonMock(...args),
+  importJsonModule: vi.fn()
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -20,7 +20,8 @@ vi.mock("../../../src/helpers/cardUtils.js", () => ({
 
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args)
+  fetchJson: (...args) => fetchJsonMock(...args),
+  importJsonModule: vi.fn()
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -18,7 +18,8 @@ vi.mock("../../../src/helpers/cardUtils.js", () => ({
 
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args)
+  fetchJson: (...args) => fetchJsonMock(...args),
+  importJsonModule: vi.fn()
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({


### PR DESCRIPTION
## Summary
- mock `importJsonModule` alongside `fetchJson` in classicBattle tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 4 failed, 1 skipped, 83 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890f52fd60c83268be3cbb7a331d641