### PR TITLE
Guard JudokaCard render usage

### DIFF
--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -62,7 +62,7 @@ function showLoadError(error) {
  * 2. Filter out judoka marked `isHidden`.
  * 3. Render a random player card using `generateRandomCard` and store the result.
  * 4. Choose a random opponent judoka avoiding duplicates.
- * 5. Render a placeholder card for the computer with obscured stats.
+ * 5. If `JudokaCard.render` exists, render a placeholder card for the computer with obscured stats; otherwise log an error.
  * 6. Return the selected judoka objects.
  *
  * @returns {Promise<{playerJudoka: object|null, computerJudoka: object|null}>}
@@ -128,13 +128,17 @@ export async function drawCards() {
     useObscuredStats: true,
     enableInspector
   });
-  const card = await judokaCard.render();
-  if (card instanceof HTMLElement) {
-    computerContainer.innerHTML = "";
-    computerContainer.appendChild(card);
-    setupLazyPortraits(card);
+  if (typeof judokaCard.render === "function") {
+    const card = await judokaCard.render();
+    if (card instanceof HTMLElement) {
+      computerContainer.innerHTML = "";
+      computerContainer.appendChild(card);
+      setupLazyPortraits(card);
+    } else {
+      console.error("JudokaCard did not render an HTMLElement");
+    }
   } else {
-    console.error("JudokaCard did not render an HTMLElement");
+    console.error("JudokaCard.render is not a function");
   }
 
   return { playerJudoka, computerJudoka };

--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -138,7 +138,7 @@ export async function drawCards() {
       console.error("JudokaCard did not render an HTMLElement");
     }
   } else {
-    console.error("JudokaCard.render is not a function");
+    console.error("Failed to render computer card: JudokaCard.render method is not available. The computer card will not be displayed.");
   }
 
   return { playerJudoka, computerJudoka };


### PR DESCRIPTION
## Summary
- ensure classic battle card creation checks for JudokaCard render method before calling
- log errors when render is missing and retain existing non-HTMLElement guard

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: classic battle card selection, match flow, stall recovery)
- `npx playwright test` (fails: battle-orientation screenshots, browse-judoka navigation)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68920633dd4c8326a87b2f2eb22ed882