### PR TITLE
feat(navbar): highlight active link in bottom navigation

### DIFF
--- a/src/helpers/navigationBar.js
+++ b/src/helpers/navigationBar.js
@@ -1,6 +1,27 @@
 import { loadNavigationItems } from "./gameModeUtils.js";
 
 /**
+ * Highlight the navigation link matching the current location.
+ *
+ * @pseudocode
+ * 1. Guard: return if `document` or `window` is undefined.
+ * 2. Select all `.bottom-navbar a` elements.
+ * 3. Resolve each link's `href` with `new URL()`.
+ * 4. Compare `URL.pathname` with `window.location.pathname`.
+ * 5. Toggle the `active` class on match.
+ */
+export function highlightActiveLink() {
+  if (typeof document === "undefined" || typeof window === "undefined") return;
+  const links = document.querySelectorAll(".bottom-navbar a");
+  const current = window.location.pathname;
+  links.forEach((link) => {
+    const href = link.getAttribute("href") || "";
+    const resolved = new URL(href, window.location.href);
+    link.classList.toggle("active", resolved.pathname === current);
+  });
+}
+
+/**
  * Adds touch feedback animations to navigation links.
  *
  * @pseudocode
@@ -63,6 +84,7 @@ export async function populateNavbar() {
     });
 
     addTouchFeedback();
+    highlightActiveLink();
   } catch (error) {
     console.error("Error applying navigation items:", error);
   }

--- a/src/styles/bottom-navbar.css
+++ b/src/styles/bottom-navbar.css
@@ -70,6 +70,7 @@
 .bottom-navbar a.active {
   background-color: var(--color-secondary);
   color: var(--color-text-inverted);
+  border-top: 3px solid var(--color-primary);
 }
 
 .bottom-navbar a.hidden {

--- a/tests/helpers/bottomNavigation.test.js
+++ b/tests/helpers/bottomNavigation.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 
+const originalLocation = window.location;
+
 function setupDom() {
   const navBar = document.createElement("nav");
   navBar.className = "bottom-navbar";
@@ -14,6 +16,10 @@ afterEach(() => {
   }
   document.body.innerHTML = "";
   vi.resetModules();
+  Object.defineProperty(window, "location", {
+    value: originalLocation,
+    configurable: true
+  });
 });
 
 describe("populateNavbar", () => {
@@ -44,5 +50,27 @@ describe("populateNavbar", () => {
     expect(links[1].style.order).toBe("1");
     expect(links[1].classList.contains("hidden")).toBe(true);
     expect(links[2].classList.contains("hidden")).toBe(true);
+  });
+
+  it("highlights the active link based on pathname", async () => {
+    const navBar = setupDom();
+    const list = navBar.querySelector("ul");
+    list.innerHTML = `
+      <li><a href="/home?x=1"></a></li>
+      <li><a href="/about"></a></li>
+    `;
+
+    Object.defineProperty(window, "location", {
+      value: { href: "https://example.com/home", pathname: "/home" },
+      configurable: true
+    });
+
+    const { highlightActiveLink } = await import("../../src/helpers/navigationBar.js");
+
+    highlightActiveLink();
+
+    const links = navBar.querySelectorAll("a");
+    expect(links[0].classList.contains("active")).toBe(true);
+    expect(links[1].classList.contains("active")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add highlightActiveLink helper to toggle `active` state via URL pathname
- accentuate active bottom-nav link with primary-colored top border
- test active link highlighting

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/bottomNavigation.test.js tests/helpers/setupBottomNavbar.test.js`
- `npx playwright test` *(fails: Test was interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6894bf68f1f48326a921c93c35f98c76