### PR TITLE
Use absolute URL for classic battle helper

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -26,7 +26,9 @@ test.describe("Classic battle flow", () => {
     const timer = page.locator("header #next-round-timer");
     await timer.waitFor();
     await page.evaluate(async () => {
-      const { createBattleStore, _resetForTest } = await import("../helpers/classicBattle.js");
+      const { createBattleStore, _resetForTest } = await import(
+        new URL("/src/helpers/classicBattle.js", window.location.href)
+      );
       _resetForTest(createBattleStore());
       document.querySelector("#next-round-timer").textContent = "Time Left: 3s";
       document.querySelector("#player-card").innerHTML =


### PR DESCRIPTION
## Summary
- import classic battle helpers via absolute URL in Playwright test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: fetch-related errors)*
- `npx playwright test classicBattleFlow.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6892571957508326b9c1b6a289110220