### PR TITLE
Rename next round button and remove skip phase control

### DIFF
--- a/playwright/statReset.spec.js
+++ b/playwright/statReset.spec.js
@@ -10,7 +10,7 @@ test.describe.parallel("Classic battle button reset", () => {
     const timer = page.locator("header #next-round-timer");
     await timer.waitFor();
     await page.locator("#stat-buttons button[data-stat='power']").click();
-    await page.locator("#next-round-button").click();
+    await page.locator("#next-button").click();
     await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
     await expect(page.locator("#stat-buttons .selected")).toHaveCount(0);
   });
@@ -22,7 +22,7 @@ test.describe.parallel("Classic battle button reset", () => {
     await timer.waitFor();
     const btn = page.locator("#stat-buttons button[data-stat='power']");
     await btn.click();
-    await page.locator("#next-round-button").click();
+    await page.locator("#next-button").click();
     await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
     const highlight = await btn.evaluate((el) => getComputedStyle(el).webkitTapHighlightColor);
     expect(highlight).toBe("rgba(0, 0, 0, 0)");

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -16,13 +16,12 @@
     "drawMessage": "_It’s a draw._\nBoth stats were equal!",
     "signatureBar": "**Signature move**\nThis bar shows the judoka’s special technique.",
     "languageToggle": "**Language toggle**\nSwitch quote language between English and pseudo-Japanese.",
-    "nextRound": "**Next round**\nBegin when you’re ready.",
-    "skipPhase": "Skip the countdown and move on.",
     "quitMatch": "**Quit match**\nReturn to the menu.",
     "drawCard": "**Draw card**\nGet a new random judoka card.",
     "roundQuick": "**Quick**\\nFirst to 5 points wins.",
     "roundMedium": "**Medium**\\nFirst to 10 points wins.",
-    "roundLong": "**Long**\\nFirst to 15 points wins."
+    "roundLong": "**Long**\\nFirst to 15 points wins.",
+    "next": "**Next**\nBegin when you’re ready."
   },
   "mode": {
     "classicBattle": "**Classic Battle Mode** pits you against an opponent.\nFirst to 10 round‑wins becomes the champion.",

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -333,7 +333,7 @@ export function _resetForTest(store) {
   infoBar.clearMessage();
   const roundResultEl = document.getElementById("round-result");
   if (roundResultEl) roundResultEl.textContent = "";
-  const nextBtn = document.getElementById("next-round-button");
+  const nextBtn = document.getElementById("next-button");
   if (nextBtn) {
     const clone = nextBtn.cloneNode(true);
     nextBtn.replaceWith(clone);

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -179,7 +179,7 @@ export function scheduleNextRound(result, startRoundFn) {
     return;
   }
 
-  const btn = document.getElementById("next-round-button");
+  const btn = document.getElementById("next-button");
   if (!btn) return;
   const timerEl = document.getElementById("next-round-timer");
 

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -65,7 +65,7 @@ export async function revealComputerCard() {
 }
 
 export function enableNextRoundButton(enable = true) {
-  const btn = document.getElementById("next-round-button");
+  const btn = document.getElementById("next-button");
   if (btn) btn.disabled = !enable;
 }
 

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -138,7 +138,6 @@ export async function setupClassicBattlePage() {
   applyFeatureFlagListeners(battleArea, banner);
 
   initDebugPanel();
-  setupSkipButton();
 
   window.startRoundOverride = () => startRoundWrapper();
   await initRoundSelectModal(() => startRoundWrapper());
@@ -205,16 +204,6 @@ function initDebugPanel() {
   } else {
     debugPanel.remove();
   }
-}
-
-function setupSkipButton() {
-  const skipBtn = document.getElementById("skip-phase-button");
-  if (!skipBtn) return;
-  skipBtn.addEventListener("click", () => skipCurrentPhase());
-  window.addEventListener("skip-handler-change", (e) => {
-    const { active } = e.detail || {};
-    skipBtn.disabled = !active;
-  });
 }
 
 function maybeShowStatHint() {

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -97,18 +97,7 @@
             </div>
 
             <p id="round-result" aria-live="polite" aria-atomic="true"></p>
-            <button id="next-round-button" disabled data-tooltip-id="ui.nextRound">
-              Next Round
-            </button>
-            <button
-              id="skip-phase-button"
-              class="info-button"
-              aria-label="Skip timer"
-              data-tooltip-id="ui.skipPhase"
-              disabled
-            >
-              &gt;
-            </button>
+            <button id="next-button" disabled data-tooltip-id="ui.next">Next</button>
             <button
               id="stat-help"
               class="info-button"

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -77,7 +77,7 @@
 }
 
 /* Control buttons */
-#next-round-button,
+#next-button,
 #quit-match-button {
   min-width: var(--touch-target-size, 44px);
   min-height: var(--touch-target-size, 44px);

--- a/tests/data/tooltipsEntries.test.js
+++ b/tests/data/tooltipsEntries.test.js
@@ -13,7 +13,7 @@ describe("tooltips.json", () => {
   it("contains new ui tooltip entries", () => {
     const keys = [
       "ui.languageToggle",
-      "ui.nextRound",
+      "ui.next",
       "ui.quitMatch",
       "ui.drawCard",
       "card.flag",

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -23,7 +23,7 @@ describe("countdown resets after stat selection", () => {
     const roundResult = document.createElement("p");
     roundResult.id = "round-result";
     const nextBtn = document.createElement("button");
-    nextBtn.id = "next-round-button";
+    nextBtn.id = "next-button";
     document.body.append(playerCard, computerCard, header, roundResult, nextBtn);
     document.body.innerHTML += '<div id="stat-buttons"><button data-stat="power"></button></div>';
     battleMod = await import("../../../src/helpers/classicBattle.js");

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -39,7 +39,7 @@ describe("classicBattle button handlers", () => {
     const { playerCard, computerCard } = createBattleCardContainers();
     const header = createBattleHeader();
     const nextBtn = document.createElement("button");
-    nextBtn.id = "next-round-button";
+    nextBtn.id = "next-button";
     nextBtn.disabled = true;
     const quitBtn = document.createElement("button");
     quitBtn.id = "quit-match-button";
@@ -66,7 +66,7 @@ describe("classicBattle button handlers", () => {
       "../../../src/helpers/classicBattle.js"
     );
     disableNextRoundButton();
-    const btn = document.getElementById("next-round-button");
+    const btn = document.getElementById("next-button");
     expect(btn.disabled).toBe(true);
     enableNextRoundButton();
     expect(btn.disabled).toBe(false);

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -178,11 +178,11 @@ describe("classicBattle match flow", () => {
   });
 
   it("scheduleNextRound waits for cooldown then enables button", async () => {
-    document.body.innerHTML += '<button id="next-round-button" disabled></button>';
+    document.body.innerHTML += '<button id="next-button" disabled></button>';
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const startStub = vi.fn();
     battleMod.scheduleNextRound({ matchEnded: false }, startStub);
-    const btn = document.getElementById("next-round-button");
+    const btn = document.getElementById("next-button");
     expect(btn.disabled).toBe(true);
     timerSpy.advanceTimersByTime(2000);
     timerSpy.advanceTimersByTime(3000);

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -58,7 +58,7 @@ describe("timerService drift handling", () => {
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
     const timer = vi.useFakeTimers();
     const btn = document.createElement("button");
-    btn.id = "next-round-button";
+    btn.id = "next-button";
     document.body.appendChild(btn);
     const timerNode = document.createElement("p");
     timerNode.id = "next-round-timer";

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -101,7 +101,7 @@ describe("classicBattlePage keyboard navigation", () => {
     stats.appendChild(statBtn);
 
     const next = document.createElement("button");
-    next.id = "next-round-button";
+    next.id = "next-button";
     const quit = document.createElement("button");
     quit.id = "quit-match-button";
     document.body.append(stats, next, quit);
@@ -160,7 +160,7 @@ describe("classicBattlePage simulated opponent mode", () => {
     btn.dataset.stat = "power";
     container.appendChild(btn);
     const next = document.createElement("button");
-    next.id = "next-round-button";
+    next.id = "next-button";
     document.body.append(container, next);
 
     const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");

--- a/tests/helpers/tooltip.test.js
+++ b/tests/helpers/tooltip.test.js
@@ -83,7 +83,7 @@ describe("initTooltips", () => {
       fetchJson: vi.fn().mockResolvedValue({
         ui: {
           languageToggle: "toggle",
-          nextRound: "next",
+          next: "next",
           quitMatch: "quit",
           drawCard: "draw"
         }
@@ -92,7 +92,7 @@ describe("initTooltips", () => {
 
     const { initTooltips } = await import("../../src/helpers/tooltip.js");
 
-    const ids = ["ui.languageToggle", "ui.nextRound", "ui.quitMatch", "ui.drawCard"];
+    const ids = ["ui.languageToggle", "ui.next", "ui.quitMatch", "ui.drawCard"];
     const text = ["toggle", "next", "quit", "draw"];
     const els = ids.map((id) => {
       const el = document.createElement("button");


### PR DESCRIPTION
## Summary
- Replace `next-round-button` with `next-button` and drop the skip-phase control on the battle page.
- Rename related selectors and add `ui.next` tooltip while removing obsolete `ui.skipPhase` entry.
- Align tests and styles with the new button identifier.

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run validate:data` *(fails: could not determine executable to run)*
- `npx vitest run`
- `npx playwright test` *(fails: 5 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68985bdd3edc8326a85a074031f283ca