### PR TITLE
Refactor classic battle card rendering

### DIFF
--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -123,13 +123,19 @@ export async function drawCards() {
   computerJudoka = compJudoka;
 
   const placeholder = judokaData.find((j) => j.id === 1) || compJudoka;
-  const card = await new JudokaCard(placeholder, gokyoLookup, {
+  // Instantiate a placeholder card for the computer with obscured stats.
+  const judokaCard = new JudokaCard(placeholder, gokyoLookup, {
     useObscuredStats: true,
     enableInspector
-  }).render();
-  computerContainer.innerHTML = "";
-  computerContainer.appendChild(card);
-  setupLazyPortraits(card);
+  });
+  const card = await judokaCard.render();
+  if (card instanceof HTMLElement) {
+    computerContainer.innerHTML = "";
+    computerContainer.appendChild(card);
+    setupLazyPortraits(card);
+  } else {
+    console.error("JudokaCard did not render an HTMLElement");
+  }
 
   return { playerJudoka, computerJudoka };
 }

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -136,4 +136,18 @@ describe("classicBattle card selection", () => {
     await Promise.resolve();
     expect(fetchJsonMock).toHaveBeenCalledTimes(3);
   });
+
+  it("logs an error when JudokaCard.render does not return an element", async () => {
+    renderMock = vi.fn(async () => "nope");
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { drawCards, _resetForTest } = await import(
+      "../../../src/helpers/classicBattle/cardSelection.js"
+    );
+    _resetForTest();
+    await drawCards();
+    expect(consoleSpy).toHaveBeenCalledWith("JudokaCard did not render an HTMLElement");
+    const container = document.getElementById("computer-card");
+    expect(container.innerHTML).toBe("");
+    consoleSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- Split JudokaCard instantiation and rendering in classic battle card selection
- Guard against non-element renders before adding to DOM
- Add tests for handling invalid JudokaCard render results

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 9 tests failing, unhandled rejections)*
- `npx playwright test` *(fails: 2 tests failed, 1 skipped)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891ee581750832683b11767d95be582