### PR TITLE
Skip round selection modal in test mode

### DIFF
--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -1,18 +1,22 @@
 import { fetchJson } from "../dataUtils.js";
-import { DATA_DIR } from "../constants.js";
+import { DATA_DIR, CLASSIC_BATTLE_POINTS_TO_WIN } from "../constants.js";
 import { createButton } from "../../components/Button.js";
 import { createModal } from "../../components/Modal.js";
 import { setPointsToWin } from "../battleEngine.js";
 import { initTooltips } from "../tooltip.js";
+import { isTestModeEnabled } from "../testModeUtils.js";
 
 /**
  * Initialize round selection modal for Classic Battle.
  *
  * @pseudocode
- * 1. Fetch `battleRounds.json` using `fetchJson`.
- * 2. Create buttons for each option with `createButton` and assign tooltip ids.
- * 3. Assemble and open a modal via `createModal`.
- * 4. When a button is clicked:
+ * 1. If test mode is enabled:
+ *    a. Set `pointsToWin` to the default value.
+ *    b. Invoke `onStart` and return early.
+ * 2. Fetch `battleRounds.json` using `fetchJson`.
+ * 3. Create buttons for each option with `createButton` and assign tooltip ids.
+ * 4. Assemble and open a modal via `createModal`.
+ * 5. When a button is clicked:
  *    a. Call `setPointsToWin` with the round value.
  *    b. Close the modal and invoke the provided start callback.
  *
@@ -20,6 +24,12 @@ import { initTooltips } from "../tooltip.js";
  * @returns {Promise<void>} Resolves when modal is initialized.
  */
 export async function initRoundSelectModal(onStart) {
+  if (isTestModeEnabled()) {
+    setPointsToWin(CLASSIC_BATTLE_POINTS_TO_WIN);
+    if (typeof onStart === "function") await onStart();
+    return;
+  }
+
   let rounds;
   try {
     rounds = await fetchJson(`${DATA_DIR}battleRounds.json`);


### PR DESCRIPTION
## Summary
- Short-circuit Classic Battle round selection when test mode is active
- Document behavior in round selection modal pseudocode

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 13 failed, 81 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68962c13e60c8326b787a02e8507104b