### PR TITLE
Log retry error in card selection

### DIFF
--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -36,7 +36,7 @@ function showLoadError(error) {
       try {
         await drawCards();
       } catch (retryError) {
-        console.error(retryError);
+        console.error("Failed to retry card draw:", retryError);
         window.location.reload();
       }
     });

--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -36,6 +36,7 @@ function showLoadError(error) {
       try {
         await drawCards();
       } catch (retryError) {
+        console.error(retryError);
         window.location.reload();
       }
     });


### PR DESCRIPTION
## Summary
- log retry errors when reattempting card draw

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: 5 failed / 96 files)
- `npx playwright test` (fails: 2 failed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891e52f27908326a9c783d4117c5441