### PR TITLE
Refactor classic battle helpers

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -1,0 +1,54 @@
+import { startTimer, scheduleNextRound } from "./timerControl.js";
+import * as infoBar from "../setupBattleInfoBar.js";
+
+/**
+ * Handle stat selection stall by prompting user and auto-selecting a random stat.
+ *
+ * @pseudocode
+ * 1. Show a stall message via `infoBar.showMessage`.
+ * 2. After 5 seconds choose a random stat using `simulateStat`.
+ * 3. Call `handleStatSelection` with the chosen stat.
+ *
+ * @param {object} store - Timer store to track timeout ids.
+ * @param {(store: object, stat: string) => Promise<void>} handleStatSelection - Callback to process the stat.
+ * @param {() => string} simulateStat - Function returning a random stat.
+ */
+export function handleStatSelectionTimeout(store, handleStatSelection, simulateStat) {
+  infoBar.showMessage("Stat selection stalled. Pick a stat or wait for auto-pick.");
+  store.autoSelectId = setTimeout(() => {
+    const randomStat = simulateStat();
+    handleStatSelection(store, randomStat);
+  }, 5000);
+}
+
+/**
+ * Start a timeout for stat selection.
+ *
+ * @pseudocode
+ * 1. After 35 seconds call `handleStatSelectionTimeout`.
+ * 2. Store the timeout id on `store.statTimeoutId`.
+ *
+ * @param {object} store
+ * @param {(store: object, stat: string) => Promise<void>} handleStatSelection
+ * @param {() => string} simulateStat
+ */
+export function scheduleStatSelectionTimeout(store, handleStatSelection, simulateStat) {
+  store.statTimeoutId = setTimeout(
+    () => handleStatSelectionTimeout(store, handleStatSelection, simulateStat),
+    35000
+  );
+}
+
+/**
+ * Clear any active stat selection timers.
+ *
+ * @param {object} store
+ */
+export function clearStatSelectionTimers(store) {
+  clearTimeout(store.statTimeoutId);
+  clearTimeout(store.autoSelectId);
+  store.statTimeoutId = null;
+  store.autoSelectId = null;
+}
+
+export { startTimer, scheduleNextRound };

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -1,0 +1,35 @@
+import { getScores } from "../battleEngine.js";
+import * as infoBar from "../setupBattleInfoBar.js";
+
+/**
+ * Display match summary with final message and scores.
+ *
+ * @pseudocode
+ * 1. Find the summary panel and text elements.
+ * 2. Insert the result message and scores.
+ * 3. Reveal the panel by removing the hidden class.
+ *
+ * @param {{message: string, playerScore: number, computerScore: number}} result
+ */
+export function showSummary(result) {
+  const panel = document.getElementById("summary-panel");
+  const messageEl = document.getElementById("summary-message");
+  const scoreEl = document.getElementById("summary-score");
+  if (panel && messageEl && scoreEl) {
+    messageEl.textContent = result.message;
+    scoreEl.textContent = `Final Score – You: ${result.playerScore} Opponent: ${result.computerScore}`;
+    panel.classList.remove("hidden");
+  }
+}
+
+/**
+ * Update the info bar with current scores.
+ *
+ * @pseudocode
+ * 1. Read scores via `getScores()`.
+ * 2. Forward the values to `infoBar.updateScore`.
+ */
+export function syncScoreDisplay() {
+  const { playerScore, computerScore } = getScores();
+  infoBar.updateScore(playerScore, computerScore);
+}

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -25,7 +25,13 @@
  *       `data-test-mode` attribute when settings change.
  * 5. Execute `setupClassicBattlePage` with `onDomReady`.
  */
-import { classicBattle, simulateOpponentStat } from "./classicBattle.js";
+import {
+  createBattleStore,
+  startRound,
+  handleStatSelection,
+  simulateOpponentStat,
+  initClassicBattle
+} from "./classicBattle.js";
 import { onDomReady } from "./domReady.js";
 import { waitForComputerCard } from "./battleJudokaPage.js";
 import { loadSettings } from "./settingsUtils.js";
@@ -46,14 +52,15 @@ function enableStatButtons(enable = true) {
 
 let simulatedOpponentMode = false;
 let aiDifficulty = "easy";
+const battleStore = createBattleStore();
 
 async function startRoundWrapper() {
   enableStatButtons(false);
-  await classicBattle.startRound();
+  await startRound(battleStore);
   await waitForComputerCard();
   if (simulatedOpponentMode) {
     const stat = simulateOpponentStat(aiDifficulty);
-    await classicBattle.handleStatSelection(stat);
+    await handleStatSelection(battleStore, stat);
   } else {
     enableStatButtons(true);
   }
@@ -99,6 +106,7 @@ function watchBattleOrientation() {
 
 export async function setupClassicBattlePage() {
   await applyStatLabels();
+  initClassicBattle(battleStore);
   const statButtons = document.querySelectorAll("#stat-buttons button");
 
   let settings;
@@ -126,7 +134,7 @@ export async function setupClassicBattlePage() {
         if (!btn.disabled) {
           enableStatButtons(false);
           btn.classList.add("selected");
-          classicBattle.handleStatSelection(btn.dataset.stat);
+          handleStatSelection(battleStore, btn.dataset.stat);
         }
       });
       btn.addEventListener("keydown", (e) => {
@@ -134,7 +142,7 @@ export async function setupClassicBattlePage() {
           e.preventDefault();
           enableStatButtons(false);
           btn.classList.add("selected");
-          classicBattle.handleStatSelection(btn.dataset.stat);
+          handleStatSelection(battleStore, btn.dataset.stat);
         }
       });
     });

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -67,11 +67,11 @@ describe("classicBattle card selection", () => {
       callCount += 1;
       return callCount === 1 ? { id: 1 } : { id: 2 };
     });
-    const { classicBattle, getComputerJudoka } = await import(
+    const { startRound, _resetForTest, getComputerJudoka } = await import(
       "../../../src/helpers/classicBattle.js"
     );
-    classicBattle._resetForTest();
-    await classicBattle.startRound();
+    _resetForTest();
+    await startRound();
     expect(JudokaCardMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 1 }),
       expect.anything(),
@@ -96,9 +96,9 @@ describe("classicBattle card selection", () => {
       if (cb) cb(d[0]);
     });
     getRandomJudokaMock = vi.fn(() => ({ id: 2 }));
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
-    await classicBattle.startRound();
+    const { startRound, _resetForTest } = await import("../../../src/helpers/classicBattle.js");
+    _resetForTest();
+    await startRound();
     expect(generateRandomCardMock).toHaveBeenCalledWith(
       [expect.objectContaining({ id: 2, isHidden: false })],
       null,

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -70,7 +70,8 @@ describe("classicBattle button handlers", () => {
   });
 
   it("quit button invokes quitMatch", async () => {
-    await import("../../../src/helpers/classicBattle.js");
+    const { initClassicBattle } = await import("../../../src/helpers/classicBattle.js");
+    initClassicBattle();
     document.getElementById("quit-match-button").click();
     const confirmBtn = document.getElementById("confirm-quit-button");
     expect(confirmBtn).not.toBeNull();
@@ -85,7 +86,8 @@ describe("classicBattle button handlers", () => {
     homeLink.href = "../../index.html";
     homeLink.dataset.testid = "home-link";
     header.appendChild(homeLink);
-    await import("../../../src/helpers/classicBattle.js");
+    const { initClassicBattle } = await import("../../../src/helpers/classicBattle.js");
+    initClassicBattle();
     await import("../../../src/helpers/setupClassicBattleHomeLink.js");
     const beforeHref = window.location.href;
     homeLink.click();

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -62,9 +62,9 @@ describe("classicBattle match flow", () => {
 
   it("auto-selects a stat when timer expires", async () => {
     vi.spyOn(Math, "random").mockReturnValue(0);
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
-    await classicBattle.startRound();
+    const mod = await import("../../../src/helpers/classicBattle.js");
+    mod._resetForTest();
+    await mod.startRound();
     timerSpy.advanceTimersByTime(31000);
     await vi.runAllTimersAsync();
     const score = document.querySelector("header #score-display").textContent;
@@ -74,8 +74,8 @@ describe("classicBattle match flow", () => {
   });
 
   it("quits match after confirmation", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle.quitMatch();
+    const mod = await import("../../../src/helpers/classicBattle.js");
+    mod.quitMatch();
     const confirmBtn = document.getElementById("confirm-quit-button");
     expect(confirmBtn).not.toBeNull();
     confirmBtn.dispatchEvent(new Event("click"));
@@ -83,10 +83,10 @@ describe("classicBattle match flow", () => {
   });
 
   it("does not quit match when cancel is chosen", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
+    const mod = await import("../../../src/helpers/classicBattle.js");
+    mod._resetForTest();
     document.querySelector("#round-message").textContent = "Select your move";
-    classicBattle.quitMatch();
+    mod.quitMatch();
     const cancelBtn = document.getElementById("cancel-quit-button");
     expect(cancelBtn).not.toBeNull();
     cancelBtn.dispatchEvent(new Event("click"));
@@ -95,10 +95,10 @@ describe("classicBattle match flow", () => {
   });
 
   it("ends the match when player reaches 10 wins", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
+    const mod = await import("../../../src/helpers/classicBattle.js");
+    mod._resetForTest();
     const selectStat = async () => {
-      const p = classicBattle.handleStatSelection("power");
+      const p = mod.handleStatSelection("power");
       await vi.runAllTimersAsync();
       await p;
     };
@@ -119,7 +119,7 @@ describe("classicBattle match flow", () => {
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     {
-      const p = classicBattle.handleStatSelection("power");
+      const p = mod.handleStatSelection("power");
       await vi.runAllTimersAsync();
       await p;
     }
@@ -130,10 +130,10 @@ describe("classicBattle match flow", () => {
   });
 
   it("ends the match when opponent reaches 10 wins", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
+    const mod = await import("../../../src/helpers/classicBattle.js");
+    mod._resetForTest();
     const selectStat = async () => {
-      const p = classicBattle.handleStatSelection("power");
+      const p = mod.handleStatSelection("power");
       await vi.runAllTimersAsync();
       await p;
     };
@@ -156,7 +156,7 @@ describe("classicBattle match flow", () => {
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
     {
-      const p = classicBattle.handleStatSelection("power");
+      const p = mod.handleStatSelection("power");
       await vi.runAllTimersAsync();
       await p;
     }
@@ -168,9 +168,11 @@ describe("classicBattle match flow", () => {
 
   it("scheduleNextRound waits for cooldown then enables button", async () => {
     document.body.innerHTML += '<button id="next-round-button" disabled></button>';
-    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const { scheduleNextRound } = await import(
+      "../../../src/helpers/classicBattle/timerService.js"
+    );
     const startStub = vi.fn();
-    battleMod.scheduleNextRound({ matchEnded: false }, startStub);
+    scheduleNextRound({ matchEnded: false }, startStub);
     const btn = document.getElementById("next-round-button");
     expect(btn.disabled).toBe(true);
     timerSpy.advanceTimersByTime(2000);
@@ -184,9 +186,9 @@ describe("classicBattle match flow", () => {
   });
 
   it("shows selection prompt until a stat is chosen", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
-    await classicBattle.startRound();
+    const mod = await import("../../../src/helpers/classicBattle.js");
+    mod._resetForTest();
+    await mod.startRound();
     expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
     timerSpy.advanceTimersByTime(5000);
     expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
@@ -195,7 +197,7 @@ describe("classicBattle match flow", () => {
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     {
-      const p = classicBattle.handleStatSelection("power");
+      const p = mod.handleStatSelection("power");
       await vi.runAllTimersAsync();
       await p;
     }

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -59,9 +59,9 @@ describe("classicBattle opponent delay", () => {
     const timer = vi.useFakeTimers();
     const mod = await import("../../../src/helpers/classicBattle.js");
     vi.spyOn(mod, "simulateOpponentStat").mockReturnValue("power");
-    vi.spyOn(mod.classicBattle, "evaluateRound").mockReturnValue({ matchEnded: false });
+    const store = mod.createBattleStore();
 
-    const promise = mod.classicBattle.handleStatSelection(mod.simulateOpponentStat());
+    const promise = mod.handleStatSelection(store, mod.simulateOpponentStat());
 
     expect(showMessage).toHaveBeenCalledWith("Waiting…");
     expect(clearMessage).not.toHaveBeenCalled();

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -61,9 +61,12 @@ describe("classicBattle stalled stat selection recovery", () => {
   });
 
   it("auto-selects after stall timeout", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
-    await classicBattle.startRound();
+    const { createBattleStore, startRound, _resetForTest } = await import(
+      "../../../src/helpers/classicBattle.js"
+    );
+    const store = createBattleStore();
+    _resetForTest(store);
+    await startRound(store);
     timerSpy.advanceTimersByTime(35000);
     expect(document.querySelector("header #round-message").textContent).toMatch(/stalled/i);
     timerSpy.advanceTimersByTime(5000);

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -37,9 +37,12 @@ function expectDeselected(button) {
 
 describe("classicBattle stat selection", () => {
   let timerSpy;
-  let classicBattle;
   let selectStat;
   let simulateOpponentStat;
+  let handleStatSelection;
+  let createBattleStore;
+  let _resetForTest;
+  let store;
 
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -63,12 +66,13 @@ describe("classicBattle stat selection", () => {
   beforeEach(async () => {
     document.body.innerHTML +=
       '<div id="stat-buttons" data-tooltip-id="ui.selectStat"><button data-stat="power"></button></div>';
-    ({ classicBattle, simulateOpponentStat } = await import(
+    ({ createBattleStore, handleStatSelection, simulateOpponentStat, _resetForTest } = await import(
       "../../../src/helpers/classicBattle.js"
     ));
-    classicBattle._resetForTest();
+    store = createBattleStore();
+    _resetForTest(store);
     selectStat = async (stat) => {
-      const p = classicBattle.handleStatSelection(stat);
+      const p = handleStatSelection(store, stat);
       await vi.runAllTimersAsync();
       await p;
     };
@@ -113,13 +117,16 @@ describe("classicBattle stat selection", () => {
   });
 
   it("evaluateRound updates the score", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
+    const { createBattleStore, evaluateRound, _resetForTest } = await import(
+      "../../../src/helpers/classicBattle.js"
+    );
+    const storeEval = createBattleStore();
+    _resetForTest(storeEval);
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    const result = classicBattle.evaluateRound("power");
+    const result = evaluateRound("power");
     expect(result.message).toMatch(/win/);
     expect(document.querySelector("header #score-display").textContent).toBe("You: 1\nOpponent: 0");
   });

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -18,7 +18,11 @@ describe("classicBattlePage keyboard navigation", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection }
+      createBattleStore: () => ({}),
+      initClassicBattle: vi.fn(),
+      startRound,
+      handleStatSelection,
+      simulateOpponentStat: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -42,7 +46,7 @@ describe("classicBattlePage keyboard navigation", () => {
 
     const [first, second] = container.querySelectorAll("button");
     first.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-    expect(handleStatSelection).toHaveBeenCalledWith("power");
+    expect(handleStatSelection).toHaveBeenCalledWith(expect.any(Object), "power");
 
     // re-enable buttons for second key simulation
     container.querySelectorAll("button").forEach((b) => {
@@ -52,7 +56,7 @@ describe("classicBattlePage keyboard navigation", () => {
     handleStatSelection.mockClear();
 
     second.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
-    expect(handleStatSelection).toHaveBeenCalledWith("speed");
+    expect(handleStatSelection).toHaveBeenCalledWith(expect.any(Object), "speed");
   });
 
   it("navigates to Next Round and Quit buttons", async () => {
@@ -66,7 +70,11 @@ describe("classicBattlePage keyboard navigation", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection }
+      createBattleStore: () => ({}),
+      initClassicBattle: vi.fn(),
+      startRound,
+      handleStatSelection,
+      simulateOpponentStat: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -124,7 +132,10 @@ describe("classicBattlePage simulated opponent mode", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection },
+      createBattleStore: () => ({}),
+      initClassicBattle: vi.fn(),
+      startRound,
+      handleStatSelection,
       simulateOpponentStat
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
@@ -144,7 +155,7 @@ describe("classicBattlePage simulated opponent mode", () => {
     await setupClassicBattlePage();
 
     expect(simulateOpponentStat).toHaveBeenCalledWith("easy");
-    expect(handleStatSelection).toHaveBeenCalledWith("power");
+    expect(handleStatSelection).toHaveBeenCalledWith(expect.any(Object), "power");
     const calls = handleStatSelection.mock.calls.length;
     btn.dispatchEvent(new Event("click", { bubbles: true }));
     expect(handleStatSelection).toHaveBeenCalledTimes(calls);
@@ -164,7 +175,11 @@ describe("classicBattlePage stat help tooltip", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection: vi.fn() }
+      createBattleStore: () => ({}),
+      initClassicBattle: vi.fn(),
+      startRound,
+      handleStatSelection: vi.fn(),
+      simulateOpponentStat: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -211,7 +226,11 @@ describe("classicBattlePage test mode flag", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection: vi.fn() }
+      createBattleStore: () => ({}),
+      initClassicBattle: vi.fn(),
+      startRound,
+      handleStatSelection: vi.fn(),
+      simulateOpponentStat: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -247,7 +266,11 @@ describe("classicBattlePage test mode flag", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection: vi.fn() }
+      createBattleStore: () => ({}),
+      initClassicBattle: vi.fn(),
+      startRound,
+      handleStatSelection: vi.fn(),
+      simulateOpponentStat: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));


### PR DESCRIPTION
## Summary
- Convert classicBattle to functional helpers with shared store and initializer
- Extract timer and UI services for stat timeout handling and score display
- Update classicBattle page and tests to use new functional API

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(failed: battle orientation screenshots, classic battle flow tie)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68923c13f96883268bd14d7975589303