### PR TITLE
Handle column gaps in carousel navigation

### DIFF
--- a/src/helpers/carousel/navigation.js
+++ b/src/helpers/carousel/navigation.js
@@ -9,10 +9,10 @@ import { CAROUSEL_SWIPE_THRESHOLD } from "../constants.js";
  *      "ArrowLeft"/"ArrowRight".
  *    - When "ArrowLeft" is pressed:
  *      - Prevent the default behavior.
- *      - Scroll left by one container width.
+ *      - Scroll left by one page width plus gap.
  *    - When "ArrowRight" is pressed:
  *      - Prevent the default behavior.
- *      - Scroll right by one container width.
+ *      - Scroll right by one page width plus gap.
  *
  * @param {HTMLElement} container - The carousel container element.
  */
@@ -22,7 +22,8 @@ export function setupKeyboardNavigation(container) {
     if (event.target !== event.currentTarget) return;
     if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
     event.preventDefault();
-    const scrollAmount = container.clientWidth;
+    const gap = parseFloat(getComputedStyle(container).columnGap) || 0;
+    const scrollAmount = container.clientWidth + gap;
     if (event.key === "ArrowLeft") {
       if (typeof container.scrollBy === "function") {
         container.scrollBy({ left: -scrollAmount });

--- a/src/helpers/carousel/scroll.js
+++ b/src/helpers/carousel/scroll.js
@@ -14,7 +14,7 @@
  *    - Add an accessible label (`aria-label`) matching the visible text.
  *
  * 3. Add a click event listener to the button:
- *    - Scroll the `container` by its current `clientWidth` in the given direction.
+ *    - Scroll the `container` by one page width plus gap in the given direction.
  *    - Use smooth scrolling for better user experience.
  *
  * 4. Return the created button element.
@@ -47,7 +47,8 @@ export function createScrollButton(direction, container) {
   button.setAttribute("aria-label", labelText);
 
   button.addEventListener("click", () => {
-    const scrollAmount = container.clientWidth;
+    const gap = parseFloat(getComputedStyle(container).columnGap) || 0;
+    const scrollAmount = container.clientWidth + gap;
     container.scrollBy({
       left: direction === "left" ? -scrollAmount : scrollAmount,
       behavior: "smooth"


### PR DESCRIPTION
## Summary
- include column gap when scrolling carousels via keyboard navigation
- apply the same gap-aware scroll amount to carousel scroll buttons

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle Judoka narrow screenshot, Settings screenshots collapsed modes, Classic battle reset)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68975fa0d4e08326bd4199f95e9ae79d