### PR TITLE
Handle modal confirmation when quitting battle

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -42,8 +42,10 @@ test.describe("Classic battle flow", () => {
 
   test("quit match confirmation", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
-    page.on("dialog", (dialog) => dialog.accept());
     await page.locator("[data-testid='home-link']").click();
+    const confirmButton = page.locator("#confirm-quit-button");
+    await confirmButton.waitFor();
+    await confirmButton.click();
     await expect(page).toHaveURL(/index.html/);
   });
 


### PR DESCRIPTION
## Summary
- update classic battle flow test to confirm quit via modal instead of dialog

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: 4 failed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891ddb9731083269dfd8b73320693fc