### PR TITLE
Extract battle UI facade

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -34,6 +34,10 @@ Key helpers include:
 - `navigationBar.js` – Injects active game modes into the persistent nav bar
 - `setupBottomNavbar.js` – Wires the nav bar into the DOM
 
+### Engine vs UI layers
+
+Core battle logic lives in `helpers/battleEngine.js` with no DOM access. UI scripts gather values from the page and delegate to this engine through the facade in `helpers/api/battleUI.js`, which exposes pure helpers like `chooseOpponentStat()` and `evaluateRound()`. Files such as `classicBattle.js` keep DOM manipulation localized and pass raw numbers into the facade, maintaining a clear separation between presentation and game mechanics.
+
 ### helpers/navigation
 
 Use `helpers/api/navigation.js` to build orientation-specific menus and responsive hamburger toggles. Pages should import only this API.

--- a/src/helpers/api/battleUI.js
+++ b/src/helpers/api/battleUI.js
@@ -1,0 +1,49 @@
+import { STATS, handleStatSelection as engineHandleStatSelection } from "../battleEngine.js";
+
+/**
+ * Choose an opponent stat based on difficulty and available values.
+ *
+ * @pseudocode
+ * 1. If `difficulty` is `hard` and `values` are provided:
+ *    a. Find the maximum value.
+ *    b. Return a random stat among those with the maximum.
+ * 2. If `difficulty` is `medium` and `values` are provided:
+ *    a. Compute the average value.
+ *    b. Collect stats at or above the average.
+ *    c. If any qualify, return a random one.
+ * 3. Otherwise, return a random stat from `STATS`.
+ *
+ * @param {{stat: string, value: number}[]} values - Stat entries to compare.
+ * @param {"easy"|"medium"|"hard"} [difficulty="easy"] - Difficulty setting.
+ * @returns {string} Chosen stat key.
+ */
+export function chooseOpponentStat(values, difficulty = "easy") {
+  if (difficulty === "hard" && values.length) {
+    const max = Math.max(...values.map((v) => v.value));
+    const best = values.filter((v) => v.value === max);
+    return best[Math.floor(Math.random() * best.length)].stat;
+  }
+  if (difficulty === "medium" && values.length) {
+    const avg = values.reduce((sum, v) => sum + v.value, 0) / values.length;
+    const eligible = values.filter((v) => v.value >= avg);
+    if (eligible.length > 0) {
+      return eligible[Math.floor(Math.random() * eligible.length)].stat;
+    }
+  }
+  return STATS[Math.floor(Math.random() * STATS.length)];
+}
+
+/**
+ * Evaluate a round using player and opponent stat values.
+ *
+ * @pseudocode
+ * 1. Delegate to `handleStatSelection` from the battle engine with the provided values.
+ * 2. Return its result.
+ *
+ * @param {number} playerVal - Player's stat value.
+ * @param {number} opponentVal - Opponent's stat value.
+ * @returns {{message: string, matchEnded: boolean, playerScore: number, computerScore: number}}
+ */
+export function evaluateRound(playerVal, opponentVal) {
+  return engineHandleStatSelection(playerVal, opponentVal);
+}

--- a/src/helpers/battleEngine.js
+++ b/src/helpers/battleEngine.js
@@ -1,8 +1,8 @@
 /**
  * JU-DO-KON! Battle Engine
  *
- * @fileoverview Implements core game logic for scoring, round timing, match state, and stat selection timer with pause/resume and auto-selection.
- * @note This module does NOT handle card rendering, stat concealment, or animation. Stat obscuring and card transitions are managed in the UI layer (see JudokaCard and battleJudokaPage.js).
+ * @fileoverview Implements core game logic for scoring, round timing, match state, and stat selection timer with pause/resume and auto-selection. UI modules should access this logic through the facade in `helpers/api/battleUI.js` to keep DOM concerns separate.
+ * @note This module does NOT handle card rendering, stat concealment, or animation. Stat obscuring and card transitions are managed in the UI layer (see JudokaCard, battleJudokaPage.js, and helpers/api/battleUI.js).
  */
 
 import { CLASSIC_BATTLE_POINTS_TO_WIN, CLASSIC_BATTLE_MAX_ROUNDS } from "./constants.js";


### PR DESCRIPTION
## Summary
- Extract DOM-free helpers to `battleUI.js` providing `chooseOpponentStat` and `evaluateRound`
- Refactor `classicBattle.js` to delegate stat logic to new facade and keep DOM work local
- Document UI/engine split in `battleEngine.js` and `design/architecture.md`

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warning: 'dataFile' is defined but never used)*
- `npx vitest run`
- `npx playwright test` *(1 failed, 1 skipped, 93 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689757d09af883268c6f6004a4e5876c