### PR TITLE
Clear timer during stat selection and prevent negative countdown

### DIFF
--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -153,6 +153,18 @@ export function showTemporaryMessage(text) {
 }
 
 /**
+ * Clear the countdown display.
+ *
+ * @pseudocode
+ * 1. If the timer element exists, set its text content to an empty string.
+ */
+export function clearTimer() {
+  if (timerEl) {
+    timerEl.textContent = "";
+  }
+}
+
+/**
  * Start a countdown timer that monitors for drift and displays a fallback when
  * desynchronization occurs.
  *
@@ -160,7 +172,7 @@ export function showTemporaryMessage(text) {
  * 1. Use `startCoolDown` to update the timer each second.
  * 2. Monitor for drift via `watchForDrift`; on drift, show "Waiting…" and
  *    restart the countdown, giving up after several retries.
- * 3. When the timer expires, stop monitoring and invoke `onFinish`.
+ * 3. When the timer expires, stop monitoring, clear the display, and invoke `onFinish`.
  *
  * @param {number} seconds - Seconds to count down from.
  * @param {Function} [onFinish] - Optional callback when countdown ends.
@@ -170,12 +182,17 @@ export function startCountdown(seconds, onFinish) {
   if (!timerEl) return;
 
   const onTick = (remaining) => {
+    if (remaining <= 0) {
+      clearTimer();
+      return;
+    }
     timerEl.textContent = `Next round in: ${remaining}s`;
   };
 
   let stopWatch;
   const onExpired = () => {
     if (stopWatch) stopWatch();
+    clearTimer();
     if (typeof onFinish === "function") onFinish();
   };
 

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -181,7 +181,7 @@ export function evaluateRound(store, stat) {
  *
  * @pseudocode
  * 1. Clear any pending timeouts.
- * 2. Show "Waiting…" in the info bar.
+ * 2. Clear the countdown and show "Opponent is choosing…" in the info bar.
  * 3. After a short delay, reveal the opponent card and evaluate the round.
  * 4. Reset stat buttons and schedule the next round.
  * 5. If the match ended, show the summary panel.
@@ -198,12 +198,12 @@ export async function handleStatSelection(store, stat) {
   store.selectionMade = true;
   clearTimeout(store.statTimeoutId);
   clearTimeout(store.autoSelectId);
-  const clearWaitingMessage = infoBar.showTemporaryMessage("Waiting…");
+  infoBar.clearTimer();
+  infoBar.showMessage("Opponent is choosing…");
   const delay = 300 + Math.floor(Math.random() * 401);
   return new Promise((resolve) => {
     setTimeout(async () => {
       await revealComputerCard();
-      clearWaitingMessage();
       const result = evaluateRound(store, stat);
       resetStatButtons();
       scheduleNextRound(result, getStartRound(store));

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -36,10 +36,16 @@ export async function startTimer(onExpiredSelect) {
   const restore = !synced ? infoBar.showTemporaryMessage("Waiting…") : () => {};
 
   const onTick = (remaining) => {
-    if (timerEl) timerEl.textContent = `Time Left: ${remaining}s`;
+    if (!timerEl) return;
+    if (remaining <= 0) {
+      infoBar.clearTimer();
+      return;
+    }
+    timerEl.textContent = `Time Left: ${remaining}s`;
   };
 
   const onExpired = async () => {
+    infoBar.clearTimer();
     const randomStat = STATS[Math.floor(seededRandom() * STATS.length)];
     infoBar.showMessage(`Time's up! Auto-selecting ${randomStat}`);
     await onExpiredSelect(randomStat);
@@ -100,10 +106,16 @@ export function scheduleNextRound(result, startRoundFn) {
   const timerEl = document.getElementById("next-round-timer");
 
   const onTick = (remaining) => {
-    if (timerEl) timerEl.textContent = `Next round in: ${remaining}s`;
+    if (!timerEl) return;
+    if (remaining <= 0) {
+      infoBar.clearTimer();
+      return;
+    }
+    timerEl.textContent = `Next round in: ${remaining}s`;
   };
 
   const onExpired = () => {
+    infoBar.clearTimer();
     btn.addEventListener("click", onClick, { once: true });
     enableNextRoundButton();
     updateDebugPanel();

--- a/src/helpers/setupBattleInfoBar.js
+++ b/src/helpers/setupBattleInfoBar.js
@@ -4,7 +4,8 @@ import {
   updateScore,
   startCountdown,
   clearMessage,
-  showTemporaryMessage
+  showTemporaryMessage,
+  clearTimer
 } from "../components/InfoBar.js";
 import { onDomReady } from "./domReady.js";
 
@@ -23,4 +24,4 @@ function setupBattleInfoBar() {
 
 onDomReady(setupBattleInfoBar);
 
-export { showMessage, updateScore, startCountdown, clearMessage, showTemporaryMessage };
+export { showMessage, updateScore, startCountdown, clearMessage, showTemporaryMessage, clearTimer };

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -63,7 +63,7 @@ describe("InfoBar component", () => {
     timer.advanceTimersByTime(1000);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
     timer.advanceTimersByTime(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 0s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("");
     timer.clearAllTimers();
   });
 
@@ -91,7 +91,7 @@ describe("InfoBar component", () => {
     startCountdown(1);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
     timer.advanceTimersByTime(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 0s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("");
     timer.clearAllTimers();
   });
 });

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
+
+vi.mock("../../../src/helpers/motionUtils.js", () => ({
+  shouldReduceMotionSync: () => true
+}));
+
+vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
+  revealComputerCard: vi.fn(),
+  disableNextRoundButton: vi.fn(),
+  enableNextRoundButton: vi.fn(),
+  updateDebugPanel: vi.fn()
+}));
+
+describe("countdown resets after stat selection", () => {
+  let battleMod;
+  let store;
+  beforeEach(async () => {
+    document.body.innerHTML = "";
+    const { playerCard, computerCard } = createBattleCardContainers();
+    const header = createBattleHeader();
+    const roundResult = document.createElement("p");
+    roundResult.id = "round-result";
+    const nextBtn = document.createElement("button");
+    nextBtn.id = "next-round-button";
+    document.body.append(playerCard, computerCard, header, roundResult, nextBtn);
+    document.body.innerHTML += '<div id="stat-buttons"><button data-stat="power"></button></div>';
+    battleMod = await import("../../../src/helpers/classicBattle.js");
+    store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+  });
+
+  it("clears timer during result animation and restarts for next round", async () => {
+    document.getElementById("next-round-timer").textContent = "Time Left: 10s";
+    document.getElementById("player-card").innerHTML =
+      '<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>';
+    document.getElementById("computer-card").innerHTML =
+      '<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>';
+
+    const timer = vi.useFakeTimers();
+    const p = battleMod.handleStatSelection(store, "power");
+    await vi.advanceTimersByTimeAsync(1000);
+    await p;
+    expect(document.getElementById("next-round-timer").textContent).toBe("");
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 3s");
+    timer.clearAllTimers();
+  });
+});

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -6,6 +6,7 @@ vi.mock("../../../src/helpers/motionUtils.js", () => ({
 
 let showMessage;
 let clearMessage;
+let clearTimer;
 let scheduleNextRound;
 let revealComputerCard;
 let resetStatButtons;
@@ -16,6 +17,7 @@ beforeEach(() => {
   vi.stubGlobal("document", { getElementById: () => null });
   showMessage = vi.fn();
   clearMessage = vi.fn();
+  clearTimer = vi.fn();
   scheduleNextRound = vi.fn();
   revealComputerCard = vi.fn();
   resetStatButtons = vi.fn();
@@ -24,10 +26,7 @@ beforeEach(() => {
   vi.mock("../../../src/helpers/setupBattleInfoBar.js", () => ({
     showMessage,
     clearMessage,
-    showTemporaryMessage: vi.fn((msg) => {
-      showMessage(msg);
-      return clearMessage;
-    }),
+    clearTimer,
     updateScore: vi.fn(),
     startCountdown: vi.fn()
   }));
@@ -69,17 +68,14 @@ describe("classicBattle opponent delay", () => {
 
     const promise = mod.handleStatSelection(store, mod.simulateOpponentStat());
 
-    expect(showMessage).toHaveBeenCalledWith("Waiting…");
-    expect(clearMessage).not.toHaveBeenCalled();
+    expect(showMessage).toHaveBeenCalledWith("Opponent is choosing…");
 
     await vi.advanceTimersByTimeAsync(299);
     expect(scheduleNextRound).not.toHaveBeenCalled();
-    expect(clearMessage).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(402);
     await promise;
     expect(scheduleNextRound).toHaveBeenCalled();
-    expect(clearMessage).toHaveBeenCalled();
     timer.clearAllTimers();
   });
 });

--- a/tests/helpers/setupBattleInfoBar.test.js
+++ b/tests/helpers/setupBattleInfoBar.test.js
@@ -44,7 +44,7 @@ describe("setupBattleInfoBar", () => {
     mod.startCountdown(1);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
     await vi.advanceTimersByTimeAsync(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 0s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("");
   });
 
   it("initializes immediately when DOM already loaded", async () => {
@@ -73,6 +73,6 @@ describe("setupBattleInfoBar", () => {
     mod.startCountdown(1);
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
     await vi.advanceTimersByTimeAsync(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 0s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- clear countdown and show "Opponent is choosing…" while waiting for round results
- stop countdown updates at zero and reset display between phases
- add regression test verifying timer blanks during result animations

## Testing
- `CI=1 npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 42 pixels (ratio 0.01 of all image pixels) are different.)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6894d7cc6f8883269207ba35e38aa82a