### PR TITLE
feat: add match summary modal

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -21,7 +21,7 @@ import { getStatValue, resetStatButtons, showResult } from "./battle/index.js";
 import { createModal } from "../components/Modal.js";
 import { createButton } from "../components/Button.js";
 import { shouldReduceMotionSync } from "./motionUtils.js";
-import { syncScoreDisplay, showSummary } from "./classicBattle/uiService.js";
+import { syncScoreDisplay, showMatchSummaryModal } from "./classicBattle/uiService.js";
 
 /**
  * Determine the opponent's stat choice based on difficulty.
@@ -84,12 +84,6 @@ export function createBattleStore() {
       quitMatch(store);
     });
   }
-  const replayButton = document.getElementById("replay-button");
-  if (replayButton) {
-    replayButton.addEventListener("click", () => {
-      handleReplay(store);
-    });
-  }
   return store;
 }
 
@@ -105,15 +99,16 @@ function getStartRound(store) {
  *
  * @pseudocode
  * 1. Reset engine scores and flags.
- * 2. Hide the summary panel and clear the last round message.
+ * 2. Close any open modals and clear the last round message.
  * 3. Call the start round function to begin a new match.
  *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
  */
 export async function handleReplay(store) {
   engineReset();
-  const panel = document.getElementById("summary-panel");
-  if (panel) panel.classList.add("hidden");
+  document.querySelectorAll(".modal-backdrop").forEach((m) => {
+    if (typeof m.remove === "function") m.remove();
+  });
   infoBar.clearMessage();
   const startRoundFn = getStartRound(store);
   await startRoundFn();
@@ -208,7 +203,7 @@ export async function handleStatSelection(store, stat) {
       resetStatButtons();
       scheduleNextRound(result, getStartRound(store));
       if (result.matchEnded) {
-        showSummary(result);
+        showMatchSummaryModal(result, () => handleReplay(store));
       }
       updateDebugPanel();
       resolve(result);

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -1,5 +1,7 @@
 import { getScores } from "../battleEngine.js";
 import * as infoBar from "../setupBattleInfoBar.js";
+import { createModal } from "../../components/Modal.js";
+import { createButton } from "../../components/Button.js";
 
 /**
  * Update the info bar with current scores.
@@ -14,22 +16,55 @@ export function syncScoreDisplay() {
 }
 
 /**
- * Display match summary with final message and scores.
+ * Show a match summary modal with result message and scores.
  *
  * @pseudocode
- * 1. Find the summary panel and text elements.
- * 2. Insert the result message and scores.
- * 3. Reveal the panel by removing the hidden class.
+ * 1. Build title and score elements.
+ * 2. Create Quit and Next buttons using `createButton`.
+ * 3. Assemble the modal via `createModal` and append it to the DOM.
+ * 4. Quit navigates to `index.html`; Next closes the modal and runs `onNext`.
  *
  * @param {{message: string, playerScore: number, computerScore: number}} result
+ * @param {Function} onNext Callback invoked when starting the next match.
+ * @returns {ReturnType<typeof createModal>} Created modal instance.
  */
-export function showSummary(result) {
-  const panel = document.getElementById("summary-panel");
-  const messageEl = document.getElementById("summary-message");
-  const scoreEl = document.getElementById("summary-score");
-  if (panel && messageEl && scoreEl) {
-    messageEl.textContent = result.message;
-    scoreEl.textContent = `Final Score – You: ${result.playerScore} Opponent: ${result.computerScore}`;
-    panel.classList.remove("hidden");
-  }
+export function showMatchSummaryModal(result, onNext) {
+  const title = document.createElement("h2");
+  title.id = "match-summary-title";
+  title.textContent = result.message;
+
+  const scoreEl = document.createElement("p");
+  scoreEl.id = "match-summary-score";
+  scoreEl.textContent = `Final Score – You: ${result.playerScore} Opponent: ${result.computerScore}`;
+
+  const actions = document.createElement("div");
+  actions.className = "modal-actions";
+
+  const quit = createButton("Quit Match", {
+    id: "match-summary-quit",
+    className: "secondary-button"
+  });
+
+  const next = createButton("Next Match", { id: "match-summary-next" });
+
+  actions.append(quit, next);
+
+  const frag = document.createDocumentFragment();
+  frag.append(title, scoreEl, actions);
+
+  const modal = createModal(frag, { labelledBy: title });
+
+  quit.addEventListener("click", () => {
+    modal.close();
+    window.location.href = "../../index.html";
+  });
+
+  next.addEventListener("click", () => {
+    modal.close();
+    if (typeof onNext === "function") onNext();
+  });
+
+  document.body.appendChild(modal.element);
+  modal.open();
+  return modal;
 }

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -124,12 +124,6 @@
         </section>
       </main>
 
-      <div id="summary-panel" class="hidden" aria-live="polite">
-        <p id="summary-message"></p>
-        <p id="summary-score"></p>
-        <button id="replay-button">Replay</button>
-      </div>
-
       <footer>
         <nav class="bottom-navbar" data-testid="bottom-nav">
           <ul>


### PR DESCRIPTION
## Summary
- remove legacy summary panel from battle page
- add `showMatchSummaryModal` that displays final score with Quit/Next actions
- adjust battle flow and tests to use modal-based match summary

## Testing
- `npx prettier . --write`
- `npx eslint src/helpers/classicBattle/uiService.js src/helpers/classicBattle.js tests/helpers/classicBattlePage.test.js src/pages/battleJudoka.html`
- `npx vitest run`
- `npx playwright test` *(fails: 10 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6895f4fb5c8c832693ef21d531a3ad92