### PR TITLE
feat(storage): centralize persistent storage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,12 @@ npx playwright test # run Playwright UI tests
 - Confirm that any new or modified functions include JSDoc with an `@pseudocode` block so documentation stays complete.
 - Playwright tests clear localStorage at startup. If a manual run fails unexpectedly, clear it in your browser and ensure [http://localhost:5000](http://localhost:5000) is served (start it with `npm start`).
 
+### Storage Utility
+
+- Persist data with `src/helpers/storage.js` rather than using `localStorage` directly.
+- The helper provides `getItem`, `setItem`, and `removeItem` with JSON serialization and in-memory fallback when storage is unavailable.
+- In unit tests, mock this module instead of the `localStorage` global.
+
 **For UI-related changes (styles, components, layout):**
 
 - Confirm responsiveness and visual correctness in desktop and simulated mobile viewport.

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -154,8 +154,8 @@ This feedback highlights why Classic Battle is needed now: new players currently
     **Restore Defaults** dialog from the Settings page.
   - A small help icon (`#stat-help`) sits between the **Next Round** and
     **Quit Match** buttons. It displays a tooltip explaining how to pick an
-    attribute and auto-opens on first visit using `localStorage` to remember the
-    dismissal.
+    attribute and auto-opens on first visit using the storage helper to remember
+    the dismissal.
   - Tooltips on stat names, country flags, weight indicators, and navigation icons provide accessible explanations.
   - **Accessibility:**
   - Minimum text contrast ratio: ≥4.5:1 (per WCAG).

--- a/design/productRequirementsDocuments/prdResetNavigation.md
+++ b/design/productRequirementsDocuments/prdResetNavigation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The "Reset Navigation Cache" feature allows users to manually clear cached navigation data (navigationItems) from localStorage and refresh the navigation bar from the Settings page. This is useful for troubleshooting, ensuring up-to-date navigation, and supporting advanced users or testers.
+The "Reset Navigation Cache" feature allows users to manually clear cached navigation data (`navigationItems`) via the storage helper and refresh the navigation bar from the Settings page. This is useful for troubleshooting, ensuring up-to-date navigation, and supporting advanced users or testers.
 
 ## Problem Statement
 
@@ -31,11 +31,11 @@ Users and testers may encounter issues where the navigation bar does not reflect
 ## Acceptance Criteria
 
 - The "Reset Navigation Cache" button appears in the Settings page only when the navCacheResetButton feature flag is enabled.
-- Clicking the button removes the navigationItems entry from localStorage.
+- Clicking the button removes the `navigationItems` entry using `src/helpers/storage.js`.
 - After clicking, the navigation bar is immediately refreshed with up-to-date navigation items.
 - A snackbar or toast message appears confirming the cache was cleared.
 - The button is not visible when the feature flag is disabled.
-- No errors are shown if navigationItems is already missing from localStorage.
+- No errors are shown if `navigationItems` is already missing from storage.
 
 ## Non-Functional Requirements / Design Considerations
 
@@ -45,7 +45,7 @@ Users and testers may encounter issues where the navigation bar does not reflect
 
 ## Dependencies and Open Questions
 
-- Depends on the navigation bar population logic (populateNavbar) and localStorage usage.
+- Depends on the navigation bar population logic (`populateNavbar`) and the storage helper.
 - Relies on the feature flag system for conditional UI display.
 - See [Navigation Bar](prdNavigationBar.md) for hover and active state requirements to ensure UI consistency after cache reset.
 - No known open questions.

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -72,7 +72,7 @@ Modules access player preferences via helpers in
 - `getFeatureFlag(flagName)` – returns `true` when the flag is enabled.
 
 `loadSettings()` should run during startup to populate the cache, avoiding
-direct `localStorage` reads throughout the app.
+direct storage access throughout the app. All persistence goes through `src/helpers/storage.js`.
 
 ## Settings Features
 
@@ -103,7 +103,7 @@ direct `localStorage` reads throughout the app.
 ## Technical Considerations
 
 - All data reads/writes should use asynchronous, promise-based functions with error handling.
-- `settings.json` must persist in localStorage/sessionStorage for session retention.
+- `settings.json` must persist via the storage helper (backed by `localStorage`/`sessionStorage`) for session retention.
 - Updates should debounce writes to avoid excessive file operations if toggles are changed rapidly.
 - Wrap the page contents in a `.home-screen` container so the fixed header does not cover the first settings control.
 

--- a/design/productRequirementsDocuments/prdViewportSimulation.md
+++ b/design/productRequirementsDocuments/prdViewportSimulation.md
@@ -27,7 +27,7 @@ Developers and testers need a reliable, efficient way to verify the game's layou
 | -------- | --------------------------- | --------------------------------------------------------------------------- |
 | P1       | Viewport Simulation Toggle  | Add a switch in Settings to enable/disable simulated mobile viewport width. |
 | P1       | Simulated Viewport Styling  | When enabled, apply a fixed width (375px) and center the game UI.           |
-| P2       | Persistent State (Optional) | Remember the toggle state across page reloads using localStorage.           |
+| P2       | Persistent State (Optional) | Remember the toggle state across page reloads using the storage helper.     |
 
 ## Acceptance Criteria
 
@@ -35,7 +35,7 @@ Developers and testers need a reliable, efficient way to verify the game's layou
 - The `<body>` element receives the `.simulate-viewport` class when simulation is enabled, and it is removed when disabled.
 - The UI is visually constrained and centered when simulation is active.
 - No errors occur if the toggle is used before the DOM is fully loaded (e.g., via `DOMContentLoaded` check).
-- (Optional) The simulation state is saved to and restored from `localStorage` after reload.
+- (Optional) The simulation state is saved to and restored from the storage helper after reload.
 - The toggle is accessible via keyboard and announced correctly by screen readers.
 - The simulation does not interfere with navigation, gameplay, or existing responsive breakpoints.
 
@@ -81,7 +81,7 @@ Developers and testers need a reliable, efficient way to verify the game's layou
 
 - [ ] 4.0 Optional: Implement Persistent Toggle State
 
-  - [ ] 4.1 Store toggle state in localStorage or equivalent
+  - [ ] 4.1 Store toggle state using `src/helpers/storage.js`
   - [ ] 4.2 On page load, read and re-apply state if stored
 
 - [ ] 5.0 Accessibility Validation

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -45,6 +45,7 @@ import { toggleInspectorPanels } from "./cardUtils.js";
 import { showSnackbar } from "./showSnackbar.js";
 import { initRoundSelectModal } from "./classicBattle/roundSelectModal.js";
 import { skipCurrentPhase } from "./classicBattle/timerService.js";
+import { getItem, setItem } from "./storage.js";
 
 function enableStatButtons(enable = true) {
   document.querySelectorAll("#stat-buttons button").forEach((btn) => {
@@ -216,19 +217,17 @@ export async function setupClassicBattlePage() {
   watchBattleOrientation();
 
   try {
-    if (typeof localStorage !== "undefined") {
-      const hintShown = localStorage.getItem("statHintShown");
-      if (!hintShown) {
-        const help = document.getElementById("stat-help");
-        help?.dispatchEvent(new Event("mouseenter"));
-        setTimeout(() => {
-          help?.dispatchEvent(new Event("mouseleave"));
-        }, 3000);
-        localStorage.setItem("statHintShown", "true");
-      }
+    const hintShown = getItem("statHintShown");
+    if (!hintShown) {
+      const help = document.getElementById("stat-help");
+      help?.dispatchEvent(new Event("mouseenter"));
+      setTimeout(() => {
+        help?.dispatchEvent(new Event("mouseleave"));
+      }, 3000);
+      setItem("statHintShown", true);
     }
   } catch {
-    // ignore localStorage errors
+    // ignore storage errors
   }
 }
 

--- a/src/helpers/country/codes.js
+++ b/src/helpers/country/codes.js
@@ -1,5 +1,6 @@
 import { debugLog } from "../debug.js";
 import { DATA_DIR } from "../constants.js";
+import { getItem, setItem } from "../storage.js";
 
 let countryCodeMappingCache = null;
 const COUNTRY_CACHE_KEY = "countryCodeMappingCache";
@@ -8,10 +9,10 @@ const COUNTRY_CACHE_KEY = "countryCodeMappingCache";
  * Load the mapping of country codes to country names.
  *
  * @pseudocode
- * 1. Return cached data when available, including localStorage cache.
+ * 1. Return cached data when available, including storage cache.
  * 2. Fetch `countryCodeMapping.json` from `DATA_DIR` when no cache exists.
  * 3. Validate each entry and log warnings for invalid data.
- * 4. Store the result in memory and localStorage, then return the mapping.
+ * 4. Store the result in memory and storage, then return the mapping.
  *
  * @returns {Promise<Array<{country:string,code:string,active:boolean}>>} Mapping data.
  */
@@ -19,16 +20,10 @@ export async function loadCountryCodeMapping() {
   if (countryCodeMappingCache) {
     return countryCodeMappingCache;
   }
-  if (typeof localStorage !== "undefined") {
-    const cached = localStorage.getItem(COUNTRY_CACHE_KEY);
-    if (cached) {
-      try {
-        countryCodeMappingCache = JSON.parse(cached);
-        return countryCodeMappingCache;
-      } catch (e) {
-        console.warn("Failed to parse cached country code mapping", e);
-      }
-    }
+  const cached = getItem(COUNTRY_CACHE_KEY);
+  if (cached) {
+    countryCodeMappingCache = cached;
+    return countryCodeMappingCache;
   }
   const response = await fetch(`${DATA_DIR}countryCodeMapping.json`);
   if (!response.ok) {
@@ -46,13 +41,7 @@ export async function loadCountryCodeMapping() {
   });
   debugLog("Loaded country code mapping:", data);
   countryCodeMappingCache = data;
-  if (typeof localStorage !== "undefined") {
-    try {
-      localStorage.setItem(COUNTRY_CACHE_KEY, JSON.stringify(data));
-    } catch (e) {
-      console.warn("Failed to cache country code mapping", e);
-    }
-  }
+  setItem(COUNTRY_CACHE_KEY, data);
   return data;
 }
 

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -22,6 +22,7 @@ import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
 import { toggleLayoutDebugPanel } from "./layoutDebugPanel.js";
 import { populateNavbar } from "./navigationBar.js";
 import { showSnackbar } from "./showSnackbar.js";
+import { removeItem } from "./storage.js";
 
 import { applyInitialControlValues } from "./settings/applyInitialValues.js";
 import { attachToggleListeners } from "./settings/listenerUtils.js";
@@ -149,7 +150,7 @@ function initializeControls(settings) {
     wrapper.appendChild(btn);
     section.appendChild(wrapper);
     btn.addEventListener("click", () => {
-      localStorage.removeItem("navigationItems");
+      removeItem("navigationItems");
       populateNavbar();
       showSnackbar("Navigation cache cleared");
     });

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -1,0 +1,57 @@
+const memoryStore = {};
+
+/**
+ * Retrieve a value from storage, parsing JSON and falling back to an in-memory store.
+ *
+ * @param {string} key - Storage key.
+ * @returns {any|null} Parsed value or null when missing.
+ */
+export function getItem(key) {
+  if (typeof key !== "string" || !key) return null;
+  if (typeof localStorage !== "undefined") {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    } catch (e) {
+      console.warn(`Failed to read storage key "${key}"`, e);
+    }
+  }
+  return Object.prototype.hasOwnProperty.call(memoryStore, key) ? memoryStore[key] : null;
+}
+
+/**
+ * Store a value using JSON serialization with memory fallback.
+ *
+ * @param {string} key - Storage key.
+ * @param {any} value - Value to store.
+ */
+export function setItem(key, value) {
+  if (typeof key !== "string" || !key) return;
+  const serialized = JSON.stringify(value);
+  if (typeof localStorage !== "undefined") {
+    try {
+      localStorage.setItem(key, serialized);
+      return;
+    } catch (e) {
+      console.warn(`Failed to set storage key "${key}"`, e);
+    }
+  }
+  memoryStore[key] = value;
+}
+
+/**
+ * Remove a value from storage.
+ *
+ * @param {string} key - Storage key.
+ */
+export function removeItem(key) {
+  if (typeof key !== "string" || !key) return;
+  if (typeof localStorage !== "undefined") {
+    try {
+      localStorage.removeItem(key);
+    } catch (e) {
+      console.warn(`Failed to remove storage key "${key}"`, e);
+    }
+  }
+  delete memoryStore[key];
+}

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createBattleHeader } from "../utils/testUtils.js";
+import * as storage from "../../src/helpers/storage.js";
 
 beforeEach(() => {
   document.body.innerHTML = "";
-  localStorage.clear();
+  storage.removeItem("statHintShown");
   vi.resetModules();
   vi.doUnmock("../../src/helpers/settingsUtils.js");
   vi.doMock("../../src/helpers/classicBattle/roundSelectModal.js", () => ({
@@ -212,7 +213,7 @@ describe("classicBattlePage stat help tooltip", () => {
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy.mock.calls[0][0].type).toBe("mouseenter");
     expect(spy.mock.calls[1][0].type).toBe("mouseleave");
-    expect(localStorage.getItem("statHintShown")).toBe("true");
+    expect(storage.getItem("statHintShown")).toBe(true);
 
     spy.mockClear();
     await setupClassicBattlePage();

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createSettingsDom } from "../utils/testUtils.js";
+import * as storage from "../../src/helpers/storage.js";
 
 const baseSettings = {
   sound: true,
@@ -677,16 +678,18 @@ describe("settingsPage module", () => {
     vi.doMock("../../src/helpers/navigationBar.js", () => ({ populateNavbar }));
     vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar }));
 
+    const removeSpy = vi.spyOn(storage, "removeItem");
     await import("../../src/helpers/settingsPage.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
     await vi.runAllTimersAsync();
 
     const btn = document.getElementById("nav-cache-reset-button");
     expect(btn).toBeTruthy();
-    localStorage.setItem("navigationItems", "foo");
+    storage.setItem("navigationItems", "foo");
     btn.dispatchEvent(new Event("click"));
     await vi.runAllTimersAsync();
-    expect(localStorage.getItem("navigationItems")).toBeNull();
+    expect(removeSpy).toHaveBeenCalledWith("navigationItems");
+    expect(storage.getItem("navigationItems")).toBeNull();
     expect(populateNavbar).toHaveBeenCalled();
     expect(showSnackbar).toHaveBeenCalledWith("Navigation cache cleared");
     vi.useRealTimers();


### PR DESCRIPTION
## Summary
- add src/helpers/storage.js with JSON parsing and in-memory fallback
- refactor country, game mode, and page helpers to use the new storage wrapper
- update related docs and tests to reference the storage utility

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: settingsPage module adds navigation cache reset button when flag enabled)*
- `npx playwright test` *(fails: Battle Judoka page narrow viewport screenshot and status aria attributes)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68971f9bcd548326a97b23b7079e515f