### PR TITLE
Reorder selection prompt in start round

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -195,9 +195,9 @@ class ClassicBattle {
     resetStatButtons();
     disableNextRoundButton();
     await drawCards();
-    showSelectionPrompt();
     this.syncScoreDisplay();
     await startTimer(this.handleStatSelection.bind(this));
+    showSelectionPrompt();
     this.statTimeoutId = setTimeout(() => this.onStatSelectionTimeout(), 35000);
     updateDebugPanel();
   }

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -196,8 +196,8 @@ class ClassicBattle {
     disableNextRoundButton();
     await drawCards();
     this.syncScoreDisplay();
-    await startTimer(this.handleStatSelection.bind(this));
     showSelectionPrompt();
+    await startTimer(this.handleStatSelection.bind(this));
     this.statTimeoutId = setTimeout(() => this.onStatSelectionTimeout(), 35000);
     updateDebugPanel();
   }


### PR DESCRIPTION
## Summary
- sync score before starting timer in ClassicBattle.startRound
- show stat prompt after timer setup

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: judokaCard.render not a function, scoring assertions)*
- `npx playwright test` *(fails: battle orientation screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6892038467448326bd75461fa3882f0c