### PR TITLE
feat: persist snackbar for countdowns

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-Displays round messages, stat selection timer, and live match score in the page header so players always know the current battle status. The countdown between rounds is surfaced via a snackbar.
+Displays round messages, stat selection timer, and live match score in the page header so players always know the current battle status. The countdown between rounds is surfaced via a single snackbar that updates its text each second.
 
 ---
 
@@ -20,7 +20,7 @@ The round message, timer, and score now sit directly inside the page header rath
 2. **Display round-specific messaging** on the **left side of the top bar**, depending on match state:
    - If a round ends: show **win/loss/result** message for **2 seconds**.
    - If awaiting action: show **selection prompt** until a decision is made.
-   - If waiting for next round: show **snackbar countdown** that begins **within 1s** of round end.
+   - If waiting for next round: show a **snackbar countdown** that begins **within 1s** of round end and updates its text each second.
    - If in stat selection phase: show **30-second countdown timer** and prompt; if timer expires, auto-select a stat (see [Classic Battle PRD](prdClassicBattle.md)).
    - After the player picks a stat: show **"Opponent is choosing..."** until the opponent's choice is revealed.
 3. Ensure all messages are clearly readable, positioned responsively, and maintain usability across devices.
@@ -47,7 +47,7 @@ The round message, timer, and score now sit directly inside the page header rath
 
 - Match score is updated within **800ms** after round ends. <!-- Implemented: see updateScore in InfoBar.js and battleEngine.js -->
 - Win/loss message is shown within **1s** of round end and remains visible for **2s**. <!-- Implemented: see showResult in battleUI.js -->
-- Countdown snackbar begins only after the 2s result message fades out, aligned with server round start delay. <!-- Implemented: see startCoolDown in battleEngine.js -->
+- Countdown snackbar begins only after the 2s result message fades out, aligned with server round start delay, and persists while updating its text. <!-- Implemented: see startCoolDown in battleEngine.js -->
 - Action prompt appears during user input phases and disappears after interaction. <!-- Implemented: see showMessage and stat selection logic -->
 - **Stat selection timer (30s) is displayed during stat selection phase; if timer expires, a random stat is auto-selected. Timer stops immediately once a stat is picked and pauses/resumes on tab inactivity.** <!-- Implemented: see startRound in battleEngine.js and [Classic Battle PRD](prdClassicBattle.md) -->
 - Auto-select messages are only shown if no stat was chosen before the timer runs out.
@@ -73,7 +73,7 @@ The round message, timer, and score now sit directly inside the page header rath
 - **Layout**
   - Right side: score display (`Player: X – Opponent: Y`)
   - Two-line score format appears on narrow screens via stacked `<span>` elements (`<span>You: X</span> <span>Opponent: Y</span>`)
-  - Left side: rotating status messages (e.g., "You won!", "Select your move", **"Time left: 29s"**). Countdown to the next round appears in a snackbar.
+  - Left side: rotating status messages (e.g., "You won!", "Select your move", **"Time left: 29s"**). Countdown to the next round appears in a single snackbar whose text updates each second.
 - **Visuals**
   - Font size: `clamp(16px, 4vw, 24px)`; on narrow screens (<375px) `clamp(14px, 5vw, 20px)`.
   - Color coding: green (win), red (loss), neutral grey (countdown).

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -35,7 +35,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - ≥70% of new players complete a Classic Battle within their first session.
 - Give new players an approachable mode to learn how judoka stats impact outcomes.
 - Reduce frustration by providing immediate, clear feedback on round results.
-- Ensure all round messages, stat selection timer, and score are surfaced via the Info Bar (see prdBattleInfoBar.md) for clarity and accessibility. The countdown to the next round is shown in a snackbar.
+- Ensure all round messages, stat selection timer, and score are surfaced via the Info Bar (see prdBattleInfoBar.md) for clarity and accessibility. The countdown to the next round is shown in a single snackbar whose text updates each second.
 
 ---
 
@@ -78,7 +78,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Detect timer drift by comparing engine state with real time; if drift exceeds 2s, display "Waiting…" and restart the countdown.
 - Opponent stat selection runs entirely on the client. After the player picks a stat (or the timer auto-chooses), the opponent's choice is revealed after a short artificial delay to mimic turn-taking.
 - During this delay, the Info Bar displays "Opponent is choosing..." to reinforce turn flow.
-- The cooldown timer between rounds begins only after round results are shown in the Info Bar and is displayed using a snackbar countdown.
+- The cooldown timer between rounds begins only after round results are shown in the Info Bar and is displayed using one persistent snackbar that updates its text each second.
 - The debug panel is available when the `battleDebugPanel` feature flag is enabled and appears beside the opponent's card.
 
 ---

--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -14,7 +14,7 @@
  */
 import { shouldReduceMotionSync } from "../helpers/motionUtils.js";
 import { startCoolDown, watchForDrift } from "../helpers/battleEngine.js";
-import { showSnackbar } from "../helpers/showSnackbar.js";
+import { showSnackbar, updateSnackbar } from "../helpers/showSnackbar.js";
 
 let messageEl;
 let timerEl;
@@ -171,7 +171,8 @@ export function clearTimer() {
  *
  * @pseudocode
  * 1. Use `startCoolDown` to update the remaining time each second.
- * 2. On each tick, call `showSnackbar` with `"Next round in: <n>s"`.
+ * 2. Call `showSnackbar` once and update its text each tick with
+ *    `"Next round in: <n>s"`.
  * 3. Monitor for drift via `watchForDrift`; on drift, show "Waiting…" and
  *    restart the countdown, giving up after several retries.
  * 4. When the timer expires, stop monitoring, clear the timer display, and invoke `onFinish`.
@@ -187,12 +188,19 @@ export function startCountdown(seconds, onFinish) {
     return;
   }
 
+  let started = false;
   const onTick = (remaining) => {
     if (remaining <= 0) {
       clearTimer();
       return;
     }
-    showSnackbar(`Next round in: ${remaining}s`);
+    const text = `Next round in: ${remaining}s`;
+    if (!started) {
+      showSnackbar(text);
+      started = true;
+    } else {
+      updateSnackbar(text);
+    }
   };
 
   let stopWatch;

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -9,7 +9,7 @@ import {
 import * as infoBar from "../setupBattleInfoBar.js";
 import { enableNextRoundButton, disableNextRoundButton, updateDebugPanel } from "./uiHelpers.js";
 import { runTimerWithDrift } from "./runTimerWithDrift.js";
-import { showSnackbar } from "../showSnackbar.js";
+import { showSnackbar, updateSnackbar } from "../showSnackbar.js";
 
 let skipHandler = null;
 
@@ -130,7 +130,7 @@ export function handleStatSelectionTimeout(store, onSelect) {
  * 1. If the match ended, return early.
  * 2. Setup a click handler that disables the button and calls `startRoundFn`.
  * 3. After a short delay, run a 3 second cooldown via `runTimerWithDrift(startCoolDown)`
- *    and display `"Next round in: <n>s"` in the snackbar and timer element.
+ *    and display `"Next round in: <n>s"` using one snackbar that updates each tick.
  * 4. Register a skip handler that stops the timer and invokes the expiration logic.
  * 5. When expired, clear the timer text, enable the button, attach the click handler, and clear the handler.
  *
@@ -152,14 +152,21 @@ export function scheduleNextRound(result, startRoundFn) {
     await startRoundFn();
   };
 
+  let started = false;
   const onTick = (remaining) => {
     if (remaining <= 0) {
       infoBar.clearTimer();
       return;
     }
-    showSnackbar(`Next round in: ${remaining}s`);
+    const text = `Next round in: ${remaining}s`;
+    if (!started) {
+      showSnackbar(text);
+      started = true;
+    } else {
+      updateSnackbar(text);
+    }
     if (timerEl) {
-      timerEl.textContent = `Next round in: ${remaining}s`;
+      timerEl.textContent = text;
     }
   };
 

--- a/src/helpers/showSnackbar.js
+++ b/src/helpers/showSnackbar.js
@@ -2,29 +2,62 @@
  * Display a temporary snackbar message near the bottom of the screen.
  *
  * @pseudocode
- * 1. Remove any existing `.snackbar` element.
+ * 1. Remove any existing `.snackbar` element and clear its timers.
  * 2. Create a new div with that class containing the provided message.
  * 3. Append the element to `document.body` and trigger the show animation.
- * 4. After `SNACKBAR_FADE_MS`, remove the `show` class to start fading.
- * 5. Remove the element from the DOM after `SNACKBAR_REMOVE_MS`.
+ * 4. Schedule fade and removal timers.
  *
  * @param {string} message - Text content to display in the snackbar.
  */
 import { SNACKBAR_FADE_MS, SNACKBAR_REMOVE_MS } from "./constants.js";
 
-export function showSnackbar(message) {
-  const existing = document.querySelector(".snackbar");
-  existing?.remove();
+let bar;
+let fadeId;
+let removeId;
 
-  const bar = document.createElement("div");
+function resetTimers() {
+  clearTimeout(fadeId);
+  clearTimeout(removeId);
+  fadeId = setTimeout(() => {
+    bar?.classList.remove("show");
+  }, SNACKBAR_FADE_MS);
+  removeId = setTimeout(() => {
+    bar?.remove();
+    bar = null;
+  }, SNACKBAR_REMOVE_MS);
+}
+
+export function showSnackbar(message) {
+  bar?.remove();
+  clearTimeout(fadeId);
+  clearTimeout(removeId);
+
+  bar = document.createElement("div");
   bar.className = "snackbar";
   bar.textContent = message;
   bar.setAttribute("role", "status");
   bar.setAttribute("aria-live", "polite");
   document.body.appendChild(bar);
-  requestAnimationFrame(() => bar.classList.add("show"));
-  setTimeout(() => {
-    bar.classList.remove("show");
-  }, SNACKBAR_FADE_MS);
-  setTimeout(() => bar.remove(), SNACKBAR_REMOVE_MS);
+  requestAnimationFrame(() => bar?.classList.add("show"));
+  resetTimers();
+}
+
+/**
+ * Update the current snackbar's text and restart its timers.
+ *
+ * @pseudocode
+ * 1. If no snackbar exists, call `showSnackbar(message)`.
+ * 2. Otherwise, set the element's text to `message` and add the `show` class.
+ * 3. Clear and restart fade and removal timers.
+ *
+ * @param {string} message - New text for the snackbar.
+ */
+export function updateSnackbar(message) {
+  if (!bar) {
+    showSnackbar(message);
+    return;
+  }
+  bar.textContent = message;
+  bar.classList.add("show");
+  resetTimers();
 }

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
-vi.mock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar: vi.fn() }));
+vi.mock("../../src/helpers/showSnackbar.js", () => ({
+  showSnackbar: vi.fn(),
+  updateSnackbar: vi.fn()
+}));
 import {
   createInfoBar,
   initInfoBar,
@@ -12,7 +15,7 @@ import {
   startCountdown,
   updateScore
 } from "../../src/components/InfoBar.js";
-import { showSnackbar } from "../../src/helpers/showSnackbar.js";
+import { showSnackbar, updateSnackbar } from "../../src/helpers/showSnackbar.js";
 import * as battleEngine from "../../src/helpers/battleEngine.js";
 import { createInfoBarHeader } from "../utils/testUtils.js";
 
@@ -21,6 +24,7 @@ describe("InfoBar component", () => {
 
   beforeEach(() => {
     showSnackbar.mockClear();
+    updateSnackbar.mockClear();
     header = document.createElement("header");
     createInfoBar(header);
     document.body.appendChild(header);
@@ -59,14 +63,15 @@ describe("InfoBar component", () => {
     expect(document.getElementById("round-message").textContent).toBe("");
   });
 
-  it("startCountdown shows snackbar each second", () => {
+  it("startCountdown updates a single snackbar each second", () => {
     const timer = vi.useFakeTimers();
     startCountdown(2);
     expect(showSnackbar).toHaveBeenCalledWith("Next round in: 2s");
+    expect(showSnackbar).toHaveBeenCalledTimes(1);
     timer.advanceTimersByTime(1000);
-    expect(showSnackbar).toHaveBeenCalledWith("Next round in: 1s");
+    expect(updateSnackbar).toHaveBeenCalledWith("Next round in: 1s");
     timer.advanceTimersByTime(1000);
-    expect(showSnackbar).toHaveBeenCalledTimes(2);
+    expect(updateSnackbar).toHaveBeenCalledTimes(1);
     timer.clearAllTimers();
   });
 
@@ -93,6 +98,7 @@ describe("InfoBar component", () => {
     expect(document.getElementById("score-display").textContent).toBe("You: 2\nOpponent: 3");
     startCountdown(1);
     expect(showSnackbar).toHaveBeenCalledWith("Next round in: 1s");
+    expect(updateSnackbar).not.toHaveBeenCalled();
     timer.advanceTimersByTime(1000);
     expect(showSnackbar).toHaveBeenCalledTimes(1);
     timer.clearAllTimers();

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
+import * as snackbar from "../../../src/helpers/showSnackbar.js";
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -38,14 +39,30 @@ describe("countdown resets after stat selection", () => {
       '<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>';
 
     const timer = vi.useFakeTimers();
+    const showSpy = vi.spyOn(snackbar, "showSnackbar");
+    const updateSpy = vi.spyOn(snackbar, "updateSnackbar");
     const p = battleMod.handleStatSelection(store, "power");
     await vi.advanceTimersByTimeAsync(1000);
     await p;
     expect(document.getElementById("next-round-timer").textContent).toBe("");
 
     await vi.advanceTimersByTimeAsync(2000);
+    expect(showSpy).toHaveBeenCalledWith("Next round in: 3s");
+    expect(updateSpy).not.toHaveBeenCalled();
     expect(document.querySelector(".snackbar").textContent).toBe("Next round in: 3s");
     expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 3s");
+    expect(document.querySelectorAll(".snackbar").length).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(updateSpy).toHaveBeenCalledWith("Next round in: 2s");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(updateSpy).toHaveBeenCalledWith("Next round in: 1s");
+    expect(showSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledTimes(2);
+    expect(document.querySelectorAll(".snackbar").length).toBe(1);
+
     timer.clearAllTimers();
+    showSpy.mockRestore();
+    updateSpy.mockRestore();
   });
 });

--- a/tests/helpers/setupBattleInfoBar.test.js
+++ b/tests/helpers/setupBattleInfoBar.test.js
@@ -3,7 +3,10 @@ import { createInfoBarHeader } from "../utils/testUtils.js";
 vi.mock("../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
-vi.mock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar: vi.fn() }));
+vi.mock("../../src/helpers/showSnackbar.js", () => ({
+  showSnackbar: vi.fn(),
+  updateSnackbar: vi.fn()
+}));
 
 const originalReadyState = Object.getOwnPropertyDescriptor(document, "readyState");
 
@@ -24,8 +27,9 @@ describe("setupBattleInfoBar", () => {
     vi.useFakeTimers();
 
     const mod = await import("../../src/helpers/setupBattleInfoBar.js");
-    const { showSnackbar } = await import("../../src/helpers/showSnackbar.js");
+    const { showSnackbar, updateSnackbar } = await import("../../src/helpers/showSnackbar.js");
     showSnackbar.mockClear();
+    updateSnackbar.mockClear();
 
     document.dispatchEvent(new Event("DOMContentLoaded"));
 
@@ -46,6 +50,7 @@ describe("setupBattleInfoBar", () => {
 
     mod.startCountdown(1);
     expect(showSnackbar).toHaveBeenCalledWith("Next round in: 1s");
+    expect(updateSnackbar).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1000);
     expect(showSnackbar).toHaveBeenCalledTimes(1);
   });
@@ -66,8 +71,9 @@ describe("setupBattleInfoBar", () => {
     document.body.innerHTML = "";
     document.body.appendChild(createInfoBarHeader());
     const mod = await import("../../src/helpers/setupBattleInfoBar.js");
-    const { showSnackbar } = await import("../../src/helpers/showSnackbar.js");
+    const { showSnackbar, updateSnackbar } = await import("../../src/helpers/showSnackbar.js");
     showSnackbar.mockClear();
+    updateSnackbar.mockClear();
     mod.showMessage("Hello");
     expect(document.getElementById("round-message").textContent).toBe("Hello");
     mod.clearMessage();
@@ -77,6 +83,7 @@ describe("setupBattleInfoBar", () => {
     vi.useFakeTimers();
     mod.startCountdown(1);
     expect(showSnackbar).toHaveBeenCalledWith("Next round in: 1s");
+    expect(updateSnackbar).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1000);
     expect(showSnackbar).toHaveBeenCalledTimes(1);
   });

--- a/tests/helpers/showSnackbar.test.js
+++ b/tests/helpers/showSnackbar.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { showSnackbar } from "../../src/helpers/showSnackbar.js";
+import { showSnackbar, updateSnackbar } from "../../src/helpers/showSnackbar.js";
 import { SNACKBAR_FADE_MS, SNACKBAR_REMOVE_MS } from "../../src/helpers/constants.js";
 
 beforeEach(() => {
@@ -7,18 +7,20 @@ beforeEach(() => {
 });
 
 describe("showSnackbar", () => {
-  it("shows and removes the snackbar", () => {
+  it("updates text and resets timers", () => {
     vi.useFakeTimers();
     vi.stubGlobal("requestAnimationFrame", (cb) => cb());
 
     showSnackbar("Hello");
+    updateSnackbar("World");
     let bar = document.querySelector(".snackbar");
     expect(bar).toBeTruthy();
+    expect(bar.textContent).toBe("World");
     expect(bar.classList.contains("show")).toBe(true);
 
-    vi.advanceTimersByTime(SNACKBAR_FADE_MS);
-    bar = document.querySelector(".snackbar");
-    expect(bar).toBeTruthy();
+    vi.advanceTimersByTime(SNACKBAR_FADE_MS - 1);
+    expect(bar.classList.contains("show")).toBe(true);
+    vi.advanceTimersByTime(1);
     expect(bar.classList.contains("show")).toBe(false);
 
     vi.advanceTimersByTime(SNACKBAR_REMOVE_MS - SNACKBAR_FADE_MS);


### PR DESCRIPTION
## Summary
- add updateSnackbar API to reuse and retime the current snackbar
- use snackbar update for countdowns in timerService and InfoBar
- document single-snackbar countdown behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed to load game modes)*
- `npx playwright test` *(fails: JudokaCard did not render an HTMLElement)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68971fc38df48326a80e5f8acf1dc8d3