### PR TITLE
Use rAF for battle message fade

### DIFF
--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -32,10 +32,27 @@ describe("battleUI helpers", () => {
   it("showResult updates text and fades after delay", () => {
     document.body.innerHTML = '<p id="round-message" class="fading"></p>';
     vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", (cb) => setTimeout(() => cb(performance.now()), 16));
+    vi.stubGlobal("cancelAnimationFrame", (id) => clearTimeout(id));
     showResult("You win!");
     const el = getRoundMessageEl();
     expect(el.textContent).toBe("You win!");
     expect(el.classList.contains("fade-transition")).toBe(true);
+    expect(el.classList.contains("fading")).toBe(false);
+    vi.advanceTimersByTime(2000);
+    expect(el.classList.contains("fading")).toBe(true);
+  });
+
+  it("showResult cancels previous fade when new text appears", () => {
+    document.body.innerHTML = '<p id="round-message" class="fading"></p>';
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", (cb) => setTimeout(() => cb(performance.now()), 16));
+    vi.stubGlobal("cancelAnimationFrame", (id) => clearTimeout(id));
+    showResult("First");
+    vi.advanceTimersByTime(1000);
+    showResult("Second");
+    const el = getRoundMessageEl();
+    expect(el.textContent).toBe("Second");
     expect(el.classList.contains("fading")).toBe(false);
     vi.advanceTimersByTime(2000);
     expect(el.classList.contains("fading")).toBe(true);


### PR DESCRIPTION
## Summary
- fade round result text with a requestAnimationFrame loop and cancel on new messages
- test battleUI fading logic and cancellation path

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: battle orientation screenshots, battleJudoka page screenshot, Browse Judoka navigation arrow key update, screenshot suite settings screenshot)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891d6d0b96883268b27f59a52bdbe18