### PR TITLE
Handle missing base in settings utils

### DIFF
--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -8,16 +8,21 @@ let settingsSchemaPromise;
 
 async function getSettingsSchema() {
   if (!settingsSchemaPromise) {
-    settingsSchemaPromise = fetch(new URL("../schemas/settings.schema.json", import.meta.url))
-      .then(async (response) => {
+    settingsSchemaPromise = (async () => {
+      const base = typeof import.meta.url === "string" ? import.meta.url : import.meta.url?.href;
+      try {
+        const url = new URL("../schemas/settings.schema.json", base);
+        const response = await fetch(url);
         if (!response.ok) {
           throw new Error(
             `Failed to fetch settings schema: ${response.status} ${response.statusText}`
           );
         }
-        return response.json();
-      })
-      .catch(async () => importJsonModule("../schemas/settings.schema.json"));
+        return await response.json();
+      } catch {
+        return importJsonModule("../schemas/settings.schema.json");
+      }
+    })();
   }
   return settingsSchemaPromise;
 }
@@ -34,16 +39,21 @@ let defaultSettingsPromise;
  */
 export async function loadDefaultSettings() {
   if (!defaultSettingsPromise) {
-    defaultSettingsPromise = fetch(new URL("../data/settings.json", import.meta.url))
-      .then(async (response) => {
+    defaultSettingsPromise = (async () => {
+      const base = typeof import.meta.url === "string" ? import.meta.url : import.meta.url?.href;
+      try {
+        const url = new URL("../data/settings.json", base);
+        const response = await fetch(url);
         if (!response.ok) {
           throw new Error(
             `Failed to fetch default settings: ${response.status} ${response.statusText}`
           );
         }
-        return response.json();
-      })
-      .catch(async () => importJsonModule("../data/settings.json"));
+        return await response.json();
+      } catch {
+        return importJsonModule("../data/settings.json");
+      }
+    })();
   }
   const data = await defaultSettingsPromise;
   if (Object.keys(DEFAULT_SETTINGS).length === 0) {

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -9,7 +9,7 @@ let settingsSchemaPromise;
 async function getSettingsSchema() {
   if (!settingsSchemaPromise) {
     settingsSchemaPromise = (async () => {
-      const base = typeof import.meta.url === "string" ? import.meta.url : import.meta.url?.href;
+      const base = typeof import.meta.url === "string" ? import.meta.url : undefined;
       try {
         const url = new URL("../schemas/settings.schema.json", base);
         const response = await fetch(url);


### PR DESCRIPTION
## Summary
- Handle cases where `import.meta.url` isn't a string when loading settings
- Gracefully fall back to `importJsonModule` if URL resolution or fetch fails

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/cardSelection.test.js` *(fails: `'toString' called on an object that is not a valid instance of Location.'`)*
- `npx vitest run` *(fails: 5 tests fail, including Location errors in classic battle card-selection)*
- `npx playwright test` *(fails: 3 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689205a276988326b0bf10e1e920472a