### PR TITLE
Use fileURLToPath for file protocol in fetchJson

### DIFF
--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -104,7 +104,8 @@ export async function fetchJson(url, schema) {
     let data;
     if (isNodeEnvironment() && parsedUrl.protocol === "file:") {
       const { readFile } = await import("fs/promises");
-      data = JSON.parse(await readFile(parsedUrl, "utf8"));
+      const { fileURLToPath } = await import("node:url");
+      data = JSON.parse(await readFile(fileURLToPath(parsedUrl), "utf8"));
     } else {
       const response = await fetch(url);
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- Convert file URLs to paths in `fetchJson` using `fileURLToPath` before reading

## Testing
- `npx eslint src/helpers/dataUtils.js`
- `npx vitest run tests/helpers/vectorSearchPage.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68978ffb50fc832696efde8735a47655