### PR TITLE
Clarify Classic Battle match-end flow in PRD

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -115,7 +115,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - After the player selects a stat, the Info Bar shows "Opponent is choosing..." until the opponent's stat is revealed.
 - If the selected stats are equal, a tie message displays and the round ends.
 - Cooldown timer to enable the next round starts only after round results are shown.
-- After the match ends, a summary panel displays the final result and score with a Replay button that restarts the match.
+- After the match ends, a modal appears showing the final result and score with **Quit Match** and **Next Match** buttons; **Quit Match** exits to the main menu and **Next Match** starts a new match.
 - Player can quit mid-match; confirmation prompt appears; if confirmed, match ends with player loss recorded.
 - After confirming the quit action, the player is returned to the main menu (index.html).
 - If AI difficulty affects stat selection, AI uses correct logic per difficulty setting.


### PR DESCRIPTION
## Summary
- Replace replay summary panel with modal offering Quit Match and Next Match buttons in Classic Battle PRD
- Specify that the modal appears when a match ends and that buttons exit or start a new match

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 103 passed, others erroring)*
- `npx playwright test` *(fails: 7 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6895f8cfe9d083269937fc5300256c36