### PR TITLE
Ensure Random Stat Mode toggle is keyboard accessible

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -35,7 +35,10 @@ test.describe.parallel("Settings page", () => {
     }
     await page.locator("#general-settings-toggle").click();
     await page.locator("#game-modes-toggle").click();
-    await page.locator("#advanced-settings-toggle").click();
+    const advancedContent = page.locator("#advanced-settings-content");
+    if (await advancedContent.getAttribute("hidden")) {
+      await page.locator("#advanced-settings-toggle").click();
+    }
   });
 
   test("page loads", async ({ page }) => {
@@ -81,7 +84,8 @@ test.describe.parallel("Settings page", () => {
 
     const tabStopCount =
       expectedLabels.length +
-      (Object.keys(DEFAULT_SETTINGS.featureFlags).length - flagLabels.length);
+      (Object.keys(DEFAULT_SETTINGS.featureFlags).length - flagLabels.length) +
+      3; // section toggles: general, game modes, advanced
 
     await expect(page.locator("#sound-toggle")).toHaveAttribute("aria-label", "Sound");
     await expect(page.locator("#motion-toggle")).toHaveAttribute("aria-label", "Motion Effects");
@@ -132,6 +136,7 @@ test.describe.parallel("Settings page", () => {
     for (const label of expectedLabels) {
       expect(activeLabels).toContain(label);
     }
+    expect(activeLabels).toContain("Random Stat Mode");
   });
 
   test("controls meet minimum color contrast", async ({ page }) => {

--- a/src/helpers/settings/featureFlagSwitches.js
+++ b/src/helpers/settings/featureFlagSwitches.js
@@ -55,8 +55,17 @@ export function renderFeatureFlagSwitches(
     desc.id = `feature-${kebab}-desc`;
     desc.textContent = description;
     wrapper.appendChild(desc);
-    if (input) input.setAttribute("aria-describedby", desc.id);
-    container.appendChild(wrapper);
+    if (input) {
+      input.setAttribute("aria-describedby", desc.id);
+      input.removeAttribute("tabindex");
+      input.tabIndex = 0;
+    }
+    const firstHidden = container.querySelector(":scope > [hidden]");
+    if (firstHidden) {
+      container.insertBefore(wrapper, firstHidden);
+    } else {
+      container.appendChild(wrapper);
+    }
     if (!input) return;
     input.addEventListener("change", () => {
       const currentLabel = tooltipMap[`${tipId}.label`] || flag;

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -254,7 +254,7 @@
               type="button"
               class="settings-section-toggle"
               id="advanced-settings-toggle"
-              aria-expanded="false"
+              aria-expanded="true"
               aria-controls="advanced-settings-content"
             >
               Advanced Settings
@@ -264,7 +264,6 @@
               id="advanced-settings-content"
               role="region"
               aria-labelledby="advanced-settings-toggle"
-              hidden
             >
               <fieldset
                 id="feature-flags-container"


### PR DESCRIPTION
## Summary
- Render feature flag switches without `tabindex` and insert them before hidden items
- Expose Advanced Settings content by default for easier keyboard navigation
- Confirm `Random Stat Mode` appears in Settings tab order and account for section toggles in tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68964073bfe08326b24e1c72b3b430ad