### PR TITLE
Use snackbar for selection prompt and cooldown

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-Displays round messages, stat selection timer, and live match score in the page header so players always know the current battle status. The countdown between rounds is surfaced via a single snackbar that updates its text each second.
+Displays round messages, stat selection timer, and live match score in the page header so players always know the current battle status. The selection prompt and the countdown between rounds are surfaced via a single snackbar that updates its text each second.
 
 ---
 
@@ -19,7 +19,7 @@ The round message, timer, and score now sit directly inside the page header rath
 1. **Display match score (player vs opponent)** on the **right side of the top bar**, updated at the **end of each round**, within **800ms** of score finalization.
 2. **Display round-specific messaging** on the **left side of the top bar**, depending on match state:
    - If a round ends: show **win/loss/result** message for **2 seconds**.
-   - If awaiting action: show **selection prompt** until a decision is made.
+   - If awaiting action: show a **selection prompt** via snackbar until a decision is made.
    - If waiting for next round: show a **snackbar countdown** that begins **within 1s** of round end and updates its text each second.
    - If in stat selection phase: show **30-second countdown timer** and prompt; if timer expires, auto-select a stat (see [Classic Battle PRD](prdClassicBattle.md)).
    - After the player picks a stat: show **"Opponent is choosing..."** until the opponent's choice is revealed.
@@ -48,7 +48,7 @@ The round message, timer, and score now sit directly inside the page header rath
 - Match score is updated within **800ms** after round ends. <!-- Implemented: see updateScore in InfoBar.js and battleEngine.js -->
 - Win/loss message is shown within **1s** of round end and remains visible for **2s**. <!-- Implemented: see showResult in battleUI.js -->
 - Countdown snackbar begins only after the 2s result message fades out, aligned with server round start delay, and persists while updating its text. <!-- Implemented: see startCoolDown in battleEngine.js -->
-- Action prompt appears during user input phases and disappears after interaction. <!-- Implemented: see showMessage and stat selection logic -->
+- Action prompt appears via snackbar during user input phases and disappears after interaction. <!-- Implemented: see showMessage and stat selection logic -->
 - **Stat selection timer (30s) is displayed during stat selection phase; if timer expires, a random stat is auto-selected. Timer stops immediately once a stat is picked and pauses/resumes on tab inactivity.** <!-- Implemented: see startRound in battleEngine.js and [Classic Battle PRD](prdClassicBattle.md) -->
 - Auto-select messages are only shown if no stat was chosen before the timer runs out.
 - After the player selects a stat, the Info Bar shows "Opponent is choosing..." until the opponent's stat is revealed.
@@ -73,7 +73,7 @@ The round message, timer, and score now sit directly inside the page header rath
 - **Layout**
   - Right side: score display (`Player: X – Opponent: Y`)
   - Two-line score format appears on narrow screens via stacked `<span>` elements (`<span>You: X</span> <span>Opponent: Y</span>`)
-  - Left side: rotating status messages (e.g., "You won!", "Select your move", **"Time left: 29s"**). Countdown to the next round appears in a single snackbar whose text updates each second.
+  - Left side: rotating status messages (e.g., "You won!", **"Time left: 29s"**, "Opponent is choosing..."). Selection prompts and the countdown to the next round appear in snackbars whose text update each second.
 - **Visuals**
   - Font size: `clamp(16px, 4vw, 24px)`; on narrow screens (<375px) `clamp(14px, 5vw, 20px)`.
   - Color coding: green (win), red (loss), neutral grey (countdown).

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -35,7 +35,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - ≥70% of new players complete a Classic Battle within their first session.
 - Give new players an approachable mode to learn how judoka stats impact outcomes.
 - Reduce frustration by providing immediate, clear feedback on round results.
-- Ensure all round messages, stat selection timer, and score are surfaced via the Info Bar (see prdBattleInfoBar.md) for clarity and accessibility. The countdown to the next round is shown in a single snackbar whose text updates each second.
+- Ensure round result messages, stat selection timer, and score are surfaced via the Info Bar (see prdBattleInfoBar.md) for clarity and accessibility. The "Select your move" prompt and the countdown to the next round are shown in snackbars that update their text each second.
 
 ---
 
@@ -100,7 +100,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 - Behavior on tie rounds: round ends with a message explaining the tie and an option to start the next round.
 - Match start conditions: both players begin with a score of zero; player goes first by drawing their card.
-- Players have 30 seconds to select a stat; if no selection is made, the system randomly selects a stat from the drawn card. **The timer and prompt are displayed in the Info Bar.**
+  - Players have 30 seconds to select a stat; if no selection is made, the system randomly selects a stat from the drawn card. **The timer is displayed in the Info Bar and the prompt appears in a snackbar.**
 - The opponent's card must always differ from the player's card for each round.
 - **Default:** 30-second timer is fixed (not adjustable by the player at launch), but can be reviewed for future difficulty settings.
 
@@ -110,7 +110,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 - Cards are revealed in the correct sequence each round.
 - The opponent card displays a placeholder ("Mystery Judoka") until the player selects a stat ([prdMysteryCard.md](prdMysteryCard.md)).
-- Player can select a stat within 30 seconds; if not, the system auto-selects a random stat automatically. **Timer and prompt are surfaced in the Info Bar.**
+- Player can select a stat within 30 seconds; if not, the system auto-selects a random stat automatically. **Timer is surfaced in the Info Bar, and the "Select your move" prompt appears in a snackbar.**
 - Stat-selection timer stops the moment a stat is chosen.
 - "Time's up! Auto-selecting <stat>" appears only if no stat was chosen before the timer expires.
 - After selection, the correct comparison is made, and the score updates based on round outcome.
@@ -131,7 +131,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 ## Edge Cases / Failure States
 
 - **Judoka or Gokyo dataset fails to load:** error message surfaces in the Info Bar and an error dialog offers a "Retry" button to reload data or the page.
-- **Player does not make a stat selection within 30 seconds:** system randomly selects a stat automatically. **Info Bar must update accordingly.**
+- **Player does not make a stat selection within 30 seconds:** system randomly selects a stat automatically. **Info Bar updates the timer, and the snackbar prompt informs the player.**
 - **AI fails to select a stat (if difficulty logic implemented):** fallback to random stat selection.
 
 ---

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -144,7 +144,6 @@ export function scheduleNextRound(result, startRoundFn) {
   }
 
   const btn = document.getElementById("next-round-button");
-  const timerEl = document.getElementById("next-round-timer");
   if (!btn) return;
 
   const onClick = async () => {
@@ -165,17 +164,11 @@ export function scheduleNextRound(result, startRoundFn) {
     } else {
       updateSnackbar(text);
     }
-    if (timerEl) {
-      timerEl.textContent = text;
-    }
   };
 
   const onExpired = () => {
     setSkipHandler(null);
     infoBar.clearTimer();
-    if (timerEl) {
-      timerEl.textContent = "";
-    }
     btn.addEventListener("click", onClick, { once: true });
     enableNextRoundButton();
     updateDebugPanel();

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -4,24 +4,25 @@ import { getScores, getTimerState, isMatchEnded } from "../battleEngine.js";
 import { isTestModeEnabled, getCurrentSeed } from "../testModeUtils.js";
 import { JudokaCard } from "../../components/JudokaCard.js";
 import { setupLazyPortraits } from "../lazyPortrait.js";
+import { showSnackbar } from "../showSnackbar.js";
 
 function getDebugOutputEl() {
   return document.getElementById("debug-output");
 }
 
 /**
- * Display a persistent prompt instructing the player to choose a stat.
+ * Display a snackbar prompting the player to choose a stat.
  *
  * @pseudocode
- * 1. Locate `#round-message` and set text to "Select your move".
- * 2. Add fade transition class and ensure the element is visible.
+ * 1. Clear any existing text in `#round-message`.
+ * 2. Show "Select your move" via `showSnackbar`.
  */
 export function showSelectionPrompt() {
   const el = document.getElementById("round-message");
-  if (!el) return;
-  el.classList.add("fade-transition");
-  el.textContent = "Select your move";
-  el.classList.remove("fading");
+  if (el) {
+    el.textContent = "";
+  }
+  showSnackbar("Select your move");
 }
 
 /**

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -50,7 +50,7 @@ describe("countdown resets after stat selection", () => {
     expect(showSpy).toHaveBeenCalledWith("Next round in: 3s");
     expect(updateSpy).not.toHaveBeenCalled();
     expect(document.querySelector(".snackbar").textContent).toBe("Next round in: 3s");
-    expect(document.getElementById("next-round-timer").textContent).toBe("Next round in: 3s");
+    expect(document.getElementById("next-round-timer").textContent).toBe("");
     expect(document.querySelectorAll(".snackbar").length).toBe(1);
 
     await vi.advanceTimersByTimeAsync(1000);
@@ -59,6 +59,7 @@ describe("countdown resets after stat selection", () => {
     expect(updateSpy).toHaveBeenCalledWith("Next round in: 1s");
     expect(showSpy).toHaveBeenCalledTimes(1);
     expect(updateSpy).toHaveBeenCalledTimes(2);
+    expect(document.getElementById("next-round-timer").textContent).toBe("");
     expect(document.querySelectorAll(".snackbar").length).toBe(1);
 
     timer.clearAllTimers();

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -92,12 +92,12 @@ describe("classicBattle match flow", () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
-    document.querySelector("#round-message").textContent = "Select your move";
+    document.querySelector("#round-message").textContent = "Ready";
     battleMod.quitMatch(store);
     const cancelBtn = document.getElementById("cancel-quit-button");
     expect(cancelBtn).not.toBeNull();
     cancelBtn.dispatchEvent(new Event("click"));
-    expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
+    expect(document.querySelector("header #round-message").textContent).toBe("Ready");
     expect(document.querySelector("header #score-display").textContent).toBe("You: 0\nOpponent: 0");
   });
 
@@ -199,9 +199,10 @@ describe("classicBattle match flow", () => {
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
     await battleMod.startRound(store);
-    expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
+    expect(document.querySelector(".snackbar").textContent).toBe("Select your move");
     timerSpy.advanceTimersByTime(5000);
-    expect(document.querySelector("header #round-message").textContent).toBe("Select your move");
+    expect(document.querySelector(".snackbar")).toBeNull();
+    expect(document.querySelector("header #round-message").textContent).toBe("");
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
     document.getElementById("computer-card").innerHTML =
@@ -211,8 +212,6 @@ describe("classicBattle match flow", () => {
       await vi.runAllTimersAsync();
       await p;
     }
-    expect(document.querySelector("header #round-message").textContent).not.toBe(
-      "Select your move"
-    );
+    expect(document.querySelector(".snackbar")?.textContent).not.toBe("Select your move");
   });
 });


### PR DESCRIPTION
## Summary
- show selection prompt in a snackbar instead of the info bar
- remove next-round countdown text from info bar
- document snackbar usage for selection prompt and countdown

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6897619f8b548326821e5234d650fd04