### PR TITLE
Use epsilon when disabling left scroll button

### DIFF
--- a/src/helpers/carousel/scroll.js
+++ b/src/helpers/carousel/scroll.js
@@ -63,7 +63,8 @@ export function createScrollButton(direction, container) {
  * @pseudocode
  * 1. Calculate the maximum scroll value using `scrollWidth` and
  *    `clientWidth` of `container`.
- * 2. Disable `leftBtn` when `scrollLeft` is at or before the first card.
+ * 2. Disable `leftBtn` when `scrollLeft` is within 1px of the carousel's
+ *    start to account for rounding differences.
  * 3. Disable `rightBtn` when `scrollLeft` is within 1px of the carousel's
  *    end to account for rounding differences.
  *
@@ -74,6 +75,6 @@ export function createScrollButton(direction, container) {
 export function updateScrollButtonState(container, leftBtn, rightBtn) {
   const maxLeft = container.scrollWidth - container.clientWidth;
   const EPSILON = 1; // allow small rounding differences
-  leftBtn.disabled = container.scrollLeft <= 0;
+  leftBtn.disabled = container.scrollLeft <= EPSILON;
   rightBtn.disabled = container.scrollLeft >= maxLeft - EPSILON;
 }

--- a/tests/helpers/scrollButtonState.test.js
+++ b/tests/helpers/scrollButtonState.test.js
@@ -48,4 +48,15 @@ describe("updateScrollButtonState", () => {
     updateScrollButtonState(container, left, right);
     expect(right.disabled).toBe(true);
   });
+
+  it("treats near-start positions as start", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "scrollWidth", { value: 300 });
+    Object.defineProperty(container, "clientWidth", { value: 100 });
+    container.scrollLeft = 0.5;
+    const left = document.createElement("button");
+    const right = document.createElement("button");
+    updateScrollButtonState(container, left, right);
+    expect(left.disabled).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- handle near-start positions when computing left scroll button state
- add regression test for fractional scroll-left values

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Cannot read properties of null (reading 'textContent'))*
- `npx playwright test` *(fails: battle-header-portrait.png snapshot mismatch)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_6891f224e4cc8326b718bccc19f0490c