### PR TITLE
Use numeric test IDs for navbar links

### DIFF
--- a/src/helpers/navigationBar.js
+++ b/src/helpers/navigationBar.js
@@ -80,18 +80,22 @@ export async function populateNavbar() {
     if (!navBar) return; // Guard: do nothing if navbar is missing
     clearBottomNavbar();
 
+    // Include numeric IDs to ensure consistent data-testid values (e.g., nav-12, nav-1)
     const fallbackItems = [
       {
+        id: 12,
         name: "Random Judoka",
         url: `${BASE_PATH}randomJudoka.html`,
         image: "./src/assets/images/randomJudoka.png"
       },
       {
+        id: 0,
         name: "Home",
         url: new URL("../../index.html", BASE_PATH),
         image: "./src/assets/images/home.png"
       },
       {
+        id: 1,
         name: "Classic Battle",
         url: `${BASE_PATH}battleJudoka.html`,
         image: "./src/assets/images/classicBattle.png"
@@ -106,9 +110,7 @@ export async function populateNavbar() {
         const linkPath = new URL(href, window.location.href).pathname.replace(/^\//, "");
         const isCurrent = linkPath === currentPath || linkPath.endsWith(currentPath);
         const attrs = isCurrent ? ` class="active" aria-current="page"` : "";
-        // Ensure Classic Battle always gets data-testid="nav-1"
-        const testId =
-          item.name === "Classic Battle" ? "nav-1" : `nav-${item.name.replace(/\s+/g, "")}`;
+        const testId = `nav-${item.id}`;
         return `<li><a href="${href}" data-testid="${testId}" data-tooltip-id="nav.${navTooltipKey(item.name)}"${attrs}>${item.name}</a></li>`;
       })
       .join("");

--- a/src/helpers/setupBottomNavbar.js
+++ b/src/helpers/setupBottomNavbar.js
@@ -28,8 +28,8 @@ function renderBottomNavbar() {
   const bottomNav = document.querySelector('[data-testid="bottom-nav"]');
   if (!bottomNav) return;
   bottomNav.innerHTML = `
-    <a href="randomJudoka.html" data-testid="nav-random-judoka">Random Judoka</a>
-    <a href="battleJudoka.html" data-testid="nav-classic-battle">Classic Battle</a>
+    <a href="randomJudoka.html" data-testid="nav-12">Random Judoka</a>
+    <a href="battleJudoka.html" data-testid="nav-1">Classic Battle</a>
     <!-- Add other nav links as needed -->
   `;
 }


### PR DESCRIPTION
## Summary
- use `nav-12` and `nav-1` data-testids in the setupBottomNavbar helper
- ensure fallback navigation uses numeric data-testids

## Testing
- `npx prettier src/helpers/setupBottomNavbar.js src/helpers/navigationBar.js --write`
- `npx eslint src/helpers/setupBottomNavbar.js src/helpers/navigationBar.js`
- `npx vitest run`
- `npx playwright test` *(fails: Classic Battle label not found; other tests failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68927c081ad483268d62266a26f2f487