### PR TITLE
test: mock battleEngine stopTimer

### DIFF
--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -53,6 +53,7 @@ beforeEach(() => {
     handleStatSelection: vi.fn().mockReturnValue({ message: "", matchEnded: false }),
     quitMatch: vi.fn(),
     pauseTimer: vi.fn(),
+    stopTimer: vi.fn(),
     getScores: vi.fn().mockReturnValue({ playerScore: 0, computerScore: 0 }),
     _resetForTest: vi.fn(),
     STATS: ["power"]


### PR DESCRIPTION
## Summary
- expose `stopTimer` in `battleEngine` mock so opponent delay tests can cover all exports

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/opponentDelay.test.js`
- `npx playwright test` *(fails: 13 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689618a139288326a45431336d55e2cb