### PR TITLE
refactor country helpers to use centralized country code utilities

### DIFF
--- a/src/components/JudokaCard.js
+++ b/src/components/JudokaCard.js
@@ -1,4 +1,4 @@
-import { getFlagUrl } from "../helpers/country/index.js";
+import { getFlagUrl } from "../helpers/country/codes.js";
 import { generateCardTopBar, createNoDataContainer } from "../helpers/cardTopBar.js";
 import { safeGenerate } from "../helpers/errorUtils.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "../helpers/judokaValidation.js";

--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -1,4 +1,4 @@
-import { getFlagUrl } from "./country/index.js";
+import { getFlagUrl } from "./country/codes.js";
 import { generateCardTopBar, createNoDataContainer } from "./cardTopBar.js";
 import { safeGenerate } from "./errorUtils.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";

--- a/src/helpers/cardTopBar.js
+++ b/src/helpers/cardTopBar.js
@@ -1,4 +1,4 @@
-import { getCountryNameFromCode } from "./country/index.js";
+import { getCountryByCode } from "../utils/countryCodes.js";
 import { getValue } from "./utils.js";
 import { debugLog } from "./debug.js";
 
@@ -53,17 +53,13 @@ function extractJudokaData(judoka) {
  *
  * @pseudocode
  * 1. Check if `countryCode` is valid (not `"unknown"`):
- *    - If valid:
- *      a. Call `getCountryNameFromCode` asynchronously.
- *      b. Return the resolved country name.
- *
- * 2. If `countryCode` is `"unknown"`:
- *    - Return `"Unknown"` as the fallback country name.
+ *    - If valid, call `getCountryByCode` and return the resolved name or `"Unknown"`.
+ * 2. If `countryCode` is `"unknown"`, return `"Unknown"`.
  */
 async function resolveCountryName(countryCode) {
   if (countryCode !== "unknown") {
-    const countryName = await getCountryNameFromCode(countryCode);
-    return countryName;
+    const countryName = await getCountryByCode(countryCode);
+    return countryName || "Unknown";
   }
   debugLog("Country name is unknown.");
   return "Unknown";

--- a/src/helpers/country/codes.js
+++ b/src/helpers/country/codes.js
@@ -1,120 +1,44 @@
-import { debugLog } from "../debug.js";
-import { DATA_DIR } from "../constants.js";
-import { getItem, setItem } from "../storage.js";
-
-/** @typedef {{country: string, code: string, lastUpdated: string, active: boolean}} CountryEntry */
-
-/** @type {Record<string, CountryEntry>|null} */
-let countryCodeMappingCache = null;
-const COUNTRY_CACHE_KEY = "countryCodeMappingCache";
-
-/**
- * Load the mapping of country codes to country names.
- *
- * @pseudocode
- * 1. Return cached data when available, including persisted storage cache.
- * 2. Fetch `countryCodeMapping.json` from `DATA_DIR` when no cache exists.
- * 3. Validate each `[code, entry]` pair:
- *    - Ensure `code` is lowercase two-letter ISO.
- *    - Verify `entry.code` matches the key and required fields exist.
- *    - Throw an error on invalid data.
- * 4. Store the result in memory and persistent storage, then return the mapping.
- *
- * @returns {Promise<Record<string, CountryEntry>>} Mapping data.
- */
-export async function loadCountryCodeMapping() {
-  if (countryCodeMappingCache) {
-    return countryCodeMappingCache;
-  }
-  const cached = getItem(COUNTRY_CACHE_KEY);
-  if (cached) {
-    countryCodeMappingCache = cached;
-    return countryCodeMappingCache;
-  }
-  const response = await fetch(`${DATA_DIR}countryCodeMapping.json`);
-  if (!response.ok) {
-    throw new Error("Error - Failed to load the country code mapping");
-  }
-  const data = await response.json();
-  for (const [code, entry] of Object.entries(data)) {
-    if (!/^[a-z]{2}$/.test(code)) {
-      throw new Error(`Invalid country code key: "${code}"`);
-    }
-    if (!entry || typeof entry !== "object") {
-      throw new Error(`Invalid entry for code "${code}": not an object`);
-    }
-    if (entry.code !== code) {
-      throw new Error(`Code mismatch for key "${code}": entry.code is "${entry.code}"`);
-    }
-    if (
-      typeof entry.country !== "string" ||
-      typeof entry.active !== "boolean" ||
-      typeof entry.lastUpdated !== "string"
-    ) {
-      throw new Error(`Invalid country code entry found for "${code}"`);
-    }
-  }
-  debugLog("Loaded country code mapping:", data);
-  countryCodeMappingCache = data;
-  setItem(COUNTRY_CACHE_KEY, data);
-  return data;
-}
+import { getCountryByCode, normalizeCode } from "../../utils/countryCodes.js";
 
 /**
  * Resolve the country name for a two-letter code.
  *
  * @pseudocode
- * 1. Validate that `code` is a two-letter string; return "Vanuatu" when invalid.
- * 2. Attempt to load the mapping via `loadCountryCodeMapping()`; return "Vanuatu" on failure.
- * 3. Look up the lower-cased `code` and return the `country` when the entry is active.
- * 4. Default to "Vanuatu" if no matching active entry is found.
+ * 1. Call `getCountryByCode(code)`.
+ * 2. Return the resolved name when available.
+ * 3. Default to "Vanuatu" if the lookup fails.
  *
  * @param {string} code - Two-letter country code.
- * @returns {Promise<string>} Resolved country name or fallback.
+ * @returns {Promise<string>} Resolved country name or "Vanuatu".
  */
 export async function getCountryNameFromCode(code) {
-  if (typeof code !== "string" || !/^[A-Za-z]{2}$/.test(code.trim())) {
-    console.warn("Invalid country code format. Expected a 2-letter code.");
-    return "Vanuatu";
-  }
-  try {
-    const countryCodeMapping = await loadCountryCodeMapping();
-    const entry = countryCodeMapping[code.toLowerCase()];
-    const result = entry && entry.active ? entry.country : "Vanuatu";
-    debugLog(`Resolved country name for code "${code}":`, result);
-    return result;
-  } catch {
-    console.warn("Failed to load country code mapping. Defaulting to Vanuatu.");
-    return "Vanuatu";
-  }
+  const name = await getCountryByCode(code);
+  return name || "Vanuatu";
 }
 
 /**
  * Build the flag image URL for a country code.
  *
  * @pseudocode
- * 1. Validate `countryCode` as a two-letter string; return the Vanuatu flag when invalid.
- * 2. Attempt to load the mapping and verify the code exists and is active; return the Vanuatu flag on failure.
- * 3. Return the CDN URL using the lower-cased code or the Vanuatu flag when invalid.
+ * 1. Normalize `countryCode`; return Vanuatu flag when invalid.
+ * 2. Verify the code exists using `getCountryByCode`.
+ * 3. Return the CDN URL for the normalized code or the Vanuatu flag when unresolved.
  *
  * @param {string} countryCode - Two-letter country code.
  * @returns {Promise<string>} URL for the flag image.
  */
 export async function getFlagUrl(countryCode) {
-  if (typeof countryCode !== "string" || !/^[A-Za-z]{2}$/.test(countryCode.trim())) {
+  const normalized = normalizeCode(countryCode);
+  if (!normalized) {
     console.warn("Invalid or missing country code. Defaulting to Vanuatu flag.");
     return "https://flagcdn.com/w320/vu.png";
   }
-  try {
-    const countryCodeMapping = await loadCountryCodeMapping();
-    const entry = countryCodeMapping[countryCode.toLowerCase()];
-    if (!entry || !entry.active) {
-      console.warn("Invalid country code. Defaulting to Vanuatu flag.");
-      return "https://flagcdn.com/w320/vu.png";
-    }
-    return `https://flagcdn.com/w320/${countryCode.toLowerCase()}.png`;
-  } catch {
-    console.warn("Failed to load country code mapping. Defaulting to Vanuatu flag.");
+
+  const exists = await getCountryByCode(normalized);
+  if (!exists) {
+    console.warn("Invalid country code. Defaulting to Vanuatu flag.");
     return "https://flagcdn.com/w320/vu.png";
   }
+
+  return `https://flagcdn.com/w320/${normalized}.png`;
 }

--- a/src/helpers/country/index.js
+++ b/src/helpers/country/index.js
@@ -1,2 +1,0 @@
-export * from "./codes.js";
-export * from "./list.js";

--- a/src/helpers/countrySlider.js
+++ b/src/helpers/countrySlider.js
@@ -1,4 +1,4 @@
-import { populateCountryList } from "./country/index.js";
+import { populateCountryList } from "./country/list.js";
 
 /**
  * Build a horizontally scrolling slider of country flags for filtering judoka cards by country.

--- a/tests/card/cardTopBar.test.js
+++ b/tests/card/cardTopBar.test.js
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import * as countryUtils from "../../src/helpers/country/index.js";
+import * as countryUtils from "../../src/utils/countryCodes.js";
 import {
   generateCardTopBar,
   createNameContainer,
@@ -19,7 +19,7 @@ const judoka = {
 const flagUrl = "https://flagcdn.com/w320/fr.png";
 
 beforeEach(() => {
-  vi.spyOn(countryUtils, "getCountryNameFromCode").mockResolvedValue("France");
+  vi.spyOn(countryUtils, "getCountryByCode").mockResolvedValue("France");
 });
 
 describe("generateCardTopBar", () => {
@@ -72,7 +72,7 @@ describe("generateCardTopBar", () => {
   });
 
   it("should fallback to 'Unknown' when countryCode is missing", async () => {
-    countryUtils.getCountryNameFromCode.mockResolvedValueOnce("Unknown");
+    countryUtils.getCountryByCode.mockResolvedValueOnce("Unknown");
     const incompleteJudoka = { firstname: "Clarisse", surname: "Agbegnenou" };
     const result = await generateCardTopBar(incompleteJudoka, flagUrl);
     expect(result.outerHTML).toContain('alt="Unknown flag"');
@@ -94,13 +94,13 @@ describe("generateCardTopBar", () => {
   });
 
   it("escapes HTML in country name for alt attribute", async () => {
-    vi.spyOn(countryUtils, "getCountryNameFromCode").mockResolvedValueOnce("<France>");
+    vi.spyOn(countryUtils, "getCountryByCode").mockResolvedValueOnce("<France>");
     const result = await generateCardTopBar(judoka, flagUrl);
     expect(result.outerHTML).toContain('alt="<France> flag"');
   });
 
   it("includes alt attribute even if countryName is falsy", async () => {
-    vi.spyOn(countryUtils, "getCountryNameFromCode").mockResolvedValueOnce("");
+    vi.spyOn(countryUtils, "getCountryByCode").mockResolvedValueOnce("");
     const result = await generateCardTopBar(judoka, flagUrl);
     expect(result.outerHTML).toContain('alt="Unknown flag"');
   });

--- a/tests/helpers/countrySlider.test.js
+++ b/tests/helpers/countrySlider.test.js
@@ -14,7 +14,7 @@ describe("createCountrySlider", () => {
       c.appendChild(slideB);
     });
 
-    vi.doMock("../../src/helpers/country/index.js", () => ({ populateCountryList }));
+    vi.doMock("../../src/helpers/country/list.js", () => ({ populateCountryList }));
 
     const { createCountrySlider } = await import("../../src/helpers/countrySlider.js");
 

--- a/tests/helpers/populateCountryList.test.js
+++ b/tests/helpers/populateCountryList.test.js
@@ -41,7 +41,7 @@ describe("populateCountryList", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => judoka })
       .mockResolvedValueOnce({ ok: true, json: async () => mapping });
 
-    const { populateCountryList } = await import("../../src/helpers/country/index.js");
+    const { populateCountryList } = await import("../../src/helpers/country/list.js");
 
     const container = document.createElement("div");
     await populateCountryList(container);
@@ -68,7 +68,7 @@ describe("populateCountryList", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => judoka })
       .mockResolvedValueOnce({ ok: true, json: async () => mapping });
 
-    const { populateCountryList } = await import("../../src/helpers/country/index.js");
+    const { populateCountryList } = await import("../../src/helpers/country/list.js");
 
     const container = document.createElement("div");
     await populateCountryList(container);
@@ -94,7 +94,7 @@ describe("populateCountryList", () => {
       .mockResolvedValueOnce({ ok: true, json: async () => judoka })
       .mockResolvedValueOnce({ ok: true, json: async () => mapping });
 
-    const { populateCountryList } = await import("../../src/helpers/country/index.js");
+    const { populateCountryList } = await import("../../src/helpers/country/list.js");
 
     const container = document.createElement("div");
     await populateCountryList(container);
@@ -136,7 +136,7 @@ describe("populateCountryList", () => {
       return Promise.resolve({ ok: true, json: async () => mapping });
     });
 
-    const { populateCountryList } = await import("../../src/helpers/country/index.js");
+    const { populateCountryList } = await import("../../src/helpers/country/list.js");
 
     const track = document.createElement("div");
     const scrollContainer = document.createElement("div");
@@ -159,7 +159,7 @@ describe("populateCountryList", () => {
 
   it("handles fetch failure gracefully", async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error("network error"));
-    const { populateCountryList } = await import("../../src/helpers/country/index.js");
+    const { populateCountryList } = await import("../../src/helpers/country/list.js");
     const container = document.createElement("div");
     await expect(populateCountryList(container)).resolves.toBeUndefined();
     expect(container.querySelectorAll(".slide").length).toBe(0);
@@ -182,7 +182,7 @@ describe("populateCountryList", () => {
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => judoka })
       .mockResolvedValueOnce({ ok: true, json: async () => mapping });
-    const { populateCountryList } = await import("../../src/helpers/country/index.js");
+    const { populateCountryList } = await import("../../src/helpers/country/list.js");
     const container = document.createElement("div");
     await populateCountryList(container);
     const slides = container.querySelectorAll(".slide");
@@ -196,7 +196,7 @@ describe("populateCountryList", () => {
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => [] })
       .mockResolvedValueOnce({ ok: true, json: async () => [] });
-    const { populateCountryList } = await import("../../src/helpers/country/index.js");
+    const { populateCountryList } = await import("../../src/helpers/country/list.js");
     const container = document.createElement("div");
     await populateCountryList(container);
     expect(container.textContent).toBe("No countries available.");


### PR DESCRIPTION
## Summary
- replace ad-hoc country code lookups with utility functions
- simplify country list and flag helpers
- adjust tests and imports after removing legacy country helper index

## Testing
- `npx eslint src/helpers src/components --fix`
- `npx prettier src/helpers src/components --write`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68973281de748326b39d7d1437b6769b