### PR TITLE
Remove unused description variable

### DIFF
--- a/src/helpers/settings/featureFlagSwitches.js
+++ b/src/helpers/settings/featureFlagSwitches.js
@@ -60,7 +60,6 @@ export function renderFeatureFlagSwitches(
     if (!input) return;
     input.addEventListener("change", () => {
       const currentLabel = tooltipMap[`${tipId}.label`] || flag;
-      const currentDesc = tooltipMap[`${tipId}.description`] || "";
       const prev = !input.checked;
       const updated = {
         ...getCurrentSettings().featureFlags,


### PR DESCRIPTION
## Summary
- drop unused `currentDesc` variable from feature flag change handler

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings)
- `npx vitest run`
- `npx playwright test` (fails: Battle Judoka page, Browse Judoka navigation, Settings screenshots)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890f94fc7188326ba3f45cb766146a8