### PR TITLE
Wait for navigation link before clicking

### DIFF
--- a/playwright/updateJudoka.spec.js
+++ b/playwright/updateJudoka.spec.js
@@ -18,7 +18,9 @@ test.describe.parallel("Update Judoka page", () => {
   });
 
   test("navigation links work", async ({ page }) => {
-    await page.getByTestId(NAV_RANDOM_JUDOKA).click();
+    const randomLink = page.getByTestId(NAV_RANDOM_JUDOKA);
+    await randomLink.waitFor();
+    await randomLink.click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
     await page.goBack({ waitUntil: "load" });
 


### PR DESCRIPTION
## Summary
- ensure Update Judoka nav tests wait for Random Judoka link before clicking

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68926a6977308326836697ee7217b4c0