### PR TITLE
Expose game modes by default on settings screen

### DIFF
--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -239,7 +239,6 @@
               id="game-modes-content"
               role="region"
               aria-labelledby="game-modes-toggle"
-              hidden
             >
               <fieldset
                 id="game-mode-toggle-container"


### PR DESCRIPTION
## Summary
- ensure the Game Modes settings section is not hidden so toggle labels are discoverable

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Classic Battle label not found)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68930eb484088326bca053bf0480be0b