### PR TITLE
test: verify countdown text after timer expiry

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -6,7 +6,7 @@ test.describe.parallel("Classic battle flow", () => {
     await page.addInitScript(() => {
       window.startCountdownOverride = () => {};
       const orig = window.setInterval;
-      window.setInterval = (fn, ms, ...args) => orig(fn, Math.min(ms, 100), ...args);
+      window.setInterval = (fn, ms, ...args) => orig(fn, ms > 1000 ? 250 : ms, ...args); // 4× speed instead of 10×
     });
     await page.goto("/src/pages/battleJudoka.html");
     const countdown = page.locator("header #next-round-timer");
@@ -14,7 +14,7 @@ test.describe.parallel("Classic battle flow", () => {
     await expect(countdown).toHaveText(/\d+/);
     const result = page.locator("header #round-message");
     await expect(result).not.toHaveText("", { timeout: 8000 });
-    await expect(countdown).toHaveText(/Next round in: \d+s/);
+    await expect.poll(async () => await countdown.textContent()).toMatch(/Next round in: \d+s/);
   });
 
   test("tie message appears on equal stats", async ({ page }) => {


### PR DESCRIPTION
## Summary
- keep the battle countdown visible longer by reducing setInterval speed to 4×
- explicitly poll for cooldown text after a round message appears

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: failed to load game modes, fetch errors, etc.)*
- `npx playwright test` *(fails: several screenshot and flow tests, including timer auto-select test)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689666185ff0832680ec547abc389fa7