### PR TITLE
Truncate next-round timer on tiny screens

### DIFF
--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -68,6 +68,7 @@
 
 @media (max-width: 320px) {
   .battle-header #round-message,
+  .battle-header #next-round-timer,
   .battle-header #score-display span {
     overflow: hidden;
     white-space: nowrap;

--- a/tests/helpers/battleHeaderEllipsis.test.js
+++ b/tests/helpers/battleHeaderEllipsis.test.js
@@ -5,50 +5,54 @@ import postcss from "postcss";
 
 function hasEllipsisRule(css) {
   const root = postcss.parse(css);
-  let found = false;
+  const selectors = ["#round-message", "#next-round-timer", "#score-display span"];
+  const found = new Set();
   root.walkAtRules("media", (at) => {
     if (/max-width:\s*320px/.test(at.params)) {
       at.walkRules((rule) => {
-        if (
-          rule.selector.includes("#round-message") ||
-          rule.selector.includes("#score-display span")
-        ) {
-          const overflow = rule.nodes.find((n) => n.prop === "text-overflow");
-          const whiteSpace = rule.nodes.find((n) => n.prop === "white-space");
-          if (overflow && /ellipsis/.test(overflow.value) && whiteSpace) {
-            found = true;
+        selectors.forEach((sel) => {
+          if (rule.selector.includes(sel)) {
+            const overflow = rule.nodes.find((n) => n.prop === "text-overflow");
+            const whiteSpace = rule.nodes.find((n) => n.prop === "white-space");
+            if (overflow && /ellipsis/.test(overflow.value) && whiteSpace) {
+              found.add(sel);
+            }
           }
-        }
+        });
       });
     }
   });
-  return found;
+  return selectors.every((sel) => found.has(sel));
 }
 
 function hasWrapRule(css) {
   const root = postcss.parse(css);
-  let found = false;
+  const selectors = [
+    '.battle-header[data-orientation="portrait"] #round-message',
+    '.battle-header[data-orientation="portrait"] #next-round-timer',
+    '.battle-header[data-orientation="portrait"] #score-display'
+  ];
+  const found = new Set();
   root.walkRules((rule) => {
-    if (
-      rule.selector.includes('.battle-header[data-orientation="portrait"] #round-message') ||
-      rule.selector.includes('.battle-header[data-orientation="portrait"] #score-display')
-    ) {
-      const wrap = rule.nodes.find((n) => n.prop === "overflow-wrap");
-      const fontSize = rule.nodes.find((n) => n.prop === "font-size");
-      if (wrap && /anywhere/.test(wrap.value) && fontSize && /clamp/.test(fontSize.value)) {
-        found = true;
+    selectors.forEach((sel) => {
+      if (rule.selector.includes(sel)) {
+        const wrap = rule.nodes.find((n) => n.prop === "overflow-wrap");
+        const fontSize = rule.nodes.find((n) => n.prop === "font-size");
+        if (wrap && /anywhere/.test(wrap.value) && fontSize && /clamp/.test(fontSize.value)) {
+          found.add(sel);
+        }
       }
-    }
+    });
   });
-  return found;
+  return selectors.every((sel) => found.has(sel));
 }
 
 describe("battle.css responsive truncation", () => {
-  it("applies ellipsis to message and score on tiny screens", () => {
+  it("applies ellipsis to message, timer, and score on tiny screens", () => {
     const css = readFileSync("src/styles/battle.css", "utf8");
     expect(hasEllipsisRule(css)).toBe(true);
   });
-  it("wraps and scales message and score on small screens", () => {
+  it("wraps and scales message, timer, and score on small screens", () => {
     const css = readFileSync("src/styles/battle.css", "utf8");
     expect(hasWrapRule(css)).toBe(true);
   });


### PR DESCRIPTION
## Summary
- ensure long next-round timer labels truncate at 320px and below
- test that battle header truncation covers message, timer and score

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-orientation screenshots, battleJudoka narrow screenshot, browse-judoka navigation)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891ba4fb16c8326853adbbd967d96bf