### PR TITLE
Expose shared battle store for classic mode

### DIFF
--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -3,14 +3,15 @@
  *
  * @pseudocode
  * 1. Import battle helpers, settings loader and DOM ready utility.
- * 2. Define `enableStatButtons` to toggle disabled state on all stat buttons.
- * 3. Define `startRoundWrapper` that:
+ * 2. Create a shared `battleStore` and expose it on `window`.
+ * 3. Define `enableStatButtons` to toggle disabled state on all stat buttons.
+ * 4. Define `startRoundWrapper` that:
  *    a. Disables stat buttons.
  *    b. Calls `startRound` from `classicBattle.js`.
  *    c. Waits for the Mystery card to render using `waitForComputerCard`.
  *    d. In simulated opponent mode, select a stat via `simulateOpponentStat`
  *       and await `handleStatSelection`; otherwise re-enable stat buttons.
- * 4. Define `setupClassicBattlePage` to:
+ * 5. Define `setupClassicBattlePage` to:
  *    a. Load feature flags and set `data-*` attributes on `#battle-area`.
  *    b. Attach click and keyboard listeners on stat buttons that call
  *       `handleStatSelection` and display a snackbar with the chosen stat when
@@ -24,7 +25,7 @@
  *       `data-orientation` attribute.
  *    h. Listen for `storage` events and update the Test Mode banner and
  *       `data-test-mode` attribute when settings change.
- * 5. Execute `setupClassicBattlePage` with `onDomReady`.
+ * 6. Execute `setupClassicBattlePage` with `onDomReady`.
  */
 import {
   createBattleStore,
@@ -53,6 +54,8 @@ function enableStatButtons(enable = true) {
 }
 
 const battleStore = createBattleStore();
+window.battleStore = battleStore;
+export const getBattleStore = () => battleStore;
 let simulatedOpponentMode = false;
 let aiDifficulty = "easy";
 

--- a/src/helpers/setupClassicBattleHomeLink.js
+++ b/src/helpers/setupClassicBattleHomeLink.js
@@ -1,24 +1,30 @@
 import { onDomReady } from "./domReady.js";
-import { createBattleStore, quitMatch } from "./classicBattle.js";
+import { quitMatch } from "./classicBattle.js";
 
 /**
  * Attach quit confirmation to the header logo in Classic Battle.
  *
  * @pseudocode
- * 1. When the DOM is ready, create the battle store.
- * 2. Select the `[data-testid="home-link"]` element.
- * 3. If found, attach a click listener that prevents navigation and calls `quitMatch()` with the link as trigger.
- * 4. After binding, set `window.homeLinkReady = true` for tests.
+ * 1. When the DOM is ready, select the `[data-testid="home-link"]` element.
+ * 2. If found, attach a click listener that:
+ *    a. Prevents navigation.
+ *    b. Calls `quitMatch()` with the shared store and link as trigger.
+ * 3. Wait for `window.battleStore` to exist, then set `window.homeLinkReady = true` for tests.
  */
 export function setupClassicBattleHomeLink() {
-  const store = createBattleStore();
   const homeLink = document.querySelector('[data-testid="home-link"]');
   if (homeLink) {
     homeLink.addEventListener("click", (e) => {
       e.preventDefault();
-      quitMatch(store, homeLink);
+      quitMatch(window.battleStore, homeLink);
     });
-    window.homeLinkReady = true;
+    (function waitForStore() {
+      if (window.battleStore) {
+        window.homeLinkReady = true;
+      } else {
+        setTimeout(waitForStore, 0);
+      }
+    })();
   }
 }
 

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -74,7 +74,7 @@ describe("classicBattle button handlers", () => {
 
   it("quit button invokes quitMatch", async () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
-    battleMod.createBattleStore();
+    window.battleStore = battleMod.createBattleStore();
     document.getElementById("quit-match-button").click();
     const confirmBtn = document.getElementById("confirm-quit-button");
     expect(confirmBtn).not.toBeNull();
@@ -90,7 +90,7 @@ describe("classicBattle button handlers", () => {
     homeLink.dataset.testid = "home-link";
     header.appendChild(homeLink);
     const battleMod = await import("../../../src/helpers/classicBattle.js");
-    battleMod.createBattleStore();
+    window.battleStore = battleMod.createBattleStore();
     await import("../../../src/helpers/setupClassicBattleHomeLink.js");
     const beforeHref = window.location.href;
     homeLink.click();


### PR DESCRIPTION
## Summary
- expose classic battle `battleStore` via `window` and getter
- use shared store for classic battle home link and wait for it to initialize
- adjust classic battle match control tests to reference shared store

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: JudokaCard did not render an HTMLElement, fetch errors)*
- `npx playwright test playwright/classicBattleFlow.spec.js -g "quit match confirmation" --reporter=line` *(fails: #confirm-quit-button not attached)*

------
https://chatgpt.com/codex/tasks/task_e_68966740c328832682a148e708858a02