### PR TITLE
test: spy on console warn in timer utils

### DIFF
--- a/tests/helpers/timerUtils.test.js
+++ b/tests/helpers/timerUtils.test.js
@@ -23,6 +23,7 @@ describe("timerUtils", () => {
   });
 
   it("falls back to import when fetch fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const fallback = [{ id: 3, value: 5, default: true, category: "coolDownTimer" }];
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockRejectedValue(new Error("fail")),
@@ -31,5 +32,7 @@ describe("timerUtils", () => {
     const { getDefaultTimer } = await import("../../src/helpers/timerUtils.js");
     const val = await getDefaultTimer("coolDownTimer");
     expect(val).toBe(5);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- mock `console.warn` in `timerUtils` failing-fetch test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (failed: Screenshot suite › @vectorSearch screenshot /src/pages/vectorSearch.html)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68984a21cb988326864a278f68c1b6ee