### PR TITLE
fix: support file urls in fetchJson

### DIFF
--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -80,10 +80,10 @@ const schemaCache = new WeakMap();
  *
  * @pseudocode
  * 1. Check the cache for `url` and return the value when present.
- * 2. Resolve the URL and attempt to request `url` using `fetch`.
- * 3. If fetching fails and running in Node with a `file:` protocol:
- *    - Convert the file URL to a path and read and parse the file with `fs.promises.readFile`.
- * 4. Parse the response or file contents as JSON.
+ * 2. Resolve the URL.
+ * 3. When running under Node with a `file:` protocol, convert the file URL to a path and
+ *    read and parse the file with `fs.promises.readFile`.
+ * 4. Otherwise, request `url` using `fetch` and parse the JSON response.
  * 5. When a `schema` is provided, validate the data with `validateWithSchema`.
  * 6. Store the parsed data in the cache and return it.
  * 7. On any error, log the issue, remove a stale cache entry, and rethrow.
@@ -102,24 +102,17 @@ export async function fetchJson(url, schema) {
 
     const parsedUrl = new URL(url, "http://localhost");
     let data;
-    try {
+    if (isNodeEnvironment() && parsedUrl.protocol === "file:") {
+      const { readFile } = await import("fs/promises");
+      const { fileURLToPath } = await import("node:url");
+      const filePath = fileURLToPath(parsedUrl.href);
+      data = JSON.parse(await readFile(filePath, "utf8"));
+    } else {
       const response = await fetch(url);
       if (!response.ok) {
         throw new Error(`Failed to fetch ${url} (HTTP ${response.status})`);
       }
       data = await response.json();
-    } catch (fetchError) {
-      const fileProtocol = parsedUrl.protocol === "file:";
-      const unsupported =
-        fetchError?.cause?.message && fetchError.cause.message.includes("not implemented");
-      if (isNodeEnvironment() && fileProtocol && unsupported) {
-        const { readFile } = await import("fs/promises");
-        const { fileURLToPath } = await import("node:url");
-        const filePath = fileURLToPath(parsedUrl.href);
-        data = JSON.parse(await readFile(filePath, "utf8"));
-      } else {
-        throw fetchError;
-      }
     }
     if (schema) {
       await validateWithSchema(data, schema);


### PR DESCRIPTION
## Summary
- avoid using fetch for file URLs in Node and read from filesystem instead
- update fetchJson pseudocode

## Testing
- `npx prettier src/helpers/dataUtils.js tests/helpers/dataUtils.test.js --check`
- `npx eslint src/helpers/dataUtils.js tests/helpers/dataUtils.test.js` *(fails: Cannot find package '@eslint/js')*
- `npx vitest tests/helpers/dataUtils.test.js` *(fails: 403 Forbidden retrieving vitest)*
- `npx playwright test` *(fails: 403 Forbidden retrieving playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68979cb6c1d48326b087f4181cea0f64