### PR TITLE
Add battle slot themes

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -187,7 +187,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
   - [ ] 3.2 Handle Judoka dataset load failure with error prompt and reload option
   - [x] 3.3 Add fallback stat selection for AI if difficulty logic fails
 - [ ] 4.0 Polish UX and Accessibility
-  - [ ] 4.1 Integrate consistent color coding (blue for player, red for AI)
+  - [x] 4.1 Integrate consistent color coding (blue for player, red for AI)
   - [ ] 4.2 Apply WCAG-compliant contrast ratios
   - [ ] 4.3 Ensure touch targets ≥44px and support keyboard navigation (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness) and prdBattleInfoBar.md)
   - [ ] 4.4 Add alt text to cards and UI elements

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -50,7 +50,7 @@
 
       <main class="container" role="main">
         <section id="battle-area">
-          <div id="player-card" class="card-slot"></div>
+          <div id="player-card" class="card-slot player-slot"></div>
           <div id="controls">
             <div class="stat-controls">
               <div
@@ -109,7 +109,11 @@
               <pre id="debug-output" role="status" aria-live="polite"></pre>
             </div>
           </div>
-          <div id="computer-card" class="card-slot" aria-label="Mystery Judoka: hidden card">
+          <div
+            id="computer-card"
+            class="card-slot opponent-slot"
+            aria-label="Mystery Judoka: hidden card"
+          >
             <!--
   Mystery Judoka card is rendered here. ARIA attributes and stat labels should be set dynamically for accessibility compliance (see PRD: Mystery Card).
  -->

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -99,3 +99,14 @@
 #stat-buttons button {
   -webkit-tap-highlight-color: transparent;
 }
+
+/* Player and opponent card slots */
+.player-slot {
+  background-color: var(--color-secondary);
+  color: var(--color-text-inverted);
+}
+
+.opponent-slot {
+  background-color: var(--color-primary);
+  color: var(--color-text-inverted);
+}

--- a/tests/styles/battleContrast.test.js
+++ b/tests/styles/battleContrast.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { hex } from "wcag-contrast";
+
+describe("battle slot color contrast", () => {
+  it("player slot background contrasts with text", () => {
+    const contrast = hex("#0c3f7a", "#ffffff");
+    expect(contrast).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("opponent slot background contrasts with text", () => {
+    const contrast = hex("#cb2504", "#ffffff");
+    expect(contrast).toBeGreaterThanOrEqual(4.5);
+  });
+});


### PR DESCRIPTION
## Summary
- style player and opponent card slots with blue/red themes
- ensure battle slot colors meet contrast standards with tests
- mark PRD task 4.1 completed

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot regressions in orientation, battle page, browse navigation, and settings)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890f989d1ac8326a76ef11ce63fe7fe