### PR TITLE
Silence console.warn in invalid settings JSON test

### DIFF
--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -124,9 +124,11 @@ describe("settings utils", () => {
   it("recovers from invalid stored JSON", async () => {
     localStorage.setItem("settings", "{bad json}");
     const { loadSettings } = await import("../../src/helpers/settingsUtils.js");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const settings = await loadSettings();
     expect(settings).toEqual(DEFAULT_SETTINGS);
     expect(localStorage.getItem("settings")).toBeNull();
+    warnSpy.mockRestore();
   });
 
   /**


### PR DESCRIPTION
## Summary
- mock `console.warn` during invalid settings JSON recovery test to prevent noisy output

## Testing
- `npx prettier . --check`
- `npx eslint .` (1 warning)
- `npx vitest run`
- `npx playwright test` (5 failed, 1 skipped, 89 passed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6897d67d56448326bd8f7fdcddb3b4dc