### PR TITLE
Improve secondary color contrast

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -134,10 +134,14 @@ The round message, timer, and score now sit directly inside the page header rath
 
 - [ ] 6.0 Testing and Validation
 
-  - [ ] 6.1 Add/expand unit tests for timer pause/resume, auto-select, and fallback logic
-  - [ ] 6.2 Add/expand Playwright UI tests for info bar responsiveness, accessibility, and edge cases
+- [ ] 6.1 Add/expand unit tests for timer pause/resume, auto-select, and fallback logic
+- [ ] 6.2 Add/expand Playwright UI tests for info bar responsiveness, accessibility, and edge cases
 
 ---
+
+## Accessibility Audit
+
+- **2025-08-05**: `npm run check:contrast` reported no issues after updating `--color-secondary` to `#0074d9`.
 
 **See also:**
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -5,7 +5,7 @@
   --slide-track-speed: 40s;
   /* Colors */
   --color-primary: #cb2504; /* For logo, emblem and accents (10% of screen) */
-  --color-secondary: #0c3f7a; /* Nav bar, UI elements (30% of screen) */
+  --color-secondary: #0074d9; /* Nav bar, UI elements (30% of screen) */
   --color-tertiary: #e8e8e8; /* Backgrounds (60% of screen) */
   --color-surface: #ffffff; /* Light mode surfaces */
   --color-background: #ffffff; /* Light mode background */


### PR DESCRIPTION
## Summary
- adjust `--color-secondary` to #0074d9 for WCAG contrast
- document latest contrast audit in Battle Info Bar PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (10 failed, 2 interrupted, 59 passed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68924fdffab88326a46e9e67e54a82a3