### PR TITLE
feat: show next round countdown in snackbar

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-Displays round messages, a countdown timer, and live match score in the page header so players always know the current battle status. The Info Bar also manages the stat selection timer and fallback logic, as required by Classic Battle mode.
+Displays round messages, stat selection timer, and live match score in the page header so players always know the current battle status. The countdown between rounds is surfaced via a snackbar.
 
 ---
 
@@ -20,7 +20,7 @@ The round message, timer, and score now sit directly inside the page header rath
 2. **Display round-specific messaging** on the **left side of the top bar**, depending on match state:
    - If a round ends: show **win/loss/result** message for **2 seconds**.
    - If awaiting action: show **selection prompt** until a decision is made.
-   - If waiting for next round: show **countdown timer** that begins **within 1s** of round end.
+   - If waiting for next round: show **snackbar countdown** that begins **within 1s** of round end.
    - If in stat selection phase: show **30-second countdown timer** and prompt; if timer expires, auto-select a stat (see [Classic Battle PRD](prdClassicBattle.md)).
    - After the player picks a stat: show **"Opponent is choosing..."** until the opponent's choice is revealed.
 3. Ensure all messages are clearly readable, positioned responsively, and maintain usability across devices.
@@ -47,7 +47,7 @@ The round message, timer, and score now sit directly inside the page header rath
 
 - Match score is updated within **800ms** after round ends. <!-- Implemented: see updateScore in InfoBar.js and battleEngine.js -->
 - Win/loss message is shown within **1s** of round end and remains visible for **2s**. <!-- Implemented: see showResult in battleUI.js -->
-- Countdown timer begins only after the 2s result message fades out, aligned with server round start delay. <!-- Implemented: see startCoolDown in battleEngine.js -->
+- Countdown snackbar begins only after the 2s result message fades out, aligned with server round start delay. <!-- Implemented: see startCoolDown in battleEngine.js -->
 - Action prompt appears during user input phases and disappears after interaction. <!-- Implemented: see showMessage and stat selection logic -->
 - **Stat selection timer (30s) is displayed during stat selection phase; if timer expires, a random stat is auto-selected. Timer stops immediately once a stat is picked and pauses/resumes on tab inactivity.** <!-- Implemented: see startRound in battleEngine.js and [Classic Battle PRD](prdClassicBattle.md) -->
 - Auto-select messages are only shown if no stat was chosen before the timer runs out.
@@ -73,7 +73,7 @@ The round message, timer, and score now sit directly inside the page header rath
 - **Layout**
   - Right side: score display (`Player: X – Opponent: Y`)
   - Two-line score format appears on narrow screens via stacked `<span>` elements (`<span>You: X</span> <span>Opponent: Y</span>`)
-  - Left side: rotating status messages (e.g., "You won!", "Next round in: 3s", "Select your move", **"Time left: 29s"**)
+  - Left side: rotating status messages (e.g., "You won!", "Select your move", **"Time left: 29s"**). Countdown to the next round appears in a snackbar.
 - **Visuals**
   - Font size: `clamp(16px, 4vw, 24px)`; on narrow screens (<375px) `clamp(14px, 5vw, 20px)`.
   - Color coding: green (win), red (loss), neutral grey (countdown).
@@ -106,7 +106,7 @@ The round message, timer, and score now sit directly inside the page header rath
 - [x] 2.0 Implement Round Info Messages
 
   - [x] 2.1 Display win/loss messages for 2 seconds
-  - [x] 2.2 Start countdown timer after message disappears
+  - [x] 2.2 Start countdown snackbar after message disappears
   - [x] 2.3 Display selection prompt when input is needed
   - [x] 2.4 Display stat selection timer and auto-select if expired (see [Classic Battle PRD](prdClassicBattle.md))
   - [x] 2.5 Pause/resume stat selection timer on tab inactivity (see battleEngine.js)

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -35,7 +35,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - ≥70% of new players complete a Classic Battle within their first session.
 - Give new players an approachable mode to learn how judoka stats impact outcomes.
 - Reduce frustration by providing immediate, clear feedback on round results.
-- Ensure all round messages, timers, and score are surfaced via the Info Bar (see prdBattleInfoBar.md) for clarity and accessibility.
+- Ensure all round messages, stat selection timer, and score are surfaced via the Info Bar (see prdBattleInfoBar.md) for clarity and accessibility. The countdown to the next round is shown in a snackbar.
 
 ---
 
@@ -78,7 +78,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Detect timer drift by comparing engine state with real time; if drift exceeds 2s, display "Waiting…" and restart the countdown.
 - Opponent stat selection runs entirely on the client. After the player picks a stat (or the timer auto-chooses), the opponent's choice is revealed after a short artificial delay to mimic turn-taking.
 - During this delay, the Info Bar displays "Opponent is choosing..." to reinforce turn flow.
-- The cooldown timer between rounds begins only after round results are shown in the Info Bar.
+- The cooldown timer between rounds begins only after round results are shown in the Info Bar and is displayed using a snackbar countdown.
 - The debug panel is available when the `battleDebugPanel` feature flag is enabled and appears beside the opponent's card.
 
 ---

--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -14,6 +14,7 @@
  */
 import { shouldReduceMotionSync } from "../helpers/motionUtils.js";
 import { startCoolDown, watchForDrift } from "../helpers/battleEngine.js";
+import { showSnackbar } from "../helpers/showSnackbar.js";
 
 let messageEl;
 let timerEl;
@@ -169,19 +170,19 @@ export function clearTimer() {
  * desynchronization occurs.
  *
  * @pseudocode
- * 1. Use `startCoolDown` to update the timer each second.
- * 2. Monitor for drift via `watchForDrift`; on drift, show "Waiting…" and
+ * 1. Use `startCoolDown` to update the remaining time each second.
+ * 2. On each tick, call `showSnackbar` with `"Next round in: <n>s"`.
+ * 3. Monitor for drift via `watchForDrift`; on drift, show "Waiting…" and
  *    restart the countdown, giving up after several retries.
- * 3. When the timer expires, stop monitoring, clear the display, and invoke `onFinish`.
+ * 4. When the timer expires, stop monitoring, clear the timer display, and invoke `onFinish`.
  *
  * @param {number} seconds - Seconds to count down from.
  * @param {Function} [onFinish] - Optional callback when countdown ends.
  * @returns {void}
  */
 export function startCountdown(seconds, onFinish) {
-  if (!timerEl) return;
+  clearTimer();
   if (seconds <= 0) {
-    clearTimer();
     if (typeof onFinish === "function") onFinish();
     return;
   }
@@ -191,7 +192,7 @@ export function startCountdown(seconds, onFinish) {
       clearTimer();
       return;
     }
-    timerEl.textContent = `Next round in: ${remaining}s`;
+    showSnackbar(`Next round in: ${remaining}s`);
   };
 
   let stopWatch;

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -4,6 +4,7 @@ import { startRound as engineStartRound, startCoolDown, STATS } from "../battleE
 import * as infoBar from "../setupBattleInfoBar.js";
 import { enableNextRoundButton, disableNextRoundButton, updateDebugPanel } from "./uiHelpers.js";
 import { runTimerWithDrift } from "./runTimerWithDrift.js";
+import { showSnackbar } from "../showSnackbar.js";
 
 /**
  * Start the round timer and auto-select a random stat when time expires.
@@ -86,7 +87,8 @@ export function handleStatSelectionTimeout(store, onSelect) {
  * @pseudocode
  * 1. If the match ended, return early.
  * 2. Setup a click handler that disables the button and calls `startRoundFn`.
- * 3. After a short delay, run a 3 second cooldown via `runTimerWithDrift(startCoolDown)`.
+ * 3. After a short delay, run a 3 second cooldown via `runTimerWithDrift(startCoolDown)`
+ *    and display `"Next round in: <n>s"` with `showSnackbar`.
  * 4. When expired, enable the button and attach the click handler.
  *
  * @param {{matchEnded: boolean}} result - Result from a completed round.
@@ -103,15 +105,12 @@ export function scheduleNextRound(result, startRoundFn) {
     await startRoundFn();
   };
 
-  const timerEl = document.getElementById("next-round-timer");
-
   const onTick = (remaining) => {
-    if (!timerEl) return;
     if (remaining <= 0) {
       infoBar.clearTimer();
       return;
     }
-    timerEl.textContent = `Next round in: ${remaining}s`;
+    showSnackbar(`Next round in: ${remaining}s`);
   };
 
   const onExpired = () => {

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
+vi.mock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar: vi.fn() }));
 import {
   createInfoBar,
   initInfoBar,
@@ -11,6 +12,7 @@ import {
   startCountdown,
   updateScore
 } from "../../src/components/InfoBar.js";
+import { showSnackbar } from "../../src/helpers/showSnackbar.js";
 import * as battleEngine from "../../src/helpers/battleEngine.js";
 import { createInfoBarHeader } from "../utils/testUtils.js";
 
@@ -18,6 +20,7 @@ describe("InfoBar component", () => {
   let header;
 
   beforeEach(() => {
+    showSnackbar.mockClear();
     header = document.createElement("header");
     createInfoBar(header);
     document.body.appendChild(header);
@@ -56,14 +59,14 @@ describe("InfoBar component", () => {
     expect(document.getElementById("round-message").textContent).toBe("");
   });
 
-  it("startCountdown updates timer each second", () => {
+  it("startCountdown shows snackbar each second", () => {
     const timer = vi.useFakeTimers();
     startCountdown(2);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 2s");
+    expect(showSnackbar).toHaveBeenCalledWith("Next round in: 2s");
     timer.advanceTimersByTime(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
+    expect(showSnackbar).toHaveBeenCalledWith("Next round in: 1s");
     timer.advanceTimersByTime(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("");
+    expect(showSnackbar).toHaveBeenCalledTimes(2);
     timer.clearAllTimers();
   });
 
@@ -89,9 +92,9 @@ describe("InfoBar component", () => {
     updateScore(2, 3);
     expect(document.getElementById("score-display").textContent).toBe("You: 2\nOpponent: 3");
     startCountdown(1);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
+    expect(showSnackbar).toHaveBeenCalledWith("Next round in: 1s");
     timer.advanceTimersByTime(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("");
+    expect(showSnackbar).toHaveBeenCalledTimes(1);
     timer.clearAllTimers();
   });
 });

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -44,7 +44,7 @@ describe("countdown resets after stat selection", () => {
     expect(document.getElementById("next-round-timer").textContent).toBe("");
 
     await vi.advanceTimersByTimeAsync(2000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 3s");
+    expect(document.querySelector(".snackbar").textContent).toBe("Next round in: 3s");
     timer.clearAllTimers();
   });
 });

--- a/tests/helpers/setupBattleInfoBar.test.js
+++ b/tests/helpers/setupBattleInfoBar.test.js
@@ -3,6 +3,7 @@ import { createInfoBarHeader } from "../utils/testUtils.js";
 vi.mock("../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
+vi.mock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar: vi.fn() }));
 
 const originalReadyState = Object.getOwnPropertyDescriptor(document, "readyState");
 
@@ -23,6 +24,8 @@ describe("setupBattleInfoBar", () => {
     vi.useFakeTimers();
 
     const mod = await import("../../src/helpers/setupBattleInfoBar.js");
+    const { showSnackbar } = await import("../../src/helpers/showSnackbar.js");
+    showSnackbar.mockClear();
 
     document.dispatchEvent(new Event("DOMContentLoaded"));
 
@@ -42,9 +45,9 @@ describe("setupBattleInfoBar", () => {
     expect(document.getElementById("score-display").textContent).toBe("You: 1\nOpponent: 2");
 
     mod.startCountdown(1);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
+    expect(showSnackbar).toHaveBeenCalledWith("Next round in: 1s");
     await vi.advanceTimersByTimeAsync(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("");
+    expect(showSnackbar).toHaveBeenCalledTimes(1);
   });
 
   it("initializes immediately when DOM already loaded", async () => {
@@ -63,6 +66,8 @@ describe("setupBattleInfoBar", () => {
     document.body.innerHTML = "";
     document.body.appendChild(createInfoBarHeader());
     const mod = await import("../../src/helpers/setupBattleInfoBar.js");
+    const { showSnackbar } = await import("../../src/helpers/showSnackbar.js");
+    showSnackbar.mockClear();
     mod.showMessage("Hello");
     expect(document.getElementById("round-message").textContent).toBe("Hello");
     mod.clearMessage();
@@ -71,8 +76,8 @@ describe("setupBattleInfoBar", () => {
     expect(document.getElementById("score-display").textContent).toBe("You: 3\nOpponent: 4");
     vi.useFakeTimers();
     mod.startCountdown(1);
-    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 1s");
+    expect(showSnackbar).toHaveBeenCalledWith("Next round in: 1s");
     await vi.advanceTimersByTimeAsync(1000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("");
+    expect(showSnackbar).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- show next-round countdown via snackbar instead of Info Bar
- adjust battle timer service and InfoBar countdown logic
- document snackbar countdown and update related tests

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68962bf9ea7c832699bc15fa8edb00f0