### PR TITLE
Enable test mode in Battle Judoka Playwright tests

### DIFF
--- a/playwright/battleJudoka.spec.js
+++ b/playwright/battleJudoka.spec.js
@@ -10,7 +10,7 @@ test.describe("Battle Judoka page", () => {
     await page.addInitScript(() => {
       localStorage.setItem(
         "settings",
-        JSON.stringify({ featureFlags: { enableTestMode: { enabled: true } } })
+        JSON.stringify({ featureFlags: { enableTestMode: true } })
       );
     });
     await page.goto("/src/pages/battleJudoka.html");


### PR DESCRIPTION
## Summary
- inject test mode settings before loading Battle Judoka page in Playwright tests

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warn: 8 warnings)*
- `npx vitest run`
- `npx playwright test` *(fail: 8 failing tests including screenshot mismatch for Battle Judoka)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6890ff6a927c8326bee9682f94cf42eb