### PR TITLE
feat(prdClassicBattle): show snackbar on stat pick

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -131,6 +131,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 - Use consistent color coding for player (blue) vs opponent (red) as shown in attached mockups.
 - Display clear, large call-to-action text for "Choose an attribute to challenge!" to guide new players.
+- When a player selects a stat, surface a snackbar via [showSnackbar.js](../../src/helpers/showSnackbar.js) reading `You Picked: <stat>` (e.g., `You Picked: Power`) so tests can confirm the feedback.
 - Provide a quit confirmation when the player clicks the logo in the header to return to the Home screen.
   - Match screens should follow the style and layouts demonstrated in shared mockups:
   - Player and opponent cards side-by-side.


### PR DESCRIPTION
## Summary
- require snackbar feedback when a player chooses a stat in Classic Battle

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle orientation screenshots, Browse Judoka navigation)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689457e1a8f48326a07e4a51b0f7937c