### PR TITLE
Run pure helper tests with Node environment

### DIFF
--- a/tests/helpers/battleEngine.coolDown.test.js
+++ b/tests/helpers/battleEngine.coolDown.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 
 describe("battleEngine startCoolDown", () => {

--- a/tests/helpers/battleEngine/pauseResumeTimer.test.js
+++ b/tests/helpers/battleEngine/pauseResumeTimer.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 let timerApi;

--- a/tests/helpers/battleEngineTimer.test.js
+++ b/tests/helpers/battleEngineTimer.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockTimers = [{ id: 1, value: 42, default: true, category: "roundTimer" }];

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -12,6 +13,7 @@ let updateDebugPanel;
 
 beforeEach(() => {
   vi.resetModules();
+  vi.stubGlobal("document", { getElementById: () => null });
   showMessage = vi.fn();
   clearMessage = vi.fn();
   scheduleNextRound = vi.fn();

--- a/tests/helpers/createCountdownTimer.test.js
+++ b/tests/helpers/createCountdownTimer.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import { createCountdownTimer } from "../../src/helpers/timerUtils.js";
 

--- a/tests/helpers/testModeUtils.test.js
+++ b/tests/helpers/testModeUtils.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import { seededRandom, setTestMode } from "../../src/helpers/testModeUtils.js";
 


### PR DESCRIPTION
## Summary
- run non-DOM helper tests under Node
- stub document for classic battle opponent delay tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-orientation screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68925d92d6048326acfaef5f29a1e1ea