### PR TITLE
docs: clarify pre-seeded navigation links

### DIFF
--- a/design/productRequirementsDocuments/prdGameModes.md
+++ b/design/productRequirementsDocuments/prdGameModes.md
@@ -8,7 +8,7 @@
 
 > After a tough **Classic Battle**, Hiroshi takes a break by entering **Meditation** Mode. Soft music and inspiring quotes help him reconnect with why he loves judo. Later, he updates his Judoka’s signature move, making his fighter truly his own. By offering more than just battles, Ju-Do-Kon! becomes a game players want to return to every day—whether they crave intense combat or quiet reflection.
 
-## Game mode IDs are numeric. Each navigation item references a mode by its ID in `navigationItems.json`.
+## Game mode IDs are numeric. Each pre-seeded navigation link references a mode by its ID in `navigationItems.json`, which drives visibility and order via CSS.
 
 ### Problem Statement
 

--- a/design/productRequirementsDocuments/prdHomePageNavigation.md
+++ b/design/productRequirementsDocuments/prdHomePageNavigation.md
@@ -20,7 +20,7 @@ The purpose of this menu is to allow players to access the core game modes quick
 
 A fast, accessible, and thematic navigation experience is crucial to ensure new players feel confident and engaged from their first visit.
 
-The list of available modes is defined in `gameModes.json`. `navigationItems.json` references each mode by `id` to control which tiles appear on the home page and in what order.
+The tile links are pre-seeded. `navigationItems.json` references each mode by `id` and drives their visibility and order via CSS.
 
 ---
 
@@ -201,7 +201,7 @@ Each tile contains:
 ## Dependencies / Integrations
 
 - `gameModes.json` lists all game modes.
-- `navigationItems.json` references those modes by `id` and sets tile order and visibility.
+- `navigationItems.json` references those modes by `id` and drives tile order and visibility via CSS.
 - Uses global CSS tokens (`--button-bg`, `--radius-md`, etc.) defined in `src/styles/base.css`.
 
 ---

--- a/design/productRequirementsDocuments/prdNavigationBar.md
+++ b/design/productRequirementsDocuments/prdNavigationBar.md
@@ -40,7 +40,7 @@ The **JU-DO-KON!** game features multiple game modes and screens. Players need e
 - Increase average session duration per player by **15%**.
 - Ensure **44px minimum** touch target size (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness)).
 - Achieve **≥60fps** animation performance on standard mid-tier devices.
-- Guarantee fallback loading time of **<2 seconds** if `navigationItems.json` fails.
+- Guarantee fallback application time of **<2 seconds** if `navigationItems.json` fails.
 - Meet a text contrast ratio of at least **4.5:1** against the navigation bar background.
 - Allow players to confidently navigate between modes without frustration.
 - Ensure a consistent, easy-to-use navigation experience across devices.
@@ -56,7 +56,7 @@ The **JU-DO-KON!** game features multiple game modes and screens. Players need e
 
 ## How It Works
 
-The bottom navigation bar appears consistently across all game screens, dynamically loading active game modes from `navigationItems.json`. Each item references an entry in `gameModes.json` via its `id` so mode names and descriptions remain consistent.
+The bottom navigation bar appears consistently across all game screens, populated with pre-seeded links whose visibility and order are driven by `navigationItems.json` via CSS. Each item references an entry in `gameModes.json` via its `id` so mode names and descriptions remain consistent.
 
 ### Standard Mode (Default View)
 
@@ -75,11 +75,11 @@ The bottom navigation bar appears consistently across all game screens, dynamica
 - After any activity, the persistent nav bar is visible.
 - In portrait view only the logo shows; tapping it expands the text list.
 - Player selects a mode and is taken to that screen.
-- If `navigationItems.json` fails, load the fallback list and auto-reload.
+- If `navigationItems.json` fails, revert to a default order and auto-reload.
 
 ### Technical Considerations
 
-- Load active game modes dynamically from `navigationItems.json`, fallback to default on failure.
+- Use `navigationItems.json` to drive CSS classes that control which pre-seeded links are visible and in what order; fallback to defaults on failure.
 - Cache loaded mode list to avoid redundant fetches across sessions.
 - Use hardware-accelerated CSS transforms for nav animations (e.g., `translate3d`).
 - Optimize for devices as small as 320px width (typical of older low-end Android devices).
@@ -109,7 +109,7 @@ The bottom navigation bar appears consistently across all game screens, dynamica
 |  **P2**  | Portrait Text Menu     | Text-based vertical menu expansion on logo click for portrait and landscape (collapsed) orientation.              |
 |  **P2**  | Small Screens Support  | Adjust text menu for screens as small as 320px — scale font and spacing.                                          |
 |  **P2**  | Visual Feedback        | Positive click/tap feedback animation for all links and buttons.                                                  |
-|  **P1**  | Fallback Data Handling | Hardcoded default mode list if `navigationItems.json` fails to load.                                              |
+|  **P1**  | Fallback Data Handling | Hardcoded default order and visibility if `navigationItems.json` fails to load.                                |
 
 ---
 
@@ -117,12 +117,12 @@ The bottom navigation bar appears consistently across all game screens, dynamica
 
 - Touch targets maintain **≥44px** size across all device resolutions (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness)).
 - Navigation is visible on **100%** of game screens.
-- Standard nav bar displays active game modes loaded from `navigationItems.json`.
+- Standard nav bar shows pre-seeded links whose visibility and order are driven by `navigationItems.json` via CSS.
 - Portrait mode initially shows only the logo in the bottom left corner (no links in the navigation bar); tapping reveals a vertical list.
 - The function of tapping the icon in the bottom left corner works in landscape or portrait mode.
 - Clicking a link navigates successfully to the intended screen.
 - Tapping the logo toggles expansion/collapse.
-- If `navigationItems.json` fails, load a hardcoded default list within **<2 seconds**.
+- If `navigationItems.json` fails, apply a hardcoded default order within **<2 seconds**.
 - Show notification and auto-reload if mid-session loading fails.
 - Smooth re-layout during device rotation mid-animation, with transition completion time **<500ms**.
 - Text contrast meets WCAG **4.5:1**.

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -53,7 +53,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 | P1       | Typewriter Effect Toggle            | Enable or disable quote animation where supported (not used on the meditation screen).                 |
 | P1       | Tooltips Toggle                     | Globally enable or disable UI tooltips.                                                                |
 | P1       | Display Mode Switch                 | Three-option switch applying mode instantly across UI.                                                 |
-| P2       | Game Modes Toggles                  | A list of all defined game modes with binary toggles from `navigationItems.json`.                      |
+| P2       | Game Modes Toggles                  | Binary toggles controlling pre-seeded links via `navigationItems.json`.                      |
 | P3       | Settings Menu Integration           | Ensure settings appear as a game mode in `navigationItems.json`.                                       |
 | P3       | View Change Log Link                | Link to `changeLog.html` for viewing recent judoka updates.                                            |
 | P3       | View PRD Documents Link             | Link to `prdViewer.html` for browsing product requirement documents.                                   |
@@ -78,7 +78,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 - **Typewriter effect (binary):** ON/OFF (default: ON, not currently used on the meditation screen) – Toggle the quote typing animation.
 - **Tooltips (binary):** ON/OFF (default: ON) – Show or hide helpful tooltips.
 - **Display mode (three options):** Light, Dark, High Contrast (default: Light)
-- **Game modes list:** Pulled from `gameModes.json` and cross-referenced with `navigationItems.json` to determine order and visibility; each mode has a binary toggle.
+- **Game modes list:** Pre-seeded entries cross-referenced with `navigationItems.json` to determine order and visibility via CSS; each mode has a binary toggle.
 - **View Change Log:** Link opens `changeLog.html` with the latest 20 judoka updates.
 - **View PRD Documents:** Link opens `prdViewer.html` for browsing product documents.
 - **View Design Mockups:** Link opens `mockupViewer.html` for viewing design mockups.
@@ -102,7 +102,7 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 
 - The Settings page **must pull current states** from data sources (`settings.json`, `gameModes.json`, and `navigationItems.json`) on load.
 - Default feature flag values live in `settings.json`, while their labels and descriptions come from `tooltips.json`.
-- `gameModes.json` defines all available modes, while `navigationItems.json` references each by `id` to control order and hidden status.
+- `gameModes.json` defines all available modes, while `navigationItems.json` references each by `id` to control order and visibility via CSS.
 - Changes should trigger **immediate data writes** without requiring a “Save Changes” button.
 - All live updates must persist across page refreshes within the same session.
 - If `navigationItems.json` fails to load, the game modes section should **disable gracefully** and show an error message.
@@ -290,7 +290,7 @@ The page begins with an `h1` heading labeled "Settings". Two `fieldset` sections
 
 ───────────────────────────────  
 | GAME MODES |  
-| (Dynamic list from JSON) |  
+| (Pre-seeded list; visibility and order driven by `navigationItems.json` via CSS) |
 ───────────────────────────────
 
 [ Game Mode 1 ]  
@@ -329,7 +329,7 @@ The page begins with an `h1` heading labeled "Settings". Two `fieldset` sections
 
 - [ ] 4.0 List Game Modes
 
-  - [x] 4.1 Load all game modes from `navigationItems.json`.
+    - [x] 4.1 Ensure game mode toggles map to pre-seeded links defined in `navigationItems.json`.
   - [x] 4.2 Display error message if loading fails.
 
 - [ ] 6.0 Add Change Log Link


### PR DESCRIPTION
## Summary
- Document navigation bar as using pre-seeded links styled by `navigationItems.json`
- Note in game mode, settings, and home page PRDs that visibility and order are CSS-driven

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: view judoka link navigates, screenshots, battle link navigates, etc.)*
- `npm run check:contrast` *(server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6893c757e6bc83269ccbfa6fa48739d1