### PR TITLE
Handle pending skip in classic battle timer

### DIFF
--- a/tests/helpers/classicBattle/timerService.skip.test.js
+++ b/tests/helpers/classicBattle/timerService.skip.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from "vitest";
+
+describe("timerService pending skip", () => {
+  it("fires handler once registered after pending skip", async () => {
+    vi.resetModules();
+    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const handler = vi.fn();
+    mod.skipCurrentPhase();
+    mod.setSkipHandler(handler);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- track pending skip requests when no handler is available
- immediately run newly registered skip handlers if a skip was requested
- test pending skip handler execution

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle orientation screenshots, battle judoka page, browse judoka navigation, classic battle flow, signature move; settings and signature move tests interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6897767fb52c83269c0eb91653ee0a8d