### PR TITLE
Refactor sidebar list into class

### DIFF
--- a/src/helpers/mockupViewerPage.js
+++ b/src/helpers/mockupViewerPage.js
@@ -1,7 +1,7 @@
 import { setupButtonEffects } from "./buttonEffects.js";
 import { onDomReady } from "./domReady.js";
 import { initTooltips } from "./tooltip.js";
-import { createSidebarList } from "../components/SidebarList.js";
+import { SidebarList } from "../components/SidebarList.js";
 
 /**
  * Initialize the mockup image carousel.
@@ -67,9 +67,11 @@ export function setupMockupViewerPage() {
   ];
 
   let currentIndex = 0;
-  const { element: listEl, select: listSelect } = createSidebarList(files, (i) => {
+  const list = new SidebarList(files, (i) => {
     if (i !== currentIndex) showImage(i);
   });
+  const listEl = list.element;
+  const listSelect = list.select.bind(list);
   listEl.id = "mockup-list";
   listPlaceholder.replaceWith(listEl);
 

--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -1,7 +1,7 @@
 import { onDomReady } from "./domReady.js";
 import { markdownToHtml } from "./markdownToHtml.js";
 import { initTooltips } from "./tooltip.js";
-import { createSidebarList } from "../components/SidebarList.js";
+import { SidebarList } from "../components/SidebarList.js";
 import { getPrdTaskStats } from "./prdTaskStats.js";
 
 /**
@@ -73,9 +73,11 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
   );
 
   let index = startIndex;
-  const { element: listEl, select: listSelect } = createSidebarList(labels, (i, _el, opts = {}) => {
+  const list = new SidebarList(labels, (i, _el, opts = {}) => {
     selectDoc(i, true, true, !opts.fromListNav);
   });
+  const listEl = list.element;
+  const listSelect = list.select.bind(list);
   listEl.id = "prd-list";
   listPlaceholder.replaceWith(listEl);
 

--- a/src/helpers/tooltipViewerPage.js
+++ b/src/helpers/tooltipViewerPage.js
@@ -2,7 +2,7 @@ import { fetchJson } from "./dataUtils.js";
 import { parseTooltipText, flattenTooltips, initTooltips } from "./tooltip.js";
 import { DATA_DIR } from "./constants.js";
 import { onDomReady } from "./domReady.js";
-import { createSidebarList } from "../components/SidebarList.js";
+import { SidebarList } from "../components/SidebarList.js";
 import { showSnackbar } from "./showSnackbar.js";
 
 const INVALID_TOOLTIP_MSG = "Empty or whitespace-only content";
@@ -161,10 +161,10 @@ export async function setupTooltipViewerPage() {
         });
       }
     });
-    const result = createSidebarList(items, (_, el) => {
+    const list = new SidebarList(items, (_, el) => {
       select(el.dataset.key);
     });
-    Array.from(result.element.children).forEach((li) => {
+    Array.from(list.element.children).forEach((li) => {
       let message = null;
       if (li.dataset.keyValid === "false") {
         message = INVALID_KEY_MSG;
@@ -185,10 +185,10 @@ export async function setupTooltipViewerPage() {
         li.append(" ", icon, sr);
       }
     });
-    listSelect = result.select;
-    result.element.id = "tooltip-list";
-    listPlaceholder.replaceWith(result.element);
-    listPlaceholder = result.element;
+    listSelect = list.select.bind(list);
+    list.element.id = "tooltip-list";
+    listPlaceholder.replaceWith(list.element);
+    listPlaceholder = list.element;
   }
 
   let selectedKey;

--- a/tests/components/SidebarList.test.js
+++ b/tests/components/SidebarList.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { createSidebarList } from "../../src/components/SidebarList.js";
+import { SidebarList } from "../../src/components/SidebarList.js";
 
-describe("createSidebarList", () => {
+describe("SidebarList", () => {
   it("creates list items with zebra classes", () => {
-    const { element } = createSidebarList(["One", "Two", "Three"]);
+    const { element } = new SidebarList(["One", "Two", "Three"]);
     const items = element.querySelectorAll("li");
     expect(element.classList.contains("sidebar-list")).toBe(true);
     expect(items).toHaveLength(3);
@@ -13,22 +13,23 @@ describe("createSidebarList", () => {
 
   it("select helper highlights items and calls callback", () => {
     const cb = vi.fn();
-    const { element, select } = createSidebarList(["A", "B"], cb);
+    const list = new SidebarList(["A", "B"], cb);
+    const { element } = list;
     const items = element.querySelectorAll("li");
-    select(1);
+    list.select(1);
     expect(items[1].classList.contains("selected")).toBe(true);
     expect(items[1].getAttribute("aria-current")).toBe("page");
     expect(cb).toHaveBeenCalledWith(1, items[1], {});
-    select(-1);
+    list.select(-1);
     expect(items[1].classList.contains("selected")).toBe(true);
     expect(items[1].getAttribute("aria-current")).toBe("page");
-    select(0);
+    list.select(0);
     expect(items[0].classList.contains("selected")).toBe(true);
     expect(items[0].getAttribute("aria-current")).toBe("page");
   });
 
   it("handles arrow key navigation and focus", () => {
-    const { element } = createSidebarList(["A", "B", "C"]);
+    const { element } = new SidebarList(["A", "B", "C"]);
     document.body.appendChild(element);
     const items = element.querySelectorAll("li");
 


### PR DESCRIPTION
## Summary
- convert SidebarList factory function into SidebarList class with public select method
- update tooltip, PRD reader, and mockup viewer helpers to use the new class
- adjust SidebarList tests for class-based API

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: changelog screenshot mismatch; battle orientation screenshot mismatch; browse-judoka swipe gesture interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891bac4e4e0832689261c9a6d219a04