### PR TITLE
Animate debug panel toggle

### DIFF
--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -549,3 +549,27 @@ svg {
   outline: 2px solid var(--color-primary);
   outline-offset: 4px;
 }
+
+/* Animate debug panel disclosure */
+details,
+.debug-panel {
+  overflow: hidden;
+  transition: opacity var(--transition-fast);
+}
+
+details[open],
+.debug-panel[open] {
+  opacity: 1;
+}
+
+details:not([open]),
+.debug-panel:not([open]) {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  details,
+  .debug-panel {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- animate `.debug-panel`/`details` open state with fade
- disable the animation for users preferring reduced motion

## Testing
- `npx prettier . --check`
- `npx prettier src/styles/card.css --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle orientation screenshot, battle Judoka narrow screenshot, browse Judoka navigation)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890f99a0f6083268aed558f34cb082c