### PR TITLE
test: verify snackbar on stat selection

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -37,6 +37,8 @@ test.describe.parallel("Classic battle flow", () => {
         `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;
     });
     await page.locator("button[data-stat='power']").click();
+    const snackbar = page.locator(".snackbar");
+    await expect(snackbar).toHaveText("You Picked: Power");
     const msg = page.locator("header #round-message");
     await expect(msg).toHaveText(/Tie/);
     await expect(timer).toHaveText(/\d+/);

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -17,6 +17,7 @@ describe("classicBattlePage keyboard navigation", () => {
     });
     const initTooltips = vi.fn().mockResolvedValue();
     const setTestMode = vi.fn();
+    const showSnackbar = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle.js", () => ({
       createBattleStore: () => store,
@@ -28,6 +29,7 @@ describe("classicBattlePage keyboard navigation", () => {
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
+    vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar }));
     vi.doMock("../../src/helpers/stats.js", () => ({
       loadStatNames: async () => [{ name: "Power" }, { name: "Speed" }]
     }));
@@ -47,6 +49,7 @@ describe("classicBattlePage keyboard navigation", () => {
     const [first, second] = container.querySelectorAll("button");
     first.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     expect(handleStatSelection).toHaveBeenCalledWith(store, "power");
+    expect(showSnackbar).toHaveBeenCalledWith("You Picked: Power");
 
     // re-enable buttons for second key simulation
     container.querySelectorAll("button").forEach((b) => {
@@ -54,9 +57,11 @@ describe("classicBattlePage keyboard navigation", () => {
       b.tabIndex = 0;
     });
     handleStatSelection.mockClear();
+    showSnackbar.mockClear();
 
     second.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
     expect(handleStatSelection).toHaveBeenCalledWith(store, "speed");
+    expect(showSnackbar).toHaveBeenCalledWith("You Picked: Speed");
   });
 
   it("navigates to Next Round and Quit buttons", async () => {


### PR DESCRIPTION
## Summary
- mock showSnackbar in classicBattlePage test and confirm snackbar message when stats selected
- ensure Playwright classic battle flow checks for snackbar feedback

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattlePage.test.js`
- `npx vitest run`
- `npx playwright test playwright/classicBattleFlow.spec.js`
- `npx playwright test` *(fails: battle-orientation screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68945c9bf79c8326a680288bf25d2f51