### PR TITLE
fix: soften settings load logging

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -249,7 +249,7 @@ async function initializeSettingsPage() {
     if (gameModesResult.status === "fulfilled" && Array.isArray(gameModesResult.value)) {
       gameModes = gameModesResult.value;
     } else {
-      console.error(
+      console.warn(
         "Failed to load game modes",
         gameModesResult.status === "fulfilled" ? gameModesResult.value : gameModesResult.reason
       );


### PR DESCRIPTION
## Summary
- warn when loading navigation items fails on Settings page

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/settingsPage.test.js`
- `npx vitest run` *(fails: 3 failed, 107 passed)*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68979483a1ec8326bcfa42b838942354