### PR TITLE
Simplify carousel swipe test

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -155,13 +155,10 @@ test.describe("Browse Judoka screen", () => {
       );
 
     const before = await container.evaluate((el) => el.scrollLeft);
-
-    for (let i = 0; i < 5; i++) {
-      await swipe(startX, startX - 600);
-    }
+    await swipe(startX, startX - box.width);
 
     await expect.poll(() => container.evaluate((el) => el.scrollLeft)).toBeGreaterThan(before);
-    await expect.poll(() => counter.textContent()).toBe("Page 6 of 6");
+    await expect(counter).toHaveText("Page 2 of 6");
   });
 
   test.skip("shows loading spinner on slow network", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Reduce swipe loop to a single simulated touch interaction
- Assert carousel scroll and counter after one swipe

## Testing
- `npx prettier playwright/browse-judoka.spec.js --check`
- `npx eslint playwright/browse-judoka.spec.js`
- `npx vitest run`
- `npx playwright test` *(fails: battleJudoka.spec.js, browse-judoka-navigation.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68912158819c832680a908129deeab0b