### PR TITLE
Pause round timer on stat selection

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -14,7 +14,8 @@ import {
   handleStatSelection as engineHandleStatSelection,
   quitMatch as engineQuitMatch,
   _resetForTest as engineReset,
-  STATS
+  STATS,
+  pauseTimer
 } from "./battleEngine.js";
 import * as infoBar from "./setupBattleInfoBar.js";
 import { getStatValue, resetStatButtons, showResult } from "./battle/index.js";
@@ -180,7 +181,7 @@ export function evaluateRound(store, stat) {
  * Handle player stat selection with a brief delay to reveal the opponent card.
  *
  * @pseudocode
- * 1. Clear any pending timeouts.
+ * 1. Pause the round timer and clear any pending timeouts.
  * 2. Clear the countdown and show "Opponent is choosing…" in the info bar.
  * 3. After a short delay, reveal the opponent card and evaluate the round.
  * 4. Reset stat buttons and schedule the next round.
@@ -196,6 +197,7 @@ export async function handleStatSelection(store, stat) {
     return { matchEnded: false };
   }
   store.selectionMade = true;
+  pauseTimer();
   clearTimeout(store.statTimeoutId);
   clearTimeout(store.autoSelectId);
   infoBar.clearTimer();

--- a/tests/helpers/classicBattle/pauseTimer.test.js
+++ b/tests/helpers/classicBattle/pauseTimer.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
+
+vi.mock("../../../src/helpers/motionUtils.js", () => ({
+  shouldReduceMotionSync: () => true
+}));
+
+let generateRandomCardMock;
+vi.mock("../../../src/helpers/randomCard.js", () => ({
+  generateRandomCard: (...args) => generateRandomCardMock(...args)
+}));
+
+let getRandomJudokaMock;
+let renderMock;
+let JudokaCardMock;
+vi.mock("../../../src/helpers/cardUtils.js", () => ({
+  getRandomJudoka: (...args) => getRandomJudokaMock(...args)
+}));
+vi.mock("../../../src/components/JudokaCard.js", () => {
+  renderMock = vi.fn();
+  JudokaCardMock = vi.fn().mockImplementation(() => ({ render: renderMock }));
+  return { JudokaCard: JudokaCardMock };
+});
+
+let fetchJsonMock;
+vi.mock("../../../src/helpers/dataUtils.js", () => ({
+  fetchJson: (...args) => fetchJsonMock(...args),
+  importJsonModule: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/utils.js", () => ({
+  createGokyoLookup: () => ({})
+}));
+
+describe("classicBattle timer pause", () => {
+  let timer;
+  let showMessage;
+  let battleMod;
+  let store;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    document.body.innerHTML = "";
+    const { playerCard, computerCard } = createBattleCardContainers();
+    const header = createBattleHeader();
+    const roundResult = document.createElement("p");
+    roundResult.id = "round-result";
+    roundResult.setAttribute("aria-live", "polite");
+    roundResult.setAttribute("aria-atomic", "true");
+    const statButtons = document.createElement("div");
+    statButtons.id = "stat-buttons";
+    statButtons.dataset.tooltipId = "ui.selectStat";
+    statButtons.innerHTML = '<button data-stat="power"></button>';
+    document.body.append(playerCard, computerCard, header, roundResult, statButtons);
+
+    timer = vi.useFakeTimers();
+
+    fetchJsonMock = vi.fn(async (url) => {
+      if (String(url).includes("gameTimers.json")) {
+        return [{ id: 1, value: 1, default: true, category: "roundTimer" }];
+      }
+      return [];
+    });
+
+    generateRandomCardMock = vi.fn(async (_d, _g, container, _pm, cb) => {
+      container.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
+      if (cb) cb({ id: 1 });
+    });
+    getRandomJudokaMock = vi.fn(() => ({ id: 2 }));
+    renderMock = vi.fn(async () => {
+      const el = document.createElement("div");
+      el.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
+      return el;
+    });
+
+    showMessage = vi.fn();
+    vi.doMock("../../../src/helpers/setupBattleInfoBar.js", () => ({
+      showMessage,
+      showTemporaryMessage: () => () => {},
+      clearTimer: vi.fn(),
+      clearMessage: vi.fn(),
+      updateScore: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/battleEngine.js", async () => {
+      const actual = await vi.importActual("../../../src/helpers/battleEngine.js");
+      return { ...actual, watchForDrift: vi.fn(() => () => {}) };
+    });
+
+    battleMod = await import("../../../src/helpers/classicBattle.js");
+    store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+  });
+
+  afterEach(() => {
+    timer.clearAllTimers();
+  });
+
+  it("does not show auto-select message when stat picked before timer expires", async () => {
+    await battleMod.startRound(store);
+    timer.advanceTimersByTime(900);
+    const p = battleMod.handleStatSelection(store, "power");
+    await vi.runAllTimersAsync();
+    await p;
+    await vi.runAllTimersAsync();
+    const messages = showMessage.mock.calls.map((c) => c[0]);
+    expect(messages.some((m) => /Time's up! Auto-selecting/.test(m))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- pause round timer as soon as a stat is chosen to avoid auto-selection messages
- document timer pause behavior in handleStatSelection pseudocode
- test that selecting a stat before the timer expires suppresses the auto-pick warning

## Testing
- `npx prettier src/helpers/classicBattle.js tests/helpers/classicBattle/pauseTimer.test.js --check`
- `npx eslint src/helpers/classicBattle.js tests/helpers/classicBattle/pauseTimer.test.js`
- `npx vitest run` *(fails: tests/helpers/classicBattle/opponentDelay.test.js)*
- `npx playwright test` *(fails: playwright/battleJudoka.spec.js etc.)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6895f82ed68883269b1c99cd30fcc15a