### PR TITLE
Use span elements for battle score display

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -69,7 +69,7 @@ The round message, timer, and score now sit directly inside the page header rath
 
 - **Layout**
   - Right side: score display (`Player: X – Opponent: Y`)
-  - Two-line score format appears on narrow screens (`Player: X` line break `Opponent: Y`)
+  - Two-line score format appears on narrow screens via stacked `<span>` elements (`<span>You: X</span> <span>Opponent: Y</span>`)
   - Left side: rotating status messages (e.g., "You won!", "Next round in: 3s", "Select your move", **"Time left: 29s"**)
 - **Visuals**
   - Font size: `clamp(16px, 4vw, 24px)`; on narrow screens (<375px) `clamp(14px, 5vw, 20px)`.

--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -36,26 +36,26 @@ test.describe(
 
     test("captures portrait and landscape headers", async ({ page }) => {
       await page.goto("/src/pages/battleJudoka.html");
-      await page.waitForSelector("#score-display br", { state: "attached" });
+      await page.waitForSelector("#score-display span", { state: "attached" });
 
       await page.setViewportSize({ width: 320, height: 480 });
       await page.waitForFunction(
         () => document.querySelector(".battle-header")?.dataset.orientation === "portrait"
       );
-      await page.waitForSelector("#score-display br", { state: "attached" });
+      await page.waitForSelector("#score-display span", { state: "attached" });
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-portrait.png");
 
       await page.setViewportSize({ width: 480, height: 320 });
       await page.waitForFunction(
         () => document.querySelector(".battle-header")?.dataset.orientation === "landscape"
       );
-      await page.waitForSelector("#score-display br", { state: "attached" });
+      await page.waitForSelector("#score-display span", { state: "attached" });
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-landscape.png");
     });
 
     test("captures extra-narrow header", async ({ page }) => {
       await page.goto("/src/pages/battleJudoka.html");
-      await page.waitForSelector("#score-display br", { state: "attached" });
+      await page.waitForSelector("#score-display span", { state: "attached" });
 
       await page.setViewportSize({ width: 300, height: 600 });
       await page.waitForFunction(

--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -137,11 +137,12 @@ export function startCountdown(seconds, onFinish) {
 }
 
 /**
- * Display the current match score on two lines.
+ * Display the current match score using two stacked spans.
  *
  * @pseudocode
- * 1. Clear existing content and append `"You: {playerScore}"`.
- * 2. Append a line break and `"Opponent: {computerScore}"` on the next line.
+ * 1. Create `playerSpan` with `"You: {playerScore}"`.
+ * 2. Create `opponentSpan` with `"\nOpponent: {computerScore}"`.
+ * 3. Replace existing children of `scoreEl` with both spans.
  *
  * @param {number} playerScore - Player's score.
  * @param {number} computerScore - Opponent's score.
@@ -149,11 +150,10 @@ export function startCountdown(seconds, onFinish) {
  */
 export function updateScore(playerScore, computerScore) {
   if (scoreEl) {
-    // Clear previous score text
-    scoreEl.textContent = "";
-    // Add "You" and "Opponent" on separate lines
-    scoreEl.append(`You: ${playerScore}`);
-    scoreEl.appendChild(document.createElement("br"));
-    scoreEl.append(`\nOpponent: ${computerScore}`);
+    const playerSpan = document.createElement("span");
+    playerSpan.textContent = `You: ${playerScore}`;
+    const opponentSpan = document.createElement("span");
+    opponentSpan.textContent = `\nOpponent: ${computerScore}`;
+    scoreEl.replaceChildren(playerSpan, opponentSpan);
   }
 }

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -39,7 +39,10 @@
           </a>
         </div>
         <div class="info-right" id="info-bar-right">
-          <p id="score-display" aria-live="polite" aria-atomic="true">You: 0 Opponent: 0</p>
+          <p id="score-display" aria-live="polite" aria-atomic="true">
+            <span>You: 0</span>
+            <span>Opponent: 0</span>
+          </p>
           <!-- Score updates announce politely; throttle updates if they become noisy. -->
         </div>
       </header>

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -34,6 +34,10 @@
   text-align: right;
 }
 
+.battle-header #score-display span {
+  display: block;
+}
+
 .battle-header[data-orientation="portrait"] {
   grid-template-columns: 1fr;
   grid-template-rows: auto auto auto;
@@ -64,7 +68,7 @@
 
 @media (max-width: 320px) {
   .battle-header #round-message,
-  .battle-header #score-display {
+  .battle-header #score-display span {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/tests/helpers/battleHeaderEllipsis.test.js
+++ b/tests/helpers/battleHeaderEllipsis.test.js
@@ -9,7 +9,10 @@ function hasEllipsisRule(css) {
   root.walkAtRules("media", (at) => {
     if (/max-width:\s*320px/.test(at.params)) {
       at.walkRules((rule) => {
-        if (rule.selector.includes("#round-message") || rule.selector.includes("#score-display")) {
+        if (
+          rule.selector.includes("#round-message") ||
+          rule.selector.includes("#score-display span")
+        ) {
           const overflow = rule.nodes.find((n) => n.prop === "text-overflow");
           const whiteSpace = rule.nodes.find((n) => n.prop === "white-space");
           if (overflow && /ellipsis/.test(overflow.value) && whiteSpace) {


### PR DESCRIPTION
## Summary
- replace `<br>` score formatting with two stacked spans
- style span layout in battle header and update tiny-screen ellipsis rule
- initialize battle page and tests to reference `#score-display span`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Unhandled rejection in tooltip.js)*
- `npx playwright test` *(fails: desktop arrow keys update markers and disable buttons)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891212801588326a4cd8043f44a486a