### PR TITLE
fix: update Nina Cutro-Kelly country

### DIFF
--- a/tests/fixtures/countryCodeMapping.json
+++ b/tests/fixtures/countryCodeMapping.json
@@ -12,9 +12,9 @@
     "active": true
   },
   "us": {
-    "country": "USA",
+    "country": "United States",
     "code": "us",
     "lastUpdated": "2025-04-23T10:00:00Z",
-    "active": false
+    "active": true
   }
 }

--- a/tests/fixtures/judoka.json
+++ b/tests/fixtures/judoka.json
@@ -29,7 +29,7 @@
     "id": 114,
     "firstname": "Nina",
     "surname": "Cutro-Kelly",
-    "country": "USA",
+    "country": "United States",
     "countryCode": "us",
     "weightClass": "+78",
     "stats": {


### PR DESCRIPTION
## Summary
- update Nina Cutro-Kelly country to United States
- activate United States in test country code mapping

## Testing
- `npm run validate:data` *(fails: could not determine executable to run)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/browse-judoka.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68975387a8888326a6cea775cc2552e6