### PR TITLE
docs: document win target selection

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -59,12 +59,13 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 ## Gameplay Basics
 
+- On first visit to `battleJudoka.html`, a modal prompts the player to select a win target of **5, 10, or 15 points** (default 10).
 - The standard deck contains **99 unique cards**.
 - Each match begins with both sides receiving **25 random cards**.
 - At the start of each round, both players draw their top card.
 - The player selects one stat (Power, Speed, Technique, etc.).
 - The higher value wins the round and scores **1 point**; used cards are discarded.
-- The match ends when a player reaches **10 points** or after **25 rounds** (draw).
+- The match ends when a player reaches a **user-selected win target of 5, 10, or 15 points** (default 10) or after **25 rounds** (draw).
 
 ---
 
@@ -89,7 +90,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 | **P1**   | Random Card Draw        | Draw one random card per player each round; the opponent card must differ from the player's.                                                                                     |
 | **P1**   | Stat Selection Timer    | Player selects stat within 30 seconds; otherwise, random stat is chosen. Default timer is fixed at 30s. Timer is displayed in the Info Bar and pauses/resumes on tab inactivity. |
 | **P1**   | Scoring                 | Increase score by one for each round win.                                                                                                                                        |
-| **P1**   | Match End Condition     | End match on 10 points or after 25 rounds.                                                                                                                                       |
+| **P1**   | Match End Condition     | End match when either player reaches a user-selected win target of 5, 10, or 15 points (default 10) or after 25 rounds.                                                                                                                                       |
 | **P2**   | Tie Handling            | Show tie message; round ends without score change; continue to next round.                                                                                                       |
 | **P2**   | Player Quit Flow        | Allow player to exit match early with confirmation; counts as a loss.                                                                                                            |
 | **P3**   | AI Stat Selection Logic | AI stat choice follows difficulty setting (`easy` random, `medium` picks stats ≥ average, `hard` selects highest stat). Difficulty can be set via Settings or `?difficulty=` URL param; defaults to `easy`. |
@@ -180,7 +181,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
   - [x] 1.2 Implement 30-second stat selection timer with auto-selection fallback (displayed in Info Bar)
   - [x] 1.3 Handle scoring updates on win, loss, and tie
   - [x] 1.4 Add "Next Round" and "Quit Match" buttons to controls
-  - [x] 1.5 End match after 10 points or 25 rounds
+  - [x] 1.5 End match after the user-selected win target (5, 10, or 15 points; default 10) or 25 rounds
 - [ ] 2.0 Add Early Quit Functionality
   - [x] 2.1 Trigger quit confirmation when the header logo is clicked
   - [x] 2.2 Create confirmation prompt flow

--- a/design/productRequirementsDocuments/prdGameModes.md
+++ b/design/productRequirementsDocuments/prdGameModes.md
@@ -69,7 +69,7 @@ Improving session variety directly supports retention and encourages more person
 
 | Priority | Feature           | Description                                         |
 | -------- | ----------------- | --------------------------------------------------- |
-| P1       | Classic Battle    | 1v1 battle vs opponent, stat-based combat to 10 pts |
+| P1       | Classic Battle    | 1v1 battle vs opponent, stat-based combat to a user-selected 5/10/15 point win target (default 10) |
 | P1       | Team Battle Modes | Gender-specific team-based battles                  |
 | P1       | Judoka Creation   | Interface for new character creation                |
 | P2       | Judoka Update     | Edit existing characters and save changes           |
@@ -83,9 +83,9 @@ Improving session variety directly supports retention and encourages more person
 
 ### Classic Battle
 
-**Japanese**: 試合 (バトルモード)  
-**URL**: `battleJudoka.html`  
-A 1v1 stat-based match against an AI opponent using a deck of 25 random judoka cards. First to 10 points wins. [Read full PRD](prdClassicBattle.md)
+**Japanese**: 試合 (バトルモード)
+**URL**: `battleJudoka.html`
+A 1v1 stat-based match against an AI opponent using a deck of 25 random judoka cards. On first visit, a modal prompts the player to choose a win target of 5, 10, or 15 points (default 10); first to that target wins. [Read full PRD](prdClassicBattle.md)
 SVG Icon: M762-96 645-212l-88 88-28-28q-23-23-23-57t23-57l169-169q23-23 57-23t57 23l28 28-88 88 116 117q12 12 12 28t-12 28l-50 50q-12 12-28 12t-28-12Zm118-628L426-270l5 4q23 23 23 57t-23 57l-28 28-88-88L198-96q-12 12-28 12t-28-12l-50-50q-12-12-12-28t12-28l116-117-88-88 28-28q23-23 57-23t57 23l4 5 454-454h160v160ZM334-583l24-23 23-24-23 24-24 23Zm-56 57L80-724v-160h160l198 198-57 56-174-174h-47v47l174 174-56 57Zm92 199 430-430v-47h-47L323-374l47 47Zm0 0-24-23-23-24 23 24 24 23Z
 
 #### Goals
@@ -98,7 +98,7 @@ SVG Icon: M762-96 645-212l-88 88-28-28q-23-23-23-57t23-57l169-169q23-23 57-23t57
 - Draw one random card from each deck per round.
 - Player selects a stat to compare.
 - Higher stat wins; score increases by one.
-- End match on 10 points or after 25 rounds.
+- End match when either player reaches a user-selected win target of 5, 10, or 15 points (default 10) or after 25 rounds.
 
 #### Acceptance Criteria
 


### PR DESCRIPTION
## Summary
- document modal for choosing 5/10/15-point win target in Classic Battle
- update game modes overview to reflect selectable win targets

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed Tests 5)*
- `npx playwright test` *(fails: 4 failed, 1 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6895e4a48c648326b4cb97da7fae90e5