### PR TITLE
refactor: clean modal backdrop once

### DIFF
--- a/playwright/fixtures/commonSetup.js
+++ b/playwright/fixtures/commonSetup.js
@@ -6,7 +6,7 @@
  * 2. Import registerCommonRoutes helper.
  * 3. Extend the base test's page fixture to:
  *    a. Clear localStorage and enable test-mode settings.
- *    b. Inject a MutationObserver to remove unexpected modal backdrops.
+ *    b. Remove unexpected modal backdrops once after DOMContentLoaded.
  *    c. Register common routes.
  * 4. Export the extended test and expect.
  */
@@ -24,10 +24,11 @@ export const test = base.extend({
       );
     });
     await page.addInitScript(() => {
-      const observer = new MutationObserver(() => {
-        document.querySelectorAll(".modal-backdrop")?.forEach((el) => el.remove());
-      });
-      observer.observe(document, { childList: true, subtree: true });
+      document.addEventListener(
+        "DOMContentLoaded",
+        () => document.querySelectorAll(".modal-backdrop").forEach((el) => el.remove()),
+        { once: true }
+      );
     });
     await registerCommonRoutes(page);
     await use(page);


### PR DESCRIPTION
## Summary
- remove continuous MutationObserver cleanup of `.modal-backdrop` and perform one-time DOMContentLoaded cleanup

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed to load game modes, tooltips, etc.)*
- `npx playwright test playwright/classicBattleFlow.spec.js` *(fails: page.goto net::ERR_CONNECTION_REFUSED)*
- `npx playwright test` *(fails: 15 failed, e.g. connection errors)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6896f1d51e0c8326ab93ea6862efb357