### PR TITLE
Reset tie flow test with battle store

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -26,8 +26,8 @@ test.describe("Classic battle flow", () => {
     const timer = page.locator("header #next-round-timer");
     await timer.waitFor();
     await page.evaluate(async () => {
-      const mod = await import("../helpers/classicBattle.js");
-      mod.classicBattle._resetForTest();
+      const { createBattleStore, _resetForTest } = await import("../helpers/classicBattle.js");
+      _resetForTest(createBattleStore());
       document.querySelector("#next-round-timer").textContent = "Time Left: 3s";
       document.querySelector("#player-card").innerHTML =
         `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;


### PR DESCRIPTION
## Summary
- reset classic battle tie test using `createBattleStore` and `_resetForTest`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Browse Judoka navigation › desktop arrow keys update markers and disable buttons)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68924e5048dc8326a14daa8ce8751856