### PR TITLE
Refactor classic battle services

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -71,6 +71,27 @@ export async function startTimer(onExpiredSelect) {
 }
 
 /**
+ * Handle stalled stat selection by prompting the player and auto-selecting a
+ * random stat.
+ *
+ * @pseudocode
+ * 1. Display "Stat selection stalled" via `infoBar.showMessage`.
+ * 2. After 5 seconds choose a random stat from `STATS`.
+ * 3. Call `onSelect` with the chosen stat.
+ *
+ * @param {{autoSelectId: ReturnType<typeof setTimeout> | null}} store
+ * - Battle state store.
+ * @param {(stat: string) => void} onSelect - Callback to handle stat selection.
+ */
+export function handleStatSelectionTimeout(store, onSelect) {
+  infoBar.showMessage("Stat selection stalled. Pick a stat or wait for auto-pick.");
+  store.autoSelectId = setTimeout(() => {
+    const randomStat = STATS[Math.floor(seededRandom() * STATS.length)];
+    onSelect(randomStat);
+  }, 5000);
+}
+
+/**
  * Enable the Next Round button after a cooldown period.
  *
  * @pseudocode

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -1,0 +1,35 @@
+import { getScores } from "../battleEngine.js";
+import * as infoBar from "../setupBattleInfoBar.js";
+
+/**
+ * Update the info bar with current scores.
+ *
+ * @pseudocode
+ * 1. Read scores via `getScores()`.
+ * 2. Forward the values to `infoBar.updateScore`.
+ */
+export function syncScoreDisplay() {
+  const { playerScore, computerScore } = getScores();
+  infoBar.updateScore(playerScore, computerScore);
+}
+
+/**
+ * Display match summary with final message and scores.
+ *
+ * @pseudocode
+ * 1. Find the summary panel and text elements.
+ * 2. Insert the result message and scores.
+ * 3. Reveal the panel by removing the hidden class.
+ *
+ * @param {{message: string, playerScore: number, computerScore: number}} result
+ */
+export function showSummary(result) {
+  const panel = document.getElementById("summary-panel");
+  const messageEl = document.getElementById("summary-message");
+  const scoreEl = document.getElementById("summary-score");
+  if (panel && messageEl && scoreEl) {
+    messageEl.textContent = result.message;
+    scoreEl.textContent = `Final Score – You: ${result.playerScore} Opponent: ${result.computerScore}`;
+    panel.classList.remove("hidden");
+  }
+}

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -25,7 +25,12 @@
  *       `data-test-mode` attribute when settings change.
  * 5. Execute `setupClassicBattlePage` with `onDomReady`.
  */
-import { classicBattle, simulateOpponentStat } from "./classicBattle.js";
+import {
+  createBattleStore,
+  startRound,
+  handleStatSelection,
+  simulateOpponentStat
+} from "./classicBattle.js";
 import { onDomReady } from "./domReady.js";
 import { waitForComputerCard } from "./battleJudokaPage.js";
 import { loadSettings } from "./settingsUtils.js";
@@ -44,16 +49,17 @@ function enableStatButtons(enable = true) {
   });
 }
 
+const battleStore = createBattleStore();
 let simulatedOpponentMode = false;
 let aiDifficulty = "easy";
 
 async function startRoundWrapper() {
   enableStatButtons(false);
-  await classicBattle.startRound();
+  await startRound(battleStore);
   await waitForComputerCard();
   if (simulatedOpponentMode) {
     const stat = simulateOpponentStat(aiDifficulty);
-    await classicBattle.handleStatSelection(stat);
+    await handleStatSelection(battleStore, stat);
   } else {
     enableStatButtons(true);
   }
@@ -126,7 +132,7 @@ export async function setupClassicBattlePage() {
         if (!btn.disabled) {
           enableStatButtons(false);
           btn.classList.add("selected");
-          classicBattle.handleStatSelection(btn.dataset.stat);
+          handleStatSelection(battleStore, btn.dataset.stat);
         }
       });
       btn.addEventListener("keydown", (e) => {
@@ -134,7 +140,7 @@ export async function setupClassicBattlePage() {
           e.preventDefault();
           enableStatButtons(false);
           btn.classList.add("selected");
-          classicBattle.handleStatSelection(btn.dataset.stat);
+          handleStatSelection(battleStore, btn.dataset.stat);
         }
       });
     });
@@ -185,7 +191,7 @@ export async function setupClassicBattlePage() {
     }
   }
 
-  window.startRoundOverride = startRoundWrapper;
+  window.startRoundOverride = () => startRoundWrapper();
   startRoundWrapper();
   await initTooltips();
   watchBattleOrientation();

--- a/src/helpers/setupClassicBattleHomeLink.js
+++ b/src/helpers/setupClassicBattleHomeLink.js
@@ -1,4 +1,4 @@
-import { quitMatch } from "./classicBattle.js";
+import { createBattleStore, quitMatch } from "./classicBattle.js";
 
 /**
  * Attach quit confirmation to the header logo in Classic Battle.
@@ -8,12 +8,14 @@ import { quitMatch } from "./classicBattle.js";
  * 2. If found, listen for click events.
  * 3. On click, prevent default navigation and call `quitMatch()`.
  */
+const store = createBattleStore();
+
 export function setupClassicBattleHomeLink() {
   const homeLink = document.querySelector('[data-testid="home-link"]');
   if (homeLink) {
     homeLink.addEventListener("click", (e) => {
       e.preventDefault();
-      quitMatch();
+      quitMatch(store);
     });
   }
 }

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -70,11 +70,11 @@ describe("classicBattle card selection", () => {
       callCount += 1;
       return callCount === 1 ? { id: 1 } : { id: 2 };
     });
-    const { classicBattle, getComputerJudoka } = await import(
-      "../../../src/helpers/classicBattle.js"
-    );
-    classicBattle._resetForTest();
-    await classicBattle.startRound();
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+    await battleMod.startRound(store);
+    const { getComputerJudoka } = battleMod;
     expect(JudokaCardMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 1 }),
       expect.anything(),
@@ -99,9 +99,10 @@ describe("classicBattle card selection", () => {
       if (cb) cb(d[0]);
     });
     getRandomJudokaMock = vi.fn(() => ({ id: 2 }));
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
-    await classicBattle.startRound();
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+    await battleMod.startRound(store);
     expect(generateRandomCardMock).toHaveBeenCalledWith(
       [expect.objectContaining({ id: 2, isHidden: false })],
       null,

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -73,7 +73,8 @@ describe("classicBattle button handlers", () => {
   });
 
   it("quit button invokes quitMatch", async () => {
-    await import("../../../src/helpers/classicBattle.js");
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    battleMod.createBattleStore();
     document.getElementById("quit-match-button").click();
     const confirmBtn = document.getElementById("confirm-quit-button");
     expect(confirmBtn).not.toBeNull();
@@ -88,7 +89,8 @@ describe("classicBattle button handlers", () => {
     homeLink.href = "../../index.html";
     homeLink.dataset.testid = "home-link";
     header.appendChild(homeLink);
-    await import("../../../src/helpers/classicBattle.js");
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    battleMod.createBattleStore();
     await import("../../../src/helpers/setupClassicBattleHomeLink.js");
     const beforeHref = window.location.href;
     homeLink.click();

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -65,9 +65,10 @@ describe("classicBattle match flow", () => {
 
   it("auto-selects a stat when timer expires", async () => {
     vi.spyOn(Math, "random").mockReturnValue(0);
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
-    await classicBattle.startRound();
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+    await battleMod.startRound(store);
     timerSpy.advanceTimersByTime(31000);
     await vi.runAllTimersAsync();
     const score = document.querySelector("header #score-display").textContent;
@@ -77,8 +78,9 @@ describe("classicBattle match flow", () => {
   });
 
   it("quits match after confirmation", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle.quitMatch();
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const store = battleMod.createBattleStore();
+    battleMod.quitMatch(store);
     const confirmBtn = document.getElementById("confirm-quit-button");
     expect(confirmBtn).not.toBeNull();
     confirmBtn.dispatchEvent(new Event("click"));
@@ -86,10 +88,11 @@ describe("classicBattle match flow", () => {
   });
 
   it("does not quit match when cancel is chosen", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
     document.querySelector("#round-message").textContent = "Select your move";
-    classicBattle.quitMatch();
+    battleMod.quitMatch(store);
     const cancelBtn = document.getElementById("cancel-quit-button");
     expect(cancelBtn).not.toBeNull();
     cancelBtn.dispatchEvent(new Event("click"));
@@ -98,10 +101,11 @@ describe("classicBattle match flow", () => {
   });
 
   it("ends the match when player reaches 10 wins", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
     const selectStat = async () => {
-      const p = classicBattle.handleStatSelection("power");
+      const p = battleMod.handleStatSelection(store, "power");
       await vi.runAllTimersAsync();
       await p;
     };
@@ -122,7 +126,7 @@ describe("classicBattle match flow", () => {
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     {
-      const p = classicBattle.handleStatSelection("power");
+      const p = battleMod.handleStatSelection(store, "power");
       await vi.runAllTimersAsync();
       await p;
     }
@@ -133,10 +137,11 @@ describe("classicBattle match flow", () => {
   });
 
   it("ends the match when opponent reaches 10 wins", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
     const selectStat = async () => {
-      const p = classicBattle.handleStatSelection("power");
+      const p = battleMod.handleStatSelection(store, "power");
       await vi.runAllTimersAsync();
       await p;
     };
@@ -159,7 +164,7 @@ describe("classicBattle match flow", () => {
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
     {
-      const p = classicBattle.handleStatSelection("power");
+      const p = battleMod.handleStatSelection(store, "power");
       await vi.runAllTimersAsync();
       await p;
     }
@@ -187,9 +192,10 @@ describe("classicBattle match flow", () => {
   });
 
   it("shows selection prompt until a stat is chosen", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
-    await classicBattle.startRound();
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+    await battleMod.startRound(store);
     expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
     timerSpy.advanceTimersByTime(5000);
     expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
@@ -198,7 +204,7 @@ describe("classicBattle match flow", () => {
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     {
-      const p = classicBattle.handleStatSelection("power");
+      const p = battleMod.handleStatSelection(store, "power");
       await vi.runAllTimersAsync();
       await p;
     }

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -37,7 +37,7 @@ beforeEach(() => {
     disableNextRoundButton: vi.fn()
   }));
 
-  vi.mock("../../../src/helpers/classicBattle/timerControl.js", () => ({
+  vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
     scheduleNextRound,
     startTimer: vi.fn()
   }));
@@ -62,9 +62,10 @@ describe("classicBattle opponent delay", () => {
     const timer = vi.useFakeTimers();
     const mod = await import("../../../src/helpers/classicBattle.js");
     vi.spyOn(mod, "simulateOpponentStat").mockReturnValue("power");
-    vi.spyOn(mod.classicBattle, "evaluateRound").mockReturnValue({ matchEnded: false });
+    vi.spyOn(mod, "evaluateRound").mockReturnValue({ matchEnded: false });
+    const store = mod.createBattleStore();
 
-    const promise = mod.classicBattle.handleStatSelection(mod.simulateOpponentStat());
+    const promise = mod.handleStatSelection(store, mod.simulateOpponentStat());
 
     expect(showMessage).toHaveBeenCalledWith("Waiting…");
     expect(clearMessage).not.toHaveBeenCalled();

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -4,10 +4,14 @@ vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
 
-vi.mock("../../../src/helpers/classicBattle/timerControl.js", () => ({
-  startTimer: vi.fn().mockResolvedValue(undefined),
-  scheduleNextRound: vi.fn()
-}));
+vi.mock("../../../src/helpers/classicBattle/timerService.js", async () => {
+  const actual = await vi.importActual("../../../src/helpers/classicBattle/timerService.js");
+  return {
+    ...actual,
+    startTimer: vi.fn().mockResolvedValue(undefined),
+    scheduleNextRound: vi.fn()
+  };
+});
 
 let generateRandomCardMock;
 vi.mock("../../../src/helpers/randomCard.js", () => ({
@@ -64,9 +68,10 @@ describe("classicBattle stalled stat selection recovery", () => {
   });
 
   it("auto-selects after stall timeout", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
-    await classicBattle.startRound();
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+    await battleMod.startRound(store);
     timerSpy.advanceTimersByTime(35000);
     expect(document.querySelector("header #round-message").textContent).toMatch(/stalled/i);
     timerSpy.advanceTimersByTime(5000);

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -40,9 +40,12 @@ function expectDeselected(button) {
 
 describe("classicBattle stat selection", () => {
   let timerSpy;
-  let classicBattle;
+  let store;
   let selectStat;
   let simulateOpponentStat;
+  let handleStatSelection;
+  let _resetForTest;
+  let createBattleStore;
 
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -70,12 +73,13 @@ describe("classicBattle stat selection", () => {
   beforeEach(async () => {
     document.body.innerHTML +=
       '<div id="stat-buttons" data-tooltip-id="ui.selectStat"><button data-stat="power"></button></div>';
-    ({ classicBattle, simulateOpponentStat } = await import(
+    ({ createBattleStore, handleStatSelection, simulateOpponentStat, _resetForTest } = await import(
       "../../../src/helpers/classicBattle.js"
     ));
-    classicBattle._resetForTest();
+    store = createBattleStore();
+    _resetForTest(store);
     selectStat = async (stat) => {
-      const p = classicBattle.handleStatSelection(stat);
+      const p = handleStatSelection(store, stat);
       await vi.runAllTimersAsync();
       await p;
     };
@@ -120,13 +124,16 @@ describe("classicBattle stat selection", () => {
   });
 
   it("evaluateRound updates the score", async () => {
-    const { classicBattle } = await import("../../../src/helpers/classicBattle.js");
-    classicBattle._resetForTest();
+    const { createBattleStore, evaluateRound, _resetForTest } = await import(
+      "../../../src/helpers/classicBattle.js"
+    );
+    const store = createBattleStore();
+    _resetForTest(store);
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
     document.getElementById("computer-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    const result = classicBattle.evaluateRound("power");
+    const result = evaluateRound(store, "power");
     expect(result.message).toMatch(/win/);
     expect(document.querySelector("header #score-display").textContent).toBe("You: 1\nOpponent: 0");
   });

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -11,6 +11,7 @@ describe("classicBattlePage keyboard navigation", () => {
     const startRound = vi.fn();
     const waitForComputerCard = vi.fn();
     const handleStatSelection = vi.fn();
+    const store = {};
     const loadSettings = vi.fn().mockResolvedValue({
       featureFlags: { randomStatMode: { enabled: true } }
     });
@@ -18,7 +19,10 @@ describe("classicBattlePage keyboard navigation", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection }
+      createBattleStore: () => store,
+      startRound,
+      handleStatSelection,
+      simulateOpponentStat: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -42,7 +46,7 @@ describe("classicBattlePage keyboard navigation", () => {
 
     const [first, second] = container.querySelectorAll("button");
     first.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-    expect(handleStatSelection).toHaveBeenCalledWith("power");
+    expect(handleStatSelection).toHaveBeenCalledWith(store, "power");
 
     // re-enable buttons for second key simulation
     container.querySelectorAll("button").forEach((b) => {
@@ -52,13 +56,14 @@ describe("classicBattlePage keyboard navigation", () => {
     handleStatSelection.mockClear();
 
     second.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
-    expect(handleStatSelection).toHaveBeenCalledWith("speed");
+    expect(handleStatSelection).toHaveBeenCalledWith(store, "speed");
   });
 
   it("navigates to Next Round and Quit buttons", async () => {
     const startRound = vi.fn();
     const waitForComputerCard = vi.fn();
     const handleStatSelection = vi.fn();
+    const store = {};
     const loadSettings = vi.fn().mockResolvedValue({
       featureFlags: { randomStatMode: { enabled: true } }
     });
@@ -66,7 +71,10 @@ describe("classicBattlePage keyboard navigation", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection }
+      createBattleStore: () => store,
+      startRound,
+      handleStatSelection,
+      simulateOpponentStat: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -117,6 +125,7 @@ describe("classicBattlePage simulated opponent mode", () => {
     const waitForComputerCard = vi.fn();
     const handleStatSelection = vi.fn().mockResolvedValue();
     const simulateOpponentStat = vi.fn(() => "power");
+    const store = {};
     const loadSettings = vi.fn().mockResolvedValue({
       featureFlags: { simulatedOpponentMode: { enabled: true } }
     });
@@ -124,7 +133,9 @@ describe("classicBattlePage simulated opponent mode", () => {
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection },
+      createBattleStore: () => store,
+      startRound,
+      handleStatSelection,
       simulateOpponentStat
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
@@ -144,7 +155,7 @@ describe("classicBattlePage simulated opponent mode", () => {
     await setupClassicBattlePage();
 
     expect(simulateOpponentStat).toHaveBeenCalledWith("easy");
-    expect(handleStatSelection).toHaveBeenCalledWith("power");
+    expect(handleStatSelection).toHaveBeenCalledWith(store, "power");
     const calls = handleStatSelection.mock.calls.length;
     btn.dispatchEvent(new Event("click", { bubbles: true }));
     expect(handleStatSelection).toHaveBeenCalledTimes(calls);
@@ -163,8 +174,12 @@ describe("classicBattlePage stat help tooltip", () => {
     const initTooltips = vi.fn().mockResolvedValue();
     const setTestMode = vi.fn();
 
+    const store = {};
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection: vi.fn() }
+      createBattleStore: () => store,
+      startRound,
+      handleStatSelection: vi.fn(),
+      simulateOpponentStat: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -210,8 +225,12 @@ describe("classicBattlePage test mode flag", () => {
     const initTooltips = vi.fn().mockResolvedValue();
     const setTestMode = vi.fn();
 
+    const store = {};
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection: vi.fn() }
+      createBattleStore: () => store,
+      startRound,
+      handleStatSelection: vi.fn(),
+      simulateOpponentStat: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
@@ -246,8 +265,12 @@ describe("classicBattlePage test mode flag", () => {
     const initTooltips = vi.fn().mockResolvedValue();
     const setTestMode = vi.fn();
 
+    const store = {};
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
-      classicBattle: { startRound, handleStatSelection: vi.fn() }
+      createBattleStore: () => store,
+      startRound,
+      handleStatSelection: vi.fn(),
+      simulateOpponentStat: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));


### PR DESCRIPTION
## Summary
- restructure classic battle into functional services
- add uiService for summary and score helpers
- update tests and page module for new APIs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/stallRecovery.test.js tests/helpers/classicBattle/statSelection.test.js`
- `npx playwright test` *(fails: screenshot and navigation expectations)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6892443b292083268b010e7d4a5fc1b2