### PR TITLE
Remove unused variable in random card test

### DIFF
--- a/tests/helpers/randomCard.test.js
+++ b/tests/helpers/randomCard.test.js
@@ -68,7 +68,6 @@ describe("generateRandomCard", () => {
   it("falls back to id 0 when selection fails", async () => {
     const container = document.createElement("div");
     const fallbackEl = document.createElement("div");
-    const judokaData = getJudokaFixture().slice(0, 2);
     const gokyoData = getGokyoFixture();
 
     getRandomJudokaMock = vi.fn(() => {


### PR DESCRIPTION
## Summary
- remove leftover judoka data variable from random card fallback test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68912cd268008326a1e32558566e16ae