### PR TITLE
docs: adjust round length tooltips

### DIFF
--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -21,9 +21,9 @@
     "nextRound": "**Next round**\nBegin when you’re ready.",
     "quitMatch": "**Quit match**\nReturn to the menu.",
     "drawCard": "**Draw card**\nGet a new random judoka card.",
-    "roundQuick": "**Quick match**\\nFirst to 5 points.",
-    "roundMedium": "**Medium match**\\nFirst to 10 points (default).",
-    "roundLong": "**Long match**\\nFirst to 15 points."
+    "roundQuick": "**Quick**\\nFirst to 5 points wins.",
+    "roundMedium": "**Medium**\\nFirst to 10 points wins.",
+    "roundLong": "**Long**\\nFirst to 15 points wins."
   },
 
   "mode": {


### PR DESCRIPTION
## Summary
- refine quick, medium, and long round tooltips

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: No "CLASSIC_BATTLE_POINTS_TO_WIN" export is defined on the mock, etc.)*
- `npx playwright test` *(fails: 10 failed)*
- `npm run check:contrast`
- `npm run validate:data` *(fails: npm error could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_6895e49dd8dc8326a64f6b768dfb79b8