### PR TITLE
feat: improve bottom navbar hover feedback

### DIFF
--- a/src/helpers/navigation/navMenu.js
+++ b/src/helpers/navigation/navMenu.js
@@ -142,7 +142,7 @@ export function togglePortraitTextMenu(gameModes) {
           data-tooltip-id="nav.${navTooltipKey(mode.name)}"
           data-testid="nav-${mode.id}"
           style="order: ${mode.order}"
-          class="${mode.isHidden ? "hidden" : ""}"
+          class="text-menu-item${mode.isHidden ? " hidden" : ""}"
         >
           ${mode.name}
         </a>`

--- a/src/styles/bottom-navbar.css
+++ b/src/styles/bottom-navbar.css
@@ -62,6 +62,13 @@
   text-decoration: underline;
 }
 
+.bottom-navbar .nav-toggle:hover,
+.expanded-map-view a:hover,
+.portrait-text-menu a:hover {
+  background-color: var(--button-hover-bg);
+  text-decoration: underline;
+}
+
 .bottom-navbar a:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;

--- a/tests/helpers/setupBottomNavbar.test.js
+++ b/tests/helpers/setupBottomNavbar.test.js
@@ -71,6 +71,17 @@ describe("setupBottomNavbar module", () => {
     expect(list.classList.contains("expanded")).toBe(true);
   });
 
+  it("retains nav-toggle class after initialization", async () => {
+    window.innerWidth = 320;
+    await import("../../src/helpers/setupBottomNavbar.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    vi.advanceTimersByTime(0);
+
+    const toggle = document.querySelector("button[aria-label='Menu']");
+    expect(toggle).toBeTruthy();
+    expect(toggle.classList.contains("nav-toggle")).toBe(true);
+  });
+
   it("does not insert hamburger menu above breakpoint", async () => {
     window.innerWidth = 1024;
     await import("../../src/helpers/setupBottomNavbar.js");


### PR DESCRIPTION
## Summary
- add hover styles to nav toggle, expanded map view, and portrait text menu links
- assign a `text-menu-item` class to portrait menu links
- test nav toggle keeps its class after initialization

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Browse Judoka navigation, Battle orientation screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6894c567d5108326b6ba50ce7e5bcbf5