### PR TITLE
Ensure fonts load before battle orientation screenshots

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -50,6 +50,7 @@ test.describe(
         () => document.querySelector(".battle-header")?.dataset.orientation === "portrait"
       );
       await page.waitForSelector("#score-display span", { state: "attached" });
+      await page.evaluate(() => document.fonts.ready);
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-portrait.png");
 
       await page.setViewportSize({ width: 480, height: 320 });
@@ -57,6 +58,7 @@ test.describe(
         () => document.querySelector(".battle-header")?.dataset.orientation === "landscape"
       );
       await page.waitForSelector("#score-display span", { state: "attached" });
+      await page.evaluate(() => document.fonts.ready);
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-landscape.png");
     });
 
@@ -70,6 +72,7 @@ test.describe(
 
       await page.goto("/src/pages/battleJudoka.html");
       await page.waitForSelector("#score-display span", { state: "attached" });
+      await page.evaluate(() => document.fonts.ready);
 
       await page.setViewportSize({ width: 300, height: 600 });
       await page.waitForFunction(


### PR DESCRIPTION
## Summary
- wait for fonts to load before taking battle orientation screenshots

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings)
- `npx vitest run` (fails: JudokaCard fallback containers, classicBattle card selection, stallRecovery)
- `npx playwright test` (fails: battle-orientation screenshot mismatch)
- `npm run check:contrast` (fails: Server start timeout)


------
https://chatgpt.com/codex/tasks/task_e_6891fe60a08c8326b49f1b8ab5b00d30