### PR TITLE
test: mock console error in fallback judoka test

### DIFF
--- a/tests/helpers/browseJudokaPage.test.js
+++ b/tests/helpers/browseJudokaPage.test.js
@@ -206,6 +206,7 @@ describe("browseJudokaPage helpers", () => {
 
   it("renders a fallback card when judoka data fails to load", async () => {
     global.requestAnimationFrame = (cb) => cb();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const fetchJson = vi.fn((url) => {
       if (url.includes("judoka.json")) {
@@ -276,5 +277,7 @@ describe("browseJudokaPage helpers", () => {
     );
     expect(carousel.querySelector(".judoka-card")).not.toBeNull();
     expect(carousel.querySelector(".error-message")).not.toBeNull();
+
+    consoleErrorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- mock `console.error` in fallback judoka data test with `vi.spyOn` and restore afterward

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Browse Judoka navigation → desktop arrow keys update markers and disable buttons, Screenshot suite → @vectorSearch screenshot /src/pages/vectorSearch.html)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689847ba8da0832697ad53d39a40c7f1