### PR TITLE
refactor: use snackbar waits in stat reset test

### DIFF
--- a/playwright/statReset.spec.js
+++ b/playwright/statReset.spec.js
@@ -6,36 +6,24 @@ import { test, expect } from "./fixtures/commonSetup.js";
 test.describe.parallel("Classic battle button reset", () => {
   test("no button stays selected after next round", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
-    await page.waitForFunction(() => {
-      const msg = document.getElementById("round-message");
-      return msg && msg.textContent.includes("Select your move");
-    });
+    await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
     const timer = page.locator("header #next-round-timer");
     await timer.waitFor();
     await page.locator("#stat-buttons button[data-stat='power']").click();
     await page.locator("#next-round-button").click();
-    await page.waitForFunction(() => {
-      const msg = document.getElementById("round-message");
-      return msg && msg.textContent.includes("Select your move");
-    });
+    await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
     await expect(page.locator("#stat-buttons .selected")).toHaveCount(0);
   });
 
   test("tap highlight color cleared after reset", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
-    await page.waitForFunction(() => {
-      const msg = document.getElementById("round-message");
-      return msg && msg.textContent.includes("Select your move");
-    });
+    await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
     const timer = page.locator("header #next-round-timer");
     await timer.waitFor();
     const btn = page.locator("#stat-buttons button[data-stat='power']");
     await btn.click();
     await page.locator("#next-round-button").click();
-    await page.waitForFunction(() => {
-      const msg = document.getElementById("round-message");
-      return msg && msg.textContent.includes("Select your move");
-    });
+    await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
     const highlight = await btn.evaluate((el) => getComputedStyle(el).webkitTapHighlightColor);
     expect(highlight).toBe("rgba(0, 0, 0, 0)");
   });


### PR DESCRIPTION
## Summary
- use snackbar-based waits in stat reset Playwright test instead of #round-message polling

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: fetch failed errors)*
- `npx playwright test playwright/statReset.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689785707d408326a4b824d099d0a382