### PR TITLE
feat: centralize country data service

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -53,6 +53,10 @@ import { buildMenu, setupHamburger } from "../helpers/api/navigation.js";
 
 Vector-search pages import DOM-free utilities from `helpers/api/vectorSearchPage.js` for match selection, tag formatting, and loading the MiniLM extractor. This keeps page scripts focused on wiring the DOM.
 
+### helpers/country service
+
+`helpers/api/countryService.js` centralizes country code lookups and flag URL generation. It loads `countryCodeMapping.json` with caching and persists the mapping through `storage.js`. UI modules like `helpers/country/codes.js` and `helpers/country/list.js` call `loadCountryMapping`, `getCountryName`, and `getFlagUrl` so country data flows from the data file through the service into the rendered flag buttons.
+
 ---
 
 ## 📦 data/

--- a/src/helpers/api/countryService.js
+++ b/src/helpers/api/countryService.js
@@ -1,0 +1,96 @@
+import { fetchJson, importJsonModule } from "../dataUtils.js";
+import { DATA_DIR } from "../constants.js";
+import { getItem, setItem } from "../storage.js";
+
+const STORAGE_KEY = "countryCodeMapping";
+const DEFAULT_COUNTRY = "Vanuatu";
+const DEFAULT_FLAG_URL = "https://flagcdn.com/w320/vu.png";
+
+let mapping;
+let mappingPromise;
+
+/**
+ * Load the country code mapping with caching and persistence.
+ *
+ * @pseudocode
+ * 1. Return cached `mapping` when available.
+ * 2. If no pending `mappingPromise`:
+ *    a. Attempt to read mapping from storage.
+ *    b. When missing, fetch `${DATA_DIR}countryCodeMapping.json`.
+ *       - On failure, import the local JSON module.
+ *    c. Persist the mapping to storage.
+ * 3. Await and store the loaded mapping.
+ * 4. Return the mapping object.
+ *
+ * @returns {Promise<Record<string, {code: string, country: string, active: boolean}>>}
+ *   Mapping keyed by country code.
+ */
+export async function loadCountryMapping() {
+  if (mapping) return mapping;
+  if (!mappingPromise) {
+    mappingPromise = (async () => {
+      const cached = getItem(STORAGE_KEY);
+      if (cached) return cached;
+      try {
+        const data = await fetchJson(`${DATA_DIR}countryCodeMapping.json`);
+        setItem(STORAGE_KEY, data);
+        return data;
+      } catch (err) {
+        console.warn("Failed to fetch countryCodeMapping.json", err);
+        const data = await importJsonModule("../../data/countryCodeMapping.json");
+        setItem(STORAGE_KEY, data);
+        return data;
+      }
+    })();
+  }
+  mapping = await mappingPromise;
+  return mapping;
+}
+
+function normalizeCode(code) {
+  if (typeof code !== "string") return undefined;
+  const normalized = code.trim().toLowerCase();
+  return /^[a-z]{2}$/.test(normalized) ? normalized : undefined;
+}
+
+/**
+ * Resolve the country name for a two-letter code.
+ *
+ * @pseudocode
+ * 1. Normalize `code`; return `DEFAULT_COUNTRY` when invalid.
+ * 2. Load the country mapping.
+ * 3. Retrieve the entry for the normalized code.
+ * 4. Return the entry's `country` when active; otherwise `DEFAULT_COUNTRY`.
+ *
+ * @param {string} code - Two-letter country code.
+ * @returns {Promise<string>} Resolved country name or default.
+ */
+export async function getCountryName(code) {
+  const normalized = normalizeCode(code);
+  if (!normalized) return DEFAULT_COUNTRY;
+  const map = await loadCountryMapping();
+  const entry = map[normalized];
+  return entry && entry.active ? entry.country : DEFAULT_COUNTRY;
+}
+
+/**
+ * Build the flag image URL for a country code.
+ *
+ * @pseudocode
+ * 1. Normalize `code`; return `DEFAULT_FLAG_URL` when invalid.
+ * 2. Load the country mapping.
+ * 3. If mapping contains an active entry for the code, return the CDN URL.
+ * 4. Otherwise return `DEFAULT_FLAG_URL`.
+ *
+ * @param {string} code - Two-letter country code.
+ * @returns {Promise<string>} URL for the flag image.
+ */
+export async function getFlagUrl(code) {
+  const normalized = normalizeCode(code);
+  if (!normalized) return DEFAULT_FLAG_URL;
+  const map = await loadCountryMapping();
+  if (map[normalized] && map[normalized].active) {
+    return `https://flagcdn.com/w320/${normalized}.png`;
+  }
+  return DEFAULT_FLAG_URL;
+}

--- a/src/helpers/country/codes.js
+++ b/src/helpers/country/codes.js
@@ -1,44 +1,29 @@
-import { getCountryByCode, normalizeCode } from "../../utils/countryCodes.js";
+import { getCountryName, getFlagUrl as serviceGetFlagUrl } from "../api/countryService.js";
 
 /**
  * Resolve the country name for a two-letter code.
  *
  * @pseudocode
- * 1. Call `getCountryByCode(code)`.
- * 2. Return the resolved name when available.
- * 3. Default to "Vanuatu" if the lookup fails.
+ * 1. Delegate to `getCountryName` from `countryService`.
+ * 2. Return the resolved name.
  *
  * @param {string} code - Two-letter country code.
  * @returns {Promise<string>} Resolved country name or "Vanuatu".
  */
-export async function getCountryNameFromCode(code) {
-  const name = await getCountryByCode(code);
-  return name || "Vanuatu";
+export function getCountryNameFromCode(code) {
+  return getCountryName(code);
 }
 
 /**
  * Build the flag image URL for a country code.
  *
  * @pseudocode
- * 1. Normalize `countryCode`; return Vanuatu flag when invalid.
- * 2. Verify the code exists using `getCountryByCode`.
- * 3. Return the CDN URL for the normalized code or the Vanuatu flag when unresolved.
+ * 1. Delegate to `getFlagUrl` from `countryService`.
+ * 2. Return the resolved URL.
  *
  * @param {string} countryCode - Two-letter country code.
  * @returns {Promise<string>} URL for the flag image.
  */
-export async function getFlagUrl(countryCode) {
-  const normalized = normalizeCode(countryCode);
-  if (!normalized) {
-    console.warn("Invalid or missing country code. Defaulting to Vanuatu flag.");
-    return "https://flagcdn.com/w320/vu.png";
-  }
-
-  const exists = await getCountryByCode(normalized);
-  if (!exists) {
-    console.warn("Invalid country code. Defaulting to Vanuatu flag.");
-    return "https://flagcdn.com/w320/vu.png";
-  }
-
-  return `https://flagcdn.com/w320/${normalized}.png`;
+export function getFlagUrl(countryCode) {
+  return serviceGetFlagUrl(countryCode);
 }


### PR DESCRIPTION
## Summary
- add `countryService` for country name and flag lookups with caching and persistence
- refactor country helpers to use `countryService`
- document country data flow in architecture guide

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: cannot fetch country data, others)*
- `npx playwright test` *(1 failing test: browse judoka navigation)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6897600c592c8326b7162ccb54ab779a