### PR TITLE
test: use partial constants mock in random judoka tests

### DIFF
--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -53,7 +53,10 @@ describe("randomJudokaPage module", () => {
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue([])
     }));
-    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+    vi.doMock("../../src/helpers/constants.js", async () => ({
+      ...(await vi.importActual("../../src/helpers/constants.js")),
+      DATA_DIR: ""
+    }));
 
     const { section, container, placeholderTemplate } = createRandomCardDom();
     document.body.append(section, container, placeholderTemplate);
@@ -102,7 +105,10 @@ describe("randomJudokaPage module", () => {
 
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
-    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+    vi.doMock("../../src/helpers/constants.js", async () => ({
+      ...(await vi.importActual("../../src/helpers/constants.js")),
+      DATA_DIR: ""
+    }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings
     }));
@@ -146,7 +152,10 @@ describe("randomJudokaPage module", () => {
 
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
-    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+    vi.doMock("../../src/helpers/constants.js", async () => ({
+      ...(await vi.importActual("../../src/helpers/constants.js")),
+      DATA_DIR: ""
+    }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings
     }));
@@ -205,7 +214,10 @@ describe("randomJudokaPage module", () => {
 
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
-    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+    vi.doMock("../../src/helpers/constants.js", async () => ({
+      ...(await vi.importActual("../../src/helpers/constants.js")),
+      DATA_DIR: ""
+    }));
     vi.doMock("../../src/components/Button.js", () => ({ createButton }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ applyMotionPreference }));
@@ -255,7 +267,10 @@ describe("randomJudokaPage module", () => {
 
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
-    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+    vi.doMock("../../src/helpers/constants.js", async () => ({
+      ...(await vi.importActual("../../src/helpers/constants.js")),
+      DATA_DIR: ""
+    }));
     vi.doMock("../../src/helpers/settingsUtils.js", () => ({
       loadSettings
     }));


### PR DESCRIPTION
## Summary
- adjust `randomJudokaPage` tests to partially mock constants while overriding `DATA_DIR`

## Testing
- `npx prettier . --check`
- `npx eslint tests/helpers/randomJudokaPage.test.js`
- `npx vitest run`
- `npx playwright test` *(fails: expected screenshots differ; tests interrupted)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_6895ef7ed5408326b32ef24714bd04f3