### PR TITLE
feat: show disabled main menu entries

### DIFF
--- a/src/helpers/navigation/navData.js
+++ b/src/helpers/navigation/navData.js
@@ -19,29 +19,30 @@ export function validateGameModes(gameModes) {
 }
 
 /**
- * Load and validate active main menu navigation items.
+ * Load and validate main menu navigation items, marking hidden modes based on
+ * user settings.
  *
  * @pseudocode
  * 1. Fetch all navigation items using `loadNavigationItems()`.
  * 2. Retrieve user settings via `loadSettings()`.
- * 3. Filter the modes to include only visible main menu items not disabled in settings.
- * 4. Sort the filtered modes by their `order` property.
- * 5. Validate the resulting array with `validateGameModes()`.
- * 6. Return the validated array.
+ * 3. Filter the modes to include only main menu items.
+ * 4. Map each mode to set `isHidden` to true if originally hidden or disabled in settings.
+ * 5. Sort the mapped modes by their `order` property.
+ * 6. Validate the resulting array with `validateGameModes()`.
+ * 7. Return the validated array.
  *
- * @returns {Promise<import("../types.js").GameMode[]>} Resolved array of active game modes.
+ * @returns {Promise<import("../types.js").GameMode[]>} Resolved array of game modes.
  */
 export async function loadMenuModes() {
   const data = await loadNavigationItems();
   const settings = await loadSettings();
   return validateGameModes(
     data
-      .filter(
-        (mode) =>
-          mode.category === "mainMenu" &&
-          mode.isHidden === false &&
-          settings.gameModes[mode.id] !== false
-      )
+      .filter((mode) => mode.category === "mainMenu")
+      .map((mode) => ({
+        ...mode,
+        isHidden: mode.isHidden || settings.gameModes[mode.id] === false
+      }))
       .sort((a, b) => a.order - b.order)
   );
 }


### PR DESCRIPTION
## Summary
- expose all main menu game modes and mark hidden ones based on settings

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6893d516a87c8326bfd78d3d5e165a2e