### PR TITLE
Use test mode flag for deterministic randomness

### DIFF
--- a/playwright/signatureMove.spec.js
+++ b/playwright/signatureMove.spec.js
@@ -8,9 +8,6 @@ test.describe.parallel(
     test.skip(!runScreenshots);
 
     test("random judoka page", async ({ page }) => {
-      await page.addInitScript(() => {
-        Math.random = () => 0.42;
-      });
       await page.goto("/src/pages/randomJudoka.html");
       await page.getByTestId("draw-button").click();
       const sigMove = page.locator(".signature-move-container");

--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -31,6 +31,7 @@ import { onDomReady } from "./domReady.js";
 import { initTooltips } from "./tooltip.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
 import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
+import { setTestMode } from "./testModeUtils.js";
 
 const DRAW_ICON =
   '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#1f1f1f"><path d="m600-200-56-57 143-143H300q-75 0-127.5-52.5T120-580q0-75 52.5-127.5T300-760h20v80h-20q-42 0-71 29t-29 71q0 42 29 71t71 29h387L544-624l56-56 240 240-240 240Z"/></svg>';
@@ -52,6 +53,8 @@ export async function setupRandomJudokaPage() {
       }
     };
   }
+
+  setTestMode(Boolean(settings.featureFlags.enableTestMode?.enabled));
 
   // Apply global motion preference
   applyMotionPreference(settings.motionEffects);


### PR DESCRIPTION
## Summary
- seed randomness in random Judoka page via test mode flag
- drop Math.random override from signature move screenshot test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 15 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68964054cd2c8326bfe67e0b016aee30