### PR TITLE
feat: announce auto-selected stat

### DIFF
--- a/src/components/InfoBar.js
+++ b/src/components/InfoBar.js
@@ -144,6 +144,19 @@ export function showTemporaryMessage(text) {
 }
 
 /**
+ * Display a message announcing an auto-selected stat.
+ *
+ * @pseudocode
+ * 1. Call `showMessage` with `"Time's up! Auto-selecting <stat>"`.
+ *
+ * @param {string} stat - Label of the auto-selected stat.
+ * @returns {void}
+ */
+export function showAutoSelect(stat) {
+  showMessage(`Time's up! Auto-selecting ${stat}`);
+}
+
+/**
  * Clear the countdown display.
  *
  * @pseudocode

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -107,9 +107,9 @@ export async function startRound(store) {
   await drawCards();
   syncScoreDisplay();
   showSelectionPrompt();
-  await startTimer((stat) => handleStatSelection(store, stat));
+  await startTimer((stat, opts) => handleStatSelection(store, stat, opts));
   store.statTimeoutId = setTimeout(
-    () => handleStatSelectionTimeout(store, (s) => handleStatSelection(store, s)),
+    () => handleStatSelectionTimeout(store, (s, opts) => handleStatSelection(store, s, opts)),
     35000
   );
   updateDebugPanel();
@@ -149,7 +149,8 @@ export function evaluateRound(store, stat) {
  *
  * @pseudocode
  * 1. Pause the round timer and clear any pending timeouts.
- * 2. Clear the countdown and show "Opponent is choosing…" in the info bar.
+ * 2. Clear the countdown and show "Opponent is choosing…" in the info bar,
+ *    optionally delaying the message when `delayOpponentMessage` is true.
  * 3. After a short delay, reveal the opponent card and evaluate the round.
  * 4. Reset stat buttons and schedule the next round.
  * 5. If the match ended, show the summary panel.
@@ -157,9 +158,10 @@ export function evaluateRound(store, stat) {
  *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
  * @param {string} stat - Chosen stat key.
+ * @param {{delayOpponentMessage?: boolean}} [options={}] - Optional settings.
  * @returns {Promise<{matchEnded: boolean}>}
  */
-export async function handleStatSelection(store, stat) {
+export async function handleStatSelection(store, stat, options = {}) {
   if (store.selectionMade) {
     return { matchEnded: false };
   }
@@ -169,7 +171,11 @@ export async function handleStatSelection(store, stat) {
   clearTimeout(store.statTimeoutId);
   clearTimeout(store.autoSelectId);
   infoBar.clearTimer();
-  infoBar.showMessage("Opponent is choosing…");
+  if (options.delayOpponentMessage) {
+    setTimeout(() => infoBar.showMessage("Opponent is choosing…"), 500);
+  } else {
+    infoBar.showMessage("Opponent is choosing…");
+  }
   const delay = 300 + Math.floor(Math.random() * 401);
   return new Promise((resolve) => {
     setTimeout(async () => {

--- a/src/helpers/setupBattleInfoBar.js
+++ b/src/helpers/setupBattleInfoBar.js
@@ -5,7 +5,8 @@ import {
   startCountdown,
   clearMessage,
   showTemporaryMessage,
-  clearTimer
+  clearTimer,
+  showAutoSelect
 } from "../components/InfoBar.js";
 import { onDomReady } from "./domReady.js";
 
@@ -24,4 +25,12 @@ function setupBattleInfoBar() {
 
 onDomReady(setupBattleInfoBar);
 
-export { showMessage, updateScore, startCountdown, clearMessage, showTemporaryMessage, clearTimer };
+export {
+  showMessage,
+  updateScore,
+  startCountdown,
+  clearMessage,
+  showTemporaryMessage,
+  clearTimer,
+  showAutoSelect
+};

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -28,7 +28,8 @@ beforeEach(() => {
     clearMessage,
     clearTimer,
     updateScore: vi.fn(),
-    startCountdown: vi.fn()
+    startCountdown: vi.fn(),
+    showAutoSelect: vi.fn()
   }));
 
   vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({

--- a/tests/helpers/classicBattle/pauseTimer.test.js
+++ b/tests/helpers/classicBattle/pauseTimer.test.js
@@ -79,7 +79,8 @@ describe("classicBattle timer pause", () => {
       showTemporaryMessage: () => () => {},
       clearTimer: vi.fn(),
       clearMessage: vi.fn(),
-      updateScore: vi.fn()
+      updateScore: vi.fn(),
+      showAutoSelect: vi.fn()
     }));
 
     battleMod = await import("../../../src/helpers/classicBattle.js");

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -6,7 +6,8 @@ describe("timerService drift handling", () => {
     const showMessage = vi.fn();
     vi.doMock("../../../src/helpers/setupBattleInfoBar.js", () => ({
       showMessage,
-      showTemporaryMessage: () => () => {}
+      showTemporaryMessage: () => () => {},
+      showAutoSelect: vi.fn()
     }));
     vi.doMock("../../../src/helpers/timerUtils.js", () => ({
       getDefaultTimer: () => 30
@@ -34,7 +35,8 @@ describe("timerService drift handling", () => {
     const showMessage = vi.fn();
     vi.doMock("../../../src/helpers/setupBattleInfoBar.js", () => ({
       showMessage,
-      showTemporaryMessage: () => () => {}
+      showTemporaryMessage: () => () => {},
+      showAutoSelect: vi.fn()
     }));
     vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
       enableNextRoundButton: vi.fn(),


### PR DESCRIPTION
## Summary
- flash stat button and surface auto-select message via snackbar and InfoBar
- allow stat handler to delay the "Opponent is choosing…" message for auto-picks
- export new InfoBar helper for auto-selection messaging

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle orientation screenshots, browse judoka navigation)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6897cc3d846483268ef8730f444741d6