### PR TITLE
test: stub console warn in settings fallback

### DIFF
--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -117,6 +117,7 @@ describe("settingsPage module", () => {
       updateNavigationItemHidden
     }));
     vi.doMock("../../src/helpers/showSettingsError.js", () => ({ showSettingsError }));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await import("../../src/helpers/settingsPage.js");
     document.dispatchEvent(new Event("DOMContentLoaded"));
@@ -130,6 +131,7 @@ describe("settingsPage module", () => {
     expect(checkboxes).toHaveLength(1);
     expect(container.querySelector("#mode-1")).toBeTruthy();
     vi.useRealTimers();
+    warnSpy.mockRestore();
   });
   it("renders checkboxes for all modes", async () => {
     vi.useFakeTimers();


### PR DESCRIPTION
## Summary
- stub `console.warn` in fallback game modes test to suppress navigation load warnings

## Testing
- `npx prettier . --check`
- `npx eslint .` (warning)
- `npx vitest run`
- `npx playwright test` (failed: browse Judoka navigation, Screenshot suite)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689847c0d3508326a13fe037c45e2837