### PR TITLE
Validate computer card rendering

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -30,7 +30,8 @@ export function showSelectionPrompt() {
  * @pseudocode
  * 1. Exit early if no stored judoka exists.
  * 2. Render `computerJudoka` into the computer card container.
- * 3. Clear the stored judoka after rendering.
+ * 3. Verify the rendered card is an `HTMLElement`; log and exit if not.
+ * 4. Clear the container, append the card, set up lazy portraits, and clear stored judoka.
  */
 export async function revealComputerCard() {
   const judoka = getComputerJudoka();
@@ -46,6 +47,10 @@ export async function revealComputerCard() {
   const card = await new JudokaCard(judoka, getGokyoLookup(), {
     enableInspector
   }).render();
+  if (!(card instanceof HTMLElement)) {
+    console.error("revealComputerCard: rendered card is not a valid HTMLElement");
+    return;
+  }
   container.innerHTML = "";
   container.appendChild(card);
   setupLazyPortraits(card);

--- a/tests/helpers/classicBattle/uiHelpers.test.js
+++ b/tests/helpers/classicBattle/uiHelpers.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+let clearComputerJudoka;
+let renderMock;
+let setupLazyPortraits;
+
+describe("classicBattle uiHelpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = '<div id="computer-card"></div>';
+    clearComputerJudoka = vi.fn();
+    renderMock = vi.fn(async () => undefined);
+    setupLazyPortraits = vi.fn();
+
+    vi.mock("../../../src/helpers/classicBattle/cardSelection.js", () => ({
+      getComputerJudoka: vi.fn(() => ({ id: 1 })),
+      getGokyoLookup: vi.fn(() => ({})),
+      clearComputerJudoka
+    }));
+
+    vi.mock("../../../src/helpers/settingsUtils.js", () => ({
+      loadSettings: vi.fn(async () => ({ featureFlags: {} }))
+    }));
+
+    vi.mock("../../../src/components/JudokaCard.js", () => ({
+      JudokaCard: vi.fn(() => ({ render: renderMock }))
+    }));
+
+    vi.mock("../../../src/helpers/lazyPortrait.js", () => ({
+      setupLazyPortraits
+    }));
+  });
+
+  afterEach(() => {
+    vi.unmock("../../../src/helpers/classicBattle/cardSelection.js");
+    vi.unmock("../../../src/helpers/settingsUtils.js");
+    vi.unmock("../../../src/components/JudokaCard.js");
+    vi.unmock("../../../src/helpers/lazyPortrait.js");
+    vi.resetModules();
+  });
+
+  it("handles missing rendered card without throwing", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { revealComputerCard } = await import("../../../src/helpers/classicBattle/uiHelpers.js");
+    await expect(revealComputerCard()).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+    expect(clearComputerJudoka).not.toHaveBeenCalled();
+    expect(setupLazyPortraits).not.toHaveBeenCalled();
+    expect(document.getElementById("computer-card").innerHTML).toBe("");
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- validate render output before showing computer card
- test revealComputerCard behavior when render fails

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 3 failing test files)*
- `npx playwright test` *(fails: 1 screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6892057812048326aa4a191eeea29c8a