### PR TITLE
Seed random and enable test mode in battle screenshots

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -34,6 +34,16 @@ test.describe.parallel(
   () => {
     test.skip(!runScreenshots);
 
+    test.beforeEach(async ({ page }) => {
+      await page.addInitScript(() => {
+        Math.random = () => 0.42;
+        localStorage.setItem(
+          "settings",
+          JSON.stringify({ featureFlags: { enableTestMode: true } })
+        );
+      });
+    });
+
     test("captures portrait and landscape headers", async ({ page }) => {
       await page.addInitScript(() => {
         window.startCountdownOverride = () => {};


### PR DESCRIPTION
## Summary
- Seed Math.random and enable test mode via localStorage for battle-orientation screenshot suite
- Share setup across screenshot tests with `test.beforeEach`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689520d69d088326aef3e39f2937b95d