### PR TITLE
Delay classic battle home link binding until DOM ready

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -46,6 +46,7 @@ test.describe.parallel("Classic battle flow", () => {
 
   test("quit match confirmation", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
+    await page.waitForFunction(() => window.homeLinkReady);
     await page.locator("[data-testid='home-link']").click();
     const confirmButton = page.locator("#confirm-quit-button");
     await confirmButton.waitFor();

--- a/src/helpers/setupClassicBattleHomeLink.js
+++ b/src/helpers/setupClassicBattleHomeLink.js
@@ -1,23 +1,25 @@
+import { onDomReady } from "./domReady.js";
 import { createBattleStore, quitMatch } from "./classicBattle.js";
 
 /**
  * Attach quit confirmation to the header logo in Classic Battle.
  *
  * @pseudocode
- * 1. Select the `[data-testid="home-link"]` element.
- * 2. If found, listen for click events.
- * 3. On click, prevent default navigation and call `quitMatch()`.
+ * 1. When the DOM is ready, create the battle store.
+ * 2. Select the `[data-testid="home-link"]` element.
+ * 3. If found, attach a click listener that prevents navigation and calls `quitMatch()`.
+ * 4. After binding, set `window.homeLinkReady = true` for tests.
  */
-const store = createBattleStore();
-
 export function setupClassicBattleHomeLink() {
+  const store = createBattleStore();
   const homeLink = document.querySelector('[data-testid="home-link"]');
   if (homeLink) {
     homeLink.addEventListener("click", (e) => {
       e.preventDefault();
       quitMatch(store);
     });
+    window.homeLinkReady = true;
   }
 }
 
-setupClassicBattleHomeLink();
+onDomReady(setupClassicBattleHomeLink);


### PR DESCRIPTION
## Summary
- wait for DOM ready before creating the battle store and binding the Classic Battle home link, exposing `window.homeLinkReady` once attached
- pause Playwright classic battle flow test until the home link is ready

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 17 failed, 77 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6896470e5c24832693d892bbb0b15880