### PR TITLE
feat: show next round countdown in snackbar

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -10,9 +10,8 @@ test.describe.parallel("Classic battle flow", () => {
     await page.evaluate(() => window.skipBattlePhase?.());
     const result = page.locator("header #round-message");
     await expect(result).not.toHaveText("", { timeout: 15000 });
-    await expect
-      .poll(() => countdown.textContent(), { timeout: 15000 })
-      .toMatch(/Next round in: \d+s/);
+    const snackbar = page.locator(".snackbar");
+    await expect(snackbar).toHaveText(/Next round in: \d+s/, { timeout: 15000 });
   });
 
   test("tie message appears on equal stats", async ({ page }) => {
@@ -36,7 +35,7 @@ test.describe.parallel("Classic battle flow", () => {
     await expect(snackbar).toHaveText("You Picked: Power");
     const msg = page.locator("header #round-message");
     await expect(msg).toHaveText(/Tie/);
-    await expect(timer).toHaveText(/Next round in: \d+s/);
+    await expect(snackbar).toHaveText(/Next round in: \d+s/, { timeout: 15000 });
   });
 
   test("quit match confirmation", async ({ page }) => {

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -143,11 +143,10 @@ export function handleStatSelectionTimeout(store, onSelect) {
  * 1. If the match ended, return early.
  * 2. Setup a click handler that disables the button and calls `startRoundFn`.
  * 3. After a short delay, run a 3 second cooldown via `runTimerWithDrift(startCoolDown)`
- *    and display `"Next round in: <n>s"` using one snackbar that updates each tick and the
- *    `#next-round-timer` element.
+ *    and display `"Next round in: <n>s"` using one snackbar that updates each tick.
  * 4. Register a skip handler that stops the timer and invokes the expiration logic.
- * 5. When expired, clear the timer text and element, enable the button, attach the click handler,
- *    and clear the handler.
+ * 5. When expired, clear the `#next-round-timer` element, enable the button, attach the click
+ *    handler, and clear the handler.
  *
  * @param {{matchEnded: boolean}} result - Result from a completed round.
  * @param {function(): Promise<void>} startRoundFn - Function to begin the next round.
@@ -169,9 +168,6 @@ export function scheduleNextRound(result, startRoundFn) {
 
   let started = false;
   const onTick = (remaining) => {
-    if (timerEl) {
-      timerEl.textContent = remaining > 0 ? `Next round in: ${remaining}s` : "";
-    }
     if (remaining <= 0) {
       infoBar.clearTimer();
       return;


### PR DESCRIPTION
## Summary
- only use snackbar for next-round cooldown display and keep timer element empty
- update classic battle flow test to expect snackbar countdown

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle orientation screenshots › captures extra-narrow header; Battle Judoka page › narrow viewport screenshot and status aria attributes; Browse Judoka navigation › desktop arrow keys update markers and disable buttons)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689789f8c00c8326b8143c9ac51e9cc3