### PR TITLE
Track inspector aria state

### DIFF
--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -207,6 +207,7 @@ function createInspectorPanel(container, judoka, sections) {
   // keep the inspector output concise.
 
   function updateDataset() {
+    summary.setAttribute("aria-expanded", panel.open ? "true" : "false");
     if (panel.open) {
       container.dataset.inspector = "true";
     } else {

--- a/tests/helpers/createInspectorPanel.test.js
+++ b/tests/helpers/createInspectorPanel.test.js
@@ -14,6 +14,7 @@ describe("createInspectorPanel accessibility", () => {
     expect(parseInt(summary.style.minHeight)).toBeGreaterThanOrEqual(44);
     expect(parseInt(summary.style.minWidth)).toBeGreaterThanOrEqual(44);
     expect(summary.tabIndex).toBe(0);
+    expect(summary.getAttribute("aria-expanded")).toBe("false");
 
     summary.dispatchEvent(new Event("focus"));
     expect(summary.style.outlineColor).toBe("rgb(0, 0, 0)");
@@ -21,7 +22,9 @@ describe("createInspectorPanel accessibility", () => {
     expect(panel.open).toBe(false);
     summary.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
     expect(panel.open).toBe(true);
+    expect(summary.getAttribute("aria-expanded")).toBe("true");
     summary.dispatchEvent(new KeyboardEvent("keydown", { key: " " }));
     expect(panel.open).toBe(false);
+    expect(summary.getAttribute("aria-expanded")).toBe("false");
   });
 });


### PR DESCRIPTION
## Summary
- keep inspector summary `aria-expanded` in sync with panel state
- test summary `aria-expanded` toggles on Enter/Space

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: validateJudoka unused, sections unused, retryError unused)*
- `npx vitest run`
- `npx playwright test` *(fails: 11)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891b12d10008326af22153f7f0f6b9c