### PR TITLE
fix: safeguard settings defaults and game mode toggles

### DIFF
--- a/src/helpers/settings/gameModeSwitches.js
+++ b/src/helpers/settings/gameModeSwitches.js
@@ -22,9 +22,8 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
   const sortedModes = [...gameModes].sort((a, b) => a.order - b.order);
   sortedModes.forEach((mode) => {
     const current = getCurrentSettings();
-    const isChecked = Object.hasOwn(current.gameModes, mode.id)
-      ? current.gameModes[mode.id]
-      : !mode.isHidden;
+    const currentModes = current.gameModes ?? {};
+    const isChecked = Object.hasOwn(currentModes, mode.id) ? currentModes[mode.id] : !mode.isHidden;
     const label = mode.name ?? mode.id ?? "Unknown mode";
     if (!mode.name) {
       console.warn("Game mode missing name", mode);
@@ -49,7 +48,10 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
     if (!input) return;
     input.addEventListener("change", () => {
       const prev = !input.checked;
-      const updated = { ...getCurrentSettings().gameModes, [mode.id]: input.checked };
+      const updated = {
+        ...(getCurrentSettings().gameModes ?? {}),
+        [mode.id]: input.checked
+      };
       Promise.resolve(
         handleUpdate("gameModes", updated, () => {
           input.checked = prev;

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -70,17 +70,21 @@ const SAVE_DELAY_MS = 100;
  *
  * @pseudocode
  * 1. Call `getSettingsSchema()` to lazily load the schema.
- * 2. Throw an error if `localStorage` is unavailable.
- * 3. Retrieve the JSON string stored under `SETTINGS_KEY`.
+ * 2. Ensure defaults are loaded by invoking `loadDefaultSettings` when `DEFAULT_SETTINGS` is empty.
+ * 3. Throw an error if `localStorage` is unavailable.
+ * 4. Retrieve the JSON string stored under `SETTINGS_KEY`.
  *    - When no value exists, return `DEFAULT_SETTINGS`.
- * 4. Parse the JSON and merge with `DEFAULT_SETTINGS`.
- * 5. Validate the merged object with `settingsSchema`.
- * 6. Return the validated settings or throw on failure.
+ * 5. Parse the JSON and merge with `DEFAULT_SETTINGS`.
+ * 6. Validate the merged object with `settingsSchema`.
+ * 7. Return the validated settings or throw on failure.
  *
  * @returns {Promise<Settings>} Resolved settings object.
  */
 export async function loadSettings() {
   await getSettingsSchema();
+  if (!Object.keys(DEFAULT_SETTINGS).length) {
+    await loadDefaultSettings();
+  }
   if (typeof localStorage === "undefined") {
     throw new Error("localStorage unavailable");
   }


### PR DESCRIPTION
## Summary
- ensure `loadSettings` always has defaults by verifying `DEFAULT_SETTINGS`
- avoid runtime errors when `gameModes` is missing in game mode switches

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Classic Battle label not found, settings page tests, screenshots, touch target size, etc.)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68935a7294d48326bf133c367c75ce6c