### PR TITLE
feat(agent): centralize storage access via wrapper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ npx playwright test # run Playwright UI tests
 
 - Confirm that any new or modified functions include JSDoc with an `@pseudocode` block so documentation stays complete.
 - Playwright tests clear localStorage at startup. If a manual run fails unexpectedly, clear it in your browser and ensure [http://localhost:5000](http://localhost:5000) is served (start it with `npm start`).
+- Use `src/helpers/storage.js` for persistent data access instead of direct `localStorage` calls.
 
 **For UI-related changes (styles, components, layout):**
 

--- a/design/productRequirementsDocuments/prdCardOfTheDay.md
+++ b/design/productRequirementsDocuments/prdCardOfTheDay.md
@@ -76,7 +76,7 @@ Currently, the JU-DO-KON! landing screen lacks dynamic content, making repeat vi
 
 ### Open Questions
 
-- Should the featured card be pinned in localStorage to avoid flicker if a user visits multiple times a day?
+- Should the featured card be pinned using the storage utility to avoid flicker if a user visits multiple times a day?
 - Will the rotation logic exclude `Mystery` cards or only include playable cards?
 - Should the feature support queued campaigns (e.g. “7 Days of Champions”)?
 

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -154,7 +154,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
     **Restore Defaults** dialog from the Settings page.
   - A small help icon (`#stat-help`) sits between the **Next Round** and
     **Quit Match** buttons. It displays a tooltip explaining how to pick an
-    attribute and auto-opens on first visit using `localStorage` to remember the
+    attribute and auto-opens on first visit using the storage helper to remember the
     dismissal.
   - Tooltips on stat names, country flags, weight indicators, and navigation icons provide accessible explanations.
   - **Accessibility:**

--- a/design/productRequirementsDocuments/prdResetNavigation.md
+++ b/design/productRequirementsDocuments/prdResetNavigation.md
@@ -31,11 +31,11 @@ Users and testers may encounter issues where the navigation bar does not reflect
 ## Acceptance Criteria
 
 - The "Reset Navigation Cache" button appears in the Settings page only when the navCacheResetButton feature flag is enabled.
-- Clicking the button invokes `navigationCache.reset()`, which removes the navigationItems entry from localStorage.
-- After clicking, the navigation bar is immediately refreshed with up-to-date navigation items.
-- A snackbar or toast message appears confirming the cache was cleared.
-- The button is not visible when the feature flag is disabled.
-- No errors are shown if navigationItems is already missing from localStorage.
+ - Clicking the button invokes `navigationCache.reset()`, which removes the navigationItems entry using the storage utility.
+ - After clicking, the navigation bar is immediately refreshed with up-to-date navigation items.
+ - A snackbar or toast message appears confirming the cache was cleared.
+ - The button is not visible when the feature flag is disabled.
+ - No errors are shown if navigationItems is already missing from storage.
 
 ## Non-Functional Requirements / Design Considerations
 
@@ -45,7 +45,7 @@ Users and testers may encounter issues where the navigation bar does not reflect
 
 ## Dependencies and Open Questions
 
-- Depends on the navigation bar population logic (populateNavbar) and localStorage usage.
+- Depends on the navigation bar population logic (populateNavbar) and storage usage.
 - Relies on the feature flag system for conditional UI display.
 - See [Navigation Bar](prdNavigationBar.md) for hover and active state requirements to ensure UI consistency after cache reset.
 - No known open questions.

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -72,7 +72,7 @@ Modules access player preferences via helpers in
 - `getFeatureFlag(flagName)` – returns `true` when the flag is enabled.
 
 `loadSettings()` should run during startup to populate the cache, avoiding
-direct `localStorage` reads throughout the app.
+direct `localStorage` reads throughout the app by using `src/helpers/storage.js`.
 
 ## Settings Features
 
@@ -103,7 +103,7 @@ direct `localStorage` reads throughout the app.
 ## Technical Considerations
 
 - All data reads/writes should use asynchronous, promise-based functions with error handling.
-- `settings.json` must persist in localStorage/sessionStorage for session retention.
+- `settings.json` must persist via the storage utility for session retention.
 - Updates should debounce writes to avoid excessive file operations if toggles are changed rapidly.
 - Wrap the page contents in a `.home-screen` container so the fixed header does not cover the first settings control.
 

--- a/design/productRequirementsDocuments/prdViewportSimulation.md
+++ b/design/productRequirementsDocuments/prdViewportSimulation.md
@@ -27,7 +27,7 @@ Developers and testers need a reliable, efficient way to verify the game's layou
 | -------- | --------------------------- | --------------------------------------------------------------------------- |
 | P1       | Viewport Simulation Toggle  | Add a switch in Settings to enable/disable simulated mobile viewport width. |
 | P1       | Simulated Viewport Styling  | When enabled, apply a fixed width (375px) and center the game UI.           |
-| P2       | Persistent State (Optional) | Remember the toggle state across page reloads using localStorage.           |
+| P2       | Persistent State (Optional) | Remember the toggle state across page reloads using the storage utility.    |
 
 ## Acceptance Criteria
 
@@ -35,7 +35,7 @@ Developers and testers need a reliable, efficient way to verify the game's layou
 - The `<body>` element receives the `.simulate-viewport` class when simulation is enabled, and it is removed when disabled.
 - The UI is visually constrained and centered when simulation is active.
 - No errors occur if the toggle is used before the DOM is fully loaded (e.g., via `DOMContentLoaded` check).
-- (Optional) The simulation state is saved to and restored from `localStorage` after reload.
+- (Optional) The simulation state is saved to and restored from persistent storage after reload.
 - The toggle is accessible via keyboard and announced correctly by screen readers.
 - The simulation does not interfere with navigation, gameplay, or existing responsive breakpoints.
 
@@ -81,7 +81,7 @@ Developers and testers need a reliable, efficient way to verify the game's layou
 
 - [ ] 4.0 Optional: Implement Persistent Toggle State
 
-  - [ ] 4.1 Store toggle state in localStorage or equivalent
+  - [ ] 4.1 Store toggle state using the storage utility
   - [ ] 4.2 On page load, read and re-apply state if stored
 
 - [ ] 5.0 Accessibility Validation

--- a/src/helpers/country/codes.js
+++ b/src/helpers/country/codes.js
@@ -1,5 +1,6 @@
 import { debugLog } from "../debug.js";
 import { DATA_DIR } from "../constants.js";
+import { getItem, setItem } from "../storage.js";
 
 let countryCodeMappingCache = null;
 const COUNTRY_CACHE_KEY = "countryCodeMappingCache";
@@ -8,10 +9,10 @@ const COUNTRY_CACHE_KEY = "countryCodeMappingCache";
  * Load the mapping of country codes to country names.
  *
  * @pseudocode
- * 1. Return cached data when available, including localStorage cache.
+ * 1. Return cached data when available, including persisted storage cache.
  * 2. Fetch `countryCodeMapping.json` from `DATA_DIR` when no cache exists.
  * 3. Validate each entry and log warnings for invalid data.
- * 4. Store the result in memory and localStorage, then return the mapping.
+ * 4. Store the result in memory and persistent storage, then return the mapping.
  *
  * @returns {Promise<Array<{country:string,code:string,active:boolean}>>} Mapping data.
  */
@@ -19,16 +20,10 @@ export async function loadCountryCodeMapping() {
   if (countryCodeMappingCache) {
     return countryCodeMappingCache;
   }
-  if (typeof localStorage !== "undefined") {
-    const cached = localStorage.getItem(COUNTRY_CACHE_KEY);
-    if (cached) {
-      try {
-        countryCodeMappingCache = JSON.parse(cached);
-        return countryCodeMappingCache;
-      } catch (e) {
-        console.warn("Failed to parse cached country code mapping", e);
-      }
-    }
+  const cached = getItem(COUNTRY_CACHE_KEY);
+  if (cached) {
+    countryCodeMappingCache = cached;
+    return countryCodeMappingCache;
   }
   const response = await fetch(`${DATA_DIR}countryCodeMapping.json`);
   if (!response.ok) {
@@ -46,13 +41,7 @@ export async function loadCountryCodeMapping() {
   });
   debugLog("Loaded country code mapping:", data);
   countryCodeMappingCache = data;
-  if (typeof localStorage !== "undefined") {
-    try {
-      localStorage.setItem(COUNTRY_CACHE_KEY, JSON.stringify(data));
-    } catch (e) {
-      console.warn("Failed to cache country code mapping", e);
-    }
-  }
+  setItem(COUNTRY_CACHE_KEY, data);
   return data;
 }
 

--- a/src/helpers/navigationCache.js
+++ b/src/helpers/navigationCache.js
@@ -1,5 +1,6 @@
 import { fetchJson, validateWithSchema, importJsonModule } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
+import { getItem, setItem, removeItem } from "./storage.js";
 
 const NAV_ITEMS_KEY = "navigationItems";
 let schemaPromise;
@@ -19,32 +20,28 @@ async function getNavigationSchema() {
 }
 
 /**
- * Load navigation items from localStorage or the bundled JSON file.
+ * Load navigation items from persistent storage or the bundled JSON file.
  *
  * @pseudocode
  * 1. Fetch `navigationItems.schema.json` lazily via `getNavigationSchema()`.
- * 2. Attempt to read `NAV_ITEMS_KEY` from `localStorage` and validate it.
- *    - On parse or validation failure, remove the stale entry.
+ * 2. Attempt to read `NAV_ITEMS_KEY` from storage and validate it.
+ *    - On validation failure, remove the stale entry.
  * 3. If no valid cached data exists, fetch `navigationItems.json` from `DATA_DIR`.
  *    - On fetch failure, dynamically import the JSON file instead.
- * 4. Persist the validated array to `localStorage` and return it.
+ * 4. Persist the validated array to storage and return it.
  *
  * @returns {Promise<Array>} Resolved array of navigation items.
  */
 export async function load() {
   await getNavigationSchema();
-  if (typeof localStorage === "undefined") {
-    throw new Error("localStorage unavailable");
-  }
-  const raw = localStorage.getItem(NAV_ITEMS_KEY);
-  if (raw) {
+  const cached = getItem(NAV_ITEMS_KEY);
+  if (cached) {
     try {
-      const parsed = JSON.parse(raw);
-      await validateWithSchema(parsed, await getNavigationSchema());
-      return parsed;
+      await validateWithSchema(cached, await getNavigationSchema());
+      return cached;
     } catch (err) {
-      console.warn("Failed to parse stored navigation items", err);
-      localStorage.removeItem(NAV_ITEMS_KEY);
+      console.warn("Failed to validate stored navigation items", err);
+      removeItem(NAV_ITEMS_KEY);
     }
   }
   let data;
@@ -55,37 +52,31 @@ export async function load() {
     data = await importJsonModule("../data/navigationItems.json");
     await validateWithSchema(data, await getNavigationSchema());
   }
-  localStorage.setItem(NAV_ITEMS_KEY, JSON.stringify(data));
+  setItem(NAV_ITEMS_KEY, data);
   return data;
 }
 
 /**
- * Persist navigation items to localStorage.
+ * Persist navigation items to storage.
  *
  * @pseudocode
  * 1. Validate `items` using the navigation schema from `getNavigationSchema()`.
- * 2. Serialize and store the array under `NAV_ITEMS_KEY` in `localStorage`.
+ * 2. Serialize and store the array under `NAV_ITEMS_KEY` in storage.
  *
  * @param {Array} items - Array of navigation items.
  * @returns {Promise<void>} Promise that resolves when saving completes.
  */
 export async function save(items) {
   await validateWithSchema(items, await getNavigationSchema());
-  if (typeof localStorage === "undefined") {
-    throw new Error("localStorage unavailable");
-  }
-  localStorage.setItem(NAV_ITEMS_KEY, JSON.stringify(items));
+  setItem(NAV_ITEMS_KEY, items);
 }
 
 /**
- * Remove cached navigation items from localStorage.
+ * Remove cached navigation items from storage.
  *
  * @pseudocode
- * 1. Delete the `NAV_ITEMS_KEY` entry from `localStorage` when available.
+ * 1. Delete the `NAV_ITEMS_KEY` entry from storage when available.
  */
 export function reset() {
-  if (typeof localStorage === "undefined") {
-    throw new Error("localStorage unavailable");
-  }
-  localStorage.removeItem(NAV_ITEMS_KEY);
+  removeItem(NAV_ITEMS_KEY);
 }

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -1,0 +1,74 @@
+import { debugLog } from "./debug.js";
+
+const memoryStore = new Map();
+
+/**
+ * Retrieve a value from persistent storage.
+ *
+ * @pseudocode
+ * 1. If `localStorage` is available, attempt to read the item.
+ * 2. Parse the JSON string when present; return `null` on parse failure.
+ * 3. When `localStorage` is unavailable, read from an in-memory Map.
+ * 4. Return the parsed value or `null` if no data exists.
+ *
+ * @param {string} key - Storage key to read.
+ * @returns {*} Parsed stored value or `null` when missing.
+ */
+export function getItem(key) {
+  try {
+    if (typeof localStorage !== "undefined") {
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    }
+  } catch (err) {
+    debugLog("storage.getItem failed", err);
+  }
+  return memoryStore.get(key) ?? null;
+}
+
+/**
+ * Persist a value to storage.
+ *
+ * @pseudocode
+ * 1. Serialize `value` using `JSON.stringify`.
+ * 2. When `localStorage` is available, write the stringified value.
+ *    - On failure, fall back to the in-memory Map.
+ * 3. If `localStorage` is unavailable, store the parsed value in memory.
+ *
+ * @param {string} key - Storage key to write.
+ * @param {*} value - Value to store; must be JSON-serializable.
+ */
+export function setItem(key, value) {
+  try {
+    const str = JSON.stringify(value);
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(key, str);
+      return;
+    }
+    memoryStore.set(key, value);
+  } catch (err) {
+    debugLog("storage.setItem failed", err);
+    memoryStore.set(key, value);
+  }
+}
+
+/**
+ * Remove a value from storage.
+ *
+ * @pseudocode
+ * 1. If `localStorage` is available, attempt to remove the entry.
+ * 2. Always remove the key from the in-memory Map as a fallback.
+ *
+ * @param {string} key - Storage key to delete.
+ */
+export function removeItem(key) {
+  try {
+    if (typeof localStorage !== "undefined") {
+      localStorage.removeItem(key);
+    }
+  } catch (err) {
+    debugLog("storage.removeItem failed", err);
+  } finally {
+    memoryStore.delete(key);
+  }
+}

--- a/tests/helpers/navigationCache.test.js
+++ b/tests/helpers/navigationCache.test.js
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 // @vitest-environment jsdom
 import { load, save, reset } from "../../src/helpers/navigationCache.js";
+import { getItem, setItem, removeItem } from "../../src/helpers/storage.js";
 
 const mockFn = () => (globalThis.jest || globalThis.vi).fn();
 
@@ -18,7 +19,7 @@ const validItems = [
 describe("navigationCache", () => {
   const originalFetch = global.fetch;
   beforeEach(() => {
-    localStorage.clear();
+    removeItem("navigationItems");
     global.fetch = mockFn().mockRejectedValue(new Error("fail"));
   });
   afterEach(() => {
@@ -27,9 +28,9 @@ describe("navigationCache", () => {
 
   test("reset clears persisted items", async () => {
     await save(validItems);
-    expect(localStorage.getItem("navigationItems")).not.toBeNull();
+    expect(getItem("navigationItems")).not.toBeNull();
     reset();
-    expect(localStorage.getItem("navigationItems")).toBeNull();
+    expect(getItem("navigationItems")).toBeNull();
   });
 
   test("save rejects invalid data", async () => {
@@ -37,9 +38,9 @@ describe("navigationCache", () => {
   });
 
   test("load removes invalid stored data", async () => {
-    localStorage.setItem("navigationItems", '[{"id":1}]');
+    setItem("navigationItems", [{ id: 1 }]);
     const items = await load();
     expect(Array.isArray(items)).toBe(true);
-    expect(localStorage.getItem("navigationItems")).not.toBe('[{"id":1}]');
+    expect(getItem("navigationItems")).not.toEqual([{ id: 1 }]);
   });
 });

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createSettingsDom } from "../utils/testUtils.js";
+import { setItem, getItem } from "../../src/helpers/storage.js";
 
 const baseSettings = {
   sound: true,
@@ -683,10 +684,10 @@ describe("settingsPage module", () => {
 
     const btn = document.getElementById("nav-cache-reset-button");
     expect(btn).toBeTruthy();
-    localStorage.setItem("navigationItems", "foo");
+    setItem("navigationItems", "foo");
     btn.dispatchEvent(new Event("click"));
     await vi.runAllTimersAsync();
-    expect(localStorage.getItem("navigationItems")).toBeNull();
+    expect(getItem("navigationItems")).toBeNull();
     expect(populateNavbar).toHaveBeenCalled();
     expect(showSnackbar).toHaveBeenCalledWith("Navigation cache cleared");
     vi.useRealTimers();


### PR DESCRIPTION
## Summary
- add `src/helpers/storage.js` to wrap `localStorage` with JSON serialization and in-memory fallback
- refactor helpers to use storage wrapper and update tests
- document storage utility in CONTRIBUTING and PRDs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed to load game modes Error: fail)*
- `npx playwright test` *(fails: Error fetching file:///workspace/judokon/src/data/navigationItems.json: TypeError: fetch failed)*
- `npm run check:contrast` *(fails: Error fetching file:///workspace/judokon/src/data/statNames.json: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68972c45b788832682381f03524fca6b