### PR TITLE
feat(settings): add cached getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ AI agents should begin by reading:
 - ✅ Validate stat blocks against rarity rules
 - ✅ Generate or evaluate PRDs for new features
 
+## Settings API
+
+Settings are loaded once and cached for synchronous use. Helpers in
+`src/helpers/settingsUtils.js` provide safe access:
+
+- `getSetting(key)` – read a setting value from the cache.
+- `getFeatureFlag(flagName)` – check whether a feature flag is enabled.
+
+Call `loadSettings()` during startup to populate the cache before using
+these helpers. This approach avoids direct `localStorage` reads in modules
+that need fast, synchronous access to settings.
+
 ## 🔄 Updating Judoka Card Codes
 
 Run `npm run update:codes` whenever you add or edit judoka in `src/data/judoka.json`. The script regenerates the `cardCode` for each entry and falls back to the code from judoka `id=0` if generation fails.

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -63,6 +63,17 @@ As a user of the game _Ju-Do-Kon!_, I want to be able to change settings such as
 
 ---
 
+### Settings API
+
+Modules access player preferences via helpers in
+`src/helpers/settingsUtils.js`:
+
+- `getSetting(key)` – synchronous access to cached settings.
+- `getFeatureFlag(flagName)` – returns `true` when the flag is enabled.
+
+`loadSettings()` should run during startup to populate the cache, avoiding
+direct `localStorage` reads throughout the app.
+
 ## Settings Features
 
 - **Sound (binary):** ON/OFF (default: ON) – Enable or mute game audio.

--- a/src/helpers/motionUtils.js
+++ b/src/helpers/motionUtils.js
@@ -2,29 +2,21 @@
  * Utilities for handling motion preference.
  */
 
+import { getSetting } from "./settingsUtils.js";
 /**
  * Determine synchronously if motion effects should be reduced.
  *
  * @pseudocode
- * 1. Attempt to read the "settings" item from `localStorage`.
- *    - Parse the JSON and check the `motionEffects` property.
- * 2. If `motionEffects` is `false`, return `true`.
- * 3. Otherwise, return whether the user prefers reduced motion via
+ * 1. Call `getSetting("motionEffects")`.
+ * 2. If the result is `false`, return `true`.
+ * 3. Otherwise, return the value of
  *    `matchMedia('(prefers-reduced-motion: reduce)')`.
  *
  * @returns {boolean} True if motion effects should be reduced.
  */
 export function shouldReduceMotionSync() {
-  try {
-    const raw = localStorage.getItem("settings");
-    if (raw) {
-      const data = JSON.parse(raw);
-      if (data && data.motionEffects === false) {
-        return true;
-      }
-    }
-  } catch {
-    // Ignore JSON and localStorage errors
+  if (getSetting("motionEffects") === false) {
+    return true;
   }
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }

--- a/src/helpers/typewriter.js
+++ b/src/helpers/typewriter.js
@@ -2,31 +2,20 @@
  * Utility for the typewriter effect on quote text.
  *
  * @pseudocode
- * 1. `shouldEnableTypewriter` reads the `settings` item from `localStorage`.
- *    - If `typewriterEffect` is `false`, return `false`.
- *    - Otherwise return `true`.
+ * 1. `shouldEnableTypewriter` calls `getSetting("typewriterEffect")` and
+ *    returns that value.
  * 2. `runTypewriterEffect` types textContent of an element character by
  *    character at the given speed and restores the final HTML when done.
  */
 
+import { getSetting } from "./settingsUtils.js";
 /**
  * Determine whether the typewriter effect should run.
  *
  * @returns {boolean} True when the effect is enabled.
  */
 export function shouldEnableTypewriter() {
-  try {
-    const raw = localStorage.getItem("settings");
-    if (raw) {
-      const data = JSON.parse(raw);
-      if (data && data.typewriterEffect === false) {
-        return false;
-      }
-    }
-  } catch {
-    // ignore
-  }
-  return true;
+  return Boolean(getSetting("typewriterEffect"));
 }
 
 /**

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -5,6 +5,7 @@ beforeEach(() => {
   document.body.innerHTML = "";
   localStorage.clear();
   vi.resetModules();
+  vi.doUnmock("../../src/helpers/settingsUtils.js");
   vi.doMock("../../src/helpers/classicBattle/roundSelectModal.js", () => ({
     initRoundSelectModal: (cb) => cb()
   }));
@@ -343,6 +344,10 @@ describe("syncScoreDisplay", () => {
       }
     }));
 
+    vi.doMock("../../src/helpers/settingsUtils.js", () => ({
+      getSetting: () => true,
+      loadSettings: vi.fn()
+    }));
     const { syncScoreDisplay, showMatchSummaryModal } = await import(
       "../../src/helpers/classicBattle/uiService.js"
     );

--- a/tests/helpers/motionUtils.test.js
+++ b/tests/helpers/motionUtils.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { shouldReduceMotionSync, applyMotionPreference } from "../../src/helpers/motionUtils.js";
+import { loadSettings, resetSettings } from "../../src/helpers/settingsUtils.js";
 
 const matchMediaMock = (matches) =>
   vi.fn().mockImplementation((query) => ({
@@ -13,9 +14,11 @@ const matchMediaMock = (matches) =>
   }));
 
 describe("motionUtils", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    resetSettings();
     localStorage.clear();
     document.body.className = "";
+    await loadSettings();
   });
 
   it("returns true when matchMedia prefers reduced motion", () => {
@@ -26,18 +29,22 @@ describe("motionUtils", () => {
   it("returns true when settings disable motion effects", () => {
     window.matchMedia = matchMediaMock(false);
     localStorage.setItem("settings", JSON.stringify({ motionEffects: false }));
-    expect(shouldReduceMotionSync()).toBe(true);
+    return loadSettings().then(() => {
+      expect(shouldReduceMotionSync()).toBe(true);
+    });
   });
 
-  it("returns false when motion is enabled and no media preference", () => {
+  it("returns false when motion is enabled and no media preference", async () => {
     window.matchMedia = matchMediaMock(false);
     localStorage.setItem("settings", JSON.stringify({ motionEffects: true }));
+    await loadSettings();
     expect(shouldReduceMotionSync()).toBe(false);
   });
 
-  it("handles invalid stored settings gracefully", () => {
+  it("handles invalid stored settings gracefully", async () => {
     window.matchMedia = matchMediaMock(true);
     localStorage.setItem("settings", "not json");
+    await loadSettings();
     expect(shouldReduceMotionSync()).toBe(true);
   });
 

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { DEFAULT_SETTINGS } from "../../src/helpers/settingsUtils.js";
+import { DEFAULT_SETTINGS, resetSettings } from "../../src/helpers/settingsUtils.js";
 
 /**
  * @fileoverview
@@ -26,6 +26,7 @@ describe("settings utils", () => {
     if (global.localStorage) {
       global.localStorage.clear();
     }
+    resetSettings();
     Object.defineProperty(global, "localStorage", {
       value: originalLocalStorage,
       configurable: true,
@@ -219,5 +220,25 @@ describe("settings utils", () => {
     const result = resetSettings();
     expect(result).toEqual(DEFAULT_SETTINGS);
     expect(JSON.parse(localStorage.getItem("settings"))).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it("provides synchronous access via getSetting", async () => {
+    localStorage.setItem("settings", JSON.stringify({ sound: false }));
+    const { loadSettings, getSetting } = await import("../../src/helpers/settingsUtils.js");
+    await loadSettings();
+    expect(getSetting("sound")).toBe(false);
+    localStorage.setItem("settings", JSON.stringify({ sound: true }));
+    expect(getSetting("sound")).toBe(false);
+  });
+
+  it("retrieves feature flags via getFeatureFlag", async () => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({ featureFlags: { enableTestMode: { enabled: true } } })
+    );
+    const { loadSettings, getFeatureFlag } = await import("../../src/helpers/settingsUtils.js");
+    await loadSettings();
+    expect(getFeatureFlag("enableTestMode")).toBe(true);
+    expect(getFeatureFlag("nonexistent")).toBe(false);
   });
 });

--- a/tests/helpers/typewriter.test.js
+++ b/tests/helpers/typewriter.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { shouldEnableTypewriter } from "../../src/helpers/typewriter.js";
+import { loadSettings, resetSettings, updateSetting } from "../../src/helpers/settingsUtils.js";
+
+// Tests for typewriter helper
+
+describe("typewriter", () => {
+  beforeEach(async () => {
+    resetSettings();
+    localStorage.clear();
+    await loadSettings();
+  });
+
+  it("returns false when disabled by default", () => {
+    expect(shouldEnableTypewriter()).toBe(false);
+  });
+
+  it("returns true when setting enabled", async () => {
+    await updateSetting("typewriterEffect", true);
+    expect(shouldEnableTypewriter()).toBe(true);
+  });
+
+  it("uses cached settings synchronously", async () => {
+    await updateSetting("typewriterEffect", true);
+    expect(shouldEnableTypewriter()).toBe(true);
+    localStorage.setItem("settings", JSON.stringify({ typewriterEffect: false }));
+    expect(shouldEnableTypewriter()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `getSetting` and `getFeatureFlag` with in-memory cache for synchronous settings access
- refactor motion and typewriter helpers to use cached settings
- document Settings API and update tests for new helpers

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Not implemented: navigation (except hash changes))*
- `npm run check:contrast` *(fails: Judoka object is missing!)*

------
https://chatgpt.com/codex/tasks/task_e_68971a7a6c5c83268d6b8c8296e0b996