### PR TITLE
Add drift safeguards to all countdown timers

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -130,7 +130,7 @@ The round message, timer, and score now sit directly inside the page header rath
   - [x] 5.1 Show “Waiting…” if backend score sync fails
   - [x] 5.2 Show “Waiting…” if countdown timer mismatches server start
   - [x] 5.3 Define recovery logic for delayed player input (show message and auto-select after stall)
-  - [ ] 5.4 Handle all possible timer/counter desyncs and display fallback (pending)
+   - [x] 5.4 Handle all timer/counter desyncs via `watchForDrift` with “Waiting…” safeguards
 
 - [ ] 6.0 Testing and Validation
 

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -11,6 +11,7 @@ import {
   startCountdown,
   updateScore
 } from "../../src/components/InfoBar.js";
+import * as battleEngine from "../../src/helpers/battleEngine.js";
 import { createInfoBarHeader } from "../utils/testUtils.js";
 
 describe("InfoBar component", () => {
@@ -64,6 +65,17 @@ describe("InfoBar component", () => {
     timer.advanceTimersByTime(1000);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 0s");
     timer.clearAllTimers();
+  });
+
+  it("startCountdown displays fallback on drift", () => {
+    const timer = vi.useFakeTimers();
+    const watchSpy = vi.spyOn(battleEngine, "watchForDrift");
+    startCountdown(2);
+    const [, onDrift] = watchSpy.mock.calls[0];
+    onDrift(1);
+    expect(document.getElementById("round-message").textContent).toBe("Waiting…");
+    timer.clearAllTimers();
+    watchSpy.mockRestore();
   });
 
   it("initializes from existing DOM", () => {

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+
+describe("timerService drift handling", () => {
+  it("startTimer shows fallback on drift", async () => {
+    vi.resetModules();
+    const showMessage = vi.fn();
+    vi.doMock("../../../src/helpers/setupBattleInfoBar.js", () => ({
+      showMessage,
+      showTemporaryMessage: () => () => {}
+    }));
+    vi.doMock("../../../src/helpers/timerUtils.js", () => ({
+      getDefaultTimer: () => 30
+    }));
+    let onDrift;
+    const watchSpy = vi.fn((dur, cb) => {
+      onDrift = cb;
+      return vi.fn();
+    });
+    const startRound = vi.fn(async (onTick) => {
+      onTick(3);
+    });
+    vi.doMock("../../../src/helpers/battleEngine.js", async () => {
+      const actual = await vi.importActual("../../../src/helpers/battleEngine.js");
+      return { ...actual, startRound, watchForDrift: watchSpy };
+    });
+    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    await mod.startTimer(async () => {});
+    onDrift(2);
+    expect(showMessage).toHaveBeenCalledWith("Waiting…");
+  });
+
+  it("scheduleNextRound shows fallback on drift", async () => {
+    vi.resetModules();
+    const showMessage = vi.fn();
+    vi.doMock("../../../src/helpers/setupBattleInfoBar.js", () => ({
+      showMessage,
+      showTemporaryMessage: () => () => {}
+    }));
+    vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
+      enableNextRoundButton: vi.fn(),
+      disableNextRoundButton: vi.fn(),
+      updateDebugPanel: vi.fn()
+    }));
+    let onDrift;
+    const watchSpy = vi.fn((dur, cb) => {
+      onDrift = cb;
+      return vi.fn();
+    });
+    const startCoolDown = vi.fn((onTick) => {
+      onTick(3);
+    });
+    vi.doMock("../../../src/helpers/battleEngine.js", async () => {
+      const actual = await vi.importActual("../../../src/helpers/battleEngine.js");
+      return { ...actual, startCoolDown, watchForDrift: watchSpy };
+    });
+    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const timer = vi.useFakeTimers();
+    const btn = document.createElement("button");
+    btn.id = "next-round-button";
+    document.body.appendChild(btn);
+    const timerNode = document.createElement("p");
+    timerNode.id = "next-round-timer";
+    document.body.appendChild(timerNode);
+    mod.scheduleNextRound({ matchEnded: false }, async () => {});
+    timer.advanceTimersByTime(2000);
+    onDrift(1);
+    expect(showMessage).toHaveBeenCalledWith("Waiting…");
+    timer.clearAllTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add watchForDrift-backed countdown with Waiting… fallback
- test drift recovery for round and cooldown timers
- document timer desync safeguards in PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-orientation screenshot, browse judoka navigation markers, classic battle flow equal stats)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68924feb31088326b64205bb6ef2f8cf