### PR TITLE
fix: remove unused error variable

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -231,7 +231,7 @@ function createQuitConfirmation(store, onConfirm) {
     // In browsers, navigate to home; in jsdom, history.replaceState avoids Not Implemented errors
     try {
       window.location.href = "../../index.html";
-    } catch (_e) {
+    } catch {
       try {
         const target = new URL("../../index.html", window.location.href).href;
         if (typeof history !== "undefined" && typeof history.replaceState === "function") {


### PR DESCRIPTION
## Summary
- remove unused variable in classic battle quit handler

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_689846b57c1c8326bdccff540b67d509