### PR TITLE
test: add round select modal tests

### DIFF
--- a/tests/data/tooltipsEntries.test.js
+++ b/tests/data/tooltipsEntries.test.js
@@ -11,7 +11,16 @@ function get(obj, path) {
 
 describe("tooltips.json", () => {
   it("contains new ui tooltip entries", () => {
-    const keys = ["ui.languageToggle", "ui.nextRound", "ui.quitMatch", "ui.drawCard", "card.flag"];
+    const keys = [
+      "ui.languageToggle",
+      "ui.nextRound",
+      "ui.quitMatch",
+      "ui.drawCard",
+      "card.flag",
+      "ui.roundQuick",
+      "ui.roundMedium",
+      "ui.roundLong"
+    ];
     for (const key of keys) {
       expect(get(tooltips, key)).toBeDefined();
     }

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
+import { CLASSIC_BATTLE_POINTS_TO_WIN } from "../../../src/helpers/constants.js";
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
@@ -100,7 +101,7 @@ describe("classicBattle match flow", () => {
     expect(document.querySelector("header #score-display").textContent).toBe("You: 0\nOpponent: 0");
   });
 
-  it("ends the match when player reaches 10 wins", async () => {
+  it("ends the match when player reaches required wins", async () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
@@ -110,7 +111,7 @@ describe("classicBattle match flow", () => {
       await vi.runAllTimersAsync();
       await p;
     };
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < CLASSIC_BATTLE_POINTS_TO_WIN; i++) {
       document.getElementById("player-card").innerHTML =
         `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
       document.getElementById("computer-card").innerHTML =
@@ -118,7 +119,7 @@ describe("classicBattle match flow", () => {
       await selectStat();
     }
     expect(document.querySelector("header #score-display").textContent).toBe(
-      "You: 10\nOpponent: 0"
+      `You: ${CLASSIC_BATTLE_POINTS_TO_WIN}\nOpponent: 0`
     );
     expect(document.querySelector("header #round-message").textContent).toMatch(/win the match/i);
 
@@ -133,11 +134,11 @@ describe("classicBattle match flow", () => {
     }
 
     expect(document.querySelector("header #score-display").textContent).toBe(
-      "You: 10\nOpponent: 0"
+      `You: ${CLASSIC_BATTLE_POINTS_TO_WIN}\nOpponent: 0`
     );
   });
 
-  it("ends the match when opponent reaches 10 wins", async () => {
+  it("ends the match when opponent reaches required wins", async () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
@@ -147,7 +148,7 @@ describe("classicBattle match flow", () => {
       await vi.runAllTimersAsync();
       await p;
     };
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < CLASSIC_BATTLE_POINTS_TO_WIN; i++) {
       document.getElementById("player-card").innerHTML =
         `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
       document.getElementById("computer-card").innerHTML =
@@ -155,7 +156,7 @@ describe("classicBattle match flow", () => {
       await selectStat();
     }
     expect(document.querySelector("header #score-display").textContent).toBe(
-      "You: 0\nOpponent: 10"
+      `You: 0\nOpponent: ${CLASSIC_BATTLE_POINTS_TO_WIN}`
     );
     expect(document.querySelector("header #round-message").textContent).toMatch(
       /opponent wins the match/i
@@ -172,7 +173,7 @@ describe("classicBattle match flow", () => {
     }
 
     expect(document.querySelector("header #score-display").textContent).toBe(
-      "You: 0\nOpponent: 10"
+      `You: 0\nOpponent: ${CLASSIC_BATTLE_POINTS_TO_WIN}`
     );
   });
 

--- a/tests/helpers/classicBattle/roundSelectModal.test.js
+++ b/tests/helpers/classicBattle/roundSelectModal.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const rounds = JSON.parse(readFileSync(resolve("src/data/battleRounds.json"), "utf8"));
+
+const mocks = vi.hoisted(() => ({
+  fetchJson: vi.fn(),
+  setPointsToWin: vi.fn(),
+  initTooltips: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/dataUtils.js", () => ({ fetchJson: mocks.fetchJson }));
+vi.mock("../../../src/components/Button.js", () => ({
+  createButton: (label, { id } = {}) => {
+    const btn = document.createElement("button");
+    if (id) btn.id = id;
+    btn.textContent = label;
+    return btn;
+  }
+}));
+vi.mock("../../../src/components/Modal.js", () => ({
+  createModal: (content) => {
+    const element = document.createElement("div");
+    element.appendChild(content);
+    return { element, open: vi.fn(), close: vi.fn() };
+  }
+}));
+vi.mock("../../../src/helpers/battleEngine.js", () => ({ setPointsToWin: mocks.setPointsToWin }));
+vi.mock("../../../src/helpers/tooltip.js", () => ({ initTooltips: mocks.initTooltips }));
+
+import { initRoundSelectModal } from "../../../src/helpers/classicBattle/roundSelectModal.js";
+
+describe("initRoundSelectModal", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    mocks.fetchJson.mockResolvedValue(rounds);
+    mocks.initTooltips.mockResolvedValue();
+  });
+
+  it("renders three options from battleRounds.json", async () => {
+    await initRoundSelectModal(vi.fn());
+    const buttons = document.querySelectorAll(".round-select-buttons button");
+    expect(buttons).toHaveLength(3);
+    expect([...buttons].map((b) => b.textContent)).toEqual(rounds.map((r) => r.label));
+  });
+
+  it("selecting an option sets points and starts the match", async () => {
+    const onStart = vi.fn();
+    await initRoundSelectModal(onStart);
+    const first = document.querySelector(".round-select-buttons button");
+    first.click();
+    expect(mocks.setPointsToWin).toHaveBeenCalledWith(rounds[0].value);
+    expect(onStart).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for round selection modal to verify options and points setting
- expand tooltip coverage for new round-length keys
- update match flow tests to use win-condition constant

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: module mock and fetch errors)*
- `npx playwright test` *(fails: 10 tests failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6895e48ece788326a97af7026647c81c