### PR TITLE
Remove inspector panel sections parameter

### DIFF
--- a/playwright/card-inspector-accessibility.spec.js
+++ b/playwright/card-inspector-accessibility.spec.js
@@ -22,7 +22,7 @@ test.describe("Card inspector accessibility", () => {
       ({ judoka, funcStr }) => {
         const createInspectorPanel = eval(`(${funcStr})`);
         const container = document.createElement("div");
-        const panel = createInspectorPanel(container, judoka, {});
+        const panel = createInspectorPanel(container, judoka);
         container.appendChild(panel);
         document.body.appendChild(container);
       },
@@ -71,7 +71,7 @@ test.describe("Card inspector accessibility", () => {
           gender: "male",
           extra: 1n
         };
-        const result = createInspectorPanel(container, badJudoka, {});
+        const result = createInspectorPanel(container, badJudoka);
         container.appendChild(result);
         document.body.appendChild(container);
       },

--- a/src/components/JudokaCard.js
+++ b/src/components/JudokaCard.js
@@ -121,12 +121,7 @@ export class JudokaCard {
     container.appendChild(card);
 
     if (this.enableInspector) {
-      const panel = createInspectorPanel(container, this.judoka, {
-        topBar,
-        portrait,
-        stats,
-        signature
-      });
+      const panel = createInspectorPanel(container, this.judoka);
       container.appendChild(panel);
     }
 

--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -36,75 +36,6 @@ import {
 // }
 
 /**
- * Determine if a value should be treated as missing.
- *
- * @pseudocode
- * 1. Return `true` when the value is `undefined` or `null`.
- * 2. If the value is a string, trim whitespace and check if it is empty.
- * 3. Otherwise, return `false`.
- *
- * @param {*} value - The value to examine.
- * @returns {boolean} `true` when the value is missing.
- */
-function isValueMissing(value) {
-  if (value === undefined || value === null) return true;
-  if (typeof value === "string") return value.trim() === "";
-  return false;
-}
-
-/**
- * Validates the required fields of a Judoka object.
- *
- * @pseudocode
- * 1. Skip validation if `judoka.id` equals `0`.
- *
- * 2. Define required fields for the judoka object:
- *    - Include fields like "firstname", "surname", "country", etc.
- *
- * 3. Check for missing fields:
- *    - Use `isValueMissing` to test each required field.
- *    - Throw an error if any required fields are missing.
- *
- * 4. Validate stats fields:
- *    - Define required stats fields like "power", "speed", etc.
- *    - Check for missing stats fields in `judoka.stats` with `isValueMissing`.
- *    - Throw an error if any required stats fields are missing.
- *
- * @param {Object} judoka - The judoka object to validate.
- * @throws {Error} If required fields are missing.
- */
-function validateJudoka(judoka) {
-  if (judoka.id === 0) return;
-
-  const requiredFields = [
-    "firstname",
-    "surname",
-    "country",
-    "countryCode",
-    "stats",
-    "weightClass",
-    "signatureMoveId",
-    "rarity"
-  ];
-  const missingFields = requiredFields.filter((field) => isValueMissing(judoka[field]));
-
-  if (missingFields.length > 0) {
-    throw new Error(`Invalid Judoka object: Missing required fields: ${missingFields.join(", ")}`);
-  }
-
-  const requiredStatsFields = ["power", "speed", "technique", "kumikata", "newaza"];
-  const missingStatsFields = requiredStatsFields.filter((field) =>
-    isValueMissing(judoka.stats?.[field])
-  );
-
-  if (missingStatsFields.length > 0) {
-    throw new Error(
-      `Invalid Judoka stats: Missing required fields: ${missingStatsFields.join(", ")}`
-    );
-  }
-}
-
-/**
  * Generates the complete DOM structure for a judoka card.
  *
  * @pseudocode
@@ -161,7 +92,7 @@ async function createTopBar(judoka, flagUrl) {
   );
 }
 
-function createInspectorPanel(container, judoka, sections) {
+function createInspectorPanel(container, judoka) {
   let json;
   try {
     json = JSON.stringify(judoka, null, 2);
@@ -289,12 +220,7 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup, options = {}) 
   cardContainer.appendChild(judokaCard);
 
   if (enableInspector) {
-    const panel = createInspectorPanel(cardContainer, judoka, {
-      topBar: topBarElement,
-      portrait: portraitElement,
-      stats: statsElement,
-      signature: signatureMoveElement
-    });
+    const panel = createInspectorPanel(cardContainer, judoka);
     cardContainer.appendChild(panel);
   }
 

--- a/src/helpers/cardUtils.js
+++ b/src/helpers/cardUtils.js
@@ -111,12 +111,7 @@ export function toggleInspectorPanels(enable) {
         const json = container.dataset.cardJson;
         const card = container.querySelector(".judoka-card");
         if (!json || !card) return;
-        const panel = createInspectorPanel(container, JSON.parse(json), {
-          topBar: card.querySelector(".card-top-bar"),
-          portrait: card.querySelector(".card-portrait"),
-          stats: card.querySelector(".card-stats"),
-          signature: card.querySelector(".signature-move-container")
-        });
+        const panel = createInspectorPanel(container, JSON.parse(json));
         container.appendChild(panel);
       }
     } else if (existing) {

--- a/tests/helpers/createInspectorPanel.test.js
+++ b/tests/helpers/createInspectorPanel.test.js
@@ -7,7 +7,7 @@ const judoka = {};
 describe("createInspectorPanel accessibility", () => {
   it("adds label, focus styles, and keyboard support", () => {
     const container = document.createElement("div");
-    const panel = createInspectorPanel(container, judoka, {});
+    const panel = createInspectorPanel(container, judoka);
     const summary = panel.querySelector("summary");
 
     expect(panel.getAttribute("aria-label")).toBe("Inspector panel");


### PR DESCRIPTION
## Summary
- simplify card inspector by dropping the unused `sections` argument
- update all inspector panel calls to use the new function signature
- clean up unused validation helpers in `cardBuilder`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: tests/helpers/classicBattle/cardSelection.test.js (4 tests | 1 failed))
- `npx playwright test` (fails: 3 failed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689222b492a083268b539c9e2e25daa2