### PR TITLE
Handle defaults in PlayerInfo component

### DIFF
--- a/src/components/PlayerInfo.js
+++ b/src/components/PlayerInfo.js
@@ -2,15 +2,43 @@
  * Define the `<player-info>` custom element for displaying player details.
  *
  * @pseudocode
- * 1. Create a class extending `HTMLElement`.
- * 2. In `connectedCallback`, set default text to "Player" if none provided.
+ * 1. Create a class extending `HTMLElement` with a constructor that sets
+ *    default text content.
+ * 2. On connection or when the `name` attribute changes, update the displayed
+ *    text using that attribute or the default.
  * 3. Register the element as `player-info`.
  */
 export class PlayerInfo extends HTMLElement {
+  /**
+   * Create a player info element.
+   *
+   * @pseudocode
+   * 1. Call `super()` to initialize `HTMLElement`.
+   * 2. Set initial `textContent` to the provided `text` or "Player".
+   *
+   * @param {string} [text="Player"] - Initial text content.
+   */
+  constructor(text = "Player") {
+    super();
+    this._defaultText = text;
+    this.textContent = text;
+  }
+
+  static get observedAttributes() {
+    return ["name"];
+  }
+
   connectedCallback() {
-    if (!this.textContent.trim()) {
-      this.textContent = "Player";
-    }
+    this._updateText();
+  }
+
+  attributeChangedCallback() {
+    this._updateText();
+  }
+
+  _updateText() {
+    const nameAttr = this.getAttribute("name");
+    this.textContent = nameAttr && nameAttr.trim() ? nameAttr : this._defaultText;
   }
 }
 

--- a/tests/components/PlayerInfo.test.js
+++ b/tests/components/PlayerInfo.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { PlayerInfo } from "../../src/components/PlayerInfo.js";
+
+describe("PlayerInfo", () => {
+  it("initializes with provided text or default", () => {
+    const defaultEl = new PlayerInfo();
+    expect(defaultEl.textContent).toBe("Player");
+
+    const customEl = new PlayerInfo("Opponent");
+    expect(customEl.textContent).toBe("Opponent");
+  });
+
+  it("updates text when name attribute changes", () => {
+    const el = new PlayerInfo();
+    document.body.appendChild(el);
+    expect(el.textContent).toBe("Player");
+    el.setAttribute("name", "Jane");
+    expect(el.textContent).toBe("Jane");
+    el.removeAttribute("name");
+    expect(el.textContent).toBe("Player");
+  });
+});


### PR DESCRIPTION
## Summary
- initialize `<player-info>` with a constructor that sets default text
- update content when `name` attribute changes and add unit tests

## Testing
- `npx prettier tests/components/PlayerInfo.test.js src/components/PlayerInfo.js --check`
- `npx eslint src/components/PlayerInfo.js tests/components/PlayerInfo.test.js`
- `npx vitest run` *(fails: expected text outputs, network and jsdom issues)*
- `npx playwright test` *(fails: snapshot mismatches)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891e540a6b88326b1eb07f5f5e24ee1