### PR TITLE
feat: add phase skip control

### DIFF
--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -6,11 +6,9 @@
     "technique": "**Technique** measures mastery of judo throws and transitions.\nHigh values indicate sharp, precise execution.",
     "newaza": "_Ne-waza_ means **ground grappling**.\nThis stat reflects skill in pins, holds, and other mat techniques."
   },
-
   "ui": {
     "countryFilter": "**Country filter**\nToggle the panel to pick flags and narrow the roster.",
     "clearFilter": "**Clear filter**\nShow all judoka.",
-
     "selectStat": "**Select a stat**\nThe higher value wins the round!",
     "cardOfTheDay": "**Card of the Day** shows a featured judoka.\nCheck back tomorrow for a new pick!",
     "winMessage": "**Victory!**\nYou chose the stronger stat.",
@@ -19,21 +17,20 @@
     "signatureBar": "**Signature move**\nThis bar shows the judoka’s special technique.",
     "languageToggle": "**Language toggle**\nSwitch quote language between English and pseudo-Japanese.",
     "nextRound": "**Next round**\nBegin when you’re ready.",
+    "skipPhase": "Skip the countdown and move on.",
     "quitMatch": "**Quit match**\nReturn to the menu.",
     "drawCard": "**Draw card**\nGet a new random judoka card.",
     "roundQuick": "**Quick**\\nFirst to 5 points wins.",
     "roundMedium": "**Medium**\\nFirst to 10 points wins.",
     "roundLong": "**Long**\\nFirst to 15 points wins."
   },
-
   "mode": {
-    "classicBattle": "**Classic Battle Mode** pits you against an opponent.\nFirst to 10 round\u2011wins becomes the champion.",
+    "classicBattle": "**Classic Battle Mode** pits you against an opponent.\nFirst to 10 round‑wins becomes the champion.",
     "teamBattle": "**Team Battle Mode** lets you fight with your whole deck of cards.\nForm a team and win more rounds than the opposing team to triumph!",
     "meditation": "**Meditation Mode** lets you reflect and compare cards.\nNo battles, just peaceful analysis.",
     "randomJudoka": "**Random Judoka** picks a random card for quick inspiration.",
     "browseJudoka": "**Browse Judoka** opens the full roster in a carousel."
   },
-
   "nav": {
     "classicBattle": "**Classic Battle**\nBegin a head-to-head match.",
     "randomJudoka": "**Random Judoka**\nShow a random judoka card.",

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -44,6 +44,7 @@ import { STATS } from "./battleEngine.js";
 import { toggleInspectorPanels } from "./cardUtils.js";
 import { showSnackbar } from "./showSnackbar.js";
 import { initRoundSelectModal } from "./classicBattle/roundSelectModal.js";
+import { skipCurrentPhase } from "./classicBattle/timerService.js";
 
 function enableStatButtons(enable = true) {
   document.querySelectorAll("#stat-buttons button").forEach((btn) => {
@@ -55,6 +56,7 @@ function enableStatButtons(enable = true) {
 
 const battleStore = createBattleStore();
 window.battleStore = battleStore;
+window.skipBattlePhase = skipCurrentPhase;
 export const getBattleStore = () => battleStore;
 let simulatedOpponentMode = false;
 let aiDifficulty = "easy";
@@ -197,6 +199,15 @@ export async function setupClassicBattlePage() {
     } else {
       debugPanel.remove();
     }
+  }
+
+  const skipBtn = document.getElementById("skip-phase-button");
+  if (skipBtn) {
+    skipBtn.addEventListener("click", () => skipCurrentPhase());
+    window.addEventListener("skip-handler-change", (e) => {
+      const { active } = e.detail || {};
+      skipBtn.disabled = !active;
+    });
   }
 
   window.startRoundOverride = () => startRoundWrapper();

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -100,6 +100,15 @@
               Next Round
             </button>
             <button
+              id="skip-phase-button"
+              class="info-button"
+              aria-label="Skip timer"
+              data-tooltip-id="ui.skipPhase"
+              disabled
+            >
+              &gt;
+            </button>
+            <button
               id="stat-help"
               class="info-button"
               aria-label="Stat selection help"


### PR DESCRIPTION
## Summary
- add skip timer button on battle screen with tooltip
- implement phase skipping via timer service and expose helper
- wire skip button to toggle based on handler and expose global function

## Testing
- `npx prettier . --write`
- `npm run validate:data` *(fails: could not determine executable to run)*
- `npx eslint . --fix`
- `npx vitest run` *(fails: Failed to load game modes Error: fail)*
- `npx playwright test` *(fails: Invalid country code entry found: { country: 'Country0', code: 'c0', active: true })*
- `npm run check:contrast` *(fails: Not implemented: navigation (except hash changes))*

------
https://chatgpt.com/codex/tasks/task_e_6897044f872083268db2de3e9b336102