### PR TITLE
Add card inspector accessibility tests

### DIFF
--- a/playwright/card-inspector-accessibility.spec.js
+++ b/playwright/card-inspector-accessibility.spec.js
@@ -1,0 +1,83 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+
+const JUDOKA = {
+  id: 1,
+  firstname: "John",
+  surname: "Doe",
+  country: "USA",
+  countryCode: "us",
+  stats: { power: 5, speed: 5, technique: 5, kumikata: 5, newaza: 5 },
+  weightClass: "-100kg",
+  signatureMoveId: 1,
+  rarity: "common",
+  gender: "male"
+};
+
+test.describe("Card inspector accessibility", () => {
+  test("summary keyboard support and ARIA state", async ({ page }) => {
+    await page.setContent("<html><body></body></html>");
+    const { createInspectorPanel } = await import("../src/helpers/cardBuilder.js");
+    const func = createInspectorPanel.toString();
+    await page.evaluate(
+      ({ judoka, funcStr }) => {
+        const createInspectorPanel = eval(`(${funcStr})`);
+        const container = document.createElement("div");
+        const panel = createInspectorPanel(container, judoka, {});
+        container.appendChild(panel);
+        document.body.appendChild(container);
+      },
+      { judoka: JUDOKA, funcStr: func }
+    );
+
+    const panel = page.locator(".debug-panel");
+    await expect(panel).toHaveAttribute("aria-label", "Inspector panel");
+
+    const summary = page.locator("summary");
+
+    await page.keyboard.press("Tab");
+    await expect(summary).toBeFocused();
+
+    await summary.press("Enter");
+    await expect(summary).toHaveJSProperty("ariaExpanded", "true");
+
+    await summary.press(" ");
+    await expect(summary).toHaveJSProperty("ariaExpanded", "false");
+  });
+
+  test("announces invalid card data on JSON failure", async ({ page }) => {
+    await page.setContent("<html><body></body></html>");
+    const { createInspectorPanel } = await import("../src/helpers/cardBuilder.js");
+    const func = createInspectorPanel.toString();
+    await page.evaluate(
+      ({ funcStr }) => {
+        const createInspectorPanel = eval(`(${funcStr})`);
+        const container = document.createElement("div");
+        const badJudoka = {
+          id: 2,
+          firstname: "Bad",
+          surname: "Data",
+          country: "USA",
+          countryCode: "us",
+          stats: {
+            power: 1,
+            speed: 1,
+            technique: 1,
+            kumikata: 1,
+            newaza: 1
+          },
+          weightClass: "-100kg",
+          signatureMoveId: 1,
+          rarity: "common",
+          gender: "male",
+          extra: 1n
+        };
+        const result = createInspectorPanel(container, badJudoka, {});
+        container.appendChild(result);
+        document.body.appendChild(container);
+      },
+      { funcStr: func }
+    );
+
+    await expect(page.getByText("Invalid card data")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright tests for card inspector keyboard toggling and aria state
- check fallback announcement when inspector JSON parsing fails

## Testing
- `npx prettier . --check`
- `npx eslint playwright/card-inspector-accessibility.spec.js`
- `npx vitest run` *(fails: unhandled error)*
- `npx playwright test playwright/card-inspector-accessibility.spec.js` *(fails: ariaExpanded property remains null)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891291ccd4c8326afef579f4640ebdb