### PR TITLE
Display next-round countdown in timer element

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -143,9 +143,11 @@ export function handleStatSelectionTimeout(store, onSelect) {
  * 1. If the match ended, return early.
  * 2. Setup a click handler that disables the button and calls `startRoundFn`.
  * 3. After a short delay, run a 3 second cooldown via `runTimerWithDrift(startCoolDown)`
- *    and display `"Next round in: <n>s"` using one snackbar that updates each tick.
+ *    and display `"Next round in: <n>s"` using one snackbar that updates each tick and the
+ *    `#next-round-timer` element.
  * 4. Register a skip handler that stops the timer and invokes the expiration logic.
- * 5. When expired, clear the timer text, enable the button, attach the click handler, and clear the handler.
+ * 5. When expired, clear the timer text and element, enable the button, attach the click handler,
+ *    and clear the handler.
  *
  * @param {{matchEnded: boolean}} result - Result from a completed round.
  * @param {function(): Promise<void>} startRoundFn - Function to begin the next round.
@@ -158,6 +160,7 @@ export function scheduleNextRound(result, startRoundFn) {
 
   const btn = document.getElementById("next-round-button");
   if (!btn) return;
+  const timerEl = document.getElementById("next-round-timer");
 
   const onClick = async () => {
     disableNextRoundButton();
@@ -166,6 +169,9 @@ export function scheduleNextRound(result, startRoundFn) {
 
   let started = false;
   const onTick = (remaining) => {
+    if (timerEl) {
+      timerEl.textContent = remaining > 0 ? `Next round in: ${remaining}s` : "";
+    }
     if (remaining <= 0) {
       infoBar.clearTimer();
       return;
@@ -182,6 +188,9 @@ export function scheduleNextRound(result, startRoundFn) {
   const onExpired = () => {
     setSkipHandler(null);
     infoBar.clearTimer();
+    if (timerEl) {
+      timerEl.textContent = "";
+    }
     btn.addEventListener("click", onClick, { once: true });
     enableNextRoundButton();
     updateDebugPanel();


### PR DESCRIPTION
## Summary
- show next-round countdown inside `#next-round-timer` while keeping snackbar updates
- clear timer element when countdown completes or round skipped

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle orientation, Battle Judoka page, Browse Judoka navigation; 2 interrupted; 1 skipped; 4 did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68977c5b88488326961dd85ce054f525