### PR TITLE
fix: refresh pseudo Japanese mapping per fetch

### DIFF
--- a/src/helpers/pseudoJapanese.js
+++ b/src/helpers/pseudoJapanese.js
@@ -1,15 +1,25 @@
 import { DATA_DIR } from "./constants.js";
-import { fetchJson } from "./dataUtils.js";
 import { seededRandom } from "./testModeUtils.js";
 
 const STATIC_FALLBACK = "\u65e5\u672c\u8a9e\u98a8\u30c6\u30ad\u30b9\u30c8"; // 日本語風テキスト
-let converterPromise;
+let cachedConverter;
+let lastFetch;
 
 async function loadConverter() {
-  if (!converterPromise) {
-    converterPromise = fetchJson(`${DATA_DIR}japaneseConverter.json`).catch(() => null);
+  if (cachedConverter && lastFetch === fetch) {
+    return cachedConverter;
   }
-  return converterPromise;
+  lastFetch = fetch;
+  try {
+    const response = await fetch(`${DATA_DIR}japaneseConverter.json`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch converter mapping: ${response.status}`);
+    }
+    cachedConverter = await response.json();
+  } catch {
+    cachedConverter = null;
+  }
+  return cachedConverter;
 }
 
 /**
@@ -17,7 +27,7 @@ async function loadConverter() {
  *
  * @pseudocode
  * 1. If input is null, undefined, or empty string, return empty string.
- * 2. Load the converter JSON once using `loadConverter`.
+ * 2. Load the converter JSON using `loadConverter`.
  *    - If loading fails, return `STATIC_FALLBACK`.
  * 3. Clean the `text` by removing characters other than letters, numbers, and whitespace.
  * 4. Build a list of fallback characters from the mapping values.


### PR DESCRIPTION
## Summary
- refresh `japaneseConverter.json` mapping whenever `fetch` changes
- drop `fetchJson` cache dependency to always honor new mappings

## Testing
- `npx prettier src/helpers/pseudoJapanese.js --check`
- `npx eslint src/helpers/pseudoJapanese.js` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run tests/helpers/pseudoJapanese.test.js` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test tests/helpers/pseudoJapanese.test.js` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6897a34245f0832698416a03d9a9b6ab