### PR TITLE
test: use skipBattlePhase in battle specs

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -47,15 +47,13 @@ test.describe.parallel(
     });
 
     test("captures portrait and landscape headers", async ({ page }) => {
-      await page.addInitScript(() => {
-        window.startCountdownOverride = () => {};
-        const originalSetInterval = window.setInterval;
-        window.setInterval = (fn, ms, ...args) =>
-          originalSetInterval(fn, Math.max(ms, 3600000), ...args);
-      });
-
       await page.goto("/src/pages/battleJudoka.html");
       await page.waitForSelector("#score-display span", { state: "attached" });
+      await page.evaluate(() => window.skipBattlePhase?.());
+      await page.waitForFunction(
+        () => document.querySelector("#round-message")?.textContent.trim().length > 0
+      );
+      await page.evaluate(() => window.skipBattlePhase?.());
 
       await page.setViewportSize({ width: 320, height: 480 });
       await page.waitForFunction(
@@ -94,15 +92,13 @@ test.describe.parallel(
     });
 
     test("captures extra-narrow header", async ({ page }) => {
-      await page.addInitScript(() => {
-        window.startCountdownOverride = () => {};
-        const originalSetInterval = window.setInterval;
-        window.setInterval = (fn, ms, ...args) =>
-          originalSetInterval(fn, Math.max(ms, 3600000), ...args);
-      });
-
       await page.goto("/src/pages/battleJudoka.html");
       await page.waitForSelector("#score-display span", { state: "attached" });
+      await page.evaluate(() => window.skipBattlePhase?.());
+      await page.waitForFunction(
+        () => document.querySelector("#round-message")?.textContent.trim().length > 0
+      );
+      await page.evaluate(() => window.skipBattlePhase?.());
       await page.evaluate(() => document.fonts.ready);
 
       await page.setViewportSize({ width: 300, height: 600 });

--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -3,15 +3,11 @@ import { test, expect } from "./fixtures/commonSetup.js";
 
 test.describe.parallel("Classic battle flow", () => {
   test("timer auto-selects when expired", async ({ page }) => {
-    await page.addInitScript(() => {
-      window.startCountdownOverride = () => {};
-      const orig = window.setInterval;
-      window.setInterval = (fn, ms, ...args) => orig(fn, ms >= 1000 ? 250 : ms, ...args); // 4× speed instead of 10×
-    });
     await page.goto("/src/pages/battleJudoka.html");
     const countdown = page.locator("header #next-round-timer");
     await countdown.waitFor();
     await expect(countdown).toHaveText(/\d+/);
+    await page.evaluate(() => window.skipBattlePhase?.());
     const result = page.locator("header #round-message");
     await expect(result).not.toHaveText("", { timeout: 15000 });
     await expect
@@ -20,12 +16,8 @@ test.describe.parallel("Classic battle flow", () => {
   });
 
   test("tie message appears on equal stats", async ({ page }) => {
-    await page.addInitScript(() => {
-      window.startCountdownOverride = () => {};
-      const orig = window.setInterval;
-      window.setInterval = (fn, ms, ...args) => orig(fn, Math.max(ms, 3600000), ...args);
-    });
     await page.goto("/src/pages/battleJudoka.html");
+    await page.evaluate(() => window.skipBattlePhase?.());
     const timer = page.locator("header #next-round-timer");
     await timer.waitFor();
     await page.evaluate(async () => {


### PR DESCRIPTION
## Summary
- remove timer overrides in battle orientation and classic battle flow specs
- advance battle phases in tests via `skipBattlePhase`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed to load game modes Error: fail)*
- `npx playwright test` *(fails: JudokaCard did not render an HTMLElement)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68971a955c248326957f944e3f916d6f