### PR TITLE
Improve token contrast for accessibility

### DIFF
--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -55,10 +55,12 @@ Ju-Do-Kon! uses a **bold, high-contrast design system** grounded in clear hierar
 | --button-hover-bg   | #0B5BB0                | Hover state for buttons     |
 | --button-active-bg  | #0C3F7A                | Active button state         |
 | --button-text-color | #FFFFFF                | Button text                 |
-| --switch-off-bg     | #878787                | Toggle off state background |
-| --switch-on-bg      | #08A700                | Toggle on state background  |
+| --switch-off-bg     | #707070                | Toggle off state background |
+| --switch-on-bg      | #007F00                | Toggle on state background  |
 
 The hex values above correspond to CSS custom properties used throughout the project. See [Tokens](#10-tokens) for the complete list. In dark mode `--color-primary` is overridden to `#ff4530` and `--link-color` to `#3399ff` to maintain contrast.
+
+Always validate colour combinations against [WCAG&nbsp;2.1 contrast minimums](https://www.w3.org/TR/WCAG21/#contrast-minimum). Run `npm run check:contrast` or use the `wcag-contrast` library to ensure text and icons meet a ratio of at least **4.5:1**.
 
 ### Rarity Colours
 
@@ -356,15 +358,15 @@ Use these CSS custom properties instead of raw pixel values. Referencing tokens 
 | --button-hover-bg         | #0B5BB0                    | Hover state for buttons; adds drop shadow |
 | --button-active-bg        | #0C3F7A                    | Active button state                       |
 | --button-text-color       | #ffffff                    | Button text                               |
-| --button-disabled-bg      | #a0a0a0                    | Disabled button background                |
+| --button-disabled-bg      | #757575                    | Disabled button background                |
 | --button-disabled-pattern | none                       | Optional disabled texture                 |
-| --switch-off-bg           | #878787                    | Toggle off state background               |
-| --switch-on-bg            | #08A700                    | Toggle on state background                |
+| --switch-off-bg           | #707070                    | Toggle off state background               |
+| --switch-on-bg            | #007F00                    | Toggle on state background                |
 | --shadow-base             | 0 4px 12px rgba(0,0,0,0.1) | Elevation; hover drop-shadow              |
 | --shadow-hover            | 0 8px 24px rgba(0,0,0,0.2) | Hover shadow effect                       |
 | --transition-fast         | all 150ms ease             | UI animations                             |
-| --color-slider-dot        | #BBB                       | Carousel indicator default                |
-| --color-slider-active     | #717171                    | Active/hover indicator                    |
+| --color-slider-dot        | #666666                    | Carousel indicator default                |
+| --color-slider-active     | #333333                    | Active/hover indicator                    |
 | --scroll-marker-size      | 10px                       | Carousel scroll marker size               |
 | --logo-max-height         | min(8dvh, 44px)            | Max height for logo images                |
 

--- a/design/codeStandards/codeUIDesignStandards.md
+++ b/design/codeStandards/codeUIDesignStandards.md
@@ -60,7 +60,7 @@ Ju-Do-Kon! uses a **bold, high-contrast design system** grounded in clear hierar
 
 The hex values above correspond to CSS custom properties used throughout the project. See [Tokens](#10-tokens) for the complete list. In dark mode `--color-primary` is overridden to `#ff4530` and `--link-color` to `#3399ff` to maintain contrast.
 
-Always validate colour combinations against [WCAG&nbsp;2.1 contrast minimums](https://www.w3.org/TR/WCAG21/#contrast-minimum). Run `npm run check:contrast` or use the `wcag-contrast` library to ensure text and icons meet a ratio of at least **4.5:1**.
+Always validate color combinations against [WCAG&nbsp;2.1 contrast minimums](https://www.w3.org/TR/WCAG21/#contrast-minimum). Run `npm run check:contrast` or use the `wcag-contrast` library to ensure text and icons meet a ratio of at least **4.5:1**.
 
 ### Rarity Colours
 

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -188,7 +188,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
   - [x] 3.3 Add fallback stat selection for AI if difficulty logic fails
 - [ ] 4.0 Polish UX and Accessibility
   - [x] 4.1 Integrate consistent color coding (blue for player, red for AI)
-  - [ ] 4.2 Apply WCAG-compliant contrast ratios
+  - [x] 4.2 Apply WCAG-compliant contrast ratios
   - [ ] 4.3 Ensure touch targets ≥44px and support keyboard navigation (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness) and prdBattleInfoBar.md)
   - [ ] 4.4 Add alt text to cards and UI elements
 - [ ] 5.0 Optimize Animations

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -17,12 +17,12 @@
   --button-hover-bg: #0b5bb0;
   --button-active-bg: var(--color-primary);
   --button-text-color: #ffffff;
-  --button-disabled-bg: #a0a0a0;
+  --button-disabled-bg: #757575;
   --button-disabled-pattern: none;
   --switch-off-bg: #707070; /* Toggle off state background */
-  --switch-on-bg: #08a700; /* Toggle on state background */
-  --color-slider-dot: #bbb; /* Carousel indicator default */
-  --color-slider-active: #717171; /* Active indicator */
+  --switch-on-bg: #007f00; /* Toggle on state background */
+  --color-slider-dot: #666666; /* Carousel indicator default */
+  --color-slider-active: #333333; /* Active indicator */
   --radius-pill: 9999px; /* capsule */
 
   /* Updated spacing tokens */


### PR DESCRIPTION
## Summary
- darken disabled buttons, switch toggles, and carousel indicators for AA contrast
- document WCAG contrast guidance and update UI token table
- mark contrast checklist item complete for Classic Battle PRD

## Testing
- `npx pa11y --config pa11y.config.cjs http://localhost:5000/src/pages/battleJudoka.html`
- `npm run check:contrast`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: fetch and schema errors)*
- `npx playwright test` *(fails: network fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891290cb3708326af6ca3a3ca88cc3f