### PR TITLE
Wait for score display attachment

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -36,26 +36,26 @@ test.describe(
 
     test("captures portrait and landscape headers", async ({ page }) => {
       await page.goto("/src/pages/battleJudoka.html");
-      await page.waitForSelector("#score-display br");
+      await page.waitForSelector("#score-display br", { state: "attached" });
 
       await page.setViewportSize({ width: 320, height: 480 });
       await page.waitForFunction(
         () => document.querySelector(".battle-header")?.dataset.orientation === "portrait"
       );
-      await page.waitForSelector("#score-display br");
+      await page.waitForSelector("#score-display br", { state: "attached" });
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-portrait.png");
 
       await page.setViewportSize({ width: 480, height: 320 });
       await page.waitForFunction(
         () => document.querySelector(".battle-header")?.dataset.orientation === "landscape"
       );
-      await page.waitForSelector("#score-display br");
+      await page.waitForSelector("#score-display br", { state: "attached" });
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-landscape.png");
     });
 
     test("captures extra-narrow header", async ({ page }) => {
       await page.goto("/src/pages/battleJudoka.html");
-      await page.waitForSelector("#score-display br");
+      await page.waitForSelector("#score-display br", { state: "attached" });
 
       await page.setViewportSize({ width: 300, height: 600 });
       await page.waitForFunction(


### PR DESCRIPTION
## Summary
- wait for score display before taking battle orientation screenshots

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle orientation screenshots › captures portrait and landscape headers; Battle Judoka page › narrow viewport screenshot and status aria attributes; Browse Judoka navigation › desktop arrow keys update markers and disable buttons)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68911c77092c83269cee4e6e800ec9ce