### PR TITLE
test: mock console error in randomCard failure cases

### DIFF
--- a/tests/helpers/randomCard.test.js
+++ b/tests/helpers/randomCard.test.js
@@ -67,48 +67,58 @@ describe("generateRandomCard", () => {
   });
 
   it("falls back to id 0 when selection fails", async () => {
-    const container = document.createElement("div");
-    const fallbackEl = document.createElement("div");
-    const judokaData = getJudokaFixture().slice(0, 2);
-    const gokyoData = getGokyoFixture();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const container = document.createElement("div");
+      const fallbackEl = document.createElement("div");
+      const judokaData = getJudokaFixture().slice(0, 2);
+      const gokyoData = getGokyoFixture();
 
-    getRandomJudokaMock = vi.fn(() => {
-      throw new Error("fail");
-    });
-    getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
+      getRandomJudokaMock = vi.fn(() => {
+        throw new Error("fail");
+      });
+      getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
 
-    const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
-    renderMock.mockClear();
-    renderMock.mockResolvedValue(fallbackEl);
+      const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
+      renderMock.mockClear();
+      renderMock.mockResolvedValue(fallbackEl);
 
-    await generateRandomCard(judokaData, gokyoData, container, true);
+      await generateRandomCard(judokaData, gokyoData, container, true);
 
-    expect(renderMock).toHaveBeenCalled();
-    expect(container.firstChild).toBe(fallbackEl);
+      expect(renderMock).toHaveBeenCalled();
+      expect(container.firstChild).toBe(fallbackEl);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it("does not refetch gokyo data when falling back", async () => {
-    const container = document.createElement("div");
-    const fallbackEl = document.createElement("div");
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const container = document.createElement("div");
+      const fallbackEl = document.createElement("div");
 
-    getRandomJudokaMock = vi.fn(() => {
-      throw new Error("fail");
-    });
-    getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
+      getRandomJudokaMock = vi.fn(() => {
+        throw new Error("fail");
+      });
+      getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
 
-    const judokaData = getJudokaFixture().slice(0, 2);
-    const gokyoData = getGokyoFixture();
-    const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
-    const { fetchJson } = await import("../../src/helpers/dataUtils.js");
-    renderMock.mockClear();
-    renderMock.mockResolvedValue(fallbackEl);
-    fetchJson.mockResolvedValue(gokyoData);
+      const judokaData = getJudokaFixture().slice(0, 2);
+      const gokyoData = getGokyoFixture();
+      const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
+      const { fetchJson } = await import("../../src/helpers/dataUtils.js");
+      renderMock.mockClear();
+      renderMock.mockResolvedValue(fallbackEl);
+      fetchJson.mockResolvedValue(gokyoData);
 
-    await generateRandomCard(judokaData, undefined, container, true);
+      await generateRandomCard(judokaData, undefined, container, true);
 
-    expect(fetchJson).toHaveBeenCalledTimes(1);
-    expect(fetchJson).toHaveBeenCalledWith(expect.stringContaining("gokyo.json"));
-    expect(container.firstChild).toBe(fallbackEl);
+      expect(fetchJson).toHaveBeenCalledTimes(1);
+      expect(fetchJson).toHaveBeenCalledWith(expect.stringContaining("gokyo.json"));
+      expect(container.firstChild).toBe(fallbackEl);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it("does not throw if container is null or undefined", async () => {
@@ -126,18 +136,23 @@ describe("generateRandomCard", () => {
   });
 
   it("handles render throwing an error", async () => {
-    const container = document.createElement("div");
-    const judokaData = getJudokaFixture().slice(0, 2);
-    const gokyoData = getGokyoFixture();
-    getRandomJudokaMock = vi.fn(() => judokaData[0]);
-    getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
-    const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
-    renderMock.mockClear();
-    renderMock.mockRejectedValue(new Error("fail"));
-    await expect(
-      generateRandomCard(judokaData, gokyoData, container, true)
-    ).resolves.toBeUndefined();
-    expect(container.childNodes.length).toBe(0);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const container = document.createElement("div");
+      const judokaData = getJudokaFixture().slice(0, 2);
+      const gokyoData = getGokyoFixture();
+      getRandomJudokaMock = vi.fn(() => judokaData[0]);
+      getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
+      const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
+      renderMock.mockClear();
+      renderMock.mockRejectedValue(new Error("fail"));
+      await expect(
+        generateRandomCard(judokaData, gokyoData, container, true)
+      ).resolves.toBeUndefined();
+      expect(container.childNodes.length).toBe(0);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it("does not update DOM if generated element is null or undefined", async () => {


### PR DESCRIPTION
## Summary
- silence console.error in randomCard tests that trigger failure paths
- restore console error spies after each test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68984281f0d483269037d6b1e970619f