### PR TITLE
refactor country code mapping schema

### DIFF
--- a/src/schemas/countryCodeMapping.schema.json
+++ b/src/schemas/countryCodeMapping.schema.json
@@ -10,10 +10,6 @@
           "type": "string",
           "description": "The name of the country."
         },
-        "code": {
-          "$ref": "https://judokon.dev/schemas/commonDefinitions.schema.json#/definitions/CountryCode",
-          "description": "The country code in ISO 3166-1 alpha-2 format."
-        },
         "lastUpdated": {
           "type": "string",
           "format": "date-time",
@@ -24,7 +20,7 @@
           "description": "Indicates whether the country is active."
         }
       },
-      "required": ["country", "code", "lastUpdated", "active"],
+      "required": ["country", "lastUpdated", "active"],
       "additionalProperties": false
     }
   },


### PR DESCRIPTION
## Summary
- simplify country code mapping schema to only allow `country`, `lastUpdated`, and `active` fields for two-letter keys

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: data/vu must NOT have additional properties)
- `npx playwright test` (fails: Browse Judoka navigation tests)
- `npm run check:contrast`
- `npm run validate:data` (fails: npm error could not determine executable to run)


------
https://chatgpt.com/codex/tasks/task_e_68973cdbbf048326bf686eb32d7b4f54