### PR TITLE
Use game mode name as toggle label

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -21,7 +21,7 @@ test.describe.parallel("Settings page", () => {
     );
     await page.goto("/src/pages/settings.html", { waitUntil: "domcontentloaded" });
     try {
-      await page.getByLabel(/Classic Battle/i).waitFor({ state: "attached", timeout: 5000 });
+      await page.getByLabel("Classic Battle").waitFor({ state: "attached", timeout: 5000 });
     } catch (e) {
       const content = await page.content();
       console.error("Classic Battle label not found. Page content:\n", content);
@@ -37,7 +37,7 @@ test.describe.parallel("Settings page", () => {
   });
 
   test("mode toggle visible", async ({ page }) => {
-    const toggle = page.getByLabel(/Classic Battle/i);
+    const toggle = page.getByLabel("Classic Battle");
     await toggle.waitFor({ state: "attached" });
     await expect(toggle).toBeVisible();
   });
@@ -51,7 +51,7 @@ test.describe.parallel("Settings page", () => {
   });
 
   test("controls expose correct labels and follow tab order", async ({ page }) => {
-    await page.getByLabel(/Classic Battle/i).waitFor({ state: "attached" });
+    await page.getByLabel("Classic Battle").waitFor({ state: "attached" });
 
     const navItems = JSON.parse(fs.readFileSync("tests/fixtures/navigationItems.json", "utf8"));
     const gameModes = JSON.parse(fs.readFileSync("tests/fixtures/gameModes.json", "utf8"));

--- a/src/helpers/settings/gameModeSwitches.js
+++ b/src/helpers/settings/gameModeSwitches.js
@@ -7,7 +7,7 @@ import { showSnackbar } from "../showSnackbar.js";
  * Render game mode toggle switches within the settings page.
  *
  * @pseudocode
- * 1. Sort `gameModes` by `order`, warn on missing `name`, and create a toggle for each.
+ * 1. Sort `gameModes` by `order`, warn on missing `name`, create a toggle for each, and attach debug data attributes.
  * 2. When toggled, update navigation visibility via `updateNavigationItemHidden`.
  * 3. Persist the updated `gameModes` setting using `handleUpdate`.
  * 4. Show a snackbar confirming the new mode state.
@@ -29,13 +29,14 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
     if (!mode.name) {
       console.warn("Game mode missing name", mode);
     }
-    const toggle = new ToggleSwitch(`${label} (${mode.category} - ${mode.order})`, {
+    const toggle = new ToggleSwitch(label, {
       id: `mode-${mode.id}`,
       name: mode.id,
-      checked: isChecked,
-      ariaLabel: label
+      checked: isChecked
     });
     const { element: wrapper, input } = toggle;
+    if (mode.category) wrapper.dataset.category = mode.category;
+    if (typeof mode.order !== "undefined") wrapper.dataset.order = String(mode.order);
     if (mode.description) {
       const desc = document.createElement("p");
       desc.className = "settings-description";

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -120,16 +120,23 @@ describe("settingsPage module", () => {
     document.dispatchEvent(new Event("DOMContentLoaded"));
     await vi.runAllTimersAsync();
 
-    const container = document.getElementById("game-mode-toggle-container");
-    const checkboxes = container.querySelectorAll("input[type='checkbox']");
-    const labels = container.querySelectorAll("label span");
-    expect(checkboxes).toHaveLength(3);
-    expect(container.querySelector("#mode-1")).toBeTruthy();
-    expect(container.querySelector("#mode-3")).toBeTruthy();
-    expect(container.querySelector("#mode-2")).toBeTruthy();
-    expect(labels[0].textContent).toBe("Classic (mainMenu - 10)");
-    expect(labels[1].textContent).toBe("Blitz (bonus - 20)");
-    expect(labels[2].textContent).toBe("Dojo (mainMenu - 30)");
+      const container = document.getElementById("game-mode-toggle-container");
+      const checkboxes = container.querySelectorAll("input[type='checkbox']");
+      const labels = container.querySelectorAll("label span");
+      const wrappers = container.querySelectorAll(".settings-item");
+      expect(checkboxes).toHaveLength(3);
+      expect(container.querySelector("#mode-1")).toBeTruthy();
+      expect(container.querySelector("#mode-3")).toBeTruthy();
+      expect(container.querySelector("#mode-2")).toBeTruthy();
+      expect(labels[0].textContent).toBe("Classic");
+      expect(labels[1].textContent).toBe("Blitz");
+      expect(labels[2].textContent).toBe("Dojo");
+      expect(wrappers[0].dataset.category).toBe("mainMenu");
+      expect(wrappers[0].dataset.order).toBe("10");
+      expect(wrappers[1].dataset.category).toBe("bonus");
+      expect(wrappers[1].dataset.order).toBe("20");
+      expect(wrappers[2].dataset.category).toBe("mainMenu");
+      expect(wrappers[2].dataset.order).toBe("30");
   });
 
   it("checkbox state reflects isHidden when no setting exists", async () => {


### PR DESCRIPTION
## Summary
- Let game mode toggle switches display only the game mode name and keep category/order in data attributes
- Update settings tests to query toggles by their visible labels
- Adjust settings page unit tests for new label and debug attribute approach

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/settings.spec.js` *(fails: Classic Battle label not found)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68934fa5ba94832685a7acebf9ddadb9