### PR TITLE
test: silence console warnings in navigation cache

### DIFF
--- a/tests/helpers/navigationCache.test.js
+++ b/tests/helpers/navigationCache.test.js
@@ -38,9 +38,14 @@ describe("navigationCache", () => {
   });
 
   test("load removes invalid stored data", async () => {
-    setItem("navigationItems", [{ id: 1 }]);
-    const items = await load();
-    expect(Array.isArray(items)).toBe(true);
-    expect(getItem("navigationItems")).not.toEqual([{ id: 1 }]);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      setItem("navigationItems", [{ id: 1 }]);
+      const items = await load();
+      expect(Array.isArray(items)).toBe(true);
+      expect(getItem("navigationItems")).not.toEqual([{ id: 1 }]);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- silence console warnings by spying on `console.warn` in navigation cache load test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: timeout/interrupt in some tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68984a1d8e988326be8f5aff3dc72577