### PR TITLE
Pass trigger element to quit match modal

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -251,19 +251,22 @@ function createQuitConfirmation(store, onConfirm) {
  * Trigger the Classic Battle quit confirmation modal.
  *
  * @pseudocode
- * 1. Create the modal if needed and open it.
+ * 1. Create the modal if needed.
+ * 2. Determine the element that opened the modal.
+ * 3. Open the modal focusing the triggering element when available.
  *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
+ * @param {HTMLElement} [trigger] - Element that initiated the quit action.
  */
-export function quitMatch(store) {
+export function quitMatch(store, trigger) {
   if (!store.quitModal) {
     store.quitModal = createQuitConfirmation(store, () => {
       const result = engineQuitMatch();
       showResult(result.message);
     });
   }
-  const trigger = document.getElementById("quit-match-button");
-  store.quitModal.open(trigger ?? undefined);
+  const fallback = document.getElementById("quit-match-button");
+  store.quitModal.open(trigger ?? fallback ?? undefined);
 }
 
 /**

--- a/src/helpers/setupClassicBattleHomeLink.js
+++ b/src/helpers/setupClassicBattleHomeLink.js
@@ -7,7 +7,7 @@ import { createBattleStore, quitMatch } from "./classicBattle.js";
  * @pseudocode
  * 1. When the DOM is ready, create the battle store.
  * 2. Select the `[data-testid="home-link"]` element.
- * 3. If found, attach a click listener that prevents navigation and calls `quitMatch()`.
+ * 3. If found, attach a click listener that prevents navigation and calls `quitMatch()` with the link as trigger.
  * 4. After binding, set `window.homeLinkReady = true` for tests.
  */
 export function setupClassicBattleHomeLink() {
@@ -16,7 +16,7 @@ export function setupClassicBattleHomeLink() {
   if (homeLink) {
     homeLink.addEventListener("click", (e) => {
       e.preventDefault();
-      quitMatch(store);
+      quitMatch(store, homeLink);
     });
     window.homeLinkReady = true;
   }


### PR DESCRIPTION
## Summary
- allow quitMatch to accept optional trigger and fallback to quit button
- pass home link as trigger when binding quit modal on classic battle page

## Testing
- `npx prettier src/helpers/classicBattle.js src/helpers/setupClassicBattleHomeLink.js --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/matchControls.test.js`
- `npx playwright test` *(fails: captures portrait/landscape headers, narrow viewport screenshot, desktop arrow key navigation; others interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689657bca4048326a70d9563dfdfaf2b