### PR TITLE
fix: deep merge settings loading

### DIFF
--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -78,7 +78,7 @@ const SAVE_DELAY_MS = 100;
  * 2. Throw an error if `localStorage` is unavailable.
  * 3. Retrieve the JSON string stored under `SETTINGS_KEY`.
  *    - When no value exists, return `DEFAULT_SETTINGS`.
- * 4. Parse the JSON and merge with `DEFAULT_SETTINGS`.
+ * 4. Parse the JSON and deep merge nested objects with `DEFAULT_SETTINGS`.
  * 5. Validate the merged object with `settingsSchema`.
  * 6. Return the validated settings or throw on failure.
  *
@@ -95,7 +95,22 @@ export async function loadSettings() {
   }
   try {
     const parsed = JSON.parse(raw);
-    const merged = { ...DEFAULT_SETTINGS, ...parsed };
+    const merged = {
+      ...DEFAULT_SETTINGS,
+      ...parsed,
+      featureFlags: {
+        ...DEFAULT_SETTINGS.featureFlags,
+        ...parsed.featureFlags
+      },
+      gameModes: {
+        ...DEFAULT_SETTINGS.gameModes,
+        ...parsed.gameModes
+      },
+      tooltipIds: {
+        ...DEFAULT_SETTINGS.tooltipIds,
+        ...parsed.tooltipIds
+      }
+    };
     await validateWithSchema(merged, await getSettingsSchema());
     return merged;
   } catch (error) {

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -43,6 +43,22 @@ describe("settings utils", () => {
   });
 
   /**
+   * Should retain default feature flags when partially loading from storage.
+   */
+  it("retains default feature flags on partial load", async () => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({ featureFlags: { enableTestMode: { enabled: true } } })
+    );
+    const { loadSettings } = await import("../../src/helpers/settingsUtils.js");
+    const settings = await loadSettings();
+    expect(settings.featureFlags.randomStatMode).toEqual(
+      DEFAULT_SETTINGS.featureFlags.randomStatMode
+    );
+    expect(settings.featureFlags.enableTestMode.enabled).toBe(true);
+  });
+
+  /**
    * Should debounce and save settings to localStorage.
    */
   it("saves settings with debounce", async () => {


### PR DESCRIPTION
## Summary
- replace shallow settings load merge with deep merge preserving nested defaults
- add unit test for partial feature flag load retaining randomStatMode

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 16 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689656ede9088326ade5b11bd7fee46a