### PR TITLE
Remove duplicate nav block from PRD viewer

### DIFF
--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -45,10 +45,6 @@
         ></nav>
       </footer>
     </div>
-    <nav>
-      <a href="/src/pages/randomJudoka.html" data-testid="nav-12">Random Judoka</a>
-      <a href="/src/pages/classicBattle.html" data-testid="nav-13">Classic Battle</a>
-    </nav>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
     <script type="module" src="../helpers/setupDisplaySettings.js"></script>
     <script type="module" src="../helpers/prdReaderPage.js"></script>


### PR DESCRIPTION
## Summary
- delete redundant `nav` with `nav-12`/`nav-13` links from `prdViewer.html`
- rely on `setupBottomNavbar.js` to inject the bottom nav links

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/prd-reader.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68928a07b86083269af4c5c675c3289b