### PR TITLE
Hide hidden bottom navbar links

### DIFF
--- a/src/styles/bottom-navbar.css
+++ b/src/styles/bottom-navbar.css
@@ -66,3 +66,7 @@
   background-color: var(--color-secondary);
   color: var(--color-text-inverted);
 }
+
+.bottom-navbar a.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Hide bottom navigation links when they have the `hidden` class
- Confirmed existing touch-target sizes and focus outlines remain

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: various fetch and schema errors)*
- `npx playwright test` *(fails: various fetch errors)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6893c1dc2b708326bc6aabf3935edc6c