### PR TITLE
feat(navigation): add menu API

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -34,6 +34,17 @@ Key helpers include:
 - `navigationBar.js` – Injects active game modes into the persistent nav bar
 - `setupBottomNavbar.js` – Wires the nav bar into the DOM
 
+### helpers/navigation
+
+Use `helpers/api/navigation.js` to build orientation-specific menus and responsive hamburger toggles. Pages should import only this API.
+
+```js
+import { buildMenu, setupHamburger } from "../helpers/api/navigation.js";
+```
+
+- `buildMenu(gameModes, { orientation })` returns the created menu element.
+- `setupHamburger(breakpoint?)` inserts a toggle button and returns `{button, list}`.
+
 ---
 
 ## 📦 data/

--- a/src/helpers/api/navigation.js
+++ b/src/helpers/api/navigation.js
@@ -1,0 +1,194 @@
+import { validateGameModes } from "../navigation/navData.js";
+
+/**
+ * Convert a game mode name to a camelCase key for tooltip ids.
+ *
+ * @pseudocode
+ * 1. Replace non-alphanumeric characters with spaces.
+ * 2. Split into words.
+ * 3. Lowercase the first word and capitalize the rest.
+ * 4. Join the words without spaces.
+ *
+ * @param {string} name - Game mode name.
+ * @returns {string} camelCase key.
+ */
+export function navTooltipKey(name) {
+  return String(name)
+    .replace(/[^a-zA-Z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .map((w, i) => (i === 0 ? w.toLowerCase() : w[0].toUpperCase() + w.slice(1)))
+    .join("");
+}
+
+/**
+ * Base path for navigation links derived from the current module location.
+ */
+export const BASE_PATH = (() => {
+  const url = new URL(import.meta.url);
+  url.pathname = url.pathname.replace(/helpers\/api\/navigation.js$/, "pages/");
+  return url;
+})();
+
+/**
+ * Clears existing content in the bottom navigation bar.
+ *
+ * @pseudocode
+ * 1. Select the `.bottom-navbar` element.
+ * 2. Exit early if the element is not found.
+ * 3. Remove all child elements to prevent duplication.
+ */
+function clearBottomNavbar() {
+  const navBar = document.querySelector(".bottom-navbar");
+  if (!navBar) return;
+  navBar.innerHTML = "";
+}
+
+/**
+ * Preserve the logo and attach toggle behavior for a menu.
+ *
+ * @pseudocode
+ * 1. Clear the existing navbar content.
+ * 2. Reinsert the logo into the navbar.
+ * 3. Append the provided menu element.
+ * 4. Toggle visibility and animation on logo click.
+ *
+ * @param {HTMLElement} navBar - The bottom navigation bar element.
+ * @param {HTMLElement} logo - The logo element to preserve.
+ * @param {HTMLElement} menu - The menu element to toggle.
+ * @param {{show: string, hide: string}} animations - CSS animations for show/hide.
+ */
+function preserveLogoAndWire(navBar, logo, menu, animations) {
+  clearBottomNavbar();
+  navBar.appendChild(logo);
+  navBar.appendChild(menu);
+  logo.addEventListener("click", () => {
+    menu.classList.toggle("visible");
+    menu.style.animation = menu.classList.contains("visible") ? animations.show : animations.hide;
+  });
+}
+
+/**
+ * Build a navigation menu for a given orientation.
+ *
+ * @pseudocode
+ * 1. Determine if the current viewport matches the provided orientation.
+ * 2. Select the navbar and logo; exit if either is missing.
+ * 3. Validate game modes and build a menu container with orientation class.
+ * 4. Populate the container using the appropriate template per mode.
+ * 5. Preserve the logo and wire click animations.
+ * 6. Return the created menu element.
+ *
+ * @param {import("../types.js").GameMode[]} gameModes - Modes to display.
+ * @param {{orientation: "landscape"|"portrait"}} options - Orientation settings.
+ * @returns {HTMLElement|null} Created menu element or null if skipped.
+ */
+export function buildMenu(gameModes, { orientation }) {
+  const matches =
+    typeof window.matchMedia === "function"
+      ? window.matchMedia(`(orientation: ${orientation})`).matches
+      : orientation === "landscape"
+        ? window.innerWidth > window.innerHeight
+        : window.innerHeight >= window.innerWidth;
+  if (!matches) return null;
+
+  const navBar = document.querySelector(".bottom-navbar");
+  if (!navBar) return null;
+  const logo = navBar.querySelector(".logo");
+  if (!logo) return null;
+
+  const validModes = validateGameModes(gameModes);
+
+  const menu = document.createElement("div");
+  const isLandscape = orientation === "landscape";
+  menu.className = isLandscape ? "expanded-map-view" : "portrait-text-menu";
+  const template = isLandscape
+    ? (mode) =>
+        `<a
+          href="${BASE_PATH}${mode.url}"
+          aria-label="${mode.name}"
+          data-tooltip-id="nav.${navTooltipKey(mode.name)}"
+          data-testid="nav-${mode.id}"
+          style="order: ${mode.order}"
+          class="map-tile${mode.isHidden ? " hidden" : ""}"
+        >
+          <img src="${mode.image}" alt="${mode.name}" loading="lazy">
+          ${mode.name}
+        </a>`
+    : (mode) =>
+        `<a
+          href="${BASE_PATH}${mode.url}"
+          aria-label="${mode.name}"
+          data-tooltip-id="nav.${navTooltipKey(mode.name)}"
+          data-testid="nav-${mode.id}"
+          style="order: ${mode.order}"
+          class="text-menu-item${mode.isHidden ? " hidden" : ""}"
+        >
+          ${mode.name}
+        </a>`;
+  menu.innerHTML = validModes.map(template).join("");
+
+  const animations = isLandscape
+    ? { show: "slide-up 500ms ease-in-out", hide: "slide-down 500ms ease-in-out" }
+    : { show: "slide-down 500ms ease-in-out", hide: "slide-up 500ms ease-in-out" };
+
+  preserveLogoAndWire(navBar, logo, menu, animations);
+  return menu;
+}
+
+/**
+ * Initialize a hamburger toggle for narrow viewports.
+ *
+ * @pseudocode
+ * 1. Select the `.bottom-navbar` and its `<ul>`; exit if either is missing.
+ * 2. Create a button with `aria-expanded="false"` linked to the list via `aria-controls`.
+ * 3. Define `update()` to insert the button and hide the list when the width is below the breakpoint; otherwise remove the button.
+ * 4. Define `toggle()` to flip `aria-expanded` and the `.expanded` class on the list.
+ * 5. Attach `click` and `resize` listeners and invoke `update()` once.
+ * 6. Return the button and list elements for further wiring.
+ *
+ * @param {number} [breakpoint=480] - Maximum width to show the hamburger menu.
+ * @returns {{button: HTMLButtonElement|null, list: HTMLUListElement|null}} DOM hooks.
+ */
+export function setupHamburger(breakpoint = 480) {
+  const navBar = document.querySelector(".bottom-navbar");
+  const list = navBar?.querySelector("ul") || null;
+  if (!navBar || !list) return { button: null, list };
+
+  const id = list.id || "bottom-nav-menu";
+  list.id = id;
+
+  const button = document.createElement("button");
+  button.className = "nav-toggle";
+  button.setAttribute("aria-expanded", "false");
+  button.setAttribute("aria-controls", id);
+  button.setAttribute("aria-label", "Menu");
+  button.innerHTML = "\u2630";
+
+  const toggle = () => {
+    const expanded = button.getAttribute("aria-expanded") === "true";
+    button.setAttribute("aria-expanded", String(!expanded));
+    list.classList.toggle("expanded", !expanded);
+  };
+
+  button.addEventListener("click", toggle);
+
+  const update = () => {
+    if (window.innerWidth < breakpoint) {
+      if (!navBar.contains(button)) {
+        navBar.insertBefore(button, list);
+      }
+      button.setAttribute("aria-expanded", "false");
+      list.classList.remove("expanded");
+    } else if (navBar.contains(button)) {
+      button.remove();
+      list.classList.remove("expanded");
+      button.setAttribute("aria-expanded", "false");
+    }
+  };
+
+  window.addEventListener("resize", update);
+  update();
+
+  return { button, list };
+}

--- a/src/helpers/navigation/navMenu.js
+++ b/src/helpers/navigation/navMenu.js
@@ -1,218 +1,45 @@
-import { validateGameModes } from "./navData.js";
+import { buildMenu, setupHamburger, navTooltipKey, BASE_PATH } from "../api/navigation.js";
 
-/**
- * Convert a game mode name to a camelCase key for tooltip ids.
- *
- * @pseudocode
- * 1. Replace non-alphanumeric characters with spaces.
- * 2. Split into words.
- * 3. Lowercase the first word and capitalize the rest.
- * 4. Join the words without spaces.
- *
- * @param {string} name - Game mode name.
- * @returns {string} camelCase key.
- */
-export function navTooltipKey(name) {
-  return String(name)
-    .replace(/[^a-zA-Z0-9]+/g, " ")
-    .trim()
-    .split(/\s+/)
-    .map((w, i) => (i === 0 ? w.toLowerCase() : w[0].toUpperCase() + w.slice(1)))
-    .join("");
-}
-
-/**
- * Base path for navigation links derived from the current module location.
- */
-export const BASE_PATH = (() => {
-  const url = new URL(import.meta.url);
-  url.pathname = url.pathname.replace(/helpers\/navigation\/navMenu.js$/, "pages/");
-  return url;
-})();
-
-/**
- * Clears existing content in the bottom navigation bar.
- *
- * @pseudocode
- * 1. Select the `.bottom-navbar` element.
- * 2. Exit early if the element is not found.
- * 3. Remove all child elements to prevent duplication.
- */
-export function clearBottomNavbar() {
-  const navBar = document.querySelector(".bottom-navbar");
-  if (!navBar) return; // Guard: do nothing if navbar is missing
-  navBar.innerHTML = ""; // Clear all existing content
-}
-
-/**
- * Preserve the logo and attach toggle behavior for a menu.
- *
- * @pseudocode
- * 1. Clear the existing navbar content.
- * 2. Reinsert the logo into the navbar.
- * 3. Append the provided menu element.
- * 4. Toggle visibility and animation on logo click.
- *
- * @param {HTMLElement} navBar - The bottom navigation bar element.
- * @param {HTMLElement} logo - The logo element to preserve.
- * @param {HTMLElement} menu - The menu element to toggle.
- * @param {{show: string, hide: string}} animations - CSS animations for show/hide.
- */
-function preserveLogoAndWire(navBar, logo, menu, animations) {
-  clearBottomNavbar();
-  navBar.appendChild(logo);
-  navBar.appendChild(menu);
-  logo.addEventListener("click", () => {
-    menu.classList.toggle("visible");
-    menu.style.animation = menu.classList.contains("visible") ? animations.show : animations.hide;
-  });
-}
-
-/**
- * Build a navigation menu for a given orientation.
- *
- * @pseudocode
- * 1. Exit early if the current orientation does not match.
- * 2. Select the `.bottom-navbar` and `.logo`; exit if either is missing.
- * 3. Validate game modes and create a menu container with orientation class.
- * 4. Populate the container using the provided template for each mode.
- * 5. Preserve the logo and wire click animations based on orientation.
- *
- * @param {object} options - Menu build options.
- * @param {import("../types.js").GameMode[]} options.gameModes - Modes to display.
- * @param {"landscape"|"portrait"} options.orientation - Required device orientation.
- * @param {(mode: import("../types.js").GameMode) => string} options.template - HTML template per mode.
- */
-export function buildNavMenu({ gameModes, orientation, template }) {
-  const matches =
-    typeof window.matchMedia === "function"
-      ? window.matchMedia(`(orientation: ${orientation})`).matches
-      : orientation === "landscape"
-        ? window.innerWidth > window.innerHeight
-        : window.innerHeight >= window.innerWidth;
-  if (!matches) return;
-
-  const navBar = document.querySelector(".bottom-navbar");
-  if (!navBar) return;
-  const logo = navBar.querySelector(".logo");
-  if (!logo) return;
-
-  const validModes = validateGameModes(gameModes);
-
-  const menu = document.createElement("div");
-  menu.className = orientation === "landscape" ? "expanded-map-view" : "portrait-text-menu";
-  menu.innerHTML = validModes.map(template).join("");
-
-  const animations =
-    orientation === "landscape"
-      ? { show: "slide-up 500ms ease-in-out", hide: "slide-down 500ms ease-in-out" }
-      : { show: "slide-down 500ms ease-in-out", hide: "slide-up 500ms ease-in-out" };
-
-  preserveLogoAndWire(navBar, logo, menu, animations);
-}
+export { navTooltipKey, BASE_PATH };
 
 /**
  * Toggles the expanded map view for landscape mode.
  *
  * @pseudocode
- * 1. Call {@link buildNavMenu} with landscape checks and tile template.
+ * 1. Delegate to {@link buildMenu} with `orientation: "landscape"`.
+ * 2. Return the created menu element.
  *
  * @param {import("../types.js").GameMode[]} gameModes - The list of game modes to display.
+ * @returns {HTMLElement|null} Created menu element or null.
  */
 export function toggleExpandedMapView(gameModes) {
-  buildNavMenu({
-    gameModes,
-    orientation: "landscape",
-    template: (mode) =>
-      `<a
-          href="${BASE_PATH}${mode.url}"
-          aria-label="${mode.name}"
-          data-tooltip-id="nav.${navTooltipKey(mode.name)}"
-          data-testid="nav-${mode.id}"
-          style="order: ${mode.order}"
-          class="map-tile${mode.isHidden ? " hidden" : ""}"
-        >
-          <img src="${mode.image}" alt="${mode.name}" loading="lazy">
-          ${mode.name}
-        </a>`
-  });
+  return buildMenu(gameModes, { orientation: "landscape" });
 }
 
 /**
  * Toggles the vertical text menu for portrait mode.
  *
  * @pseudocode
- * 1. Call {@link buildNavMenu} with portrait checks and text template.
+ * 1. Delegate to {@link buildMenu} with `orientation: "portrait"`.
+ * 2. Return the created menu element.
  *
  * @param {import("../types.js").GameMode[]} gameModes - The list of game modes to display.
+ * @returns {HTMLElement|null} Created menu element or null.
  */
 export function togglePortraitTextMenu(gameModes) {
-  buildNavMenu({
-    gameModes,
-    orientation: "portrait",
-    template: (mode) =>
-      `<a
-          href="${BASE_PATH}${mode.url}"
-          aria-label="${mode.name}"
-          data-tooltip-id="nav.${navTooltipKey(mode.name)}"
-          data-testid="nav-${mode.id}"
-          style="order: ${mode.order}"
-          class="text-menu-item${mode.isHidden ? " hidden" : ""}"
-        >
-          ${mode.name}
-        </a>`
-  });
+  return buildMenu(gameModes, { orientation: "portrait" });
 }
 
 /**
  * Initialize a hamburger toggle for narrow viewports.
  *
  * @pseudocode
- * 1. Select the `.bottom-navbar` and its `<ul>`; exit if either is missing.
- * 2. Create a button with `aria-expanded="false"` linked to the list via `aria-controls`.
- * 3. Define `update()` to insert the button and hide the list when the width is below the breakpoint; otherwise remove the button.
- * 4. Define `toggle()` to flip `aria-expanded` and the `.expanded` class on the list.
- * 5. Attach `click` and `resize` listeners and invoke `update()` once.
+ * 1. Delegate to {@link setupHamburger} with the provided breakpoint.
+ * 2. Return the DOM hooks from the API.
  *
  * @param {number} [breakpoint=480] - Maximum width to show the hamburger menu.
+ * @returns {{button: HTMLButtonElement|null, list: HTMLUListElement|null}} DOM hooks.
  */
 export function setupHamburgerMenu(breakpoint = 480) {
-  const navBar = document.querySelector(".bottom-navbar");
-  const list = navBar?.querySelector("ul");
-  if (!navBar || !list) return;
-
-  const id = list.id || "bottom-nav-menu";
-  list.id = id;
-
-  const button = document.createElement("button");
-  button.className = "nav-toggle";
-  button.setAttribute("aria-expanded", "false");
-  button.setAttribute("aria-controls", id);
-  button.setAttribute("aria-label", "Menu");
-  button.innerHTML = "\u2630"; // ☰
-
-  const toggle = () => {
-    const expanded = button.getAttribute("aria-expanded") === "true";
-    button.setAttribute("aria-expanded", String(!expanded));
-    list.classList.toggle("expanded", !expanded);
-  };
-
-  button.addEventListener("click", toggle);
-
-  const update = () => {
-    if (window.innerWidth < breakpoint) {
-      if (!navBar.contains(button)) {
-        navBar.insertBefore(button, list);
-      }
-      button.setAttribute("aria-expanded", "false");
-      list.classList.remove("expanded");
-    } else if (navBar.contains(button)) {
-      button.remove();
-      list.classList.remove("expanded");
-      button.setAttribute("aria-expanded", "false");
-    }
-  };
-
-  window.addEventListener("resize", update);
-  update();
+  return setupHamburger(breakpoint);
 }

--- a/src/helpers/setupBottomNavbar.js
+++ b/src/helpers/setupBottomNavbar.js
@@ -3,20 +3,16 @@
  *
  * @pseudocode
  * 1. Import `loadMenuModes` from `navigation/navData.js`.
- * 2. Import `toggleExpandedMapView`, `togglePortraitTextMenu`, and `setupHamburgerMenu` from `navigation/navMenu.js`.
+ * 2. Import `buildMenu` and `setupHamburger` from `api/navigation.js`.
  * 3. Import `populateNavbar` from `navigationBar.js`.
  * 4. Import `setupButtonEffects` from `buttonEffects.js`.
  * 5. Import `onDomReady`.
- * 6. Define async `configureBottomNavbar` to load active modes and apply both navigation layouts.
- * 7. Define async `init` to call `setupButtonEffects`, `setupHamburgerMenu`, await `populateNavbar`, and `configureBottomNavbar`.
+ * 6. Define async `configureBottomNavbar` to load active modes and apply both navigation layouts via `buildMenu`.
+ * 7. Define async `init` to call `setupButtonEffects`, `setupHamburger`, await `populateNavbar`, and `configureBottomNavbar`.
  * 8. Use `onDomReady` to invoke `init` with guarded error handling.
  */
 import { loadMenuModes } from "./navigation/navData.js";
-import {
-  toggleExpandedMapView,
-  togglePortraitTextMenu,
-  setupHamburgerMenu
-} from "./navigation/navMenu.js";
+import { buildMenu, setupHamburger } from "./api/navigation.js";
 import { populateNavbar } from "./navigationBar.js";
 import { setupButtonEffects } from "./buttonEffects.js";
 import { onDomReady } from "./domReady.js";
@@ -24,8 +20,8 @@ import { onDomReady } from "./domReady.js";
 async function configureBottomNavbar() {
   try {
     const modes = await loadMenuModes();
-    toggleExpandedMapView(modes);
-    togglePortraitTextMenu(modes);
+    buildMenu(modes, { orientation: "landscape" });
+    buildMenu(modes, { orientation: "portrait" });
   } catch {
     // Ignore configuration errors
   }
@@ -33,7 +29,7 @@ async function configureBottomNavbar() {
 
 async function init() {
   setupButtonEffects();
-  setupHamburgerMenu();
+  setupHamburger();
   await populateNavbar();
   configureBottomNavbar();
 }

--- a/tests/helpers/navMenuResponsive.test.js
+++ b/tests/helpers/navMenuResponsive.test.js
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { setupHamburgerMenu } from "../../src/helpers/navigation/navMenu.js";
+import { setupHamburger } from "../../src/helpers/api/navigation.js";
 
-describe("setupHamburgerMenu", () => {
+describe("setupHamburger", () => {
   beforeEach(() => {
     document.body.innerHTML = '<nav class="bottom-navbar"><ul><li></li></ul></nav>';
     window.innerWidth = 320;
   });
 
   it("creates a toggle button and toggles aria-expanded", () => {
-    setupHamburgerMenu();
+    setupHamburger();
     const button = document.querySelector(".nav-toggle");
     const list = document.querySelector(".bottom-navbar ul");
     expect(button).toBeTruthy();
@@ -19,7 +19,7 @@ describe("setupHamburgerMenu", () => {
   });
 
   it("removes the button when resized above breakpoint", () => {
-    setupHamburgerMenu();
+    setupHamburger();
     window.innerWidth = 1024;
     window.dispatchEvent(new Event("resize"));
     expect(document.querySelector(".nav-toggle")).toBeNull();

--- a/tests/helpers/setupBottomNavbar.test.js
+++ b/tests/helpers/setupBottomNavbar.test.js
@@ -6,12 +6,11 @@ vi.mock("../../src/helpers/navigation/navData.js", () => ({
   loadMenuModes: vi.fn().mockResolvedValue([])
 }));
 
-vi.mock("../../src/helpers/navigation/navMenu.js", async () => {
-  const actual = await vi.importActual("../../src/helpers/navigation/navMenu.js");
+vi.mock("../../src/helpers/api/navigation.js", async () => {
+  const actual = await vi.importActual("../../src/helpers/api/navigation.js");
   return {
     ...actual,
-    toggleExpandedMapView: vi.fn(),
-    togglePortraitTextMenu: vi.fn()
+    buildMenu: vi.fn()
   };
 });
 


### PR DESCRIPTION
## Summary
- add navigation API with `buildMenu` and `setupHamburger`
- switch nav helpers and bottom navbar to API
- document navigation API usage

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle Judoka page, Browse Judoka navigation)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68973d3e4f70832683840a4830bfd15f