### PR TITLE
Refactor next-round button to use skip handler and aria-disabled

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -194,7 +194,7 @@ export async function handleStatSelection(store, stat, options = {}) {
         infoBar.clearRoundCounter();
       }
       resetStatButtons();
-      scheduleNextRound(result, getStartRound(store));
+      scheduleNextRound(result);
       if (result.matchEnded) {
         showMatchSummaryModal(result, () => handleReplay(store));
       }
@@ -337,7 +337,8 @@ export function _resetForTest(store) {
   if (nextBtn) {
     const clone = nextBtn.cloneNode(true);
     nextBtn.replaceWith(clone);
-    clone.disabled = true;
+    clone.setAttribute("aria-disabled", "true");
+    delete clone.dataset.nextReady;
   }
   const quitBtn = document.getElementById("quit-match-button");
   if (quitBtn) {

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -7,7 +7,7 @@ import {
   stopTimer
 } from "../battleEngine.js";
 import * as infoBar from "../setupBattleInfoBar.js";
-import { enableNextRoundButton, disableNextRoundButton, updateDebugPanel } from "./uiHelpers.js";
+import { enableNextRoundButton, updateDebugPanel } from "./uiHelpers.js";
 import { runTimerWithDrift } from "./runTimerWithDrift.js";
 import { showSnackbar, updateSnackbar } from "../showSnackbar.js";
 
@@ -167,13 +167,12 @@ export function handleStatSelectionTimeout(store, onSelect) {
  * 3. After a short delay, run a 3 second cooldown via `runTimerWithDrift(startCoolDown)`
  *    and display `"Next round in: <n>s"` using one snackbar that updates each tick.
  * 4. Register a skip handler that stops the timer and invokes the expiration logic.
- * 5. When expired, clear the `#next-round-timer` element, enable the button, attach the click
- *    handler, and clear the handler.
+ * 5. When expired, clear the `#next-round-timer` element, enable the button, mark it ready,
+ *    and clear the handler.
  *
  * @param {{matchEnded: boolean}} result - Result from a completed round.
- * @param {function(): Promise<void>} startRoundFn - Function to begin the next round.
  */
-export function scheduleNextRound(result, startRoundFn) {
+export function scheduleNextRound(result) {
   if (result.matchEnded) {
     setSkipHandler(null);
     return;
@@ -182,11 +181,6 @@ export function scheduleNextRound(result, startRoundFn) {
   const btn = document.getElementById("next-button");
   if (!btn) return;
   const timerEl = document.getElementById("next-round-timer");
-
-  const onClick = async () => {
-    disableNextRoundButton();
-    await startRoundFn();
-  };
 
   let started = false;
   const onTick = (remaining) => {
@@ -209,8 +203,8 @@ export function scheduleNextRound(result, startRoundFn) {
     if (timerEl) {
       timerEl.textContent = "";
     }
-    btn.addEventListener("click", onClick, { once: true });
     enableNextRoundButton();
+    btn.dataset.nextReady = "true";
     updateDebugPanel();
   };
 

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -66,11 +66,15 @@ export async function revealComputerCard() {
 
 export function enableNextRoundButton(enable = true) {
   const btn = document.getElementById("next-button");
-  if (btn) btn.disabled = !enable;
+  if (!btn) return;
+  btn.setAttribute("aria-disabled", String(!enable));
 }
 
 export function disableNextRoundButton() {
+  const btn = document.getElementById("next-button");
+  if (!btn) return;
   enableNextRoundButton(false);
+  delete btn.dataset.nextReady;
 }
 
 export function updateDebugPanel() {

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -61,6 +61,7 @@ window.skipBattlePhase = skipCurrentPhase;
 export const getBattleStore = () => battleStore;
 let simulatedOpponentMode = false;
 let aiDifficulty = "easy";
+let skipActive = false;
 
 async function startRoundWrapper() {
   enableStatButtons(false);
@@ -72,6 +73,22 @@ async function startRoundWrapper() {
   } else {
     enableStatButtons(true);
   }
+}
+
+function setupNextButton() {
+  const btn = document.getElementById("next-button");
+  if (!btn) return;
+  window.addEventListener("skip-handler-change", (e) => {
+    skipActive = e.detail.active;
+  });
+  btn.addEventListener("click", async () => {
+    if (skipActive) {
+      skipCurrentPhase();
+    }
+    if (btn.dataset.nextReady === "true") {
+      await startRoundWrapper();
+    }
+  });
 }
 
 async function applyStatLabels() {
@@ -115,6 +132,7 @@ function watchBattleOrientation() {
 export async function setupClassicBattlePage() {
   await applyStatLabels();
   const statButtons = document.querySelectorAll("#stat-buttons button");
+  setupNextButton();
 
   const settings = await safeLoadSettings();
   toggleInspectorPanels(isEnabled("enableCardInspector"));

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -97,7 +97,7 @@
             </div>
 
             <p id="round-result" aria-live="polite" aria-atomic="true"></p>
-            <button id="next-button" disabled data-tooltip-id="ui.next">Next</button>
+            <button id="next-button" aria-disabled="true" data-tooltip-id="ui.next">Next</button>
             <button
               id="stat-help"
               class="info-button"

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -40,7 +40,7 @@ describe("classicBattle button handlers", () => {
     const header = createBattleHeader();
     const nextBtn = document.createElement("button");
     nextBtn.id = "next-button";
-    nextBtn.disabled = true;
+    nextBtn.setAttribute("aria-disabled", "true");
     const quitBtn = document.createElement("button");
     quitBtn.id = "quit-match-button";
     document.body.append(playerCard, computerCard, header, nextBtn, quitBtn);
@@ -67,9 +67,9 @@ describe("classicBattle button handlers", () => {
     );
     disableNextRoundButton();
     const btn = document.getElementById("next-button");
-    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute("aria-disabled")).toBe("true");
     enableNextRoundButton();
-    expect(btn.disabled).toBe(false);
+    expect(btn.getAttribute("aria-disabled")).toBe("false");
   });
 
   it("quit button invokes quitMatch", async () => {

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -178,20 +178,16 @@ describe("classicBattle match flow", () => {
   });
 
   it("scheduleNextRound waits for cooldown then enables button", async () => {
-    document.body.innerHTML += '<button id="next-button" disabled></button>';
+    document.body.innerHTML += '<button id="next-button" aria-disabled="true"></button>';
     const battleMod = await import("../../../src/helpers/classicBattle.js");
-    const startStub = vi.fn();
-    battleMod.scheduleNextRound({ matchEnded: false }, startStub);
+    battleMod.scheduleNextRound({ matchEnded: false });
     const btn = document.getElementById("next-button");
-    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute("aria-disabled")).toBe("true");
     timerSpy.advanceTimersByTime(2000);
     timerSpy.advanceTimersByTime(3000);
     await Promise.resolve();
-    expect(btn.disabled).toBe(false);
-    btn.click();
-    await Promise.resolve();
-    expect(btn.disabled).toBe(true);
-    expect(startStub).toHaveBeenCalled();
+    expect(btn.getAttribute("aria-disabled")).toBe("false");
+    expect(btn.dataset.nextReady).toBe("true");
   });
 
   it("shows selection prompt until a stat is chosen", async () => {

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -63,7 +63,7 @@ describe("timerService drift handling", () => {
     const timerNode = document.createElement("p");
     timerNode.id = "next-round-timer";
     document.body.appendChild(timerNode);
-    mod.scheduleNextRound({ matchEnded: false }, async () => {});
+    mod.scheduleNextRound({ matchEnded: false });
     timer.advanceTimersByTime(2000);
     onDrift(1);
     expect(showMessage).toHaveBeenCalledWith("Waiting…");


### PR DESCRIPTION
## Summary
- Make next button accessible by replacing `disabled` with `aria-disabled`
- Drive next button clicks through skip handler and data flag instead of `setupSkipButton`
- Simplify `scheduleNextRound` and update tests for new workflow

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Browse Judoka navigation › desktop arrow keys update markers and disable buttons)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6898641d32308326835ce88277814706