### PR TITLE
Handle missing inspector flag in random card

### DIFF
--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -150,7 +150,7 @@ export async function setupRandomJudokaPage() {
       prefersReducedMotion,
       addToHistory,
       {
-        enableInspector: settings.featureFlags.enableCardInspector.enabled
+        enableInspector: Boolean(settings.featureFlags?.enableCardInspector?.enabled)
       }
     );
     function enableButton() {


### PR DESCRIPTION
## Summary
- safely read the `enableCardInspector` flag when drawing a random judoka card

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 11)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68964039839c83269178e8fc9fbd7895