### PR TITLE
docs(agent): document country code utilities

### DIFF
--- a/design/dataSchemas/README.md
+++ b/design/dataSchemas/README.md
@@ -85,3 +85,22 @@ Edit the arrays under `CountryCode` and `WeightClass` in the shared schema to
 add or remove values. You can update them manually or run a local script that
 rebuilds the lists from the JSON data files. After changing the enums, run
 `npm run validate:data` to ensure all data still passes validation.
+
+## Country Code Mapping
+
+Country names and codes are stored in
+[`src/data/countryCodeMapping.json`](../../src/data/countryCodeMapping.json) as a
+dictionary keyed by two-letter ISO code. Helper functions in
+[`src/utils/countryCodes.js`](../../src/utils/countryCodes.js) provide safe
+access to this mapping without manual array lookups.
+
+```javascript
+import { getCountryByCode, getCodeByCountry, listCountries } from "../../src/utils/countryCodes.js";
+
+await getCountryByCode("fr"); // "France"
+await getCodeByCountry("Japan"); // "jp"
+await listCountries(); // ["Brazil", "France", "Japan", ...]
+```
+
+Using an object mapping ensures direct lookups and simplifies updates compared
+to iterating through arrays.

--- a/src/utils/countryCodes.js
+++ b/src/utils/countryCodes.js
@@ -2,6 +2,17 @@ import { fetchJson, importJsonModule } from "../helpers/dataUtils.js";
 import { DATA_DIR } from "../helpers/constants.js";
 
 /**
+ * Utilities for working with two-letter ISO country codes backed by a
+ * dictionary mapping. The data file `countryCodeMapping.json` stores entries
+ * keyed by code, enabling direct lookups without array traversal.
+ *
+ * @example
+ * import { getCountryByCode, getCodeByCountry, listCountries } from "./countryCodes.js";
+ * const name = await getCountryByCode("fr"); // "France"
+ * const code = await getCodeByCountry("Japan"); // "jp"
+ * const countries = await listCountries(); // ["Brazil", "France", "Japan", ...]
+ */
+/**
  * @typedef {import("../helpers/types.js").CountryCodeEntry} CountryCodeEntry
  * @exports CountryCodeEntry
  */
@@ -50,6 +61,10 @@ export function normalizeCode(code) {
  *
  * @param {string} code - Two-letter country code.
  * @returns {Promise<string|undefined>} Resolved country name or undefined.
+ *
+ * @example
+ * const name = await getCountryByCode("fr");
+ * console.log(name); // "France"
  */
 export async function getCountryByCode(code) {
   const normalized = normalizeCode(code);
@@ -71,6 +86,10 @@ export async function getCountryByCode(code) {
  *
  * @param {string} country - Country name to search.
  * @returns {Promise<string|undefined>} Resolved code or undefined.
+ *
+ * @example
+ * const code = await getCodeByCountry("Japan");
+ * console.log(code); // "jp"
  */
 export async function getCodeByCountry(country) {
   if (typeof country !== "string" || !country.trim()) return undefined;
@@ -112,6 +131,10 @@ export async function toArray() {
  * 3. Return the array of names.
  *
  * @returns {Promise<Array<string>>} Sorted list of country names.
+ *
+ * @example
+ * const countries = await listCountries();
+ * console.log(countries); // ["Brazil", "France", "Japan", ...]
  */
 export async function listCountries() {
   const entries = await toArray();


### PR DESCRIPTION
## Summary
- clarify dictionary-based country code mapping and export helpers
- add usage examples for `getCountryByCode`, `getCodeByCountry`, and `listCountries`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: data/vu must NOT have additional properties)*
- `npx playwright test` *(fails: battle orientation screenshots, Browse Judoka navigation markers)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68974b2139548326a7f9aa96a81ee9c6