### PR TITLE
Handle rounding in carousel scroll buttons

### DIFF
--- a/src/helpers/carousel/scroll.js
+++ b/src/helpers/carousel/scroll.js
@@ -64,7 +64,8 @@ export function createScrollButton(direction, container) {
  * 1. Calculate the maximum scroll value using `scrollWidth` and
  *    `clientWidth` of `container`.
  * 2. Disable `leftBtn` when `scrollLeft` is at or before the first card.
- * 3. Disable `rightBtn` when `scrollLeft` reaches the end of the carousel.
+ * 3. Disable `rightBtn` when `scrollLeft` is within 1px of the carousel's
+ *    end to account for rounding differences.
  *
  * @param {HTMLElement} container - The scrolling container element.
  * @param {HTMLButtonElement} leftBtn - Button that scrolls left.
@@ -72,6 +73,7 @@ export function createScrollButton(direction, container) {
  */
 export function updateScrollButtonState(container, leftBtn, rightBtn) {
   const maxLeft = container.scrollWidth - container.clientWidth;
-  leftBtn.disabled = container.scrollLeft <= 0;
-  rightBtn.disabled = container.scrollLeft >= maxLeft;
+  const EPSILON = 1; // allow small rounding differences
+  leftBtn.disabled = container.scrollLeft <= EPSILON;
+  rightBtn.disabled = container.scrollLeft >= maxLeft - EPSILON;
 }

--- a/src/helpers/carousel/scroll.js
+++ b/src/helpers/carousel/scroll.js
@@ -74,6 +74,6 @@ export function createScrollButton(direction, container) {
 export function updateScrollButtonState(container, leftBtn, rightBtn) {
   const maxLeft = container.scrollWidth - container.clientWidth;
   const EPSILON = 1; // allow small rounding differences
-  leftBtn.disabled = container.scrollLeft <= EPSILON;
+  leftBtn.disabled = container.scrollLeft <= 0;
   rightBtn.disabled = container.scrollLeft >= maxLeft - EPSILON;
 }

--- a/tests/helpers/scrollButtonState.test.js
+++ b/tests/helpers/scrollButtonState.test.js
@@ -37,4 +37,15 @@ describe("updateScrollButtonState", () => {
     expect(left.disabled).toBe(false);
     expect(right.disabled).toBe(false);
   });
+
+  it("treats near-end positions as end", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "scrollWidth", { value: 300 });
+    Object.defineProperty(container, "clientWidth", { value: 100 });
+    container.scrollLeft = 199.5;
+    const left = document.createElement("button");
+    const right = document.createElement("button");
+    updateScrollButtonState(container, left, right);
+    expect(right.disabled).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- handle rounding differences when determining scroll button disabled state
- test scroll button tolerance for near-end positions

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6891a77e02348326887bdaedb376b65c