### PR TITLE
Ensure battle orientation screenshots wait for score display

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -36,23 +36,38 @@ test.describe(
 
     test("captures portrait and landscape headers", async ({ page }) => {
       await page.goto("/src/pages/battleJudoka.html");
+      await page.waitForSelector("#score-display br");
 
       await page.setViewportSize({ width: 320, height: 480 });
+      await page.waitForFunction(
+        () => document.querySelector(".battle-header")?.dataset.orientation === "portrait"
+      );
+      await page.waitForSelector("#score-display br");
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-portrait.png");
 
       await page.setViewportSize({ width: 480, height: 320 });
+      await page.waitForFunction(
+        () => document.querySelector(".battle-header")?.dataset.orientation === "landscape"
+      );
+      await page.waitForSelector("#score-display br");
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-landscape.png");
     });
 
     test("captures extra-narrow header", async ({ page }) => {
       await page.goto("/src/pages/battleJudoka.html");
+      await page.waitForSelector("#score-display br");
+
       await page.setViewportSize({ width: 300, height: 600 });
+      await page.waitForFunction(
+        () => document.querySelector(".battle-header")?.dataset.orientation === "portrait"
+      );
       await page
         .locator("#round-message")
         .evaluate(
           (el) =>
             (el.textContent = "A very long round message that should overflow on narrow screens")
         );
+      await page.waitForSelector("#score-display br");
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-300.png");
     });
   }


### PR DESCRIPTION
## Summary
- wait for `#score-display` to render `<br>` before taking orientation screenshots
- verify orientation `data-orientation` matches expected before capturing each screenshot

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings)*
- `npx vitest run`
- `npx playwright test` *(fails: battle-orientation spec and others)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890ff133e8c8326aa06a0dea17dafcb