### PR TITLE
Mock stats panel errors in fallback tests

### DIFF
--- a/tests/card/judokaCardHtmlFallback.test.js
+++ b/tests/card/judokaCardHtmlFallback.test.js
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import { JudokaCard } from "../../src/components/JudokaCard.js";
 import * as cardRender from "../../src/helpers/cardRender.js";
+import * as statsPanel from "../../src/components/StatsPanel.js";
 
 const judoka = {
   id: 1,
@@ -31,8 +32,8 @@ describe("JudokaCard fallback containers", () => {
     expect(card.textContent).toContain("No data available");
   });
 
-  it("adds fallback when stats generation throws", async () => {
-    vi.spyOn(cardRender, "generateCardStats").mockImplementation(() =>
+  it("adds fallback when stats panel generation throws", async () => {
+    vi.spyOn(statsPanel, "createStatsPanel").mockImplementation(() =>
       Promise.reject(new Error("stats fail"))
     );
 
@@ -59,8 +60,8 @@ describe("JudokaCard fallback containers", () => {
     expect(card.textContent).toContain("No data available");
   });
 
-  it("adds fallback when cardRender throws undefined", async () => {
-    vi.spyOn(cardRender, "generateCardStats").mockImplementation(() => Promise.reject(undefined));
+  it("adds fallback when stats panel throws undefined", async () => {
+    vi.spyOn(statsPanel, "createStatsPanel").mockImplementation(() => Promise.reject(undefined));
     const card = await new JudokaCard(judoka, gokyoLookup).render();
     expect(card.textContent).toContain("No data available");
   });


### PR DESCRIPTION
## Summary
- import StatsPanel in judoka card fallback tests
- mock createStatsPanel failure cases instead of cardRender.generateCardStats
- update test descriptions to reference the stats panel

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: classicBattle tests)*
- `npx playwright test` *(fails: settings screenshots, battle orientation screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6891ffb428f883269cc336a4eabc1246