### PR TITLE
chore: trim game mode fixture

### DIFF
--- a/tests/fixtures/gameModes.json
+++ b/tests/fixtures/gameModes.json
@@ -4,9 +4,6 @@
     "name": "Classic Battle",
     "japaneseName": "試合 (バトルモード)",
     "description": "A standard one-on-one battle mode where players compete to win.",
-    "category": "mainMenu",
-    "order": 20,
-    "url": "battleJudoka.html",
     "isHidden": false,
     "rules": {
       "rounds": 25,
@@ -20,9 +17,6 @@
     "name": "Team Battle Selection",
     "japaneseName": "団体戦選択",
     "description": "Choose between Male, Female, or Mixed Team Battle modes.",
-    "category": "subMenu",
-    "order": 35,
-    "url": "teamBattleSelection.html",
     "isHidden": true,
     "rules": {
       "options": ["teamBattleMale", "teamBattleFemale", "teamBattleMixed"]
@@ -33,9 +27,6 @@
     "name": "Manage Judoka",
     "japaneseName": "柔道家編集モード",
     "description": "Choose to update or create a judoka.",
-    "category": "subMenu",
-    "order": 40,
-    "url": "judokaUpdateSelection.html",
     "isHidden": true,
     "rules": {
       "options": ["createJudoka", "updateJudoka"]
@@ -46,9 +37,6 @@
     "name": "Team Battle (Male)",
     "japaneseName": "男子団体戦",
     "description": "A team-based mode where male players compete in groups.",
-    "category": "teamBattle",
-    "order": 50,
-    "url": "teamBattleMale.html",
     "isHidden": true,
     "rules": {
       "base": "teamBattle",
@@ -60,9 +48,6 @@
     "name": "Team Battle (Female)",
     "japaneseName": "女子団体戦",
     "description": "A team-based mode where female players compete in groups.",
-    "category": "teamBattle",
-    "order": 60,
-    "url": "teamBattleFemale.html",
     "isHidden": true,
     "rules": {
       "base": "teamBattle",
@@ -74,9 +59,6 @@
     "name": "Team Battle (Mixed)",
     "japaneseName": "混合団体戦",
     "description": "A team-based mode where male and female players compete together in groups.",
-    "category": "teamBattle",
-    "order": 70,
-    "url": "teamBattleMixed.html",
     "isHidden": false,
     "rules": {
       "rounds": 6,
@@ -90,9 +72,6 @@
     "name": "Browse Judoka",
     "japaneseName": "柔道家を閲覧",
     "description": "Explore the available judoka and their stats.",
-    "category": "mainMenu",
-    "order": 80,
-    "url": "browseJudoka.html",
     "isHidden": false,
     "rules": {
       "note": "Rules will be defined in the future."
@@ -103,9 +82,6 @@
     "name": "Create A Judoka",
     "japaneseName": "柔道家を作成",
     "description": "Create a new judoka by entering their details and stats.",
-    "category": "judokaUpdate",
-    "order": 90,
-    "url": "createJudoka.html",
     "isHidden": false,
     "rules": {
       "note": "Rules will be defined in the future."
@@ -116,9 +92,6 @@
     "name": "Update Judoka",
     "japaneseName": "柔道家を更新",
     "description": "Edit the details of an existing judoka.",
-    "category": "mainMenu",
-    "order": 30,
-    "url": "updateJudoka.html",
     "isHidden": false,
     "rules": {
       "note": "Rules will be defined in the future."
@@ -129,9 +102,6 @@
     "name": "teamBattle Ruleset",
     "japaneseName": "団体戦ルールセット",
     "description": "Defining the common ruleset for Team Battles.",
-    "category": "none",
-    "order": 65,
-    "url": "teamBattleRuleset.html",
     "isHidden": true,
     "rules": {
       "rounds": 5,
@@ -144,9 +114,6 @@
     "name": "Meditation",
     "japaneseName": "メディテーション",
     "description": "Take a moment to pause, breathe, and reflect.",
-    "category": "mainMenu",
-    "order": 85,
-    "url": "meditation.html",
     "isHidden": false,
     "rules": {
       "note": "Rules will be defined in the future."
@@ -157,9 +124,6 @@
     "name": "View Judoka",
     "japaneseName": "ランダム柔道家",
     "description": "Displays a random judoka from the available list.",
-    "category": "mainMenu",
-    "order": 40,
-    "url": "randomJudoka.html",
     "isHidden": false,
     "rules": {
       "note": "Rules will be defined in the future."
@@ -170,9 +134,6 @@
     "name": "Settings",
     "japaneseName": "設定",
     "description": "Change game settings.",
-    "category": "mainMenu",
-    "order": 90,
-    "url": "settings.html",
     "isHidden": false,
     "rules": {
       "note": "Rules will be defined in the future."


### PR DESCRIPTION
## Summary
- remove non-schema fields from gameModes fixture

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run validate:data` *(fails: could not determine executable to run)*
- `npx vitest run` *(fails: Failed to load game modes Error: fail)*
- `npx playwright test` *(fails: browse-judoka navigation and others)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_6893a6ca81fc8326a94a787806e64945