### PR TITLE
feat: allow configuring points needed to win battles

### DIFF
--- a/src/helpers/battleEngine.js
+++ b/src/helpers/battleEngine.js
@@ -12,6 +12,7 @@ export const STATS = ["power", "speed", "technique", "kumikata", "newaza"];
 
 const DRIFT_THRESHOLD = 2;
 
+let pointsToWin = CLASSIC_BATTLE_POINTS_TO_WIN;
 let playerScore = 0;
 let computerScore = 0;
 let currentTimer = null;
@@ -22,6 +23,31 @@ let paused = false;
 let onTickCb = null;
 let onExpiredCb = null;
 
+/**
+ * Set the points required to win the match.
+ *
+ * @pseudocode
+ * 1. Assign `value` to `pointsToWin`.
+ *
+ * @param {number} value - New points threshold to win.
+ * @returns {void}
+ */
+export function setPointsToWin(value) {
+  pointsToWin = value;
+}
+
+/**
+ * Get the points required to win the match.
+ *
+ * @pseudocode
+ * 1. Return `pointsToWin`.
+ *
+ * @returns {number}
+ */
+export function getPointsToWin() {
+  return pointsToWin;
+}
+
 function stopTimer() {
   if (currentTimer) {
     currentTimer.stop();
@@ -31,8 +57,8 @@ function stopTimer() {
 
 function endMatchIfNeeded() {
   if (
-    playerScore >= CLASSIC_BATTLE_POINTS_TO_WIN ||
-    computerScore >= CLASSIC_BATTLE_POINTS_TO_WIN ||
+    playerScore >= pointsToWin ||
+    computerScore >= pointsToWin ||
     roundsPlayed >= CLASSIC_BATTLE_MAX_ROUNDS
   ) {
     matchEnded = true;
@@ -261,6 +287,7 @@ export function watchForDrift(duration, onDrift) {
 }
 
 export function _resetForTest() {
+  pointsToWin = CLASSIC_BATTLE_POINTS_TO_WIN;
   playerScore = 0;
   computerScore = 0;
   matchEnded = false;

--- a/tests/helpers/battleEngine.pointsToWin.test.js
+++ b/tests/helpers/battleEngine.pointsToWin.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { CLASSIC_BATTLE_POINTS_TO_WIN } from "../../src/helpers/constants.js";
+import { getPointsToWin, setPointsToWin, _resetForTest } from "../../src/helpers/battleEngine.js";
+
+describe("battleEngine pointsToWin", () => {
+  afterEach(() => _resetForTest());
+
+  it("returns default points to win", () => {
+    expect(getPointsToWin()).toBe(CLASSIC_BATTLE_POINTS_TO_WIN);
+  });
+
+  it("updates points to win", () => {
+    setPointsToWin(5);
+    expect(getPointsToWin()).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- allow configurable points needed to win a match
- expose `setPointsToWin` and `getPointsToWin`
- test updating and resetting points threshold

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: fetch and rendering errors, interrupted)*
- `npx playwright test --reporter=line` *(fails: page counter expectations, interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6895cf5ed65c8326ac2c3ff557f33fc1