### PR TITLE
test: suppress console errors in safeGenerate tests

### DIFF
--- a/tests/helpers/errorUtils.test.js
+++ b/tests/helpers/errorUtils.test.js
@@ -1,9 +1,10 @@
 // @vitest-environment node
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import { safeGenerate } from "../../src/helpers/errorUtils.js";
 
 describe("safeGenerate", () => {
   test("returns fallback for synchronous errors", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const result = await safeGenerate(
       () => {
         throw new Error("fail");
@@ -12,9 +13,11 @@ describe("safeGenerate", () => {
       "fallback"
     );
     expect(result).toBe("fallback");
+    errorSpy.mockRestore();
   });
 
   test("returns fallback for asynchronous errors", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const result = await safeGenerate(
       async () => {
         throw new Error("fail");
@@ -23,6 +26,7 @@ describe("safeGenerate", () => {
       42
     );
     expect(result).toBe(42);
+    errorSpy.mockRestore();
   });
 
   test("returns value when no error is thrown", async () => {
@@ -32,6 +36,7 @@ describe("safeGenerate", () => {
 
   test("passes error to fallback if fallback is a function", async () => {
     const fallback = (err) => err.message;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const result = await safeGenerate(
       () => {
         throw new Error("fail");
@@ -40,9 +45,11 @@ describe("safeGenerate", () => {
       fallback
     );
     expect(result).toBe("fail");
+    errorSpy.mockRestore();
   });
 
   test("handles non-Error thrown values", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const result = await safeGenerate(
       () => {
         throw "not an error object";
@@ -51,12 +58,15 @@ describe("safeGenerate", () => {
       "fallback"
     );
     expect(result).toBe("fallback");
+    errorSpy.mockRestore();
   });
 
   test("handles undefined fallback", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const result = await safeGenerate(() => {
       throw new Error("fail");
     }, "error");
     expect(result).toBeUndefined();
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- suppress console.error in safeGenerate tests by spying and restoring

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: 1 warning)*
- `npx vitest run`
- `npx playwright test` *(fails: 4 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6897d677bc848326b2e4bef91fe8cf35