### PR TITLE
test: extend timer wait in classic battle

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -13,8 +13,10 @@ test.describe.parallel("Classic battle flow", () => {
     await countdown.waitFor();
     await expect(countdown).toHaveText(/\d+/);
     const result = page.locator("header #round-message");
-    await expect(result).not.toHaveText("", { timeout: 8000 });
-    await expect.poll(async () => await countdown.textContent()).toMatch(/Next round in: \d+s/);
+    await expect(result).not.toHaveText("", { timeout: 15000 });
+    await expect
+      .poll(() => countdown.textContent(), { timeout: 15000 })
+      .toMatch(/Next round in: \d+s/);
   });
 
   test("tie message appears on equal stats", async ({ page }) => {


### PR DESCRIPTION
## Summary
- wait up to 15s for round message before polling timer in classic battle flow test
- poll countdown with a 15s timeout to ensure next-round timer appears

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/classicBattleFlow.spec.js:5`
- `npx playwright test` *(fails: Battle orientation screenshots, Battle Judoka page, Browse Judoka navigation, Change log page, Screenshot suite, Settings screenshots, Signature move screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6896f865a8b48326bc28c35f184e2222