### PR TITLE
Use data attribute for Classic Battle next-round state

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -311,6 +311,26 @@ export function showStatComparison(store, stat, playerVal, compVal) {
 }
 
 /**
+ * Reset the Next Round button to its initial disabled state.
+ *
+ * @pseudocode
+ * 1. Locate `#next-button` and exit if missing.
+ * 2. Replace it with a cloned element to drop event listeners.
+ * 3. Remove `data-next-ready` and add the `disabled` class on the clone.
+ *
+ * @returns {void}
+ */
+export function resetGame() {
+  const nextBtn = document.getElementById("next-button");
+  if (nextBtn) {
+    const clone = nextBtn.cloneNode(true);
+    clone.classList.add("disabled");
+    delete clone.dataset.nextReady;
+    nextBtn.replaceWith(clone);
+  }
+}
+
+/**
  * Reset internal state for tests.
  *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
@@ -333,13 +353,7 @@ export function _resetForTest(store) {
   infoBar.clearMessage();
   const roundResultEl = document.getElementById("round-result");
   if (roundResultEl) roundResultEl.textContent = "";
-  const nextBtn = document.getElementById("next-button");
-  if (nextBtn) {
-    const clone = nextBtn.cloneNode(true);
-    nextBtn.replaceWith(clone);
-    clone.setAttribute("aria-disabled", "true");
-    delete clone.dataset.nextReady;
-  }
+  resetGame();
   const quitBtn = document.getElementById("quit-match-button");
   if (quitBtn) {
     quitBtn.replaceWith(quitBtn.cloneNode(true));

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -64,16 +64,17 @@ export async function revealComputerCard() {
   clearComputerJudoka();
 }
 
-export function enableNextRoundButton(enable = true) {
+export function enableNextRoundButton() {
   const btn = document.getElementById("next-button");
   if (!btn) return;
-  btn.setAttribute("aria-disabled", String(!enable));
+  btn.classList.remove("disabled");
+  btn.dataset.nextReady = "true";
 }
 
 export function disableNextRoundButton() {
   const btn = document.getElementById("next-button");
   if (!btn) return;
-  enableNextRoundButton(false);
+  btn.classList.add("disabled");
   delete btn.dataset.nextReady;
 }
 

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -44,7 +44,7 @@ import { STATS } from "./battleEngine.js";
 import { toggleInspectorPanels } from "./cardUtils.js";
 import { showSnackbar } from "./showSnackbar.js";
 import { initRoundSelectModal } from "./classicBattle/roundSelectModal.js";
-import { skipCurrentPhase } from "./classicBattle/timerService.js";
+import { skipCurrentPhase, onNextButtonClick } from "./classicBattle/timerService.js";
 import { isEnabled, featureFlagsEmitter } from "./featureFlags.js";
 
 function enableStatButtons(enable = true) {
@@ -61,7 +61,6 @@ window.skipBattlePhase = skipCurrentPhase;
 export const getBattleStore = () => battleStore;
 let simulatedOpponentMode = false;
 let aiDifficulty = "easy";
-let skipActive = false;
 
 async function startRoundWrapper() {
   enableStatButtons(false);
@@ -78,17 +77,7 @@ async function startRoundWrapper() {
 function setupNextButton() {
   const btn = document.getElementById("next-button");
   if (!btn) return;
-  window.addEventListener("skip-handler-change", (e) => {
-    skipActive = e.detail.active;
-  });
-  btn.addEventListener("click", async () => {
-    if (skipActive) {
-      skipCurrentPhase();
-    }
-    if (btn.dataset.nextReady === "true") {
-      await startRoundWrapper();
-    }
-  });
+  btn.addEventListener("click", onNextButtonClick);
 }
 
 async function applyStatLabels() {

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -97,7 +97,7 @@
             </div>
 
             <p id="round-result" aria-live="polite" aria-atomic="true"></p>
-            <button id="next-button" aria-disabled="true" data-tooltip-id="ui.next">Next</button>
+            <button id="next-button" class="disabled" data-tooltip-id="ui.next">Next</button>
             <button
               id="stat-help"
               class="info-button"

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -40,7 +40,7 @@ describe("classicBattle button handlers", () => {
     const header = createBattleHeader();
     const nextBtn = document.createElement("button");
     nextBtn.id = "next-button";
-    nextBtn.setAttribute("aria-disabled", "true");
+    nextBtn.className = "disabled";
     const quitBtn = document.createElement("button");
     quitBtn.id = "quit-match-button";
     document.body.append(playerCard, computerCard, header, nextBtn, quitBtn);
@@ -67,9 +67,11 @@ describe("classicBattle button handlers", () => {
     );
     disableNextRoundButton();
     const btn = document.getElementById("next-button");
-    expect(btn.getAttribute("aria-disabled")).toBe("true");
+    expect(btn.classList.contains("disabled")).toBe(true);
+    expect(btn.dataset.nextReady).toBeUndefined();
     enableNextRoundButton();
-    expect(btn.getAttribute("aria-disabled")).toBe("false");
+    expect(btn.classList.contains("disabled")).toBe(false);
+    expect(btn.dataset.nextReady).toBe("true");
   });
 
   it("quit button invokes quitMatch", async () => {

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -178,15 +178,15 @@ describe("classicBattle match flow", () => {
   });
 
   it("scheduleNextRound waits for cooldown then enables button", async () => {
-    document.body.innerHTML += '<button id="next-button" aria-disabled="true"></button>';
+    document.body.innerHTML += '<button id="next-button" class="disabled"></button>';
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     battleMod.scheduleNextRound({ matchEnded: false });
     const btn = document.getElementById("next-button");
-    expect(btn.getAttribute("aria-disabled")).toBe("true");
+    expect(btn.classList.contains("disabled")).toBe(true);
     timerSpy.advanceTimersByTime(2000);
     timerSpy.advanceTimersByTime(3000);
     await Promise.resolve();
-    expect(btn.getAttribute("aria-disabled")).toBe("false");
+    expect(btn.classList.contains("disabled")).toBe(false);
     expect(btn.dataset.nextReady).toBe("true");
   });
 


### PR DESCRIPTION
## Summary
- switch Classic Battle next-round button to `data-next-ready` and unified click handler
- toggle button readiness via helpers and reset clone when resetting game
- update page setup and HTML to match new data attribute

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 3 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689867d36adc832699489fa3eb20c0f0