### PR TITLE
test: spy on console error in populateCountryList failure test

### DIFF
--- a/tests/helpers/populateCountryList.test.js
+++ b/tests/helpers/populateCountryList.test.js
@@ -143,15 +143,21 @@ describe("populateCountryList", () => {
   });
 
   it("handles fetch failure gracefully", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockRejectedValue(new Error("network error"))
     }));
     vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
     loadCountryMapping.mockResolvedValue({});
+
     const { populateCountryList } = await import("../../src/helpers/country/list.js");
     const container = document.createElement("div");
+
     await expect(populateCountryList(container)).resolves.toBeUndefined();
     expect(container.querySelectorAll(".slide").length).toBe(0);
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("does not duplicate countries if mapping has duplicates", async () => {


### PR DESCRIPTION
## Summary
- test: spy on `console.error` in `populateCountryList` failure test for cleaner logs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 2)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6898427a75cc8326b6a856ddd124e237