### PR TITLE
feat: centralize navigation item cache

### DIFF
--- a/design/dataSchemas/README.md
+++ b/design/dataSchemas/README.md
@@ -13,7 +13,7 @@ npx ajv validate -s src/schemas/judoka.schema.json -d src/data/judoka.json
 Run the command for every pair of schema and data file (e.g. `gameModes`,
 `weightCategories`). The CLI reports any mismatches so they can be fixed before
 runtime. A new schema, `navigationItems.schema.json`, validates the structure of
-`navigationItems.json` which drives navigation order and visibility. Another
+`navigationItems.json` which drives navigation order and visibility and is cached via the `navigationCache` helper. Another
 schema, `aesopsMeta.schema.json`, describes the quote metadata file used on the
 meditation screen. A third schema, `statNames.schema.json`, defines the
 structure of `statNames.json` which lists all available stats. This file is the

--- a/design/productRequirementsDocuments/prdResetNavigation.md
+++ b/design/productRequirementsDocuments/prdResetNavigation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The "Reset Navigation Cache" feature allows users to manually clear cached navigation data (navigationItems) from localStorage and refresh the navigation bar from the Settings page. This is useful for troubleshooting, ensuring up-to-date navigation, and supporting advanced users or testers.
+The "Reset Navigation Cache" feature allows users to manually clear cached navigation data (navigationItems) using the `navigationCache.reset()` API and refresh the navigation bar from the Settings page. This is useful for troubleshooting, ensuring up-to-date navigation, and supporting advanced users or testers.
 
 ## Problem Statement
 
@@ -31,7 +31,7 @@ Users and testers may encounter issues where the navigation bar does not reflect
 ## Acceptance Criteria
 
 - The "Reset Navigation Cache" button appears in the Settings page only when the navCacheResetButton feature flag is enabled.
-- Clicking the button removes the navigationItems entry from localStorage.
+- Clicking the button invokes `navigationCache.reset()`, which removes the navigationItems entry from localStorage.
 - After clicking, the navigation bar is immediately refreshed with up-to-date navigation items.
 - A snackbar or toast message appears confirming the cache was cleared.
 - The button is not visible when the feature flag is disabled.

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -111,7 +111,7 @@ direct `localStorage` reads throughout the app.
 
 ## Data & Persistence
 
-- The Settings page **must pull current states** from data sources (`settings.json`, `gameModes.json`, and `navigationItems.json`) on load.
+- The Settings page **must pull current states** from data sources (`settings.json`, `gameModes.json`, and `navigationItems.json`) on load, using the `navigationCache` helper for navigation persistence.
 - Default feature flag values live in `settings.json`, while their labels and descriptions come from `tooltips.json`.
 - `gameModes.json` defines all available modes, while `navigationItems.json` references each by `id` to control order and visibility via CSS.
 - Changes should trigger **immediate data writes** without requiring a “Save Changes” button.

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: "jsdom",
+  extensionsToTreatAsEsm: [".js"]
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "pa11y": "^9.0.0",
     "prettier": "^3.6.2",
     "vitest": "^3.2.4",
-    "wcag-contrast": "^3.0.0"
+    "wcag-contrast": "^3.0.0",
+    "jest": "^29.7.0"
   },
   "dependencies": {
     "agent-base": "^7.1.4",

--- a/src/helpers/navigationCache.js
+++ b/src/helpers/navigationCache.js
@@ -1,0 +1,91 @@
+import { fetchJson, validateWithSchema, importJsonModule } from "./dataUtils.js";
+import { DATA_DIR } from "./constants.js";
+
+const NAV_ITEMS_KEY = "navigationItems";
+let schemaPromise;
+
+async function getNavigationSchema() {
+  if (!schemaPromise) {
+    schemaPromise = fetch(new URL("../schemas/navigationItems.schema.json", import.meta.url))
+      .then(async (r) => {
+        if (!r.ok) {
+          throw new Error(`Failed to fetch navigation schema: ${r.status}`);
+        }
+        return r.json();
+      })
+      .catch(async () => importJsonModule("../schemas/navigationItems.schema.json"));
+  }
+  return schemaPromise;
+}
+
+/**
+ * Load navigation items from localStorage or the bundled JSON file.
+ *
+ * @pseudocode
+ * 1. Fetch `navigationItems.schema.json` lazily via `getNavigationSchema()`.
+ * 2. Attempt to read `NAV_ITEMS_KEY` from `localStorage` and validate it.
+ *    - On parse or validation failure, remove the stale entry.
+ * 3. If no valid cached data exists, fetch `navigationItems.json` from `DATA_DIR`.
+ *    - On fetch failure, dynamically import the JSON file instead.
+ * 4. Persist the validated array to `localStorage` and return it.
+ *
+ * @returns {Promise<Array>} Resolved array of navigation items.
+ */
+export async function load() {
+  await getNavigationSchema();
+  if (typeof localStorage === "undefined") {
+    throw new Error("localStorage unavailable");
+  }
+  const raw = localStorage.getItem(NAV_ITEMS_KEY);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      await validateWithSchema(parsed, await getNavigationSchema());
+      return parsed;
+    } catch (err) {
+      console.warn("Failed to parse stored navigation items", err);
+      localStorage.removeItem(NAV_ITEMS_KEY);
+    }
+  }
+  let data;
+  try {
+    data = await fetchJson(`${DATA_DIR}navigationItems.json`, await getNavigationSchema());
+  } catch (error) {
+    console.warn("Failed to fetch navigation items, falling back to import", error);
+    data = await importJsonModule("../data/navigationItems.json");
+    await validateWithSchema(data, await getNavigationSchema());
+  }
+  localStorage.setItem(NAV_ITEMS_KEY, JSON.stringify(data));
+  return data;
+}
+
+/**
+ * Persist navigation items to localStorage.
+ *
+ * @pseudocode
+ * 1. Validate `items` using the navigation schema from `getNavigationSchema()`.
+ * 2. Serialize and store the array under `NAV_ITEMS_KEY` in `localStorage`.
+ *
+ * @param {Array} items - Array of navigation items.
+ * @returns {Promise<void>} Promise that resolves when saving completes.
+ */
+export async function save(items) {
+  await validateWithSchema(items, await getNavigationSchema());
+  if (typeof localStorage === "undefined") {
+    throw new Error("localStorage unavailable");
+  }
+  localStorage.setItem(NAV_ITEMS_KEY, JSON.stringify(items));
+}
+
+/**
+ * Remove cached navigation items from localStorage.
+ *
+ * @pseudocode
+ * 1. Delete the `NAV_ITEMS_KEY` entry from `localStorage` when available.
+ */
+export function reset() {
+  if (typeof localStorage === "undefined") {
+    throw new Error("localStorage unavailable");
+  }
+  localStorage.removeItem(NAV_ITEMS_KEY);
+}

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -21,6 +21,7 @@ import { toggleViewportSimulation } from "./viewportDebug.js";
 import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
 import { toggleLayoutDebugPanel } from "./layoutDebugPanel.js";
 import { populateNavbar } from "./navigationBar.js";
+import { reset as resetNavigationCache } from "./navigationCache.js";
 import { showSnackbar } from "./showSnackbar.js";
 
 import { applyInitialControlValues } from "./settings/applyInitialValues.js";
@@ -149,7 +150,7 @@ function initializeControls(settings) {
     wrapper.appendChild(btn);
     section.appendChild(wrapper);
     btn.addEventListener("click", () => {
-      localStorage.removeItem("navigationItems");
+      resetNavigationCache();
       populateNavbar();
       showSnackbar("Navigation cache cleared");
     });

--- a/tests/helpers/navigationCache.test.js
+++ b/tests/helpers/navigationCache.test.js
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+// @vitest-environment jsdom
+import { load, save, reset } from "../../src/helpers/navigationCache.js";
+
+const mockFn = () => (globalThis.jest || globalThis.vi).fn();
+
+const validItems = [
+  {
+    id: 1,
+    gameModeId: 1,
+    url: "pages/test.html",
+    category: "mainMenu",
+    order: 1,
+    isHidden: false
+  }
+];
+
+describe("navigationCache", () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    localStorage.clear();
+    global.fetch = mockFn().mockRejectedValue(new Error("fail"));
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test("reset clears persisted items", async () => {
+    await save(validItems);
+    expect(localStorage.getItem("navigationItems")).not.toBeNull();
+    reset();
+    expect(localStorage.getItem("navigationItems")).toBeNull();
+  });
+
+  test("save rejects invalid data", async () => {
+    await expect(save([{ id: 1 }])).rejects.toThrow();
+  });
+
+  test("load removes invalid stored data", async () => {
+    localStorage.setItem("navigationItems", '[{"id":1}]');
+    const items = await load();
+    expect(Array.isArray(items)).toBe(true);
+    expect(localStorage.getItem("navigationItems")).not.toBe('[{"id":1}]');
+  });
+});


### PR DESCRIPTION
## Summary
- add navigationCache helper for loading, saving, and resetting nav items
- move nav persistence into navigationCache across settings and game utilities
- document navigationCache usage in PRDs and schema design notes

## Testing
- `npx prettier src/helpers/navigationCache.js src/helpers/gameModeUtils.js src/helpers/settingsPage.js tests/helpers/navigationCache.test.js jest.config.mjs design/productRequirementsDocuments/prdResetNavigation.md design/productRequirementsDocuments/prdSettingsMenu.md design/dataSchemas/README.md package.json --check`
- `npx eslint . && echo ESLint passed`
- `npx jest tests/helpers/navigationCache.test.js` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npx vitest run tests/helpers/navigationCache.test.js`
- `npx vitest run` *(fails: fetch errors across existing tests)*
- `npx playwright test` *(fails: multiple fetch errors across tests)*
- `npm run check:contrast` *(fails: fetch/tooltips errors)*

------
https://chatgpt.com/codex/tasks/task_e_689729230928832692c7da9b799c384a