### PR TITLE
docs: document skip button

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ AI agents should begin by reading:
 - ✅ Validate stat blocks against rarity rules
 - ✅ Generate or evaluate PRDs for new features
 
+## 🧪 Testing
+
+The game includes a **Skip** button that bypasses the current round and cooldown timers. Use it to fast-forward through matches when debugging or running rapid gameplay tests.
+
 ## 🔄 Updating Judoka Card Codes
 
 Run `npm run update:codes` whenever you add or edit judoka in `src/data/judoka.json`. The script regenerates the `cardCode` for each entry and falls back to the code from judoka `id=0` if generation fails.

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -94,6 +94,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 | **P2**   | Tie Handling            | Show tie message; round ends without score change; continue to next round.                                                                                                       |
 | **P2**   | Player Quit Flow        | Allow player to exit match early with confirmation; counts as a loss.                                                                                                            |
 | **P3**   | AI Stat Selection Logic | AI stat choice follows difficulty setting (`easy` random, `medium` picks stats ≥ average, `hard` selects highest stat). Difficulty can be set via Settings or `?difficulty=` URL param; defaults to `easy`. |
+| **P3**   | Skip Control            | Optional control that bypasses round and cooldown timers so testers can fast-forward gameplay or users can quickly move through a match. |
 
 **Additional Behavioral Requirements:**
 


### PR DESCRIPTION
## Summary
- Document skip button for rapid round and cooldown bypass during testing
- Note skip control’s debug purpose in Classic Battle PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed to load game modes Error: fail)*
- `npx playwright test` *(fails: 2 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68971a98efd08326b76e75c052ed19e1