### PR TITLE
Log error when JudokaCard fails to render element

### DIFF
--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -62,7 +62,7 @@ function showLoadError(error) {
  * 2. Filter out judoka marked `isHidden`.
  * 3. Render a random player card using `generateRandomCard` and store the result.
  * 4. Choose a random opponent judoka avoiding duplicates.
- * 5. If `JudokaCard.render` exists, render a placeholder card for the computer with obscured stats; otherwise log an error.
+ * 5. If `JudokaCard.render` returns an HTMLElement, render a placeholder card for the computer with obscured stats; otherwise log an error.
  * 6. Return the selected judoka objects.
  *
  * @returns {Promise<{playerJudoka: object|null, computerJudoka: object|null}>}
@@ -141,9 +141,7 @@ export async function drawCards() {
     computerContainer.appendChild(card);
     setupLazyPortraits(card);
   } else {
-    console.error(
-      "Failed to render computer card: JudokaCard.render method is not available. The computer card will not be displayed."
-    );
+    console.error("JudokaCard did not render an HTMLElement");
   }
 
   return { playerJudoka, computerJudoka };


### PR DESCRIPTION
## Summary
- refine error handling when a JudokaCard render does not return an HTMLElement
- clarify card selection pseudocode

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-orientation screenshot diff)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68921297cd588326b74428d1194b16fb