### PR TITLE
test: mock console error in quote fallback

### DIFF
--- a/tests/helpers/quoteBuilder.test.js
+++ b/tests/helpers/quoteBuilder.test.js
@@ -60,12 +60,14 @@ describe("loadQuote", () => {
     document.body.append(quoteDiv, loader);
     localStorage.setItem("settings", JSON.stringify({ typewriterEffect: false }));
 
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     global.fetch = vi.fn().mockRejectedValue(new Error("fail"));
 
     await loadQuote();
     await vi.runAllTimersAsync();
 
     expect(quoteDiv.textContent).toContain("Take a breath. Even a still pond reflects the sky.");
+    consoleErrorSpy.mockRestore();
   });
 
   it("handles empty or invalid quote data gracefully", async () => {


### PR DESCRIPTION
## Summary
- mock `console.error` in quote fallback test to silence expected error output

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Browse Judoka navigation desktop keys; vectorSearch screenshot; Settings screenshots dark expanded)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689847bd7ba88326bd851b9410682b71