### PR TITLE
test: wait for high contrast control

### DIFF
--- a/playwright/responsive-contrast.spec.js
+++ b/playwright/responsive-contrast.spec.js
@@ -22,7 +22,7 @@ test.describe.parallel("Responsive scenarios", () => {
 
   test("toggles high-contrast display mode", async ({ page }) => {
     await page.goto("/src/pages/settings.html");
-    await page.getByLabel(/Classic Battle/i).waitFor({ state: "attached" });
+    await page.locator("#display-mode-high-contrast").waitFor();
     await page.check("#display-mode-high-contrast");
     await expect(page.locator("body")).toHaveAttribute("data-theme", "high-contrast");
   });


### PR DESCRIPTION
## Summary
- adjust responsive contrast spec to wait for high contrast control before assertion

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Error fetching file:///... and other network errors; run interrupted)*
- `npx playwright test playwright/responsive-contrast.spec.js` *(fails: expected body data-theme to be high-contrast, got light)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689289ef4e448326acd203e82948461e