### PR TITLE
test: mock console error in vector search failure tests

### DIFF
--- a/tests/helpers/vectorSearch.test.js
+++ b/tests/helpers/vectorSearch.test.js
@@ -36,10 +36,12 @@ describe("vectorSearch", () => {
   });
 
   it("returns null when loading fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     fetchJsonMock.mockRejectedValueOnce(new Error("fail"));
     const { loadEmbeddings } = await import("../../src/helpers/vectorSearch.js");
     const result = await loadEmbeddings();
     expect(result).toBeNull();
+    errorSpy.mockRestore();
   });
 
   it("computes cosine similarity", async () => {
@@ -94,10 +96,12 @@ describe("vectorSearch", () => {
   });
 
   it("returns null when embeddings fail to load", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     fetchJsonMock.mockRejectedValueOnce(new Error("fail"));
     const { findMatches } = await import("../../src/helpers/vectorSearch.js");
     const res = await findMatches([1, 0], 1);
     expect(res).toBeNull();
+    errorSpy.mockRestore();
   });
 
   it("fetches context around an id", async () => {


### PR DESCRIPTION
## Summary
- suppress console errors in vector search loading failure tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: desktop arrow keys update markers and disable buttons, @vectorSearch screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68984a1a5c48832681bf5ca8e7e0d905