### PR TITLE
fix: refine PRD reader start doc lookup

### DIFF
--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -45,9 +45,8 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
   const baseNames = FILES.map((f) => f.replace(/\.md$/, ""));
 
   const params = new URLSearchParams(window.location.search);
-  let startDoc = params.get("doc");
-  if (startDoc && !startDoc.endsWith(".md")) startDoc += ".md";
-  let startIndex = startDoc ? FILES.indexOf(startDoc) : 0;
+  const docParam = params.get("doc");
+  let startIndex = docParam ? baseNames.indexOf(docParam.replace(/\.md$/, "")) : 0;
   if (startIndex === -1) startIndex = 0;
 
   const container = document.getElementById("prd-content");
@@ -194,7 +193,7 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
 
   const url = new URL(window.location);
   url.searchParams.set("doc", baseNames[startIndex]);
-  history.replaceState({ index: startIndex }, "", url.pathname + url.search);
+  history.replaceState({ index: startIndex }, "", url.toString());
   selectDoc(startIndex, false);
   if (spinner) spinner.style.display = "none";
 }


### PR DESCRIPTION
## Summary
- compare `doc` query parameter against base filenames without `.md`
- ensure history uses absolute URLs when selecting PRDs

## Testing
- `npx prettier . --write`
- `npx eslint . --fix`
- `npx vitest run` *(fails: prdReaderPage > updates URL when navigating)*

------
https://chatgpt.com/codex/tasks/task_e_6897d0969b3c8326a6e95f7caa501bd3