### PR TITLE
Register Playwright routes in parallel

### DIFF
--- a/playwright/fixtures/commonRoutes.js
+++ b/playwright/fixtures/commonRoutes.js
@@ -2,7 +2,7 @@
  * Register routes to serve fixture data for core JSON files and flag images.
  *
  * @param {import('@playwright/test').Page} page - The Playwright page.
- * @returns {Promise<void>} Promise resolving when routes have been registered.
+ * @returns {Promise<void>} Promise resolving when all routes have been registered in parallel.
  */
 export async function registerCommonRoutes(page) {
   await Promise.all([

--- a/playwright/fixtures/commonRoutes.js
+++ b/playwright/fixtures/commonRoutes.js
@@ -5,28 +5,30 @@
  * @returns {Promise<void>} Promise resolving when routes have been registered.
  */
 export async function registerCommonRoutes(page) {
-  await page.route("**/src/data/judoka.json", (route) =>
-    route.fulfill({ path: "tests/fixtures/judoka.json" })
-  );
-  await page.route("**/src/data/gokyo.json", (route) =>
-    route.fulfill({ path: "tests/fixtures/gokyo.json" })
-  );
-  await page.route("**/src/data/countryCodeMapping.json", (route) =>
-    route.fulfill({ path: "tests/fixtures/countryCodeMapping.json" })
-  );
-  await page.route("**/src/data/tooltips.json", (route) =>
-    route.fulfill({ path: "tests/fixtures/tooltips.json" })
-  );
-  await page.route("https://flagcdn.com/**", (route) =>
-    route.fulfill({ path: "src/assets/countryFlags/placeholder-flag.png" })
-  );
-  await page.route("https://esm.sh/ajv@6*", (route) =>
-    route.fulfill({ path: "src/vendor/ajv6.min.js" })
-  );
-  await page.route("**/marked.esm.js", (route) =>
-    route.fulfill({
-      contentType: "application/javascript",
-      body: "export const marked={parse:(m)=>m};"
-    })
-  );
+  await Promise.all([
+    page.route("**/src/data/judoka.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/judoka.json" })
+    ),
+    page.route("**/src/data/gokyo.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/gokyo.json" })
+    ),
+    page.route("**/src/data/countryCodeMapping.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/countryCodeMapping.json" })
+    ),
+    page.route("**/src/data/tooltips.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/tooltips.json" })
+    ),
+    page.route("https://flagcdn.com/**", (route) =>
+      route.fulfill({ path: "src/assets/countryFlags/placeholder-flag.png" })
+    ),
+    page.route("https://esm.sh/ajv@6*", (route) =>
+      route.fulfill({ path: "src/vendor/ajv6.min.js" })
+    ),
+    page.route("**/marked.esm.js", (route) =>
+      route.fulfill({
+        contentType: "application/javascript",
+        body: "export const marked={parse:(m)=>m};"
+      })
+    )
+  ]);
 }


### PR DESCRIPTION
## Summary
- Register common Playwright routes with `Promise.all` to reduce per-test setup time

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Browse Judoka navigation, Settings screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689128f8874c8326a0893e41674e61fc