### PR TITLE
Load quote via meditation page

### DIFF
--- a/playwright/battleJudoka.spec.js
+++ b/playwright/battleJudoka.spec.js
@@ -8,10 +8,7 @@ import {
 test.describe("Battle Judoka page", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      localStorage.setItem(
-        "settings",
-        JSON.stringify({ featureFlags: { enableTestMode: true } })
-      );
+      localStorage.setItem("settings", JSON.stringify({ featureFlags: { enableTestMode: true } }));
     });
     await page.goto("/src/pages/battleJudoka.html");
   });

--- a/src/helpers/meditationPage.js
+++ b/src/helpers/meditationPage.js
@@ -2,10 +2,12 @@
  * Initialize the Meditation page.
  *
  * @pseudocode
- * 1. Import `setupLanguageToggle` from `pseudoJapanese.js`.
+ * 1. Import `setupLanguageToggle` from `pseudoJapanese.js` and `loadQuote` from `quoteBuilder.js`.
  * 2. Define `setupMeditationPage` which:
  *    a. Retrieves the quote element from the DOM.
- *    b. Calls `setupLanguageToggle` with the quote element.
+ *    b. Calls `loadQuote` to display a random quote.
+ *    c. Calls `setupLanguageToggle` with the quote element.
+ *    d. Initializes tooltips.
  * 3. Use `onDomReady` to run `setupMeditationPage` once the DOM is ready.
  *
  * @returns {void}
@@ -13,9 +15,11 @@
 import { setupLanguageToggle } from "./pseudoJapanese.js";
 import { onDomReady } from "./domReady.js";
 import { initTooltips } from "./tooltip.js";
+import { loadQuote } from "./quoteBuilder.js";
 
 export function setupMeditationPage() {
   const quoteEl = document.getElementById("quote");
+  loadQuote();
   setupLanguageToggle(quoteEl);
   initTooltips();
 }

--- a/src/pages/meditation.html
+++ b/src/pages/meditation.html
@@ -96,7 +96,6 @@
         import { preloadMeditationAssets } from "../helpers/preload.js";
         preloadMeditationAssets();
       </script>
-      <script type="module" src="../helpers/quoteBuilder.js"></script>
       <script type="module" src="../helpers/meditationPage.js"></script>
       <script type="module" src="../helpers/setupSvgFallback.js"></script>
     </div>


### PR DESCRIPTION
## Summary
- call `loadQuote` from meditation page setup and update documentation
- remove direct `quoteBuilder` script include from meditation page
- format `battleJudoka` Playwright test for Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 3 tests, screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891040088348326b98ba0b1517ef1c0