### PR TITLE
Quit match when clicking battle logo

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -179,7 +179,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
   - [x] 1.4 Add "Next Round" and "Quit Match" buttons to controls
   - [x] 1.5 End match after 10 points or 25 rounds
 - [ ] 2.0 Add Early Quit Functionality
-  - [ ] 2.1 Trigger quit confirmation when the header logo is clicked
+  - [x] 2.1 Trigger quit confirmation when the header logo is clicked
   - [x] 2.2 Create confirmation prompt flow
   - [x] 2.3 Record match as player loss upon quit confirmation
 - [ ] 3.0 Handle Edge Cases
@@ -197,7 +197,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 ### Outstanding Subtasks
 
-- [ ] 2.1 Trigger quit confirmation when the header logo is clicked
+- [x] 2.1 Trigger quit confirmation when the header logo is clicked
 - [ ] 3.1 Implement player disconnect logic: abandon match and redirect to main menu
 
 ---

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -282,6 +282,16 @@ class ClassicBattle {
 
 export const classicBattle = new ClassicBattle();
 
+/**
+ * Trigger the Classic Battle quit confirmation modal.
+ *
+ * @pseudocode
+ * 1. Call `classicBattle.quitMatch()` to show the existing confirmation modal.
+ */
+export function quitMatch() {
+  classicBattle.quitMatch();
+}
+
 export {
   revealComputerCard,
   enableNextRoundButton,

--- a/src/helpers/setupClassicBattleHomeLink.js
+++ b/src/helpers/setupClassicBattleHomeLink.js
@@ -1,0 +1,21 @@
+import { quitMatch } from "./classicBattle.js";
+
+/**
+ * Attach quit confirmation to the header logo in Classic Battle.
+ *
+ * @pseudocode
+ * 1. Select the `[data-testid="home-link"]` element.
+ * 2. If found, listen for click events.
+ * 3. On click, prevent default navigation and call `quitMatch()`.
+ */
+export function setupClassicBattleHomeLink() {
+  const homeLink = document.querySelector('[data-testid="home-link"]');
+  if (homeLink) {
+    homeLink.addEventListener("click", (e) => {
+      e.preventDefault();
+      quitMatch();
+    });
+  }
+}
+
+setupClassicBattleHomeLink();

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -149,6 +149,7 @@
       </script>
       <script type="module" src="../helpers/setupSvgFallback.js"></script>
       <script type="module" src="../helpers/setupBattleInfoBar.js"></script>
+      <script type="module" src="../helpers/setupClassicBattleHomeLink.js"></script>
       <script type="module" src="../helpers/classicBattlePage.js"></script>
     </div>
   </body>

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -71,4 +71,22 @@ describe("classicBattle button handlers", () => {
     expect(document.querySelector("#round-message").textContent).toMatch(/quit/i);
     expect(window.location.href).toMatch(/(?:index\.html)?\/?$/);
   });
+
+  it("home link invokes quitMatch", async () => {
+    const header = document.querySelector("header");
+    const homeLink = document.createElement("a");
+    homeLink.href = "../../index.html";
+    homeLink.dataset.testid = "home-link";
+    header.appendChild(homeLink);
+    await import("../../../src/helpers/classicBattle.js");
+    await import("../../../src/helpers/setupClassicBattleHomeLink.js");
+    const beforeHref = window.location.href;
+    homeLink.click();
+    expect(window.location.href).toBe(beforeHref);
+    const confirmBtn = document.getElementById("confirm-quit-button");
+    expect(confirmBtn).not.toBeNull();
+    confirmBtn.dispatchEvent(new Event("click"));
+    expect(document.querySelector("#round-message").textContent).toMatch(/quit/i);
+    expect(window.location.href).toMatch(/(?:index\.html)?\/?$/);
+  });
 });


### PR DESCRIPTION
## Summary
- Export `quitMatch` from classicBattle and hook the header logo to trigger the confirmation modal
- Add tests for quitting via the logo link
- Document logo-based quit flow in Classic Battle PRD

## Testing
- `CI=true npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 4)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891d81f40c08326ad437499e490eee1