### PR TITLE
Refactor classicBattle match control imports

### DIFF
--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -52,16 +52,18 @@ describe("classicBattle button handlers", () => {
   });
 
   it("enable/disable helpers toggle button state", async () => {
-    const battleMod = await import("../../../src/helpers/classicBattle.js");
-    battleMod.disableNextRoundButton();
+    const { disableNextRoundButton, enableNextRoundButton } = await import(
+      "../../../src/helpers/classicBattle.js"
+    );
+    disableNextRoundButton();
     const btn = document.getElementById("next-round-button");
     expect(btn.disabled).toBe(true);
-    battleMod.enableNextRoundButton();
+    enableNextRoundButton();
     expect(btn.disabled).toBe(false);
   });
 
   it("quit button invokes quitMatch", async () => {
-    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    await import("../../../src/helpers/classicBattle.js");
     document.getElementById("quit-match-button").click();
     const confirmBtn = document.getElementById("confirm-quit-button");
     expect(confirmBtn).not.toBeNull();


### PR DESCRIPTION
## Summary
- simplify classicBattle button control tests by destructuring helpers from dynamic import
- drop unused module variable for quit button test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch and interrupted tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689128c759c08326aa5af879a39d4184