### PR TITLE
Simplify card render error log

### DIFF
--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -141,7 +141,7 @@ export async function drawCards() {
     computerContainer.appendChild(card);
     setupLazyPortraits(card);
   } else {
-    console.error("JudokaCard did not render an HTMLElement", { placeholder, card });
+    console.error("JudokaCard did not render an HTMLElement");
   }
 
   return { playerJudoka, computerJudoka };


### PR DESCRIPTION
## Summary
- log a concise message when JudokaCard fails to render

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6892228608e883268147a528dca4c66f