### PR TITLE
Refactor card component into class with subclass demo

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,35 +1,48 @@
 /**
- * Create a basic card container element.
+ * Basic card container class.
  *
  * @pseudocode
  * 1. Use a `<div>` element by default or an `<a>` element when `href` is provided.
  * 2. Apply `id`, `href`, `className` and `onClick` options if present.
  * 3. Always include the `card` class plus any additional `className`.
  * 4. Insert string content via `innerHTML` or append a DOM node directly.
- * 5. Return the configured element.
+ *
+ * @class
+ */
+export class Card {
+  /**
+   * @param {string|Node} content - Markup string or DOM node to place inside the card.
+   * @param {{id?: string, className?: string, href?: string, onClick?: Function}} [options] - Optional settings.
+   */
+  constructor(content, options = {}) {
+    const { id, className, href, onClick } = options;
+    this.element = href ? document.createElement("a") : document.createElement("div");
+    if (id) this.element.id = id;
+    if (href) this.element.href = href;
+    this.element.classList.add("card");
+    if (className) {
+      for (const cls of className.split(/\s+/)) {
+        if (cls) this.element.classList.add(cls);
+      }
+    }
+    if (typeof onClick === "function") {
+      this.element.addEventListener("click", onClick);
+    }
+    if (typeof content === "string") {
+      this.element.innerHTML = content;
+    } else if (content instanceof Node) {
+      this.element.append(content);
+    }
+  }
+}
+
+/**
+ * Factory wrapper for backward compatibility with function callers.
  *
  * @param {string|Node} content - Markup string or DOM node to place inside the card.
- * @param {object} [options] - Optional settings.
- * @param {string} [options.id] - Id attribute for the element.
- * @param {string} [options.className] - Extra class names.
- * @param {string} [options.href] - If set, create an `<a>` element with this href.
- * @param {Function} [options.onClick] - Click handler attached to the element.
+ * @param {object} [options] - Optional settings passed to the `Card` constructor.
  * @returns {HTMLElement} The card element.
  */
 export function createCard(content, options = {}) {
-  const { id, className, href, onClick } = options;
-  const element = href ? document.createElement("a") : document.createElement("div");
-  if (id) element.id = id;
-  if (href) element.href = href;
-  element.classList.add("card");
-  if (className) element.classList.add(className);
-  if (typeof onClick === "function") {
-    element.addEventListener("click", onClick);
-  }
-  if (typeof content === "string") {
-    element.innerHTML = content;
-  } else if (content instanceof Node) {
-    element.append(content);
-  }
-  return element;
+  return new Card(content, options).element;
 }

--- a/src/components/EpicCard.js
+++ b/src/components/EpicCard.js
@@ -1,0 +1,24 @@
+import { JudokaCard } from "./JudokaCard.js";
+
+/**
+ * Epic judoka card with a special badge.
+ *
+ * @extends JudokaCard
+ */
+export class EpicCard extends JudokaCard {
+  /**
+   * Render the card with an added epic badge.
+   *
+   * @returns {Promise<HTMLElement>} Resolves with the card container element.
+   */
+  async render() {
+    const container = await super.render();
+    const badge = document.createElement("span");
+    badge.className = "epic-badge";
+    badge.textContent = "EPIC";
+    this.element.appendChild(badge);
+    return container;
+  }
+}
+
+export default EpicCard;

--- a/src/components/JudokaCard.js
+++ b/src/components/JudokaCard.js
@@ -9,6 +9,7 @@ import {
   createSignatureMoveSection
 } from "../helpers/cardSections.js";
 import { createInspectorPanel } from "../helpers/cardBuilder.js";
+import { Card } from "./Card.js";
 
 /**
  * Component for rendering a judoka card.
@@ -26,7 +27,7 @@ import { createInspectorPanel } from "../helpers/cardBuilder.js";
  *    - Append an inspector panel when enabled.
  *    - Return the container element.
  */
-export class JudokaCard {
+export class JudokaCard extends Card {
   /**
    * @param {import("../helpers/types.js").Judoka} judoka - Judoka data.
    * @param {Record<number, import("../helpers/types.js").GokyoEntry>} gokyoLookup - Move lookup.
@@ -42,13 +43,23 @@ export class JudokaCard {
     }
 
     const { useObscuredStats = false, enableInspector = false } = options;
-    this.judoka = useObscuredStats ? this.#obscureJudoka(judoka) : judoka;
+    const processedJudoka = useObscuredStats ? JudokaCard.#obscureJudoka(judoka) : judoka;
+    const cardType = processedJudoka.rarity?.toLowerCase() || "common";
+
+    super("", { className: `judoka-card ${cardType}` });
+
+    this.judoka = processedJudoka;
     this.gokyoLookup = gokyoLookup;
     this.enableInspector = enableInspector;
-    this.cardType = this.judoka.rarity?.toLowerCase() || "common";
+    this.cardType = cardType;
+
+    this.element.setAttribute("role", "button");
+    this.element.setAttribute("tabindex", "0");
+    this.element.setAttribute("aria-label", `${this.judoka.firstname} ${this.judoka.surname} card`);
+    this.element.classList.add(this.judoka.gender === "female" ? "female-card" : "male-card");
   }
 
-  #obscureJudoka(judoka) {
+  static #obscureJudoka(judoka) {
     const clone = structuredClone(judoka);
     clone.firstname = "?";
     clone.surname = "?";
@@ -80,16 +91,6 @@ export class JudokaCard {
     return createSignatureMoveSection(this.judoka, this.gokyoLookup, this.cardType);
   }
 
-  #createCardElement() {
-    const el = document.createElement("div");
-    el.className = `judoka-card ${this.cardType}`;
-    el.setAttribute("role", "button");
-    el.setAttribute("tabindex", "0");
-    el.setAttribute("aria-label", `${this.judoka.firstname} ${this.judoka.surname} card`);
-    el.classList.add(this.judoka.gender === "female" ? "female-card" : "male-card");
-    return el;
-  }
-
   /**
    * Render the card and return the container element.
    *
@@ -110,7 +111,7 @@ export class JudokaCard {
       "https://flagcdn.com/w320/vu.png"
     );
 
-    const card = this.#createCardElement();
+    const card = this.element;
     const topBar = await this.#buildTopBar(flagUrl);
     const portrait = this.#buildPortraitSection();
     const stats = await this.#buildStatsSection();

--- a/tests/card/epicCardBadge.test.js
+++ b/tests/card/epicCardBadge.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { EpicCard } from "../../src/components/EpicCard.js";
+
+vi.mock("../../src/helpers/stats.js", () => ({
+  loadStatNames: () =>
+    Promise.resolve([
+      { name: "Power" },
+      { name: "Speed" },
+      { name: "Technique" },
+      { name: "Kumi-kata" },
+      { name: "Ne-waza" }
+    ])
+}));
+
+const judoka = {
+  id: 1,
+  firstname: "John",
+  surname: "Doe",
+  country: "USA",
+  countryCode: "us",
+  stats: { power: 5, speed: 5, technique: 5, kumikata: 5, newaza: 5 },
+  weightClass: "-100kg",
+  signatureMoveId: 1,
+  rarity: "epic",
+  gender: "male"
+};
+
+const gokyoLookup = {
+  1: { id: 1, name: "Uchi-mata" }
+};
+
+describe("EpicCard", () => {
+  it("appends an epic badge", async () => {
+    const container = await new EpicCard(judoka, gokyoLookup).render();
+    const badge = container.querySelector(".epic-badge");
+    expect(badge).not.toBeNull();
+    expect(badge.textContent).toBe("EPIC");
+  });
+});

--- a/tests/helpers/cardComponent.test.js
+++ b/tests/helpers/cardComponent.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { createCard } from "../../src/components/Card.js";
+import { Card, createCard } from "../../src/components/Card.js";
 
 describe("createCard", () => {
   it("creates a div card with text content", () => {
@@ -30,5 +30,13 @@ describe("createCard", () => {
     span.textContent = "inside";
     const card = createCard(span);
     expect(card.firstChild).toBe(span);
+  });
+});
+
+describe("Card class", () => {
+  it("exposes the created element", () => {
+    const instance = new Card("Hello");
+    expect(instance.element).toBeInstanceOf(HTMLDivElement);
+    expect(instance.element.classList.contains("card")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- convert card factory into reusable `Card` class with backward-compatible `createCard` wrapper
- refactor `JudokaCard` to extend `Card` and add epic badge subclass `EpicCard`
- document new API and add tests for class and epic badge rendering

## Testing
- `npx prettier src/components/Card.js src/components/JudokaCard.js src/components/EpicCard.js tests/helpers/cardComponent.test.js tests/card/epicCardBadge.test.js --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-orientation.spec.js screenshot diffs, battleJudoka.spec narrow screenshot, screenshot.spec vectorSearch screenshot, signatureMove.spec random judoka)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68984eec5b18832683577f382e1eaafd