### PR TITLE
Deduplicate country entries when populating list

### DIFF
--- a/src/helpers/country/list.js
+++ b/src/helpers/country/list.js
@@ -32,7 +32,9 @@ export async function populateCountryList(container) {
     const entries = Object.values(mapping)
       .filter((e) => e.active)
       .sort((a, b) => a.country.localeCompare(b.country));
-    const activeCountries = entries
+    const uniqueEntries = [...new Map(entries.map((e) => [e.country, e])).values()];
+    const nameToCode = new Map(uniqueEntries.map((e) => [e.country, e.code]));
+    const activeCountries = uniqueEntries
       .map((e) => e.country)
       .filter((name) => uniqueCountries.has(name));
 
@@ -42,8 +44,6 @@ export async function populateCountryList(container) {
       container.replaceChildren(message);
       return;
     }
-
-    const nameToCode = new Map(entries.map((e) => [e.country, e.code]));
 
     const allButton = document.createElement("button");
     allButton.className = "flag-button slide";


### PR DESCRIPTION
## Summary
- Build a unique country list by mapping entries by `country`
- Derive `nameToCode` and `activeCountries` from the deduplicated entries

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: fetch errors)
- `npx playwright test` (fails: 8 failed)
- `npm run check:contrast`
- `npm test tests/helpers/populateCountryList.test.js` (fails: network error)


------
https://chatgpt.com/codex/tasks/task_e_68976dbcae2c8326879723ee1af0adc9