### PR TITLE
test: relax classic battle timer interval

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -6,7 +6,7 @@ test.describe.parallel("Classic battle flow", () => {
     await page.addInitScript(() => {
       window.startCountdownOverride = () => {};
       const orig = window.setInterval;
-      window.setInterval = (fn, ms, ...args) => orig(fn, Math.min(ms, 10), ...args);
+      window.setInterval = (fn, ms, ...args) => orig(fn, Math.min(ms, 100), ...args);
     });
     await page.goto("/src/pages/battleJudoka.html");
     const countdown = page.locator("header #next-round-timer");


### PR DESCRIPTION
## Summary
- slow down `setInterval` override in classic battle flow test so timers run no faster than 100ms

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68965eba898c83268e0ff9c215ffb33e