### PR TITLE
test: stub pauseTimer in opponent delay test

### DIFF
--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -52,6 +52,7 @@ beforeEach(() => {
   vi.mock("../../../src/helpers/battleEngine.js", () => ({
     handleStatSelection: vi.fn().mockReturnValue({ message: "", matchEnded: false }),
     quitMatch: vi.fn(),
+    pauseTimer: vi.fn(),
     getScores: vi.fn().mockReturnValue({ playerScore: 0, computerScore: 0 }),
     _resetForTest: vi.fn(),
     STATS: ["power"]


### PR DESCRIPTION
## Summary
- add `pauseTimer` mock to opponent delay test so battle engine interface is fully mocked

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/opponentDelay.test.js`
- `npx playwright test` *(fails: 13 failed, 1 skipped, 81 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68960334ee508326b1b2220a025c83bc