### PR TITLE
feat: add responsive bottom nav

### DIFF
--- a/src/helpers/navigation/navMenu.js
+++ b/src/helpers/navigation/navMenu.js
@@ -153,3 +153,56 @@ export function togglePortraitTextMenu(gameModes) {
       : "slide-up 500ms ease-in-out";
   });
 }
+
+/**
+ * Initialize a hamburger toggle for narrow viewports.
+ *
+ * @pseudocode
+ * 1. Select the `.bottom-navbar` and its `<ul>`; exit if either is missing.
+ * 2. Create a button with `aria-expanded="false"` linked to the list via `aria-controls`.
+ * 3. Define `update()` to insert the button and hide the list when the width is below the breakpoint; otherwise remove the button.
+ * 4. Define `toggle()` to flip `aria-expanded` and the `.expanded` class on the list.
+ * 5. Attach `click` and `resize` listeners and invoke `update()` once.
+ *
+ * @param {number} [breakpoint=480] - Maximum width to show the hamburger menu.
+ */
+export function setupHamburgerMenu(breakpoint = 480) {
+  const navBar = document.querySelector(".bottom-navbar");
+  const list = navBar?.querySelector("ul");
+  if (!navBar || !list) return;
+
+  const id = list.id || "bottom-nav-menu";
+  list.id = id;
+
+  const button = document.createElement("button");
+  button.className = "nav-toggle";
+  button.setAttribute("aria-expanded", "false");
+  button.setAttribute("aria-controls", id);
+  button.setAttribute("aria-label", "Menu");
+  button.innerHTML = "\u2630"; // ☰
+
+  const toggle = () => {
+    const expanded = button.getAttribute("aria-expanded") === "true";
+    button.setAttribute("aria-expanded", String(!expanded));
+    list.classList.toggle("expanded", !expanded);
+  };
+
+  button.addEventListener("click", toggle);
+
+  const update = () => {
+    if (window.innerWidth < breakpoint) {
+      if (!navBar.contains(button)) {
+        navBar.insertBefore(button, list);
+      }
+      button.setAttribute("aria-expanded", "false");
+      list.classList.remove("expanded");
+    } else if (navBar.contains(button)) {
+      button.remove();
+      list.classList.remove("expanded");
+      button.setAttribute("aria-expanded", "false");
+    }
+  };
+
+  window.addEventListener("resize", update);
+  update();
+}

--- a/src/helpers/setupBottomNavbar.js
+++ b/src/helpers/setupBottomNavbar.js
@@ -3,15 +3,19 @@
  *
  * @pseudocode
  * 1. Import `loadMenuModes` from `navigation/navData.js`.
- * 2. Import `toggleExpandedMapView` and `togglePortraitTextMenu` from `navigation/navMenu.js`.
+ * 2. Import `toggleExpandedMapView`, `togglePortraitTextMenu`, and `setupHamburgerMenu` from `navigation/navMenu.js`.
  * 3. Import `setupButtonEffects` from `buttonEffects.js`.
  * 4. Import `onDomReady`.
  * 5. Define async `configureBottomNavbar` to load active modes and apply both navigation layouts.
- * 6. Define async `init` to call `setupButtonEffects` then `configureBottomNavbar`.
+ * 6. Define async `init` to call `setupButtonEffects`, `configureBottomNavbar`, and `setupHamburgerMenu`.
  * 7. Use `onDomReady` to invoke `init` with guarded error handling.
  */
 import { loadMenuModes } from "./navigation/navData.js";
-import { toggleExpandedMapView, togglePortraitTextMenu } from "./navigation/navMenu.js";
+import {
+  toggleExpandedMapView,
+  togglePortraitTextMenu,
+  setupHamburgerMenu
+} from "./navigation/navMenu.js";
 import { setupButtonEffects } from "./buttonEffects.js";
 import { onDomReady } from "./domReady.js";
 
@@ -28,6 +32,7 @@ async function configureBottomNavbar() {
 async function init() {
   setupButtonEffects();
   await configureBottomNavbar();
+  setupHamburgerMenu();
 }
 
 onDomReady(() => init().catch(() => {}));

--- a/src/styles/bottom-navbar.css
+++ b/src/styles/bottom-navbar.css
@@ -75,3 +75,29 @@
 .bottom-navbar a.hidden {
   display: none;
 }
+
+.bottom-navbar .nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--button-text-color);
+  font-size: 2rem;
+  cursor: pointer;
+  min-width: var(--touch-target-size);
+  min-height: var(--touch-target-size);
+}
+
+@media (max-width: 480px) {
+  .bottom-navbar .nav-toggle {
+    display: block;
+  }
+
+  .bottom-navbar ul {
+    display: none;
+    flex-direction: column;
+  }
+
+  .bottom-navbar ul.expanded {
+    display: flex;
+  }
+}

--- a/tests/helpers/navMenuResponsive.test.js
+++ b/tests/helpers/navMenuResponsive.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { setupHamburgerMenu } from "../../src/helpers/navigation/navMenu.js";
+
+describe("setupHamburgerMenu", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<nav class="bottom-navbar"><ul><li></li></ul></nav>';
+    window.innerWidth = 320;
+  });
+
+  it("creates a toggle button and toggles aria-expanded", () => {
+    setupHamburgerMenu();
+    const button = document.querySelector(".nav-toggle");
+    const list = document.querySelector(".bottom-navbar ul");
+    expect(button).toBeTruthy();
+    expect(button?.getAttribute("aria-expanded")).toBe("false");
+    button?.dispatchEvent(new Event("click"));
+    expect(button?.getAttribute("aria-expanded")).toBe("true");
+    expect(list?.classList.contains("expanded")).toBe(true);
+  });
+
+  it("removes the button when resized above breakpoint", () => {
+    setupHamburgerMenu();
+    window.innerWidth = 1024;
+    window.dispatchEvent(new Event("resize"));
+    expect(document.querySelector(".nav-toggle")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add `setupHamburgerMenu` for responsive bottom navigation
- style hamburger toggle and collapsed menu for narrow viewports
- initialize hamburger toggle and add unit test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-orientation.spec.js, browse-judoka-navigation.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68945c8ac53c832684a946fb4e4c6b1c