### PR TITLE
feat: add ajv-cli and cross-platform validation

### DIFF
--- a/design/dataSchemas/README.md
+++ b/design/dataSchemas/README.md
@@ -4,7 +4,7 @@ This project stores gameplay data in JSON files under `src/data`. Each file has 
 
 ## Running Validation
 
-Run `npm run validate:data` to check all schema and data pairs at once. The command executes `scripts/validateData.js`, which calls the Ajv CLI internally. If needed, you can validate a single pair manually using `npx ajv validate`:
+Run `npm run validate:data` to check all schema and data pairs at once. The command executes `scripts/validateData.js`, which calls the Ajv CLI provided by the `ajv-cli` dev dependency. After running `npm install`, you can also validate a single pair manually using `npx ajv validate`:
 
 ```bash
 npx ajv validate -s src/schemas/judoka.schema.json -d src/data/judoka.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@playwright/test": "^1.54.2",
+        "ajv-cli": "^5.0.0",
         "eslint": "^9.32.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@playwright/test": "^1.54.2",
+    "ajv-cli": "^5.0.0",
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.3",

--- a/scripts/validateData.js
+++ b/scripts/validateData.js
@@ -17,6 +17,7 @@ if (!schemaFiles.includes("src/schemas/statNames.schema.json")) {
 }
 
 let hasErrors = false;
+const npxCmd = process.platform === "win32" ? "npx.cmd" : "npx";
 for (const schemaPath of schemaFiles) {
   const baseName = path.basename(schemaPath, ".schema.json");
   const dataPath = path.join("src", "data", `${baseName}.json`);
@@ -25,7 +26,7 @@ for (const schemaPath of schemaFiles) {
   }
   await new Promise((resolve) => {
     const child = spawn(
-      "npx",
+      npxCmd,
       [
         "ajv",
         "validate",


### PR DESCRIPTION
## Summary
- install ajv-cli as a dev dependency
- fix validateData script to resolve `npx` on Windows
- note local Ajv CLI usage in schema validation docs

## Testing
- `npx prettier . --check --log-level warn`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: Browse Judoka navigation → desktop arrow keys update markers and disable buttons)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689867133ac08326baae37da04f6df29