### PR TITLE
feat: consolidate next tooltip

### DIFF
--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -21,7 +21,7 @@
     "roundQuick": "**Quick**\\nFirst to 5 points wins.",
     "roundMedium": "**Medium**\\nFirst to 10 points wins.",
     "roundLong": "**Long**\\nFirst to 15 points wins.",
-    "next": "**Next**\nBegin when you’re ready."
+    "next": "**Next**\nStart the next round or skip the current phase."
   },
   "mode": {
     "classicBattle": "**Classic Battle Mode** pits you against an opponent.\nFirst to 10 round‑wins becomes the champion.",

--- a/tests/helpers/tooltip.test.js
+++ b/tests/helpers/tooltip.test.js
@@ -83,7 +83,7 @@ describe("initTooltips", () => {
       fetchJson: vi.fn().mockResolvedValue({
         ui: {
           languageToggle: "toggle",
-          next: "next",
+          next: "advance or skip",
           quitMatch: "quit",
           drawCard: "draw"
         }
@@ -93,7 +93,7 @@ describe("initTooltips", () => {
     const { initTooltips } = await import("../../src/helpers/tooltip.js");
 
     const ids = ["ui.languageToggle", "ui.next", "ui.quitMatch", "ui.drawCard"];
-    const text = ["toggle", "next", "quit", "draw"];
+    const text = ["toggle", "advance or skip", "quit", "draw"];
     const els = ids.map((id) => {
       const el = document.createElement("button");
       el.dataset.tooltipId = id;


### PR DESCRIPTION
## Summary
- merge `ui.nextRound`/`ui.skipPhase` into unified `ui.next` tooltip covering both behaviors
- adjust tooltip initialization test fixture to look for `ui.next`

## Testing
- `npm run validate:data` *(fails: src/data/tooltips.json invalid - must NOT have additional properties 'nav')*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 4 tests failing)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68986e2bbfa883269bbce68c4934c865