### PR TITLE
Wait for quit modal to attach

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -50,7 +50,7 @@ test.describe.parallel("Classic battle flow", () => {
     await page.waitForFunction(() => window.homeLinkReady);
     await page.locator("[data-testid='home-link']").click();
     const confirmButton = page.locator("#confirm-quit-button");
-    await confirmButton.waitFor();
+    await confirmButton.waitFor({ state: "attached" });
     await confirmButton.click();
     await expect(page).toHaveURL(/index.html/);
   });


### PR DESCRIPTION
## Summary
- ensure classic battle quit flow waits for modal button to attach before clicking

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: fetch and navigation errors)*
- `npx playwright test` *(fails: 2 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68965ed1597083268f079f1aa232ead3