### PR TITLE
Ensure Playwright init scripts run before navigation

### DIFF
--- a/playwright/fixtures/commonSetup.js
+++ b/playwright/fixtures/commonSetup.js
@@ -14,7 +14,6 @@ import { registerCommonRoutes } from "./commonRoutes.js";
 export const test = base.extend({
   /** @type {import('@playwright/test').Page} */
   page: async ({ page }, use) => {
-    await registerCommonRoutes(page);
     await page.addInitScript(() => {
       localStorage.clear();
       localStorage.setItem(
@@ -22,6 +21,7 @@ export const test = base.extend({
         JSON.stringify({ featureFlags: { enableTestMode: { enabled: true } } })
       );
     });
+    await registerCommonRoutes(page);
     await use(page);
   }
 });


### PR DESCRIPTION
## Summary
- Run test-mode localStorage script before registering routes in Playwright fixtures to guarantee settings are applied before page load.

## Testing
- `node -e "const { chromium } = require('playwright');(async () => { const browser = await chromium.launch(); const page = await browser.newPage(); await page.addInitScript(() => { localStorage.clear(); localStorage.setItem('settings', JSON.stringify({ featureFlags: { enableTestMode: { enabled: true } } })); }); await page.goto('file://' + process.cwd() + '/src/pages/battleJudoka.html'); const dialogCount = await page.locator('[role=\"dialog\"], .modal, .modal-container').count(); console.log('Modal elements:', dialogCount); await browser.close(); })();"`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Error fetching files in tests/helpers settingsPage, vectorSearchPage, etc.)*
- `npx playwright test` *(fails: numerous fetch errors and localStorage undefined issues)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68963b23c9888326b32dd1b3da5de072