### PR TITLE
feat: add feature flag helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,16 @@ Settings are loaded once and cached for synchronous use. Helpers in
 `src/helpers/settingsUtils.js` provide safe access:
 
 - `getSetting(key)` – read a setting value from the cache.
-- `getFeatureFlag(flagName)` – check whether a feature flag is enabled.
+
+Feature flags are managed through `src/helpers/featureFlags.js`:
+
+- `isEnabled(flag)` – synchronous check for a flag's enabled state.
+- `setFlag(flag, value)` – persist a flag change and emit an update.
+- `featureFlagsEmitter` – listen for `change` events when flags toggle.
 
 Call `loadSettings()` during startup to populate the cache before using
-these helpers. This approach avoids direct `localStorage` reads in modules
-that need fast, synchronous access to settings.
+these helpers. Pages should rely on `featureFlags.isEnabled` rather than
+accessing `settings.featureFlags` directly.
 
 ## Vector Search Helpers
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -69,10 +69,16 @@ Modules access player preferences via helpers in
 `src/helpers/settingsUtils.js`:
 
 - `getSetting(key)` – synchronous access to cached settings.
-- `getFeatureFlag(flagName)` – returns `true` when the flag is enabled.
+
+Feature flags are handled by `src/helpers/featureFlags.js`:
+
+- `isEnabled(flag)` – check whether a flag is enabled.
+- `setFlag(flag, value)` – persist a flag change and emit a `change` event via `featureFlagsEmitter`.
 
 `loadSettings()` should run during startup to populate the cache, avoiding
 direct `localStorage` reads throughout the app by using `src/helpers/storage.js`.
+Pages should query `featureFlags.isEnabled` rather than reading
+`settings.featureFlags` directly.
 
 ## Settings Features
 

--- a/src/game.js
+++ b/src/game.js
@@ -6,6 +6,7 @@ import { shouldReduceMotionSync } from "./helpers/motionUtils.js";
 import { initTooltips } from "./helpers/tooltip.js";
 import { loadSettings } from "./helpers/settingsUtils.js";
 import { toggleInspectorPanels } from "./helpers/cardUtils.js";
+import { isEnabled, featureFlagsEmitter } from "./helpers/featureFlags.js";
 
 let inspectorEnabled = false;
 
@@ -152,21 +153,16 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   try {
-    const settings = await loadSettings();
-    inspectorEnabled = Boolean(settings.featureFlags?.enableCardInspector?.enabled);
+    await loadSettings();
+    inspectorEnabled = isEnabled("enableCardInspector");
   } catch {
     inspectorEnabled = false;
   }
   toggleInspectorPanels(inspectorEnabled);
 
-  window.addEventListener("storage", (e) => {
-    if (e.key === "settings" && e.newValue) {
-      try {
-        const s = JSON.parse(e.newValue);
-        inspectorEnabled = Boolean(s.featureFlags?.enableCardInspector?.enabled);
-        toggleInspectorPanels(inspectorEnabled);
-      } catch {}
-    }
+  featureFlagsEmitter.addEventListener("change", () => {
+    inspectorEnabled = isEnabled("enableCardInspector");
+    toggleInspectorPanels(inspectorEnabled);
   });
 
   setupCarouselToggle(showCarouselButton, carouselContainer);

--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -1,6 +1,7 @@
 import { generateRandomCard } from "../randomCard.js";
 import { getRandomJudoka } from "../cardUtils.js";
 import { loadSettings } from "../settingsUtils.js";
+import { isEnabled } from "../featureFlags.js";
 import { fetchJson } from "../dataUtils.js";
 import { createGokyoLookup } from "../utils.js";
 import { DATA_DIR } from "../constants.js";
@@ -91,13 +92,10 @@ export async function drawCards() {
   const playerContainer = document.getElementById("player-card");
   const computerContainer = document.getElementById("computer-card");
 
-  let settings;
   try {
-    settings = await loadSettings();
-  } catch {
-    settings = { featureFlags: {} };
-  }
-  const enableInspector = Boolean(settings.featureFlags?.enableCardInspector?.enabled);
+    await loadSettings();
+  } catch {}
+  const enableInspector = isEnabled("enableCardInspector");
 
   let playerJudoka = null;
   await generateRandomCard(

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -1,5 +1,6 @@
 import { getComputerJudoka, getGokyoLookup, clearComputerJudoka } from "./cardSelection.js";
 import { loadSettings } from "../settingsUtils.js";
+import { isEnabled } from "../featureFlags.js";
 import { getScores, getTimerState, isMatchEnded } from "../battleEngine.js";
 import { isTestModeEnabled, getCurrentSeed } from "../testModeUtils.js";
 import { JudokaCard } from "../../components/JudokaCard.js";
@@ -37,13 +38,10 @@ export async function revealComputerCard() {
   const judoka = getComputerJudoka();
   if (!judoka) return;
   const container = document.getElementById("computer-card");
-  let settings;
   try {
-    settings = await loadSettings();
-  } catch {
-    settings = { featureFlags: {} };
-  }
-  const enableInspector = Boolean(settings.featureFlags?.enableCardInspector?.enabled);
+    await loadSettings();
+  } catch {}
+  const enableInspector = isEnabled("enableCardInspector");
   let card;
   try {
     card = await new JudokaCard(judoka, getGokyoLookup(), {

--- a/src/helpers/featureFlags.js
+++ b/src/helpers/featureFlags.js
@@ -1,0 +1,73 @@
+import { loadSettings, updateSetting } from "./settingsUtils.js";
+
+/**
+ * Event emitter broadcasting feature flag changes.
+ *
+ * @type {EventTarget}
+ */
+export const featureFlagsEmitter = new EventTarget();
+
+let cachedFlags = {};
+try {
+  const settings = await loadSettings();
+  cachedFlags = settings.featureFlags || {};
+} catch {
+  cachedFlags = {};
+}
+
+/**
+ * Check whether a feature flag is enabled.
+ *
+ * @pseudocode
+ * 1. Return `cachedFlags[flag]?.enabled ?? false`.
+ *
+ * @param {string} flag - Feature flag name.
+ * @returns {boolean} True when the flag is enabled.
+ */
+export function isEnabled(flag) {
+  return cachedFlags[flag]?.enabled ?? false;
+}
+
+/**
+ * Update a feature flag and persist the change.
+ *
+ * @pseudocode
+ * 1. Call `loadSettings()` to retrieve current settings.
+ * 2. Merge `flag`/`value` into `settings.featureFlags`.
+ * 3. Persist the merged object with `updateSetting('featureFlags', merged)`.
+ * 4. Update `cachedFlags` with the saved flags.
+ * 5. Dispatch a `change` event on `featureFlagsEmitter`.
+ * 6. Return the updated settings object.
+ *
+ * @param {string} flag - Feature flag to update.
+ * @param {boolean} value - Desired enabled state.
+ * @returns {Promise<import("./settingsUtils.js").Settings>} Updated settings.
+ */
+export async function setFlag(flag, value) {
+  const settings = await loadSettings();
+  const updatedFlags = {
+    ...settings.featureFlags,
+    [flag]: {
+      ...settings.featureFlags[flag],
+      enabled: value
+    }
+  };
+  const updated = await updateSetting("featureFlags", updatedFlags);
+  cachedFlags = updated.featureFlags || {};
+  featureFlagsEmitter.dispatchEvent(new CustomEvent("change", { detail: { flag, value } }));
+  return updated;
+}
+
+// Sync changes across tabs by relaying storage events.
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === "settings") {
+      loadSettings()
+        .then((s) => {
+          cachedFlags = s.featureFlags || {};
+          featureFlagsEmitter.dispatchEvent(new CustomEvent("change", { detail: { flag: null } }));
+        })
+        .catch(() => {});
+    }
+  });
+}

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -23,6 +23,7 @@ import { toggleLayoutDebugPanel } from "./layoutDebugPanel.js";
 import { populateNavbar } from "./navigationBar.js";
 import { reset as resetNavigationCache } from "./navigationCache.js";
 import { showSnackbar } from "./showSnackbar.js";
+import { isEnabled } from "./featureFlags.js";
 
 import { applyInitialControlValues } from "./settings/applyInitialValues.js";
 import { attachToggleListeners } from "./settings/listenerUtils.js";
@@ -141,7 +142,7 @@ function initializeControls(settings) {
     const existing = document.getElementById("nav-cache-reset-button");
     existing?.parentElement?.remove();
     if (!section) return;
-    if (!currentSettings.featureFlags.navCacheResetButton?.enabled) return;
+    if (!isEnabled("navCacheResetButton")) return;
     const wrapper = document.createElement("div");
     wrapper.className = "settings-item";
     const btn = createButton("Reset Navigation Cache", {
@@ -193,9 +194,9 @@ function initializeControls(settings) {
       applyDisplayMode(currentSettings.displayMode);
     });
     applyMotionPreference(currentSettings.motionEffects);
-    toggleViewportSimulation(Boolean(currentSettings.featureFlags.viewportSimulation?.enabled));
-    toggleTooltipOverlayDebug(Boolean(currentSettings.featureFlags.tooltipOverlayDebug?.enabled));
-    toggleLayoutDebugPanel(Boolean(currentSettings.featureFlags.layoutDebugPanel?.enabled));
+    toggleViewportSimulation(isEnabled("viewportSimulation"));
+    toggleTooltipOverlayDebug(isEnabled("tooltipOverlayDebug"));
+    toggleLayoutDebugPanel(isEnabled("layoutDebugPanel"));
     renderSwitches(latestGameModes, latestTooltipMap);
     setupSectionToggles();
   });
@@ -236,9 +237,9 @@ async function initializeSettingsPage() {
     const settings = await loadSettings();
     applyDisplayMode(settings.displayMode);
     applyMotionPreference(settings.motionEffects);
-    toggleViewportSimulation(Boolean(settings.featureFlags.viewportSimulation?.enabled));
-    toggleTooltipOverlayDebug(Boolean(settings.featureFlags.tooltipOverlayDebug?.enabled));
-    toggleLayoutDebugPanel(Boolean(settings.featureFlags.layoutDebugPanel?.enabled));
+    toggleViewportSimulation(isEnabled("viewportSimulation"));
+    toggleTooltipOverlayDebug(isEnabled("tooltipOverlayDebug"));
+    toggleLayoutDebugPanel(isEnabled("layoutDebugPanel"));
     const controlsApi = initializeControls(settings);
     const [gameModesResult, tooltipMapResult] = await Promise.all([
       gameModesPromise,

--- a/src/helpers/setupDisplaySettings.js
+++ b/src/helpers/setupDisplaySettings.js
@@ -6,7 +6,8 @@
  *    a. Call `loadSettings()` to retrieve stored settings.
  *    b. Call `applyDisplayMode` with `settings.displayMode`.
  *    c. Call `applyMotionPreference` with `settings.motionEffects`.
- *    d. Call `toggleViewportSimulation` with `settings.featureFlags.viewportSimulation.enabled`.
+ *    d. Call `toggleViewportSimulation` with `featureFlags.isEnabled('viewportSimulation')`.
+ *    e. Call `toggleLayoutDebugPanel` with `featureFlags.isEnabled('layoutDebugPanel')`.
  *    e. Log any errors to the console.
  * 2. Use `onDomReady` to run `init` when the DOM is ready.
  */
@@ -16,14 +17,15 @@ import { applyMotionPreference } from "./motionUtils.js";
 import { onDomReady } from "./domReady.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
 import { toggleLayoutDebugPanel } from "./layoutDebugPanel.js";
+import { isEnabled } from "./featureFlags.js";
 
 async function init() {
   try {
     const settings = await loadSettings();
     applyDisplayMode(settings.displayMode);
     applyMotionPreference(settings.motionEffects);
-    toggleViewportSimulation(Boolean(settings.featureFlags.viewportSimulation?.enabled));
-    toggleLayoutDebugPanel(Boolean(settings.featureFlags.layoutDebugPanel?.enabled));
+    toggleViewportSimulation(isEnabled("viewportSimulation"));
+    toggleLayoutDebugPanel(isEnabled("layoutDebugPanel"));
   } catch (error) {
     console.error("Failed to apply display mode:", error);
   }


### PR DESCRIPTION
## Summary
- add `featureFlags` helper with change emitter and setter
- refactor pages to check flags via `featureFlags.isEnabled`
- document feature flag API in README and settings PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Cannot read properties of undefined (reading 'then'), Embedding metadata version undefined does not match 1, etc.)*
- `npx playwright test` *(fails: 2 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6897a986221883269f6b5afac9a96aae