### PR TITLE
feat: add classic battle round selection modal

### DIFF
--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -20,7 +20,10 @@
     "languageToggle": "**Language toggle**\nSwitch quote language between English and pseudo-Japanese.",
     "nextRound": "**Next round**\nBegin when you’re ready.",
     "quitMatch": "**Quit match**\nReturn to the menu.",
-    "drawCard": "**Draw card**\nGet a new random judoka card."
+    "drawCard": "**Draw card**\nGet a new random judoka card.",
+    "roundQuick": "**Quick match**\\nFirst to 5 points.",
+    "roundMedium": "**Medium match**\\nFirst to 10 points (default).",
+    "roundLong": "**Long match**\\nFirst to 15 points."
   },
 
   "mode": {

--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -1,0 +1,57 @@
+import { fetchJson } from "../dataUtils.js";
+import { DATA_DIR } from "../constants.js";
+import { createButton } from "../../components/Button.js";
+import { createModal } from "../../components/Modal.js";
+import { setPointsToWin } from "../battleEngine.js";
+import { initTooltips } from "../tooltip.js";
+
+/**
+ * Initialize round selection modal for Classic Battle.
+ *
+ * @pseudocode
+ * 1. Fetch `battleRounds.json` using `fetchJson`.
+ * 2. Create buttons for each option with `createButton` and assign tooltip ids.
+ * 3. Assemble and open a modal via `createModal`.
+ * 4. When a button is clicked:
+ *    a. Call `setPointsToWin` with the round value.
+ *    b. Close the modal and invoke the provided start callback.
+ *
+ * @param {Function} onStart - Callback to invoke after selecting rounds.
+ * @returns {Promise<void>} Resolves when modal is initialized.
+ */
+export async function initRoundSelectModal(onStart) {
+  let rounds;
+  try {
+    rounds = await fetchJson(`${DATA_DIR}battleRounds.json`);
+  } catch (err) {
+    console.error("Failed to load battle rounds:", err);
+    if (typeof onStart === "function") onStart();
+    return;
+  }
+
+  const title = document.createElement("h2");
+  title.id = "round-select-title";
+  title.textContent = "Select Match Length";
+
+  const btnWrap = document.createElement("div");
+  btnWrap.className = "round-select-buttons";
+
+  const frag = document.createDocumentFragment();
+  frag.append(title, btnWrap);
+
+  const modal = createModal(frag, { labelledBy: title });
+  rounds.forEach((r) => {
+    const btn = createButton(r.label, { id: `round-select-${r.id}` });
+    btn.dataset.tooltipId = `ui.round${r.label}`;
+    btn.addEventListener("click", () => {
+      setPointsToWin(r.value);
+      modal.close();
+      if (typeof onStart === "function") onStart();
+    });
+    btnWrap.appendChild(btn);
+  });
+
+  document.body.appendChild(modal.element);
+  await initTooltips(modal.element);
+  modal.open();
+}

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -18,7 +18,7 @@
  *    c. Set `window.startRoundOverride` to `startRoundWrapper` so the battle
  *       module uses it for subsequent rounds.
  *    d. Toggle the debug panel and viewport simulation flags.
- *    e. Invoke `startRoundWrapper` to begin the match.
+ *    e. Show a round selection modal that sets points-to-win and starts the first round.
  *    f. Initialize tooltips and show the stat help tooltip once for new users.
  *    g. Watch for orientation changes and update the battle header's
  *       `data-orientation` attribute.
@@ -42,6 +42,7 @@ import { loadStatNames } from "./stats.js";
 import { STATS } from "./battleEngine.js";
 import { toggleInspectorPanels } from "./cardUtils.js";
 import { showSnackbar } from "./showSnackbar.js";
+import { initRoundSelectModal } from "./classicBattle/roundSelectModal.js";
 
 function enableStatButtons(enable = true) {
   document.querySelectorAll("#stat-buttons button").forEach((btn) => {
@@ -196,7 +197,7 @@ export async function setupClassicBattlePage() {
   }
 
   window.startRoundOverride = () => startRoundWrapper();
-  startRoundWrapper();
+  await initRoundSelectModal(() => startRoundWrapper());
   await initTooltips();
   watchBattleOrientation();
 

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -5,6 +5,9 @@ beforeEach(() => {
   document.body.innerHTML = "";
   localStorage.clear();
   vi.resetModules();
+  vi.doMock("../../src/helpers/classicBattle/roundSelectModal.js", () => ({
+    initRoundSelectModal: (cb) => cb()
+  }));
 });
 
 describe("classicBattlePage keyboard navigation", () => {


### PR DESCRIPTION
## Summary
- add round selection modal to configure match length before first round
- wire modal into classic battle page and add tooltips for each option
- update tests for modal setup

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run validate:data` (fails: could not determine executable to run)
- `npx vitest run` (fails: multiple missing fetch dependencies)
- `npx playwright test` (fails: 4 failed, 2 interrupted)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6895e177cf74832690080b07c7a7034c