### PR TITLE
Remove redundant judoka validation

### DIFF
--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -36,75 +36,6 @@ import {
 // }
 
 /**
- * Determine if a value should be treated as missing.
- *
- * @pseudocode
- * 1. Return `true` when the value is `undefined` or `null`.
- * 2. If the value is a string, trim whitespace and check if it is empty.
- * 3. Otherwise, return `false`.
- *
- * @param {*} value - The value to examine.
- * @returns {boolean} `true` when the value is missing.
- */
-function isValueMissing(value) {
-  if (value === undefined || value === null) return true;
-  if (typeof value === "string") return value.trim() === "";
-  return false;
-}
-
-/**
- * Validates the required fields of a Judoka object.
- *
- * @pseudocode
- * 1. Skip validation if `judoka.id` equals `0`.
- *
- * 2. Define required fields for the judoka object:
- *    - Include fields like "firstname", "surname", "country", etc.
- *
- * 3. Check for missing fields:
- *    - Use `isValueMissing` to test each required field.
- *    - Throw an error if any required fields are missing.
- *
- * 4. Validate stats fields:
- *    - Define required stats fields like "power", "speed", etc.
- *    - Check for missing stats fields in `judoka.stats` with `isValueMissing`.
- *    - Throw an error if any required stats fields are missing.
- *
- * @param {Object} judoka - The judoka object to validate.
- * @throws {Error} If required fields are missing.
- */
-function validateJudoka(judoka) {
-  if (judoka.id === 0) return;
-
-  const requiredFields = [
-    "firstname",
-    "surname",
-    "country",
-    "countryCode",
-    "stats",
-    "weightClass",
-    "signatureMoveId",
-    "rarity"
-  ];
-  const missingFields = requiredFields.filter((field) => isValueMissing(judoka[field]));
-
-  if (missingFields.length > 0) {
-    throw new Error(`Invalid Judoka object: Missing required fields: ${missingFields.join(", ")}`);
-  }
-
-  const requiredStatsFields = ["power", "speed", "technique", "kumikata", "newaza"];
-  const missingStatsFields = requiredStatsFields.filter((field) =>
-    isValueMissing(judoka.stats?.[field])
-  );
-
-  if (missingStatsFields.length > 0) {
-    throw new Error(
-      `Invalid Judoka stats: Missing required fields: ${missingStatsFields.join(", ")}`
-    );
-  }
-}
-
-/**
  * Generates the complete DOM structure for a judoka card.
  *
  * @pseudocode
@@ -161,7 +92,7 @@ async function createTopBar(judoka, flagUrl) {
   );
 }
 
-function createInspectorPanel(container, judoka, sections) {
+function createInspectorPanel(container, judoka) {
   let json;
   try {
     json = JSON.stringify(judoka, null, 2);


### PR DESCRIPTION
## Summary
- drop unused `validateJudoka` helper in cardBuilder
- rely on shared `getMissingJudokaFields`/`hasRequiredJudokaFields`
- tidy inspector helper args

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689222adf6d08326b463489106575cfc