### PR TITLE
Ensure header assets load before screenshot tests

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -60,6 +60,8 @@ test.describe(
           throw new Error("Font loading failed or timed out: " + err.message);
         });
       });
+      await page.waitForFunction(() => document.querySelector(".battle-header img.logo")?.complete);
+      await page.waitForLoadState("networkidle");
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-portrait.png");
 
       await page.setViewportSize({ width: 480, height: 320 });
@@ -68,6 +70,8 @@ test.describe(
       );
       await page.waitForSelector("#score-display span", { state: "attached" });
       await page.evaluate(() => document.fonts.ready);
+      await page.waitForFunction(() => document.querySelector(".battle-header img.logo")?.complete);
+      await page.waitForLoadState("networkidle");
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-landscape.png");
     });
 


### PR DESCRIPTION
## Summary
- wait for battle header logo image to finish loading before Playwright screenshot assertions
- wait for network to be idle to stabilize screenshot captures

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: classicBattle card selection logs error)*
- `npx playwright test playwright/battle-orientation.spec.js --update-snapshots`
- `npx playwright test` *(fails: screenshots and navigation)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68921fd0d4948326b8d7a957175cc538