### PR TITLE
fix: prevent nav merge from overwriting mode data

### DIFF
--- a/src/helpers/gameModeUtils.js
+++ b/src/helpers/gameModeUtils.js
@@ -117,10 +117,10 @@ async function loadRawNavigationItems() {
 export async function loadNavigationItems() {
   const navItems = await loadRawNavigationItems();
   const modes = await loadGameModes();
-  return navItems.map((item) => ({
-    ...(modes.find((m) => m.id === Number(item.gameModeId)) || {}),
-    ...item
-  }));
+  return navItems.map((item) => {
+    const mode = modes.find((m) => m.id === Number(item.gameModeId)) || {};
+    return { ...item, ...mode };
+  });
 }
 
 /**
@@ -175,10 +175,10 @@ export async function updateNavigationItemHidden(id, isHidden) {
   items[index] = { ...items[index], isHidden };
   await saveNavigationItems(items);
   const modes = await loadGameModes();
-  return items.map((item) => ({
-    ...(modes.find((m) => m.id === Number(item.gameModeId)) || {}),
-    ...item
-  }));
+  return items.map((item) => {
+    const mode = modes.find((m) => m.id === Number(item.gameModeId)) || {};
+    return { ...item, ...mode };
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure navigation data keeps game-mode fields when merging
- keep game mode ids when updating navigation hidden state

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/settings.spec.js` *(fails: Classic Battle label not found)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689325c7352883268027339017de511b