### PR TITLE
chore: remove unused dataFile parameter

### DIFF
--- a/tests/data/schemaValidation.test.js
+++ b/tests/data/schemaValidation.test.js
@@ -43,25 +43,22 @@ const datasets = await Promise.all(
 );
 
 describe("data files conform to schemas", () => {
-  it.each(datasets)(
-    "$dataFile matches $schemaFile",
-    async ({ dataFile, data, schema, validate }) => {
-      expect(typeof validate).toBe("function");
+  it.each(datasets)("$dataFile matches $schemaFile", async ({ data, schema, validate }) => {
+    expect(typeof validate).toBe("function");
 
-      const items = Array.isArray(data) && schema.type !== "array" ? data : [data];
+    const items = Array.isArray(data) && schema.type !== "array" ? data : [data];
 
-      await Promise.all(
-        items.map(async (item) => {
-          const valid = validate(item);
-          if (!valid) {
-            console.error(validate.errors);
-            throw new Error(ajv.errorsText(validate.errors) || JSON.stringify(validate.errors));
-          }
-          expect(valid).toBe(true);
-        })
-      );
-    }
-  );
+    await Promise.all(
+      items.map(async (item) => {
+        const valid = validate(item);
+        if (!valid) {
+          console.error(validate.errors);
+          throw new Error(ajv.errorsText(validate.errors) || JSON.stringify(validate.errors));
+        }
+        expect(valid).toBe(true);
+      })
+    );
+  });
 
   it("fails validation for intentionally broken data", () => {
     const { validate } = datasets.find(({ schemaFile }) => schemaFile === "judoka.schema.json");


### PR DESCRIPTION
## Summary
- remove unused `dataFile` param from schema validation test

## Testing
- `npx prettier . --check`
- `npx eslint tests/data/schemaValidation.test.js`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Browse Judoka navigation › desktop arrow keys update markers and disable buttons)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689757b69ac48326802d10fb795db0b4