### PR TITLE
test: ensure classic battle home link uses shared store

### DIFF
--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -90,11 +90,14 @@ describe("classicBattle button handlers", () => {
     homeLink.dataset.testid = "home-link";
     header.appendChild(homeLink);
     const battleMod = await import("../../../src/helpers/classicBattle.js");
-    window.battleStore = battleMod.createBattleStore();
+    const store = (window.battleStore = battleMod.createBattleStore());
+    const quitSpy = vi.spyOn(battleMod, "quitMatch");
     await import("../../../src/helpers/setupClassicBattleHomeLink.js");
     const beforeHref = window.location.href;
     homeLink.click();
     expect(window.location.href).toBe(beforeHref);
+    expect(quitSpy).toHaveBeenCalledWith(store, homeLink);
+    expect(window.battleStore).toBe(store);
     const confirmBtn = document.getElementById("confirm-quit-button");
     expect(confirmBtn).not.toBeNull();
     confirmBtn.dispatchEvent(new Event("click"));


### PR DESCRIPTION
## Summary
- verify Classic Battle home link uses existing battle store before quitting

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: homepage.spec.js etc.)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68967005d79c8326b0110a3fb47010f4