### PR TITLE
Refine judoka tests

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -45,12 +45,10 @@ test.describe("Browse Judoka screen", () => {
 
     await toggle.click();
     const panel = page.getByRole("region");
-    await panel.waitFor();
-    await page.waitForTimeout(500);
-    const countAfterFilter = await page
-      .locator("[data-testid=carousel-container] .judoka-card")
-      .count();
-    expect(countAfterFilter).toBe(initialCount);
+    await expect(panel).toBeVisible();
+    await expect(page.locator("[data-testid=carousel-container] .judoka-card")).toHaveCount(
+      initialCount
+    );
     await page.getByRole("button", { name: "Japan" }).click({ force: true });
 
     const filteredCards = page.locator("[data-testid=carousel-container] .judoka-card");
@@ -62,9 +60,10 @@ test.describe("Browse Judoka screen", () => {
     }
 
     await toggle.click();
-    await panel.waitFor();
-    await page.waitForTimeout(350);
-    await page.getByRole("button", { name: "All" }).click({ force: true });
+    await expect(panel).toBeVisible();
+    const allButton = page.getByRole("button", { name: "All" });
+    await expect(allButton).toBeVisible();
+    await allButton.click({ force: true });
 
     await expect(page.locator("[data-testid=carousel-container] .judoka-card")).toHaveCount(
       initialCount

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -50,7 +50,6 @@ test.describe("View Judoka screen", () => {
     await btn.click();
     await expect(btn).toHaveText(/drawing/i);
     await expect(btn).toHaveAttribute("aria-busy", "true");
-    await page.waitForTimeout(600);
     await expect(btn).toHaveText(/draw card/i);
     await expect(btn).not.toHaveAttribute("aria-busy");
   });


### PR DESCRIPTION
## Summary
- remove fixed delays in random judoka button test
- rely on DOM state to await country filter updates

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battleJudoka, browse-judoka-navigation, settings screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890f970f5f48326881514ba5fc1bb5e