### PR TITLE
refactor vector search helpers

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -45,6 +45,10 @@ import { buildMenu, setupHamburger } from "../helpers/api/navigation.js";
 - `buildMenu(gameModes, { orientation })` returns the created menu element.
 - `setupHamburger(breakpoint?)` inserts a toggle button and returns `{button, list}`.
 
+### helpers/vector search
+
+Vector-search pages import DOM-free utilities from `helpers/api/vectorSearchPage.js` for match selection, tag formatting, and loading the MiniLM extractor. This keeps page scripts focused on wiring the DOM.
+
 ---
 
 ## 📦 data/

--- a/src/helpers/api/vectorSearchPage.js
+++ b/src/helpers/api/vectorSearchPage.js
@@ -1,0 +1,120 @@
+let extractor;
+
+/**
+ * Similarity threshold separating strong from weak matches.
+ */
+export const SIMILARITY_THRESHOLD = 0.6;
+
+/**
+ * Score difference threshold for strong matches.
+ * When the top score exceeds the second best by more than this value,
+ * only the highest scoring result is shown.
+ * @type {number}
+ */
+const DROP_OFF_THRESHOLD = 0.4;
+
+/**
+ * Select matches to render based on similarity scores.
+ *
+ * @pseudocode
+ * 1. If `strongMatches` has entries:
+ *    a. When multiple strong matches and the score gap between the first two exceeds `DROP_OFF_THRESHOLD`, return only the first.
+ *    b. Otherwise, return all strong matches.
+ * 2. If no strong matches, return the first three `weakMatches`.
+ *
+ * @param {Array<{score:number}>} strongMatches - Results meeting the similarity threshold.
+ * @param {Array<{score:number}>} weakMatches - Results below the threshold.
+ * @returns {Array} Matches chosen for display.
+ */
+export function selectMatches(strongMatches, weakMatches) {
+  if (strongMatches.length > 0) {
+    if (
+      strongMatches.length > 1 &&
+      strongMatches[0].score - strongMatches[1].score > DROP_OFF_THRESHOLD
+    ) {
+      return [strongMatches[0]];
+    }
+    return strongMatches;
+  }
+  return weakMatches.slice(0, 3);
+}
+
+/**
+ * Load the MiniLM feature extractor on first use.
+ *
+ * @pseudocode
+ * 1. Return the cached `extractor` when available.
+ * 2. Dynamically import the Transformers.js `pipeline` helper.
+ * 3. Instantiate a quantized feature-extraction pipeline with the MiniLM model and store it.
+ *    - On failure, log the error, reset `extractor` to `null`, and rethrow.
+ * 4. Return the initialized `extractor`.
+ *
+ * @returns {Promise<any>} The feature extraction pipeline instance.
+ */
+export async function getExtractor() {
+  if (!extractor) {
+    try {
+      const { pipeline } = await import(
+        "https://cdn.jsdelivr.net/npm/@xenova/transformers@2.6.0/dist/transformers.min.js"
+      );
+      extractor = await pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", {
+        quantized: true
+      });
+    } catch (error) {
+      console.error("Model failed to load", error);
+      extractor = null;
+      throw error;
+    }
+  }
+  return extractor;
+}
+
+/**
+ * Format a file path string for display in the Source column.
+ * Each path segment appears on a new line.
+ *
+ * @pseudocode
+ * 1. Create an empty `DocumentFragment`.
+ * 2. Split `source` by `/`.
+ * 3. For each segment:
+ *    a. Append a `<span>` with the segment text.
+ *    b. Append a `<br>` if it is not the last segment.
+ * 4. Return the fragment.
+ *
+ * @param {string} source - File path like "design/foo/bar.md".
+ * @returns {DocumentFragment} Fragment with line breaks between segments.
+ */
+export function formatSourcePath(source) {
+  const fragment = document.createDocumentFragment();
+  source.split("/").forEach((part, idx, arr) => {
+    const span = document.createElement("span");
+    span.textContent = part;
+    fragment.appendChild(span);
+    if (idx < arr.length - 1) {
+      fragment.appendChild(document.createElement("br"));
+    }
+  });
+  return fragment;
+}
+
+/**
+ * Format tag arrays for display.
+ *
+ * @pseudocode
+ * 1. If `tags` is an array, join with `", "`.
+ * 2. Otherwise, return an empty string.
+ *
+ * @param {string[]} tags - Tag names.
+ * @returns {string} Comma separated tag string.
+ */
+export function formatTags(tags) {
+  return Array.isArray(tags) ? tags.join(", ") : "";
+}
+
+/**
+ * Inject a custom extractor for testing.
+ * @param {any} model - Mock extractor to use.
+ */
+export function __setExtractor(model) {
+  extractor = model;
+}

--- a/tests/helpers/vectorSearchPage.test.js
+++ b/tests/helpers/vectorSearchPage.test.js
@@ -5,46 +5,6 @@ vi.doMock("../../src/helpers/domReady.js", () => ({
   onDomReady: vi.fn()
 }));
 
-/**
- * Unit tests for selectMatches helper in vectorSearchPage.
- */
-
-describe("selectMatches", () => {
-  it("returns only the top match when drop off exceeds threshold", async () => {
-    const { selectMatches } = await import("../../src/helpers/vectorSearchPage.js");
-    const strong = [
-      { id: "1", score: 0.95 },
-      { id: "2", score: 0.4 },
-      { id: "3", score: 0.39 }
-    ];
-    const result = selectMatches(strong, []);
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("1");
-  });
-
-  it("returns all strong matches when drop off is small", async () => {
-    const { selectMatches } = await import("../../src/helpers/vectorSearchPage.js");
-    const strong = [
-      { id: "1", score: 0.8 },
-      { id: "2", score: 0.7 }
-    ];
-    const result = selectMatches(strong, []);
-    expect(result).toEqual(strong);
-  });
-
-  it("uses weak matches when no strong matches exist", async () => {
-    const { selectMatches } = await import("../../src/helpers/vectorSearchPage.js");
-    const weak = [
-      { id: "a", score: 0.5 },
-      { id: "b", score: 0.4 },
-      { id: "c", score: 0.3 },
-      { id: "d", score: 0.2 }
-    ];
-    const result = selectMatches([], weak);
-    expect(result).toEqual(weak.slice(0, 3));
-  });
-});
-
 describe("vector search page integration", () => {
   it("passes selected tag to findMatches", async () => {
     const findMatches = vi.fn().mockResolvedValue([]);
@@ -58,9 +18,8 @@ describe("vector search page integration", () => {
       }
     }));
 
-    const { handleSearch, init, __setExtractor } = await import(
-      "../../src/helpers/vectorSearchPage.js"
-    );
+    const { handleSearch, init } = await import("../../src/helpers/vectorSearchPage.js");
+    const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
 
     __setExtractor(async () => ({ data: [0, 0, 0] }));
 
@@ -145,9 +104,8 @@ describe("search result message styling", () => {
       DATA_DIR: "./"
     }));
 
-    const { handleSearch, init, __setExtractor } = await import(
-      "../../src/helpers/vectorSearchPage.js"
-    );
+    const { handleSearch, init } = await import("../../src/helpers/vectorSearchPage.js");
+    const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
 
     __setExtractor(async () => ({ data: [0, 0, 0] }));
 
@@ -196,9 +154,8 @@ describe("search result message styling", () => {
       DATA_DIR: "./"
     }));
 
-    const { handleSearch, init, __setExtractor } = await import(
-      "../../src/helpers/vectorSearchPage.js"
-    );
+    const { handleSearch, init } = await import("../../src/helpers/vectorSearchPage.js");
+    const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
 
     __setExtractor(async () => ({ data: [0, 0, 0] }));
 
@@ -247,9 +204,8 @@ describe("search result message styling", () => {
       DATA_DIR: "./"
     }));
 
-    const { handleSearch, init, __setExtractor } = await import(
-      "../../src/helpers/vectorSearchPage.js"
-    );
+    const { handleSearch, init } = await import("../../src/helpers/vectorSearchPage.js");
+    const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
 
     __setExtractor(async () => ({ data: [0, 0, 0] }));
 
@@ -313,9 +269,8 @@ describe("snippet highlighting", () => {
       DATA_DIR: "./"
     }));
 
-    const { handleSearch, init, __setExtractor } = await import(
-      "../../src/helpers/vectorSearchPage.js"
-    );
+    const { handleSearch, init } = await import("../../src/helpers/vectorSearchPage.js");
+    const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
 
     __setExtractor(async () => ({ data: [0, 0, 0] }));
 
@@ -388,9 +343,8 @@ describe("synonym expansion", () => {
       DATA_DIR: "./"
     }));
 
-    const { handleSearch, init, __setExtractor } = await import(
-      "../../src/helpers/vectorSearchPage.js"
-    );
+    const { handleSearch, init } = await import("../../src/helpers/vectorSearchPage.js");
+    const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
 
     let captured = "";
     __setExtractor(async (text) => {

--- a/tests/vectorSearch/vectorSearchHelpers.test.js
+++ b/tests/vectorSearch/vectorSearchHelpers.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  selectMatches,
+  formatSourcePath,
+  formatTags
+} from "../../src/helpers/api/vectorSearchPage.js";
+
+/**
+ * Unit tests for vector search helper utilities.
+ */
+
+describe("selectMatches", () => {
+  it("returns only the top match when drop off exceeds threshold", () => {
+    const strong = [
+      { id: "1", score: 0.95 },
+      { id: "2", score: 0.4 },
+      { id: "3", score: 0.39 }
+    ];
+    const result = selectMatches(strong, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+  });
+
+  it("returns all strong matches when drop off is small", () => {
+    const strong = [
+      { id: "1", score: 0.8 },
+      { id: "2", score: 0.7 }
+    ];
+    const result = selectMatches(strong, []);
+    expect(result).toEqual(strong);
+  });
+
+  it("uses weak matches when no strong matches exist", () => {
+    const weak = [
+      { id: "a", score: 0.5 },
+      { id: "b", score: 0.4 },
+      { id: "c", score: 0.3 },
+      { id: "d", score: 0.2 }
+    ];
+    const result = selectMatches([], weak);
+    expect(result).toEqual(weak.slice(0, 3));
+  });
+});
+
+describe("formatSourcePath", () => {
+  it("splits path segments with line breaks", () => {
+    const frag = formatSourcePath("design/foo/bar.md");
+    const container = document.createElement("div");
+    container.appendChild(frag);
+    expect(container.innerHTML).toBe(
+      "<span>design</span><br><span>foo</span><br><span>bar.md</span>"
+    );
+  });
+});
+
+describe("formatTags", () => {
+  it("joins tag names with commas", () => {
+    expect(formatTags(["alpha", "beta"])).toBe("alpha, beta");
+  });
+
+  it("returns empty string for non-arrays", () => {
+    expect(formatTags(null)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- move vector search utilities to helpers/api/vectorSearchPage.js
- adjust vectorSearchPage.js to use new helper exports
- document vector-search helper usage and add dedicated unit tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: fetch failed errors)*
- `npx playwright test` *(fails: navigation not implemented)*
- `npm run check:contrast` *(fails: fetch failed)*


------
https://chatgpt.com/codex/tasks/task_e_689757d8b3188326a1cb4bfa6893f105