### PR TITLE
fix: prevent auto-select message from overriding round result

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -154,8 +154,9 @@ export function evaluateRound(store, stat) {
  *
  * @pseudocode
  * 1. Pause the round timer and clear any pending timeouts.
- * 2. Clear the countdown and show "Opponent is choosing…" in the info bar,
- *    optionally delaying the message when `delayOpponentMessage` is true.
+ * 2. Clear the countdown and show "Opponent is choosing…" in the info bar.
+ *    When `delayOpponentMessage` is true, delay the message by 500ms and
+ *    cancel it if the round resolves before it displays.
  * 3. After a short delay, reveal the opponent card and evaluate the round.
  * 4. If the match ended, clear the round counter.
  * 5. Reset stat buttons and schedule the next round.
@@ -177,14 +178,16 @@ export async function handleStatSelection(store, stat, options = {}) {
   clearTimeout(store.statTimeoutId);
   clearTimeout(store.autoSelectId);
   infoBar.clearTimer();
+  let opponentMsgId = 0;
   if (options.delayOpponentMessage) {
-    setTimeout(() => infoBar.showMessage("Opponent is choosing…"), 500);
+    opponentMsgId = setTimeout(() => infoBar.showMessage("Opponent is choosing…"), 500);
   } else {
     infoBar.showMessage("Opponent is choosing…");
   }
   const delay = 300 + Math.floor(Math.random() * 401);
   return new Promise((resolve) => {
     setTimeout(async () => {
+      clearTimeout(opponentMsgId);
       await revealComputerCard();
       const result = evaluateRound(store, stat);
       if (result.matchEnded) {


### PR DESCRIPTION
## Summary
- avoid delayed "Opponent is choosing…" message overwriting round result during auto-select
- document new behavior in `handleStatSelection`

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6898575f8c5c83268a6ef7bb4ec56518