### PR TITLE
feat: support file URLs in data utils

### DIFF
--- a/tests/helpers/dataUtils.test.js
+++ b/tests/helpers/dataUtils.test.js
@@ -40,6 +40,19 @@ describe("fetchJson", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("loads and caches data from file URLs without using fetch", async () => {
+    const fileUrl = new URL("../../src/data/statNames.json", import.meta.url).href;
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock;
+    const schema = { type: "array" };
+    const { fetchJson } = await import("../../src/helpers/dataUtils.js");
+    const first = await fetchJson(fileUrl, schema);
+    const second = await fetchJson(fileUrl, schema);
+    expect(Array.isArray(first)).toBe(true);
+    expect(second).toBe(first);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("does not share cache between different URLs", async () => {
     const data1 = { foo: "bar" };
     const data2 = { baz: "qux" };

--- a/tests/helpers/stats.test.js
+++ b/tests/helpers/stats.test.js
@@ -1,11 +1,5 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { readFile } from "fs/promises";
-import { fileURLToPath } from "url";
-import path from "path";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const dataPath = path.resolve(__dirname, "../../src/data/statNames.json");
 const originalFetch = global.fetch;
 
 const sample = [
@@ -69,8 +63,7 @@ describe("stats helper", () => {
       "../../src/helpers/dataUtils.js",
       async () => await vi.importActual("../../src/helpers/dataUtils.js")
     );
-    const fileData = JSON.parse(await readFile(dataPath, "utf8"));
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => fileData });
+    const fetchMock = vi.fn();
     global.fetch = fetchMock;
     const { loadStatNames } = await import("../../src/helpers/stats.js");
     const stats = await loadStatNames();
@@ -81,6 +74,6 @@ describe("stats helper", () => {
       "Kumi-kata",
       "Ne-waza"
     ]);
-    expect(fetchMock).toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- handle `file:` URLs in Node by reading from the filesystem with caching and schema validation
- expose `isNodeEnvironment` helper
- test `fetchJson` and `loadStatNames` using local files

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689788de7dc4832698855d48bf143e69