### PR TITLE
feat(agent): centralize vector search helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ Call `loadSettings()` during startup to populate the cache before using
 these helpers. This approach avoids direct `localStorage` reads in modules
 that need fast, synchronous access to settings.
 
+## Vector Search Helpers
+
+Utilities for working with the embedding database are centralized in
+`src/helpers/vectorSearch/index.js`. The default export provides methods to
+load embeddings, expand queries, find matches, and fetch surrounding
+context:
+
+```javascript
+import vectorSearch from "./src/helpers/vectorSearch/index.js";
+const embeddings = await vectorSearch.loadEmbeddings();
+const expanded = await vectorSearch.expandQueryWithSynonyms("grip fighting");
+const results = await vectorSearch.findMatches([0, 1, 0], 5, ["prd"], expanded);
+```
+
 ## 🧪 Testing
 
 The game includes a **Skip** button that bypasses the current round and cooldown timers. Use it to fast-forward through matches when debugging or running rapid gameplay tests.

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -32,11 +32,11 @@ Agents can filter by these tag values when calling `findMatches`.
 
 ## Prompt Examples
 
-Agent scripts can import `findMatches` from `src/helpers/vectorSearch.js` to query the embeddings programmatically.
+Agent scripts can import the bundled helper from `src/helpers/vectorSearch/index.js` to query the embeddings programmatically.
 
 ```javascript
-import { findMatches } from "../../src/helpers/vectorSearch.js";
-const matches = await findMatches(vector, 5, ["prd"]);
+import vectorSearch from "../../src/helpers/vectorSearch/index.js";
+const matches = await vectorSearch.findMatches(vector, 5, ["prd"]);
 ```
 
 Because embeddings capture semantics, synonyms like "grip fighting" and "kumi-kata" map closely. The demo interface marks scores of 0.6 and above as strong matches and only shows weaker results when no strong hits are returned.
@@ -53,12 +53,12 @@ Query: "settings feature flags order"
 To narrow results, pass tag filters to your search call:
 
 ```
-findMatches(queryVector, 5, ["judoka-data"]);
+vectorSearch.findMatches(queryVector, 5, ["judoka-data"]);
 ```
 
 ```
-const results = await findMatches(queryVector, 5);
-const context = await fetchContextById(results[0].id);
+const results = await vectorSearch.findMatches(queryVector, 5);
+const context = await vectorSearch.fetchContextById(results[0].id);
 ```
 
 ### Card Generation Agent
@@ -88,7 +88,7 @@ pretty-printed for easier diffing, so agents search the latest content. Commit
 the regenerated JSON file along with your changes.
 
 The vector search page checks each embedding's `version` against the
-`CURRENT_EMBEDDING_VERSION` constant in `src/helpers/vectorSearch.js`.
+`CURRENT_EMBEDDING_VERSION` constant provided by `vectorSearch.CURRENT_EMBEDDING_VERSION`.
 If a mismatch warning appears, bump the constant and rerun
 `npm run generate:embeddings` to refresh both
 `client_embeddings.json` and `client_embeddings.meta.json`.

--- a/src/helpers/vectorSearch/index.js
+++ b/src/helpers/vectorSearch/index.js
@@ -1,0 +1,24 @@
+import {
+  loadEmbeddings,
+  findMatches,
+  fetchContextById,
+  CURRENT_EMBEDDING_VERSION
+} from "../vectorSearch.js";
+import { expandQueryWithSynonyms } from "../vectorSearchQuery.js";
+
+/**
+ * Centralized vector search API.
+ *
+ * @pseudocode
+ * 1. Re-export helpers from existing modules under a single object.
+ * 2. Provide access to embedding utilities and query expansion.
+ */
+const vectorSearch = {
+  loadEmbeddings,
+  findMatches,
+  expandQueryWithSynonyms,
+  fetchContextById,
+  CURRENT_EMBEDDING_VERSION
+};
+
+export default vectorSearch;

--- a/tests/helpers/vectorSearchIndex.test.js
+++ b/tests/helpers/vectorSearchIndex.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.doMock("../../src/helpers/vectorSearch.js", () => ({
+  loadEmbeddings: vi.fn().mockResolvedValue([1]),
+  findMatches: vi.fn().mockResolvedValue([2]),
+  fetchContextById: vi.fn().mockResolvedValue(["ctx"]),
+  CURRENT_EMBEDDING_VERSION: 1
+}));
+vi.doMock("../../src/helpers/vectorSearchQuery.js", () => ({
+  expandQueryWithSynonyms: vi.fn().mockResolvedValue("expanded")
+}));
+
+describe("vectorSearch index", () => {
+  it("exposes bundled helpers", async () => {
+    const vectorSearch = (await import("../../src/helpers/vectorSearch/index.js")).default;
+    expect(await vectorSearch.loadEmbeddings()).toEqual([1]);
+    expect(await vectorSearch.findMatches()).toEqual([2]);
+    expect(await vectorSearch.expandQueryWithSynonyms("q")).toBe("expanded");
+    expect(await vectorSearch.fetchContextById("id")).toEqual(["ctx"]);
+    expect(vectorSearch.CURRENT_EMBEDDING_VERSION).toBe(1);
+  });
+});

--- a/tests/helpers/vectorSearchPage.test.js
+++ b/tests/helpers/vectorSearchPage.test.js
@@ -48,11 +48,14 @@ describe("selectMatches", () => {
 describe("vector search page integration", () => {
   it("passes selected tag to findMatches", async () => {
     const findMatches = vi.fn().mockResolvedValue([]);
-    vi.doMock("../../src/helpers/vectorSearch.js", () => ({
-      findMatches,
-      fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([{ tags: ["foo"], version: 1 }]),
-      CURRENT_EMBEDDING_VERSION: 1
+    vi.doMock("../../src/helpers/vectorSearch/index.js", () => ({
+      default: {
+        findMatches,
+        fetchContextById: vi.fn(),
+        loadEmbeddings: vi.fn().mockResolvedValue([{ tags: ["foo"], version: 1 }]),
+        expandQueryWithSynonyms: vi.fn((q) => q),
+        CURRENT_EMBEDDING_VERSION: 1
+      }
     }));
 
     const { handleSearch, init, __setExtractor } = await import(
@@ -87,11 +90,14 @@ describe("vector search page integration", () => {
       { tags: ["alpha"], version: 1 },
       { tags: ["beta"], version: 1 }
     ];
-    vi.doMock("../../src/helpers/vectorSearch.js", () => ({
-      findMatches: vi.fn(),
-      fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue(embeddings),
-      CURRENT_EMBEDDING_VERSION: 1
+    vi.doMock("../../src/helpers/vectorSearch/index.js", () => ({
+      default: {
+        findMatches: vi.fn(),
+        fetchContextById: vi.fn(),
+        loadEmbeddings: vi.fn().mockResolvedValue(embeddings),
+        expandQueryWithSynonyms: vi.fn((q) => q),
+        CURRENT_EMBEDDING_VERSION: 1
+      }
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue({ count: 2, version: 1 })
@@ -123,11 +129,14 @@ describe("vector search page integration", () => {
 describe("search result message styling", () => {
   it("adds search-result-empty class when no matches", async () => {
     const findMatches = vi.fn().mockResolvedValue([]);
-    vi.doMock("../../src/helpers/vectorSearch.js", () => ({
-      findMatches,
-      fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([]),
-      CURRENT_EMBEDDING_VERSION: 1
+    vi.doMock("../../src/helpers/vectorSearch/index.js", () => ({
+      default: {
+        findMatches,
+        fetchContextById: vi.fn(),
+        loadEmbeddings: vi.fn().mockResolvedValue([]),
+        expandQueryWithSynonyms: vi.fn((q) => q),
+        CURRENT_EMBEDDING_VERSION: 1
+      }
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue({ count: 0, version: 1 })
@@ -171,11 +180,14 @@ describe("search result message styling", () => {
       version: 1
     };
     const findMatches = vi.fn().mockResolvedValue([match]);
-    vi.doMock("../../src/helpers/vectorSearch.js", () => ({
-      findMatches,
-      fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([match]),
-      CURRENT_EMBEDDING_VERSION: 1
+    vi.doMock("../../src/helpers/vectorSearch/index.js", () => ({
+      default: {
+        findMatches,
+        fetchContextById: vi.fn(),
+        loadEmbeddings: vi.fn().mockResolvedValue([match]),
+        expandQueryWithSynonyms: vi.fn((q) => q),
+        CURRENT_EMBEDDING_VERSION: 1
+      }
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue({ count: 1, version: 1 })
@@ -219,11 +231,14 @@ describe("search result message styling", () => {
       version: 1
     };
     const findMatches = vi.fn().mockResolvedValue([match]);
-    vi.doMock("../../src/helpers/vectorSearch.js", () => ({
-      findMatches,
-      fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([match]),
-      CURRENT_EMBEDDING_VERSION: 1
+    vi.doMock("../../src/helpers/vectorSearch/index.js", () => ({
+      default: {
+        findMatches,
+        fetchContextById: vi.fn(),
+        loadEmbeddings: vi.fn().mockResolvedValue([match]),
+        expandQueryWithSynonyms: vi.fn((q) => q),
+        CURRENT_EMBEDDING_VERSION: 1
+      }
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue({ count: 1, version: 1 })
@@ -282,11 +297,14 @@ describe("snippet highlighting", () => {
       version: 1
     };
     const findMatches = vi.fn().mockResolvedValue([match]);
-    vi.doMock("../../src/helpers/vectorSearch.js", () => ({
-      findMatches,
-      fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([match]),
-      CURRENT_EMBEDDING_VERSION: 1
+    vi.doMock("../../src/helpers/vectorSearch/index.js", () => ({
+      default: {
+        findMatches,
+        fetchContextById: vi.fn(),
+        loadEmbeddings: vi.fn().mockResolvedValue([match]),
+        expandQueryWithSynonyms: vi.fn((q) => q),
+        CURRENT_EMBEDDING_VERSION: 1
+      }
     }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue({ count: 1, version: 1 })
@@ -323,12 +341,18 @@ describe("snippet highlighting", () => {
 describe("synonym expansion", () => {
   it("expands query terms using the synonym list", async () => {
     const synonyms = { "shoulder throw": ["seoi-nage"] };
-    vi.doMock("../../src/helpers/vectorSearch.js", () => ({
-      findMatches: vi.fn().mockResolvedValue([]),
-      fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([]),
-      CURRENT_EMBEDDING_VERSION: 1
-    }));
+    vi.doMock("../../src/helpers/vectorSearch/index.js", async () => {
+      const { expandQueryWithSynonyms } = await import("../../src/helpers/vectorSearchQuery.js");
+      return {
+        default: {
+          findMatches: vi.fn().mockResolvedValue([]),
+          fetchContextById: vi.fn(),
+          loadEmbeddings: vi.fn().mockResolvedValue([]),
+          expandQueryWithSynonyms,
+          CURRENT_EMBEDDING_VERSION: 1
+        }
+      };
+    });
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue(synonyms)
     }));
@@ -336,21 +360,27 @@ describe("synonym expansion", () => {
       DATA_DIR: "./"
     }));
 
-    const { expandQueryWithSynonyms } = await import("../../src/helpers/vectorSearchQuery.js");
+    const vectorSearch = (await import("../../src/helpers/vectorSearch/index.js")).default;
 
-    const result = await expandQueryWithSynonyms("shoulder throw");
+    const result = await vectorSearch.expandQueryWithSynonyms("shoulder throw");
     expect(result).toContain("seoi-nage");
   });
 
   it("handles misspellings via Levenshtein check", async () => {
     const synonyms = { "seoi nage": ["seoi-nage"] };
     const findMatches = vi.fn().mockResolvedValue([]);
-    vi.doMock("../../src/helpers/vectorSearch.js", () => ({
-      findMatches,
-      fetchContextById: vi.fn(),
-      loadEmbeddings: vi.fn().mockResolvedValue([]),
-      CURRENT_EMBEDDING_VERSION: 1
-    }));
+    vi.doMock("../../src/helpers/vectorSearch/index.js", async () => {
+      const { expandQueryWithSynonyms } = await import("../../src/helpers/vectorSearchQuery.js");
+      return {
+        default: {
+          findMatches,
+          fetchContextById: vi.fn(),
+          loadEmbeddings: vi.fn().mockResolvedValue([]),
+          expandQueryWithSynonyms,
+          CURRENT_EMBEDDING_VERSION: 1
+        }
+      };
+    });
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue(synonyms)
     }));


### PR DESCRIPTION
## Summary
- bundle vector search utilities in `src/helpers/vectorSearch/index.js`
- refactor page and tests to use unified module
- document vector search API for contributors and add unit coverage

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: buttons not disabled)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68972f131b9c8326b195e70e83d96d29