### PR TITLE
fix timer interval check

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -6,7 +6,7 @@ test.describe.parallel("Classic battle flow", () => {
     await page.addInitScript(() => {
       window.startCountdownOverride = () => {};
       const orig = window.setInterval;
-      window.setInterval = (fn, ms, ...args) => orig(fn, ms > 1000 ? 250 : ms, ...args); // 4× speed instead of 10×
+      window.setInterval = (fn, ms, ...args) => orig(fn, ms >= 1000 ? 250 : ms, ...args); // 4× speed instead of 10×
     });
     await page.goto("/src/pages/battleJudoka.html");
     const countdown = page.locator("header #next-round-timer");


### PR DESCRIPTION
## Summary
- ensure timer auto-select logic uses `>=` to cap intervals of 1000ms or more

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed to load game modes Error: fail, and others)*
- `npx playwright test` *(fails: playwright/changelog.spec.js:17:3 › Change log page › captures screenshot ───)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6896f2026118832683c626ae7830d462