### PR TITLE
Freeze battle header timers in screenshots

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -35,6 +35,13 @@ test.describe(
     test.skip(!runScreenshots);
 
     test("captures portrait and landscape headers", async ({ page }) => {
+      await page.addInitScript(() => {
+        window.startCountdownOverride = () => {};
+        const originalSetInterval = window.setInterval;
+        window.setInterval = (fn, ms, ...args) =>
+          originalSetInterval(fn, Math.max(ms, 3600000), ...args);
+      });
+
       await page.goto("/src/pages/battleJudoka.html");
       await page.waitForSelector("#score-display span", { state: "attached" });
 
@@ -54,6 +61,13 @@ test.describe(
     });
 
     test("captures extra-narrow header", async ({ page }) => {
+      await page.addInitScript(() => {
+        window.startCountdownOverride = () => {};
+        const originalSetInterval = window.setInterval;
+        window.setInterval = (fn, ms, ...args) =>
+          originalSetInterval(fn, Math.max(ms, 3600000), ...args);
+      });
+
       await page.goto("/src/pages/battleJudoka.html");
       await page.waitForSelector("#score-display span", { state: "attached" });
 


### PR DESCRIPTION
## Summary
- freeze battle header timers for screenshots by overriding `startCountdown` and stretching `setInterval`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: classicBattle card selection > draws a different card for the computer)*
- `npx playwright test playwright/battle-orientation.spec.js`
- `npx playwright test` *(fails: Battle Judoka page screenshot, Settings screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891e461f7f483269b8c0c9e05b2d5b6