### PR TITLE
Refactor screenshot tests to use shared data routes

### DIFF
--- a/playwright/fixtures/commonRoutes.js
+++ b/playwright/fixtures/commonRoutes.js
@@ -1,3 +1,5 @@
+import fs from "fs";
+
 /**
  * Register routes to serve fixture data for core JSON files and flag images.
  *
@@ -18,6 +20,18 @@ export async function registerCommonRoutes(page) {
     page.route("**/src/data/tooltips.json", (route) =>
       route.fulfill({ path: "tests/fixtures/tooltips.json" })
     ),
+    page.route("**/src/data/navigationItems.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/navigationItems.json" })
+    ),
+    page.route("**/src/data/*.json", (route) => {
+      const file = route.request().url().split("/").pop();
+      const fixturePath = `tests/fixtures/${file}`;
+      if (fs.existsSync(fixturePath)) {
+        route.fulfill({ path: fixturePath });
+      } else {
+        route.continue();
+      }
+    }),
     page.route("https://flagcdn.com/**", (route) =>
       route.fulfill({ path: "src/assets/countryFlags/placeholder-flag.png" })
     ),

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -1,5 +1,4 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import fs from "fs";
 
 // Allow skipping screenshots via the SKIP_SCREENSHOTS environment variable
 const runScreenshots = process.env.SKIP_SCREENSHOTS !== "true";
@@ -9,18 +8,6 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
   test.skip(!runScreenshots);
 
   test.beforeEach(async ({ page }) => {
-    await page.route("**/src/data/navigationItems.json", (route) => {
-      route.fulfill({ path: "tests/fixtures/navigationItems.json" });
-    });
-    await page.route("**/src/data/*.json", (route) => {
-      const file = route.request().url().split("/").pop();
-      const fixturePath = `tests/fixtures/${file}`;
-      if (fs.existsSync(fixturePath)) {
-        route.fulfill({ path: fixturePath });
-      } else {
-        route.continue();
-      }
-    });
     await page.addInitScript(() => {
       Math.random = () => 0.42;
       localStorage.setItem("settings", JSON.stringify({ typewriterEffect: false }));

--- a/playwright/settings-screenshot.spec.js
+++ b/playwright/settings-screenshot.spec.js
@@ -1,5 +1,4 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import fs from "fs";
 
 const runScreenshots = process.env.SKIP_SCREENSHOTS !== "true";
 
@@ -13,18 +12,6 @@ test.describe.parallel(
 
     for (const mode of modes) {
       test(`mode ${mode} collapsed`, async ({ page }) => {
-        await page.route("**/src/data/navigationItems.json", (route) => {
-          route.fulfill({ path: "tests/fixtures/navigationItems.json" });
-        });
-        await page.route("**/src/data/*.json", (route) => {
-          const file = route.request().url().split("/").pop();
-          const fixturePath = `tests/fixtures/${file}`;
-          if (fs.existsSync(fixturePath)) {
-            route.fulfill({ path: fixturePath });
-          } else {
-            route.continue();
-          }
-        });
         await page.addInitScript((mode) => {
           localStorage.setItem(
             "settings",
@@ -36,18 +23,6 @@ test.describe.parallel(
       });
 
       test(`mode ${mode} expanded`, async ({ page }) => {
-        await page.route("**/src/data/navigationItems.json", (route) => {
-          route.fulfill({ path: "tests/fixtures/navigationItems.json" });
-        });
-        await page.route("**/src/data/*.json", (route) => {
-          const file = route.request().url().split("/").pop();
-          const fixturePath = `tests/fixtures/${file}`;
-          if (fs.existsSync(fixturePath)) {
-            route.fulfill({ path: fixturePath });
-          } else {
-            route.continue();
-          }
-        });
         await page.addInitScript((mode) => {
           localStorage.setItem(
             "settings",


### PR DESCRIPTION
## Summary
- extend `registerCommonRoutes` with navigation items and wildcard JSON fixtures
- simplify screenshot specs to rely on shared route setup

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68925d9cc35c832694d7196c92284511