### PR TITLE
Refactor toggle switch component

### DIFF
--- a/src/components/ToggleSwitch.js
+++ b/src/components/ToggleSwitch.js
@@ -1,50 +1,71 @@
 /**
- * Create a toggle switch element with optional id, name and checked state.
+ * Toggle switch UI component for settings controls.
  *
  * @pseudocode
  * 1. Create a wrapper div with class `settings-item`.
- * 2. Create a label with class `switch` and set `htmlFor` when an id is provided.
- * 3. Inside the label, add an `input` of type checkbox using provided options
- *    for `id`, `name`, `checked`, `aria-label` and optional `tooltipId`.
- * 4. Add a `div` acting as the slider and a `span` containing the label text.
- * 5. Append the input, slider and span to the label and return the wrapper
- *    containing the complete toggle switch markup.
- *
- * @param {string} labelText - Visible text for the toggle label.
- * @param {object} [options] - Additional configuration.
- * @param {string} [options.id] - Id attribute for the input/label.
- * @param {string} [options.name] - Name attribute for the input.
- * @param {boolean} [options.checked=false] - Initial checked state.
- * @param {string} [options.ariaLabel] - Custom ARIA label, defaults to labelText.
- * @param {string} [options.tooltipId] - Tooltip identifier to attach to the input.
- * @returns {HTMLDivElement} Wrapper element containing the toggle switch.
+ * 2. Build a label containing a checkbox input, slider div and text span.
+ * 3. Apply provided options such as `id`, `name`, `checked`, `aria-label` and `tooltipId` to the input.
+ * 4. Append the label to the wrapper and store references to the wrapper and input.
+ * 5. Wire a change event to keep the instance's `checked` state in sync with the input element.
  */
-export function createToggleSwitch(labelText, options = {}) {
-  const { id, name, checked = false, ariaLabel = labelText, tooltipId } = options;
+export class ToggleSwitch {
+  /**
+   * @param {string} labelText - Visible text for the toggle label.
+   * @param {object} [options] - Additional configuration.
+   * @param {string} [options.id] - Id attribute for the input/label.
+   * @param {string} [options.name] - Name attribute for the input.
+   * @param {boolean} [options.checked=false] - Initial checked state.
+   * @param {string} [options.ariaLabel] - Custom ARIA label, defaults to labelText.
+   * @param {string} [options.tooltipId] - Tooltip identifier to attach to the input.
+   */
+  constructor(labelText, options = {}) {
+    const { id, name, checked = false, ariaLabel = labelText, tooltipId } = options;
 
-  const wrapper = document.createElement("div");
-  wrapper.className = "settings-item";
+    this.element = document.createElement("div");
+    this.element.className = "settings-item";
 
-  const label = document.createElement("label");
-  label.className = "switch";
-  if (id) label.htmlFor = id;
+    const label = document.createElement("label");
+    label.className = "switch";
+    if (id) label.htmlFor = id;
 
-  const input = document.createElement("input");
-  input.type = "checkbox";
-  if (id) input.id = id;
-  if (name) input.name = name;
-  input.checked = checked;
-  input.setAttribute("aria-label", ariaLabel);
-  if (tooltipId) input.dataset.tooltipId = tooltipId;
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    if (id) input.id = id;
+    if (name) input.name = name;
+    input.checked = checked;
+    input.setAttribute("aria-label", ariaLabel);
+    if (tooltipId) input.dataset.tooltipId = tooltipId;
 
-  const slider = document.createElement("div");
-  slider.className = "slider round";
+    const slider = document.createElement("div");
+    slider.className = "slider round";
 
-  const span = document.createElement("span");
-  span.textContent = labelText;
+    const span = document.createElement("span");
+    span.textContent = labelText;
 
-  label.append(input, slider, span);
-  wrapper.appendChild(label);
+    label.append(input, slider, span);
+    this.element.appendChild(label);
 
-  return wrapper;
+    this.input = input;
+    this.checked = input.checked;
+    input.addEventListener("change", () => {
+      this.checked = input.checked;
+    });
+  }
+
+  /**
+   * Determine whether the switch is checked.
+   * @returns {boolean} Current checked state.
+   */
+  isChecked() {
+    return this.input.checked;
+  }
+
+  /**
+   * Set the switch checked state.
+   * @param {boolean} value - Desired checked value.
+   */
+  setChecked(value) {
+    this.input.checked = value;
+    this.checked = value;
+  }
 }

--- a/src/helpers/settings/featureFlagSwitches.js
+++ b/src/helpers/settings/featureFlagSwitches.js
@@ -1,4 +1,4 @@
-import { createToggleSwitch } from "../../components/ToggleSwitch.js";
+import { ToggleSwitch } from "../../components/ToggleSwitch.js";
 import { showSnackbar } from "../showSnackbar.js";
 import { toggleViewportSimulation } from "../viewportDebug.js";
 import { toggleTooltipOverlayDebug } from "../tooltipOverlayDebug.js";
@@ -41,14 +41,14 @@ export function renderFeatureFlagSwitches(
     const label = tooltipMap[`${tipId}.label`] || formatFlagLabel(flag);
     const getDescription = () => tooltipMap[`${tipId}.description`] || "";
     const description = getDescription();
-    const wrapper = createToggleSwitch(label, {
+    const toggle = new ToggleSwitch(label, {
       id: `feature-${kebab}`,
       name: flag,
       checked: Boolean(getCurrentSettings().featureFlags[flag]?.enabled),
       ariaLabel: label,
       tooltipId: info.tooltipId
     });
-    const input = wrapper.querySelector("input");
+    const { element: wrapper, input } = toggle;
     if (input) input.dataset.flag = flag;
     const desc = document.createElement("p");
     desc.className = "settings-description";

--- a/src/helpers/settings/gameModeSwitches.js
+++ b/src/helpers/settings/gameModeSwitches.js
@@ -1,4 +1,4 @@
-import { createToggleSwitch } from "../../components/ToggleSwitch.js";
+import { ToggleSwitch } from "../../components/ToggleSwitch.js";
 import { updateNavigationItemHidden } from "../gameModeUtils.js";
 import { showSettingsError } from "../showSettingsError.js";
 import { showSnackbar } from "../showSnackbar.js";
@@ -25,13 +25,13 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
     const isChecked = Object.hasOwn(current.gameModes, mode.id)
       ? current.gameModes[mode.id]
       : !mode.isHidden;
-    const wrapper = createToggleSwitch(`${mode.name} (${mode.category} - ${mode.order})`, {
+    const toggle = new ToggleSwitch(`${mode.name} (${mode.category} - ${mode.order})`, {
       id: `mode-${mode.id}`,
       name: mode.id,
       checked: isChecked,
       ariaLabel: mode.name
     });
-    const input = wrapper.querySelector("input");
+    const { element: wrapper, input } = toggle;
     if (mode.description) {
       const desc = document.createElement("p");
       desc.className = "settings-description";

--- a/tests/helpers/toggleSwitch.test.js
+++ b/tests/helpers/toggleSwitch.test.js
@@ -1,21 +1,21 @@
 import { describe, it, expect } from "vitest";
-import { createToggleSwitch } from "../../src/components/ToggleSwitch.js";
+import { ToggleSwitch } from "../../src/components/ToggleSwitch.js";
 
-describe("createToggleSwitch", () => {
+describe("ToggleSwitch", () => {
   it("creates the correct DOM structure", () => {
-    const wrapper = createToggleSwitch("Sound", {
+    const toggle = new ToggleSwitch("Sound", {
       id: "sound-toggle",
       name: "sound",
       checked: true,
       ariaLabel: "Sound toggle",
       tooltipId: "settings.sound"
     });
-    const label = wrapper.querySelector("label.switch");
-    const input = wrapper.querySelector("input[type='checkbox']");
-    const slider = wrapper.querySelector(".slider");
-    const span = wrapper.querySelector("span");
+    const { element, input } = toggle;
+    const label = element.querySelector("label.switch");
+    const slider = element.querySelector(".slider");
+    const span = element.querySelector("span");
 
-    expect(wrapper.className).toBe("settings-item");
+    expect(element.className).toBe("settings-item");
     expect(label).toBeInstanceOf(HTMLLabelElement);
     expect(label?.htmlFor).toBe("sound-toggle");
     expect(input?.id).toBe("sound-toggle");
@@ -28,20 +28,23 @@ describe("createToggleSwitch", () => {
   });
 
   it("defaults to unchecked when not specified", () => {
-    const wrapper = createToggleSwitch("Option");
-    const input = wrapper.querySelector("input[type='checkbox']");
-    expect(input?.checked).toBe(false);
+    const toggle = new ToggleSwitch("Option");
+    expect(toggle.isChecked()).toBe(false);
   });
 
   it("uses label text as aria-label by default", () => {
-    const wrapper = createToggleSwitch("AutoToggle");
-    const input = wrapper.querySelector("input[type='checkbox']");
-    expect(input).toHaveAttribute("aria-label", "AutoToggle");
+    const toggle = new ToggleSwitch("AutoToggle");
+    expect(toggle.input).toHaveAttribute("aria-label", "AutoToggle");
   });
 
   it("omits tooltip attribute when none provided", () => {
-    const wrapper = createToggleSwitch("NoTip");
-    const input = wrapper.querySelector("input[type='checkbox']");
-    expect(input?.dataset.tooltipId).toBeUndefined();
+    const toggle = new ToggleSwitch("NoTip");
+    expect(toggle.input.dataset.tooltipId).toBeUndefined();
+  });
+
+  it("allows programmatic state changes", () => {
+    const toggle = new ToggleSwitch("Changeable");
+    toggle.setChecked(true);
+    expect(toggle.isChecked()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- implement ToggleSwitch class with DOM construction and state helpers
- migrate settings helpers to instantiate the new ToggleSwitch
- expand tests to cover methods and default behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-orientation screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68923ff282e8832685751b95b36fb19b