### PR TITLE
docs: document card code update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ AI agents should begin by reading:
 - ✅ Validate stat blocks against rarity rules
 - ✅ Generate or evaluate PRDs for new features
 
+## 🔄 Updating Judoka Card Codes
+
+Run `npm run update:codes` whenever you add or edit judoka in `src/data/judoka.json`. The script regenerates the `cardCode` for each entry and falls back to the code from judoka `id=0` if generation fails.
+
 ---
 
 ## 📎 Related Docs for Agents

--- a/design/productRequirementsDocuments/prdCardCodes.md
+++ b/design/productRequirementsDocuments/prdCardCodes.md
@@ -229,9 +229,9 @@ F7KP-WQ9M-ZD23-HYTR
   - [x] 1.4 Map encoded string to 32-character readable alphabet.
   - [x] 1.5 Format string into chunks of 4 characters with hyphens.
   - [x] 1.6 Return the final formatted code.
-  - [ ] 1.7 Save the generated code into `judoka.json`.
+  - [x] 1.7 Save the generated code into `judoka.json`.
 - [ ] 2.0 Error Handling and Edge Cases
-  - [ ] 2.1 Fallback to a generic card code (judoka id=0) if encoding fails.
+  - [x] 2.1 Fallback to a generic card code (judoka id=0) if encoding fails. ([tests/helpers/cardCode.test.js](../../tests/helpers/cardCode.test.js))
   - [ ] 2.2 Handle unusually large string input safely.
 - [ ] 3.0 Unit Tests
   - [x] 3.1 Test valid Judoka object produces correct code format.


### PR DESCRIPTION
## Summary
- explain new npm script for updating judoka card codes and document when to run it
- mark card-code generation task complete and document fallback behavior with link to tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: Failed to load game modes; fetch errors)
- `npx playwright test` (fails: numerous fetch errors and navigation not implemented)
- `npm run check:contrast` (fails: fetch errors for navigation items and game modes)


------
https://chatgpt.com/codex/tasks/task_e_6894ebc6230c832683f5cc7bff6e0a73