### PR TITLE
chore: expose update codes script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prepare": "husky install",
     "validate:data": "node scripts/validateData.js",
     "generate:embeddings": "node --max-old-space-size=8192 scripts/generateEmbeddings.js",
-    "pretest": "node scripts/generatePrdIndex.js"
+    "pretest": "node scripts/generatePrdIndex.js",
+    "update:codes": "node updateCodes.mjs"
   },
   "keywords": [],
   "author": "",

--- a/updateCodes.mjs
+++ b/updateCodes.mjs
@@ -1,15 +1,15 @@
-// update-codes.js
+// updateCodes.mjs
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import { generateCardCode } from "./cardCode.js";
+import { generateCardCode } from "./src/helpers/cardCode.js";
 
 // Resolve __dirname equivalent for ES modules
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Load judoka.json
-const judokaPath = path.join(__dirname, "../data/judoka.json");
+const judokaPath = path.join(__dirname, "src/data/judoka.json");
 const rawData = fs.readFileSync(judokaPath, "utf8");
 const judokaList = JSON.parse(rawData);
 


### PR DESCRIPTION
## Summary
- move update codes helper to repo root with .mjs extension
- add `update:codes` npm script

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Browse Judoka navigation - desktop arrow keys update markers and disable buttons, Battle orientation screenshots - captures portrait and landscape headers, Battle Judoka page - narrow viewport screenshot and status aria attributes)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6894d0727c748326a3fcb2fa64f63ee4