### PR TITLE
test: update navbar tests for hamburger

### DIFF
--- a/playwright/homepage-layout.spec.js
+++ b/playwright/homepage-layout.spec.js
@@ -40,6 +40,16 @@ test.describe.parallel("Homepage layout", () => {
         fullPage: true
       });
     });
+
+    test("bottom navbar displays in a single row", async ({ page }) => {
+      const tops = await page
+        .locator(".bottom-navbar li")
+        .evaluateAll((els) => els.map((el) => el.getBoundingClientRect().top));
+      const maxTop = Math.max(...tops);
+      const minTop = Math.min(...tops);
+      expect(maxTop - minTop).toBeLessThanOrEqual(ALLOWED_OFFSET);
+      await expect(page.locator(".bottom-navbar .nav-toggle")).toHaveCount(0);
+    });
   });
 
   test.describe.parallel("mobile", () => {
@@ -77,6 +87,19 @@ test.describe.parallel("Homepage layout", () => {
         path: testInfo.outputPath("mobile-layout.png"),
         fullPage: true
       });
+    });
+
+    test("hamburger menu expands navigation", async ({ page }) => {
+      await page.setViewportSize({ width: 400, height: 800 });
+      await page.goto("/index.html");
+      await page.waitForSelector(".bottom-navbar .nav-toggle");
+      const toggle = page.locator(".bottom-navbar .nav-toggle");
+      const list = page.locator(".bottom-navbar ul");
+      await expect(toggle).toHaveAttribute("aria-expanded", "false");
+      await expect(list).not.toHaveClass(/expanded/);
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-expanded", "true");
+      await expect(list).toHaveClass(/expanded/);
     });
   });
 });

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -47,6 +47,19 @@ test.describe.parallel("Homepage", () => {
     expect(updateOrder).toBeLessThan(randomOrder);
   });
 
+  test("hamburger menu toggles navigation on narrow screens", async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 800 });
+    await page.reload();
+    await page.waitForSelector(".bottom-navbar .nav-toggle");
+    const toggle = page.locator(".bottom-navbar .nav-toggle");
+    const list = page.locator(".bottom-navbar ul");
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(list).not.toHaveClass(/expanded/);
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(list).toHaveClass(/expanded/);
+  });
+
   test("view judoka link navigates", async ({ page }) => {
     await page.getByTestId(NAV_RANDOM_JUDOKA).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 function setupDom() {
-  const navBar = document.createElement("div");
+  const navBar = document.createElement("nav");
   navBar.className = "bottom-navbar";
+  navBar.innerHTML = "<ul></ul>";
   document.body.appendChild(navBar);
   return navBar;
 }
@@ -18,10 +19,11 @@ afterEach(() => {
 describe("populateNavbar", () => {
   it("applies order and visibility from navigation data", async () => {
     const navBar = setupDom();
-    navBar.innerHTML = `
-      <a data-testid="nav-1"></a>
-      <a data-testid="nav-2"></a>
-      <a data-testid="nav-3"></a>
+    const list = navBar.querySelector("ul");
+    list.innerHTML = `
+      <li><a data-testid="nav-1"></a></li>
+      <li><a data-testid="nav-2"></a></li>
+      <li><a data-testid="nav-3"></a></li>
     `;
 
     vi.mock("../../src/helpers/gameModeUtils.js", () => ({


### PR DESCRIPTION
## Summary
- refactor bottom navigation unit tests for new `<ul>` layout
- extend bottom navbar setup tests to cover hamburger toggle
- add Playwright checks for single-row layout and hamburger menu

## Testing
- `npx prettier tests/helpers/setupBottomNavbar.test.js tests/helpers/bottomNavigation.test.js playwright/homepage.spec.js playwright/homepage-layout.spec.js --check`
- `npx eslint tests/helpers/setupBottomNavbar.test.js tests/helpers/bottomNavigation.test.js playwright/homepage.spec.js playwright/homepage-layout.spec.js`
- `npx vitest run`
- `npx playwright test` *(fails: missing nav-toggle in some specs)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68945fd2e6948326a48c18ab98ccbb52