### PR TITLE
fix: guard settings render on invalid game modes

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -227,6 +227,11 @@ async function initializeSettingsPage() {
     toggleLayoutDebugPanel(Boolean(settings.featureFlags.layoutDebugPanel?.enabled));
     const controlsApi = initializeControls(settings);
     const [gameModes, tooltipMap] = await Promise.all([gameModesPromise, tooltipMapPromise]);
+    if (!Array.isArray(gameModes)) {
+      console.error("Failed to load game modes", gameModes);
+      showSettingsError();
+      return;
+    }
     controlsApi.renderSwitches(gameModes, tooltipMap);
   } catch (error) {
     console.error("Error loading settings page:", error);


### PR DESCRIPTION
## Summary
- avoid rendering settings when game modes fail to load

## Testing
- `npx prettier . --write`
- `npx eslint . --fix`
- `npx vitest run`
- `npx playwright test` *(fails: Settings page › controls expose correct labels and follow tab order, etc.)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_689384aaa5888326a989f9e109ce6cd1