### PR TITLE
Wait for round message before battle header screenshots

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -62,6 +62,9 @@ test.describe.parallel(
       });
       await page.waitForFunction(() => document.querySelector(".battle-header img.logo")?.complete);
       await page.waitForLoadState("networkidle");
+      await page.waitForFunction(
+        () => document.querySelector("#round-message")?.textContent.trim().length > 0
+      );
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-portrait.png");
 
       await page.setViewportSize({ width: 480, height: 320 });
@@ -72,6 +75,9 @@ test.describe.parallel(
       await page.evaluate(() => document.fonts.ready);
       await page.waitForFunction(() => document.querySelector(".battle-header img.logo")?.complete);
       await page.waitForLoadState("networkidle");
+      await page.waitForFunction(
+        () => document.querySelector("#round-message")?.textContent.trim().length > 0
+      );
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-landscape.png");
     });
 
@@ -97,6 +103,9 @@ test.describe.parallel(
           (el) =>
             (el.textContent = "A very long round message that should overflow on narrow screens")
         );
+      await page.waitForFunction(
+        () => document.querySelector("#round-message")?.textContent.trim().length > 0
+      );
       await expect(page.locator(".battle-header")).toHaveScreenshot("battle-header-300.png");
     });
   }


### PR DESCRIPTION
## Summary
- ensure portrait, landscape and narrow header screenshots wait for round-message text before capture

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle orientation screenshots › captures portrait and landscape headers; Browse Judoka navigation › desktop arrow keys update markers and disable buttons)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68926266ef28832685465014db64a7b1