### PR TITLE
Display next round timer during cooldown

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -14,6 +14,7 @@ test.describe.parallel("Classic battle flow", () => {
     await expect(countdown).toHaveText(/\d+/);
     const result = page.locator("header #round-message");
     await expect(result).not.toHaveText("", { timeout: 8000 });
+    await expect(countdown).toHaveText(/Next round in: \d+s/);
   });
 
   test("tie message appears on equal stats", async ({ page }) => {
@@ -41,7 +42,7 @@ test.describe.parallel("Classic battle flow", () => {
     await expect(snackbar).toHaveText("You Picked: Power");
     const msg = page.locator("header #round-message");
     await expect(msg).toHaveText(/Tie/);
-    await expect(timer).toHaveText(/\d+/);
+    await expect(timer).toHaveText(/Next round in: \d+s/);
   });
 
   test("quit match confirmation", async ({ page }) => {

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -88,8 +88,8 @@ export function handleStatSelectionTimeout(store, onSelect) {
  * 1. If the match ended, return early.
  * 2. Setup a click handler that disables the button and calls `startRoundFn`.
  * 3. After a short delay, run a 3 second cooldown via `runTimerWithDrift(startCoolDown)`
- *    and display `"Next round in: <n>s"` with `showSnackbar`.
- * 4. When expired, enable the button and attach the click handler.
+ *    and display `"Next round in: <n>s"` in the snackbar and timer element.
+ * 4. When expired, clear the timer text, enable the button, and attach the click handler.
  *
  * @param {{matchEnded: boolean}} result - Result from a completed round.
  * @param {function(): Promise<void>} startRoundFn - Function to begin the next round.
@@ -98,6 +98,7 @@ export function scheduleNextRound(result, startRoundFn) {
   if (result.matchEnded) return;
 
   const btn = document.getElementById("next-round-button");
+  const timerEl = document.getElementById("next-round-timer");
   if (!btn) return;
 
   const onClick = async () => {
@@ -111,10 +112,16 @@ export function scheduleNextRound(result, startRoundFn) {
       return;
     }
     showSnackbar(`Next round in: ${remaining}s`);
+    if (timerEl) {
+      timerEl.textContent = `Next round in: ${remaining}s`;
+    }
   };
 
   const onExpired = () => {
     infoBar.clearTimer();
+    if (timerEl) {
+      timerEl.textContent = "";
+    }
     btn.addEventListener("click", onClick, { once: true });
     enableNextRoundButton();
     updateDebugPanel();

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -45,6 +45,7 @@ describe("countdown resets after stat selection", () => {
 
     await vi.advanceTimersByTimeAsync(2000);
     expect(document.querySelector(".snackbar").textContent).toBe("Next round in: 3s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 3s");
     timer.clearAllTimers();
   });
 });


### PR DESCRIPTION
## Summary
- Show "Next round in" countdown in the timer element during cooldown and clear on expiry
- Expect timer text in classic battle flow tests
- Verify timer text after stat selection reset

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 16 failed, 78 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689646ff5ee4832683e0a1024c88a547