### PR TITLE
Use card helper in fallback

### DIFF
--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -117,20 +117,13 @@ export async function generateRandomCard(
     console.error("Error generating random card:", error);
 
     const fallbackJudoka = await getFallbackJudoka();
-
-    try {
-      if (typeof onSelect === "function") {
-        onSelect(fallbackJudoka);
-      }
-      const card = await new JudokaCard(fallbackJudoka, gokyoLookup, {
-        enableInspector: options.enableInspector
-      }).render();
-      if (card) {
-        displayCard(containerEl, card, prefersReducedMotion);
-      }
-    } catch (fallbackError) {
-      console.error("Error displaying fallback card:", fallbackError);
-      // Do not update DOM if fallback also fails
+    if (typeof onSelect === "function") {
+      onSelect(fallbackJudoka);
     }
+    await createCardForJudoka(fallbackJudoka, gokyoLookup, containerEl, prefersReducedMotion).catch(
+      (fallbackError) => {
+        console.error("Error displaying fallback card:", fallbackError);
+      }
+    );
   }
 }


### PR DESCRIPTION
## Summary
- call `createCardForJudoka` when generating fallback random card
- log fallback card errors without nested try/catch

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: classicBattle stalled stat selection recovery, JudokaCard obscures stats)
- `npx playwright test` (fails: battle orientation screenshots, browse-judoka navigation)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891ee6b1e3083268db89ffbc00d9017