### PR TITLE
refactor navbar population

### DIFF
--- a/src/helpers/navigationBar.js
+++ b/src/helpers/navigationBar.js
@@ -1,5 +1,4 @@
-import { loadMenuModes } from "./navigation/navData.js";
-import { BASE_PATH, clearBottomNavbar, navTooltipKey } from "./navigation/navMenu.js";
+import { loadNavigationItems } from "./gameModeUtils.js";
 
 /**
  * Adds touch feedback animations to navigation links.
@@ -27,96 +26,44 @@ function addTouchFeedback() {
 }
 
 /**
- * Populates the bottom navigation bar with game modes from a JSON file.
+ * Apply navigation order and visibility to existing links.
  *
  * @pseudocode
- * 1. Guard: return immediately if `document` is undefined.
- * 2. Select the `.bottom-navbar` element and exit if not found.
- * 3. Clear existing content using `clearBottomNavbar()`.
- * 4. Call `loadMenuModes()` to retrieve active game modes.
- * 5. If none are returned, display "No game modes available".
- * 6. Map the modes to list items, adding `aria-label` for accessibility, and
- *    mark the current page link as active.
- * 7. Append the list to the navigation bar and add touch feedback.
- * 8. On error, log the issue and show fallback items.
+ * 1. Guard: return if `document` is undefined.
+ * 2. Select all `<a>` elements with `data-testid` beginning with "nav-".
+ * 3. Load navigation items via `loadNavigationItems()` and filter for `category === "mainMenu"`.
+ * 4. For each selected link:
+ *    a. Extract the numeric ID from `data-testid`.
+ *    b. Find the matching navigation item.
+ *    c. If found, set `style.order` and toggle the `hidden` class based on `isHidden`.
+ *    d. If not found, add the `hidden` class.
+ * 5. Apply touch feedback to the links.
+ * 6. On error, log the issue.
  *
- * @returns {Promise<void>} A promise that resolves once the navbar is populated.
+ * @returns {Promise<void>} Resolves when the navbar has been updated.
  */
-
 export async function populateNavbar() {
-  if (typeof document === "undefined") return; // Guard for non-DOM environments
+  if (typeof document === "undefined") return;
   try {
-    const navBar = document.querySelector(".bottom-navbar");
-    if (!navBar) return; // Guard: do nothing if navbar is missing
-    clearBottomNavbar();
+    const links = document.querySelectorAll('a[data-testid^="nav-"]');
+    if (links.length === 0) return;
 
-    const activeModes = await loadMenuModes();
+    const items = await loadNavigationItems();
+    const mainMenu = items.filter((item) => item.category === "mainMenu");
 
-    if (activeModes.length === 0) {
-      navBar.innerHTML = "<ul><li>No game modes available</li></ul>";
-      return;
-    }
-
-    const currentPath = window.location.pathname.replace(/^\//, "");
-    const ul = document.createElement("ul");
-    ul.innerHTML = activeModes
-      .map((mode) => {
-        const href = new URL(mode.url, BASE_PATH).href;
-        const linkPath = new URL(href, window.location.href).pathname.replace(/^\//, "");
-        const isCurrent = linkPath === currentPath || linkPath.endsWith(currentPath);
-        const attrs = isCurrent ? ` class="active" aria-current="page"` : "";
-        // Ensure Classic Battle always gets data-testid="nav-1"
-        const testId = mode.name === "Classic Battle" || mode.id === 1 ? "nav-1" : `nav-${mode.id}`;
-        return `<li><a href="${href}" aria-label="${mode.name}" data-testid="${testId}" data-tooltip-id="nav.${navTooltipKey(mode.name)}"${attrs}>${mode.name}</a></li>`;
-      })
-      .join("");
-    navBar.appendChild(ul);
+    links.forEach((link) => {
+      const id = Number((link.getAttribute("data-testid") || "").replace("nav-", ""));
+      const match = mainMenu.find((m) => Number(m.id) === id);
+      if (match) {
+        link.style.order = String(match.order);
+        link.classList.toggle("hidden", match.isHidden);
+      } else {
+        link.classList.add("hidden");
+      }
+    });
 
     addTouchFeedback();
   } catch (error) {
-    console.error("Error loading game modes:", error);
-
-    if (typeof document === "undefined") return; // Guard if DOM is gone
-    const navBar = document.querySelector(".bottom-navbar");
-    if (!navBar) return; // Guard: do nothing if navbar is missing
-    clearBottomNavbar();
-
-    // Include numeric IDs to ensure consistent data-testid values (e.g., nav-12, nav-1)
-    const fallbackItems = [
-      {
-        id: 12,
-        name: "Random Judoka",
-        url: `${BASE_PATH}randomJudoka.html`,
-        image: "./src/assets/images/randomJudoka.png"
-      },
-      {
-        id: 0,
-        name: "Home",
-        url: new URL("../../index.html", BASE_PATH),
-        image: "./src/assets/images/home.png"
-      },
-      {
-        id: 1,
-        name: "Classic Battle",
-        url: `${BASE_PATH}battleJudoka.html`,
-        image: "./src/assets/images/classicBattle.png"
-      }
-    ];
-
-    const currentPath = window.location.pathname.replace(/^\//, "");
-    const ul = document.createElement("ul");
-    ul.innerHTML = fallbackItems
-      .map((item) => {
-        const href = new URL(item.url, BASE_PATH).href;
-        const linkPath = new URL(href, window.location.href).pathname.replace(/^\//, "");
-        const isCurrent = linkPath === currentPath || linkPath.endsWith(currentPath);
-        const attrs = isCurrent ? ` class="active" aria-current="page"` : "";
-        const testId = `nav-${item.id}`;
-        return `<li><a href="${href}" aria-label="${item.name}" data-testid="${testId}" data-tooltip-id="nav.${navTooltipKey(item.name)}"${attrs}>${item.name}</a></li>`;
-      })
-      .join("");
-    navBar.appendChild(ul);
-
-    console.error("Fallback game modes loaded due to error.");
+    console.error("Error applying navigation items:", error);
   }
 }


### PR DESCRIPTION
## Summary
- repurpose populateNavbar to update pre-existing nav links with ordering and visibility data
- add tests covering new navigation population logic

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6893b92af2748326ad9b65709a5d7166