### PR TITLE
Use cardRender stats generator

### DIFF
--- a/src/helpers/cardSections.js
+++ b/src/helpers/cardSections.js
@@ -1,5 +1,8 @@
-import { generateCardPortrait, generateCardSignatureMove } from "./cardRender.js";
-import { createStatsPanel } from "../components/StatsPanel.js";
+import {
+  generateCardPortrait,
+  generateCardSignatureMove,
+  generateCardStats
+} from "./cardRender.js";
 import { createNoDataContainer } from "./cardTopBar.js";
 
 /**
@@ -38,8 +41,8 @@ export function createPortraitSection(judoka) {
  * Build the stats section for a judoka card.
  *
  * @pseudocode
- * 1. Call `createStatsPanel` with the judoka stats and card type.
- * 2. Await the generated element and return it.
+ * 1. Call `generateCardStats(judoka, cardType)` to get stats HTML.
+ * 2. Parse the HTML into a fragment and return its first element.
  * 3. On error, log and return `createNoDataContainer()`.
  *
  * @param {import("./types.js").Judoka} judoka - Judoka data object.
@@ -48,7 +51,9 @@ export function createPortraitSection(judoka) {
  */
 export async function createStatsSection(judoka, cardType) {
   try {
-    return await createStatsPanel(judoka.stats, { type: cardType });
+    const statsHTML = await generateCardStats(judoka, cardType);
+    const fragment = document.createRange().createContextualFragment(statsHTML);
+    return fragment.firstElementChild;
   } catch (error) {
     console.error("Failed to generate stats:", error);
     return createNoDataContainer();


### PR DESCRIPTION
## Summary
- use `generateCardStats` to build stats section
- parse stats HTML into DOM and fall back to no-data container on error

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891ff7630488326a63f9f35f9eacea5