### PR TITLE
Refactor classic battle module

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -27,7 +27,7 @@ test.describe("Classic battle flow", () => {
     await timer.waitFor();
     await page.evaluate(async () => {
       const mod = await import("../helpers/classicBattle.js");
-      mod._resetForTest();
+      mod.classicBattle._resetForTest();
       document.querySelector("#next-round-timer").textContent = "Time Left: 3s";
       document.querySelector("#player-card").innerHTML =
         `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -18,17 +18,6 @@ import { getStatValue, resetStatButtons, showResult } from "./battle/index.js";
 import { createModal } from "../components/Modal.js";
 import { createButton } from "../components/Button.js";
 
-export function getStartRound() {
-  if (typeof window !== "undefined" && window.startRoundOverride) {
-    return window.startRoundOverride;
-  }
-  return startRound;
-}
-
-let quitModal = null;
-let statTimeoutId = null;
-let autoSelectId = null;
-
 /**
  * Determine the opponent's stat choice based on difficulty.
  *
@@ -92,172 +81,206 @@ function showSummary(result) {
   }
 }
 
-/**
- * Reset match state and start a new game.
- *
- * @pseudocode
- * 1. Reset engine scores and flags.
- * 2. Hide the summary panel and clear the last round message.
- * 3. Call the start round function to begin a new match.
- */
-async function handleReplay() {
-  engineReset();
-  const panel = document.getElementById("summary-panel");
-  if (panel) panel.classList.add("hidden");
-  infoBar.clearMessage();
-  const startRoundFn = getStartRound();
-  await startRoundFn();
-}
+class ClassicBattle {
+  constructor() {
+    /** @type {ReturnType<typeof createModal> | null} */
+    this.quitModal = null;
+    /** @type {ReturnType<typeof setTimeout> | null} */
+    this.statTimeoutId = null;
+    /** @type {ReturnType<typeof setTimeout> | null} */
+    this.autoSelectId = null;
 
-/**
- * Handle stalled stat selection by prompting the player and auto-selecting a
- * random stat after a short delay.
- *
- * @pseudocode
- * 1. Display "Stat selection stalled" via `infoBar.showMessage`.
- * 2. After 5 seconds choose a random stat from `STATS`.
- * 3. Call `handleStatSelection` with the chosen stat.
- */
-function onStatSelectionTimeout() {
-  infoBar.showMessage("Stat selection stalled. Pick a stat or wait for auto-pick.");
-  autoSelectId = setTimeout(() => {
-    const randomStat = simulateOpponentStat();
-    handleStatSelection(randomStat);
-  }, 5000);
-}
+    const quitButton = document.getElementById("quit-match-button");
+    if (quitButton) {
+      quitButton.addEventListener("click", () => {
+        this.quitMatch();
+      });
+    }
 
-/**
- * Update the info bar with current scores.
- *
- * @pseudocode
- * 1. Read scores via `getScores()`.
- * 2. Forward the values to `infoBar.updateScore`.
- */
-function syncScoreDisplay() {
-  const { playerScore, computerScore } = getScores();
-  infoBar.updateScore(playerScore, computerScore);
-}
-
-function createQuitConfirmation(onConfirm) {
-  const title = document.createElement("h2");
-  title.id = "quit-modal-title";
-  title.textContent = "Quit the match?";
-
-  const desc = document.createElement("p");
-  desc.id = "quit-modal-desc";
-  desc.textContent = "Your progress will be lost.";
-
-  const actions = document.createElement("div");
-  actions.className = "modal-actions";
-
-  const cancel = createButton("Cancel", {
-    id: "cancel-quit-button",
-    className: "secondary-button"
-  });
-  const quit = createButton("Quit", { id: "confirm-quit-button" });
-  actions.append(cancel, quit);
-
-  const frag = document.createDocumentFragment();
-  frag.append(title, desc, actions);
-
-  const modal = createModal(frag, { labelledBy: title, describedBy: desc });
-  cancel.addEventListener("click", modal.close);
-  quit.addEventListener("click", () => {
-    onConfirm();
-    modal.close();
-    window.location.href = "../../index.html";
-  });
-  document.body.appendChild(modal.element);
-  return modal;
-}
-
-export async function startRound() {
-  resetStatButtons();
-  disableNextRoundButton();
-  await drawCards();
-  showSelectionPrompt();
-  syncScoreDisplay();
-  await startTimer(handleStatSelection);
-  statTimeoutId = setTimeout(onStatSelectionTimeout, 35000);
-  updateDebugPanel();
-}
-
-export function evaluateRound(stat) {
-  const playerContainer = document.getElementById("player-card");
-  const computerContainer = document.getElementById("computer-card");
-  const playerVal = getStatValue(playerContainer, stat);
-  const compVal = getStatValue(computerContainer, stat);
-  const result = engineHandleStatSelection(playerVal, compVal);
-  if (result.message) {
-    showResult(result.message);
+    const replayButton = document.getElementById("replay-button");
+    if (replayButton) {
+      replayButton.addEventListener("click", () => {
+        this.handleReplay();
+      });
+    }
   }
-  syncScoreDisplay();
-  updateDebugPanel();
-  return result;
-}
 
-export async function handleStatSelection(stat) {
-  clearTimeout(statTimeoutId);
-  clearTimeout(autoSelectId);
-  const clearWaitingMessage = infoBar.showTemporaryMessage("Waiting…");
-  const delay = 300 + Math.floor(Math.random() * 401);
-  return new Promise((resolve) => {
-    setTimeout(async () => {
-      await revealComputerCard();
-      clearWaitingMessage();
-      const result = evaluateRound(stat);
-      resetStatButtons();
-      scheduleNextRound(result, getStartRound());
-      if (result.matchEnded) {
-        showSummary(result);
-      }
-      updateDebugPanel();
-      resolve(result);
-    }, delay);
-  });
-}
+  getStartRound() {
+    if (typeof window !== "undefined" && window.startRoundOverride) {
+      return window.startRoundOverride;
+    }
+    return this.startRound.bind(this);
+  }
 
-export function quitMatch() {
-  if (!quitModal) {
-    quitModal = createQuitConfirmation(() => {
-      const result = engineQuitMatch();
+  /**
+   * Reset match state and start a new game.
+   *
+   * @pseudocode
+   * 1. Reset engine scores and flags.
+   * 2. Hide the summary panel and clear the last round message.
+   * 3. Call the start round function to begin a new match.
+   */
+  async handleReplay() {
+    engineReset();
+    const panel = document.getElementById("summary-panel");
+    if (panel) panel.classList.add("hidden");
+    infoBar.clearMessage();
+    const startRoundFn = this.getStartRound();
+    await startRoundFn();
+  }
+
+  /**
+   * Handle stalled stat selection by prompting the player and auto-selecting a
+   * random stat after a short delay.
+   *
+   * @pseudocode
+   * 1. Display "Stat selection stalled" via `infoBar.showMessage`.
+   * 2. After 5 seconds choose a random stat from `STATS`.
+   * 3. Call `handleStatSelection` with the chosen stat.
+   */
+  onStatSelectionTimeout() {
+    infoBar.showMessage("Stat selection stalled. Pick a stat or wait for auto-pick.");
+    this.autoSelectId = setTimeout(() => {
+      const randomStat = simulateOpponentStat();
+      this.handleStatSelection(randomStat);
+    }, 5000);
+  }
+
+  /**
+   * Update the info bar with current scores.
+   *
+   * @pseudocode
+   * 1. Read scores via `getScores()`.
+   * 2. Forward the values to `infoBar.updateScore`.
+   */
+  syncScoreDisplay() {
+    const { playerScore, computerScore } = getScores();
+    infoBar.updateScore(playerScore, computerScore);
+  }
+
+  createQuitConfirmation(onConfirm) {
+    const title = document.createElement("h2");
+    title.id = "quit-modal-title";
+    title.textContent = "Quit the match?";
+
+    const desc = document.createElement("p");
+    desc.id = "quit-modal-desc";
+    desc.textContent = "Your progress will be lost.";
+
+    const actions = document.createElement("div");
+    actions.className = "modal-actions";
+
+    const cancel = createButton("Cancel", {
+      id: "cancel-quit-button",
+      className: "secondary-button"
+    });
+    const quit = createButton("Quit", { id: "confirm-quit-button" });
+    actions.append(cancel, quit);
+
+    const frag = document.createDocumentFragment();
+    frag.append(title, desc, actions);
+
+    const modal = createModal(frag, { labelledBy: title, describedBy: desc });
+    cancel.addEventListener("click", modal.close);
+    quit.addEventListener("click", () => {
+      onConfirm();
+      modal.close();
+      window.location.href = "../../index.html";
+    });
+    document.body.appendChild(modal.element);
+    return modal;
+  }
+
+  async startRound() {
+    resetStatButtons();
+    disableNextRoundButton();
+    await drawCards();
+    showSelectionPrompt();
+    this.syncScoreDisplay();
+    await startTimer(this.handleStatSelection.bind(this));
+    this.statTimeoutId = setTimeout(() => this.onStatSelectionTimeout(), 35000);
+    updateDebugPanel();
+  }
+
+  evaluateRound(stat) {
+    const playerContainer = document.getElementById("player-card");
+    const computerContainer = document.getElementById("computer-card");
+    const playerVal = getStatValue(playerContainer, stat);
+    const compVal = getStatValue(computerContainer, stat);
+    const result = engineHandleStatSelection(playerVal, compVal);
+    if (result.message) {
       showResult(result.message);
+    }
+    this.syncScoreDisplay();
+    updateDebugPanel();
+    return result;
+  }
+
+  async handleStatSelection(stat) {
+    clearTimeout(this.statTimeoutId);
+    clearTimeout(this.autoSelectId);
+    const clearWaitingMessage = infoBar.showTemporaryMessage("Waiting…");
+    const delay = 300 + Math.floor(Math.random() * 401);
+    return new Promise((resolve) => {
+      setTimeout(async () => {
+        await revealComputerCard();
+        clearWaitingMessage();
+        const result = this.evaluateRound(stat);
+        resetStatButtons();
+        scheduleNextRound(result, this.getStartRound());
+        if (result.matchEnded) {
+          showSummary(result);
+        }
+        updateDebugPanel();
+        resolve(result);
+      }, delay);
     });
   }
-  const trigger = document.getElementById("quit-match-button");
-  quitModal.open(trigger ?? undefined);
+
+  quitMatch() {
+    if (!this.quitModal) {
+      this.quitModal = this.createQuitConfirmation(() => {
+        const result = engineQuitMatch();
+        showResult(result.message);
+      });
+    }
+    const trigger = document.getElementById("quit-match-button");
+    this.quitModal.open(trigger ?? undefined);
+  }
+
+  _resetForTest() {
+    resetSelection();
+    engineReset();
+    if (typeof window !== "undefined") {
+      delete window.startRoundOverride;
+    }
+    clearTimeout(this.statTimeoutId);
+    clearTimeout(this.autoSelectId);
+    this.statTimeoutId = null;
+    this.autoSelectId = null;
+    const timerEl = document.getElementById("next-round-timer");
+    if (timerEl) timerEl.textContent = "";
+    infoBar.clearMessage();
+    const nextBtn = document.getElementById("next-round-button");
+    if (nextBtn) {
+      const clone = nextBtn.cloneNode(true);
+      nextBtn.replaceWith(clone);
+      clone.disabled = true;
+    }
+    const quitBtn = document.getElementById("quit-match-button");
+    if (quitBtn) {
+      quitBtn.replaceWith(quitBtn.cloneNode(true));
+    }
+    if (this.quitModal) {
+      this.quitModal.element.remove();
+      this.quitModal = null;
+    }
+    this.syncScoreDisplay();
+    updateDebugPanel();
+  }
 }
 
-export function _resetForTest() {
-  resetSelection();
-  engineReset();
-  if (typeof window !== "undefined") {
-    delete window.startRoundOverride;
-  }
-  clearTimeout(statTimeoutId);
-  clearTimeout(autoSelectId);
-  statTimeoutId = null;
-  autoSelectId = null;
-  const timerEl = document.getElementById("next-round-timer");
-  if (timerEl) timerEl.textContent = "";
-  infoBar.clearMessage();
-  const nextBtn = document.getElementById("next-round-button");
-  if (nextBtn) {
-    const clone = nextBtn.cloneNode(true);
-    nextBtn.replaceWith(clone);
-    clone.disabled = true;
-  }
-  const quitBtn = document.getElementById("quit-match-button");
-  if (quitBtn) {
-    quitBtn.replaceWith(quitBtn.cloneNode(true));
-  }
-  if (quitModal) {
-    quitModal.element.remove();
-    quitModal = null;
-  }
-  syncScoreDisplay();
-  updateDebugPanel();
-}
+export const classicBattle = new ClassicBattle();
 
 export {
   revealComputerCard,
@@ -267,17 +290,3 @@ export {
 } from "./classicBattle/uiHelpers.js";
 export { getComputerJudoka } from "./classicBattle/cardSelection.js";
 export { scheduleNextRound } from "./classicBattle/timerControl.js";
-
-const quitButton = document.getElementById("quit-match-button");
-if (quitButton) {
-  quitButton.addEventListener("click", () => {
-    quitMatch();
-  });
-}
-
-const replayButton = document.getElementById("replay-button");
-if (replayButton) {
-  replayButton.addEventListener("click", () => {
-    handleReplay();
-  });
-}

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -25,11 +25,7 @@
  *       `data-test-mode` attribute when settings change.
  * 5. Execute `setupClassicBattlePage` with `onDomReady`.
  */
-import {
-  startRound as classicStartRound,
-  handleStatSelection,
-  simulateOpponentStat
-} from "./classicBattle.js";
+import { classicBattle, simulateOpponentStat } from "./classicBattle.js";
 import { onDomReady } from "./domReady.js";
 import { waitForComputerCard } from "./battleJudokaPage.js";
 import { loadSettings } from "./settingsUtils.js";
@@ -53,11 +49,11 @@ let aiDifficulty = "easy";
 
 async function startRoundWrapper() {
   enableStatButtons(false);
-  await classicStartRound();
+  await classicBattle.startRound();
   await waitForComputerCard();
   if (simulatedOpponentMode) {
     const stat = simulateOpponentStat(aiDifficulty);
-    await handleStatSelection(stat);
+    await classicBattle.handleStatSelection(stat);
   } else {
     enableStatButtons(true);
   }
@@ -130,7 +126,7 @@ export async function setupClassicBattlePage() {
         if (!btn.disabled) {
           enableStatButtons(false);
           btn.classList.add("selected");
-          handleStatSelection(btn.dataset.stat);
+          classicBattle.handleStatSelection(btn.dataset.stat);
         }
       });
       btn.addEventListener("keydown", (e) => {
@@ -138,7 +134,7 @@ export async function setupClassicBattlePage() {
           e.preventDefault();
           enableStatButtons(false);
           btn.classList.add("selected");
-          handleStatSelection(btn.dataset.stat);
+          classicBattle.handleStatSelection(btn.dataset.stat);
         }
       });
     });

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -62,11 +62,11 @@ describe("classicBattle card selection", () => {
       callCount += 1;
       return callCount === 1 ? { id: 1 } : { id: 2 };
     });
-    const { startRound, getComputerJudoka, _resetForTest } = await import(
+    const { classicBattle, getComputerJudoka } = await import(
       "../../../src/helpers/classicBattle.js"
     );
-    _resetForTest();
-    await startRound();
+    classicBattle._resetForTest();
+    await classicBattle.startRound();
     expect(renderJudokaCardMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 1 }),
       expect.anything(),
@@ -92,9 +92,9 @@ describe("classicBattle card selection", () => {
       if (cb) cb(d[0]);
     });
     getRandomJudokaMock = vi.fn(() => ({ id: 2 }));
-    const { startRound, _resetForTest } = await import("../../../src/helpers/classicBattle.js");
-    _resetForTest();
-    await startRound();
+    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
+    classicBattle._resetForTest();
+    await classicBattle.startRound();
     expect(generateRandomCardMock).toHaveBeenCalledWith(
       [expect.objectContaining({ id: 2, isHidden: false })],
       null,

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -55,9 +55,9 @@ describe("classicBattle match flow", () => {
 
   it("auto-selects a stat when timer expires", async () => {
     vi.spyOn(Math, "random").mockReturnValue(0);
-    const { startRound, _resetForTest } = await import("../../../src/helpers/classicBattle.js");
-    _resetForTest();
-    await startRound();
+    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
+    classicBattle._resetForTest();
+    await classicBattle.startRound();
     timerSpy.advanceTimersByTime(31000);
     await vi.runAllTimersAsync();
     const score = document.querySelector("header #score-display").textContent;
@@ -67,8 +67,8 @@ describe("classicBattle match flow", () => {
   });
 
   it("quits match after confirmation", async () => {
-    const { quitMatch } = await import("../../../src/helpers/classicBattle.js");
-    quitMatch();
+    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
+    classicBattle.quitMatch();
     const confirmBtn = document.getElementById("confirm-quit-button");
     expect(confirmBtn).not.toBeNull();
     confirmBtn.dispatchEvent(new Event("click"));
@@ -76,10 +76,10 @@ describe("classicBattle match flow", () => {
   });
 
   it("does not quit match when cancel is chosen", async () => {
-    const { quitMatch, _resetForTest } = await import("../../../src/helpers/classicBattle.js");
-    _resetForTest();
+    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
+    classicBattle._resetForTest();
     document.querySelector("#round-message").textContent = "Select your move";
-    quitMatch();
+    classicBattle.quitMatch();
     const cancelBtn = document.getElementById("cancel-quit-button");
     expect(cancelBtn).not.toBeNull();
     cancelBtn.dispatchEvent(new Event("click"));
@@ -88,12 +88,10 @@ describe("classicBattle match flow", () => {
   });
 
   it("ends the match when player reaches 10 wins", async () => {
-    const { handleStatSelection, _resetForTest } = await import(
-      "../../../src/helpers/classicBattle.js"
-    );
-    _resetForTest();
+    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
+    classicBattle._resetForTest();
     const selectStat = async () => {
-      const p = handleStatSelection("power");
+      const p = classicBattle.handleStatSelection("power");
       await vi.runAllTimersAsync();
       await p;
     };
@@ -114,7 +112,7 @@ describe("classicBattle match flow", () => {
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     {
-      const p = handleStatSelection("power");
+      const p = classicBattle.handleStatSelection("power");
       await vi.runAllTimersAsync();
       await p;
     }
@@ -125,12 +123,10 @@ describe("classicBattle match flow", () => {
   });
 
   it("ends the match when opponent reaches 10 wins", async () => {
-    const { handleStatSelection, _resetForTest } = await import(
-      "../../../src/helpers/classicBattle.js"
-    );
-    _resetForTest();
+    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
+    classicBattle._resetForTest();
     const selectStat = async () => {
-      const p = handleStatSelection("power");
+      const p = classicBattle.handleStatSelection("power");
       await vi.runAllTimersAsync();
       await p;
     };
@@ -153,7 +149,7 @@ describe("classicBattle match flow", () => {
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
     {
-      const p = handleStatSelection("power");
+      const p = classicBattle.handleStatSelection("power");
       await vi.runAllTimersAsync();
       await p;
     }
@@ -181,11 +177,9 @@ describe("classicBattle match flow", () => {
   });
 
   it("shows selection prompt until a stat is chosen", async () => {
-    const { startRound, handleStatSelection, _resetForTest } = await import(
-      "../../../src/helpers/classicBattle.js"
-    );
-    _resetForTest();
-    await startRound();
+    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
+    classicBattle._resetForTest();
+    await classicBattle.startRound();
     expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
     timerSpy.advanceTimersByTime(5000);
     expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
@@ -194,7 +188,7 @@ describe("classicBattle match flow", () => {
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     {
-      const p = handleStatSelection("power");
+      const p = classicBattle.handleStatSelection("power");
       await vi.runAllTimersAsync();
       await p;
     }

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -59,9 +59,9 @@ describe("classicBattle opponent delay", () => {
     const timer = vi.useFakeTimers();
     const mod = await import("../../../src/helpers/classicBattle.js");
     vi.spyOn(mod, "simulateOpponentStat").mockReturnValue("power");
-    vi.spyOn(mod, "evaluateRound").mockReturnValue({ matchEnded: false });
+    vi.spyOn(mod.classicBattle, "evaluateRound").mockReturnValue({ matchEnded: false });
 
-    const promise = mod.handleStatSelection(mod.simulateOpponentStat());
+    const promise = mod.classicBattle.handleStatSelection(mod.simulateOpponentStat());
 
     expect(showMessage).toHaveBeenCalledWith("Waiting…");
     expect(clearMessage).not.toHaveBeenCalled();

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -54,9 +54,9 @@ describe("classicBattle stalled stat selection recovery", () => {
   });
 
   it("auto-selects after stall timeout", async () => {
-    const { startRound, _resetForTest } = await import("../../../src/helpers/classicBattle.js");
-    _resetForTest();
-    await startRound();
+    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
+    classicBattle._resetForTest();
+    await classicBattle.startRound();
     timerSpy.advanceTimersByTime(35000);
     expect(document.querySelector("header #round-message").textContent).toMatch(/stalled/i);
     timerSpy.advanceTimersByTime(5000);

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -32,8 +32,7 @@ function expectDeselected(button) {
 
 describe("classicBattle stat selection", () => {
   let timerSpy;
-  let handleStatSelection;
-  let _resetForTest;
+  let classicBattle;
   let selectStat;
   let simulateOpponentStat;
 
@@ -57,12 +56,12 @@ describe("classicBattle stat selection", () => {
   beforeEach(async () => {
     document.body.innerHTML +=
       '<div id="stat-buttons" data-tooltip-id="ui.selectStat"><button data-stat="power"></button></div>';
-    ({ handleStatSelection, _resetForTest, simulateOpponentStat } = await import(
+    ({ classicBattle, simulateOpponentStat } = await import(
       "../../../src/helpers/classicBattle.js"
     ));
-    _resetForTest();
+    classicBattle._resetForTest();
     selectStat = async (stat) => {
-      const p = handleStatSelection(stat);
+      const p = classicBattle.handleStatSelection(stat);
       await vi.runAllTimersAsync();
       await p;
     };
@@ -107,13 +106,13 @@ describe("classicBattle stat selection", () => {
   });
 
   it("evaluateRound updates the score", async () => {
-    const { evaluateRound, _resetForTest } = await import("../../../src/helpers/classicBattle.js");
-    _resetForTest();
+    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
+    classicBattle._resetForTest();
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    const result = evaluateRound("power");
+    const result = classicBattle.evaluateRound("power");
     expect(result.message).toMatch(/win/);
     expect(document.querySelector("header #score-display").textContent).toBe("You: 1\nOpponent: 0");
   });

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -18,8 +18,7 @@ describe("classicBattlePage keyboard navigation", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      startRound,
-      handleStatSelection
+      classicBattle: { startRound, handleStatSelection }
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -67,8 +66,7 @@ describe("classicBattlePage keyboard navigation", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      startRound,
-      handleStatSelection
+      classicBattle: { startRound, handleStatSelection }
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -126,8 +124,7 @@ describe("classicBattlePage simulated opponent mode", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      startRound,
-      handleStatSelection,
+      classicBattle: { startRound, handleStatSelection },
       simulateOpponentStat
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
@@ -167,8 +164,7 @@ describe("classicBattlePage stat help tooltip", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      startRound,
-      handleStatSelection: vi.fn()
+      classicBattle: { startRound, handleStatSelection: vi.fn() }
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -215,8 +211,7 @@ describe("classicBattlePage test mode flag", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      startRound,
-      handleStatSelection: vi.fn()
+      classicBattle: { startRound, handleStatSelection: vi.fn() }
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -252,8 +247,7 @@ describe("classicBattlePage test mode flag", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      startRound,
-      handleStatSelection: vi.fn()
+      classicBattle: { startRound, handleStatSelection: vi.fn() }
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));


### PR DESCRIPTION
## Summary
- encapsulate battle state in a `ClassicBattle` class
- update classic battle page and tests to use a singleton instance

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891c84a874c8326a3c4dde985e714a3