### PR TITLE
Refactor country code mapping utilities and tests

### DIFF
--- a/playwright/fixtures/commonRoutes.js
+++ b/playwright/fixtures/commonRoutes.js
@@ -17,9 +17,6 @@ export async function registerCommonRoutes(page) {
     page.route("**/src/data/gameModes.json", (route) =>
       route.fulfill({ path: "tests/fixtures/gameModes.json" })
     ),
-    page.route("**/src/data/countryCodeMapping.json", (route) =>
-      route.fulfill({ path: "tests/fixtures/countryCodeMapping.json" })
-    ),
     page.route("**/src/data/tooltips.json", (route) =>
       route.fulfill({ path: "tests/fixtures/tooltips.json" })
     ),

--- a/src/schemas/countryCodeMapping.schema.json
+++ b/src/schemas/countryCodeMapping.schema.json
@@ -10,6 +10,11 @@
           "type": "string",
           "description": "The name of the country."
         },
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z]{2}$",
+          "description": "The two-letter country code."
+        },
         "lastUpdated": {
           "type": "string",
           "format": "date-time",
@@ -20,7 +25,7 @@
           "description": "Indicates whether the country is active."
         }
       },
-      "required": ["country", "lastUpdated", "active"],
+      "required": ["country", "code", "lastUpdated", "active"],
       "additionalProperties": false
     }
   },

--- a/tests/data/schemaValidation.test.js
+++ b/tests/data/schemaValidation.test.js
@@ -43,22 +43,25 @@ const datasets = await Promise.all(
 );
 
 describe("data files conform to schemas", () => {
-  it.each(datasets)("$dataFile matches $schemaFile", async ({ data, schema, validate }) => {
-    expect(typeof validate).toBe("function");
+  it.each(datasets)(
+    "$dataFile matches $schemaFile",
+    async ({ dataFile, data, schema, validate }) => {
+      expect(typeof validate).toBe("function");
 
-    const items = Array.isArray(data) && schema.type !== "array" ? data : [data];
+      const items = Array.isArray(data) && schema.type !== "array" ? data : [data];
 
-    await Promise.all(
-      items.map(async (item) => {
-        const valid = validate(item);
-        if (!valid) {
-          console.error(validate.errors);
-          throw new Error(ajv.errorsText(validate.errors) || JSON.stringify(validate.errors));
-        }
-        expect(valid).toBe(true);
-      })
-    );
-  });
+      await Promise.all(
+        items.map(async (item) => {
+          const valid = validate(item);
+          if (!valid) {
+            console.error(validate.errors);
+            throw new Error(ajv.errorsText(validate.errors) || JSON.stringify(validate.errors));
+          }
+          expect(valid).toBe(true);
+        })
+      );
+    }
+  );
 
   it("fails validation for intentionally broken data", () => {
     const { validate } = datasets.find(({ schemaFile }) => schemaFile === "judoka.schema.json");

--- a/tests/fixtures/countryCodeMapping.json
+++ b/tests/fixtures/countryCodeMapping.json
@@ -15,6 +15,6 @@
     "country": "USA",
     "code": "us",
     "lastUpdated": "2025-04-23T10:00:00Z",
-    "active": true
+    "active": false
   }
 }

--- a/tests/utils/countryCodes.test.js
+++ b/tests/utils/countryCodes.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeCode,
+  getCountryByCode,
+  getCodeByCountry,
+  listCountries,
+  toArray
+} from "../../src/utils/countryCodes.js";
+
+describe("countryCodes utilities", () => {
+  it("normalizes country codes", () => {
+    expect(normalizeCode(" JP ")).toBe("jp");
+    expect(normalizeCode("br")).toBe("br");
+    expect(normalizeCode("invalid")).toBeUndefined();
+  });
+
+  it("gets country by code", async () => {
+    await expect(getCountryByCode("fr")).resolves.toBe("France");
+    await expect(getCountryByCode("zz")).resolves.toBeUndefined();
+  });
+
+  it("gets code by country", async () => {
+    await expect(getCodeByCountry("Japan")).resolves.toBe("jp");
+    await expect(getCodeByCountry("Unknown")).resolves.toBeUndefined();
+  });
+
+  it("lists countries alphabetically", async () => {
+    const list = await listCountries();
+    const sorted = [...list].sort();
+    expect(list).toEqual(sorted);
+    expect(list).toContain("Japan");
+  });
+
+  it("converts mapping to an array of active entries", async () => {
+    const arr = await toArray();
+    expect(arr.every((e) => e.active)).toBe(true);
+    const names = arr.map((e) => e.country);
+    expect(names).toEqual([...names].sort());
+  });
+});


### PR DESCRIPTION
## Summary
- convert country code fixture to object mapping with inactive entry
- add comprehensive unit tests for country code utilities
- update dropdown tests to use listCountries and adjust schema validation
- remove unused mapping route from Playwright fixtures

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-orientation.spec.js:94:5, browse-judoka.spec.js:75:3)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68974b19db8c8326b3c12235c4249c6c