### PR TITLE
test: stabilize battle header screenshot

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -44,6 +44,7 @@ test.describe.parallel(
           })
         );
       });
+      await page.emulateMedia({ reducedMotion: "reduce" });
     });
 
     test("captures portrait and landscape headers", async ({ page }) => {


### PR DESCRIPTION
## Summary
- reduce motion in battle orientation screenshot tests to avoid animation-induced snapshot changes

## Testing
- `npx prettier playwright/battle-orientation.spec.js --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68974d177c3c8326aed253a27c9cf1e9