### PR TITLE
Use local fonts

### DIFF
--- a/playwright/fixtures/commonRoutes.js
+++ b/playwright/fixtures/commonRoutes.js
@@ -29,6 +29,43 @@ export async function registerCommonRoutes(page) {
         contentType: "application/javascript",
         body: "export const marked={parse:(m)=>m};"
       })
-    )
+    ),
+    page.route("https://fonts.googleapis.com/**", (route) =>
+      route.fulfill({
+        contentType: "text/css",
+        body: `@font-face {
+  font-family: "Russo One";
+  src: url("/src/assets/fonts/RussoOneRegular.woff2") format("woff2");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Open Sans";
+  src: url("/src/assets/fonts/OpenSansRegular.woff2") format("woff2");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Open Sans";
+  src: url("/src/assets/fonts/OpenSans600.woff2") format("woff2");
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+`
+      })
+    ),
+    page.route("https://fonts.gstatic.com/**", (route) => {
+      const url = route.request().url();
+      if (url.includes("Russo")) {
+        route.fulfill({ path: "src/assets/fonts/RussoOneRegular.woff2" });
+      } else if (url.includes("600") || url.includes("SemiBold")) {
+        route.fulfill({ path: "src/assets/fonts/OpenSans600.woff2" });
+      } else {
+        route.fulfill({ path: "src/assets/fonts/OpenSansRegular.woff2" });
+      }
+    })
   ]);
 }

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -21,5 +21,3 @@
   font-style: normal;
   font-display: swap;
 }
-
-@import url("https://fonts.googleapis.com/css2?family=Russo+One&family=Open+Sans:wght@400;600&display=swap");


### PR DESCRIPTION
## Summary
- Load Russo One and Open Sans only from local `.woff2` assets
- Serve local font files during Playwright tests to cover Google Fonts requests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-orientation screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68923fc9d5a48326aca7e8755fd209a4