### PR TITLE
docs: unify next button behavior

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -39,7 +39,7 @@ The round message, timer, and score now sit directly inside the page header rath
 | **P2**   | Countdown Timer        | Display countdown to next round with fallback for server sync                                                                                                                                                                              |
 | **P2**   | User Action Prompt     | Prompt player for input and hide after interaction                                                                                                                                                                                         |
 | **P3**   | Responsive Layout      | Adapt layout for small screens and collapse content as needed                                                                                                                                                                              |
-| **P3**   | Accessibility Features | Ensure text contrast, screen reader compatibility (via `role="status"` on messages and timers), minimum touch target size, and keyboard navigation for stat, Next Round, and Quit controls (see [Classic Battle PRD](prdClassicBattle.md)) |
+| **P3**   | Accessibility Features | Ensure text contrast, screen reader compatibility (via `role="status"` on messages and timers), minimum touch target size, and keyboard navigation for stat, Next, and Quit controls. The **Next** button advances rounds and skips timers (see [Classic Battle PRD](prdClassicBattle.md)) |
 | **P2**   | Edge Case Handling     | Fallback messages for backend sync failure and display issues                                                                                                                                                                              |
 
 ---
@@ -55,7 +55,7 @@ The round message, timer, and score now sit directly inside the page header rath
 - After the player selects a stat, the Info Bar shows "Opponent is choosing..." until the opponent's stat is revealed.
 - Top bar content adapts responsively to different screen sizes and orientations. <!-- Partially implemented: stacking/truncation CSS present, but some edge cases pending -->
 - All messages meet minimum contrast ratio of **4.5:1** and are screen reader compatible. Run `npm run check:contrast` to audit these colors. <!-- Implemented: screen reader labels via `aria-live` and `role="status"`; contrast via CSS variables -->
-- **All interactive elements, including stat, Next Round, and Quit buttons, meet minimum touch target size (≥44px) and support keyboard navigation with Enter or Space.** <!-- Implemented: see CSS min-width/min-height and stat button logic -->
+- **All interactive elements, including stat, Next, and Quit buttons, meet minimum touch target size (≥44px) and support keyboard navigation with Enter or Space. The Next button doubles as the timer skip and round progression control.** <!-- Implemented: see CSS min-width/min-height and stat button logic -->
 
 ---
 
@@ -127,7 +127,7 @@ The round message, timer, and score now sit directly inside the page header rath
   - [ ] 4.1 Ensure text contrast meets 4.5:1 ratio. Verify with `npm run check:contrast`.
   - [x] 4.2 Add screen reader labels for dynamic messages (`aria-live="polite"` and `role="status"`)
   - [x] 4.3 Ensure all interactive elements have minimum 44px touch targets (CSS min-width/min-height present)
-  - [x] 4.4 Ensure all interactive elements support keyboard navigation; tests cover stat, Next Round, and Quit controls
+  - [x] 4.4 Ensure all interactive elements support keyboard navigation; tests cover stat, Next, and Quit controls
   - [x] 4.5 Announce score and timer updates via `aria-live` for screen readers (see [Classic Battle PRD](prdClassicBattle.md)) <!-- Implemented: aria-live regions in battleJudoka.html -->
   - [x] 4.6 Provide high-contrast theme for Info Bar elements <!-- Implemented: `[data-theme="high-contrast"]` in base.css -->
 

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -94,11 +94,11 @@ This feedback highlights why Classic Battle is needed now: new players currently
 | **P2**   | Tie Handling            | Show tie message; round ends without score change; continue to next round.                                                                                                       |
 | **P2**   | Player Quit Flow        | Allow player to exit match early with confirmation; counts as a loss.                                                                                                            |
 | **P3**   | AI Stat Selection Logic | AI stat choice follows difficulty setting (`easy` random, `medium` picks stats ≥ average, `hard` selects highest stat). Difficulty can be set via Settings or `?difficulty=` URL param; defaults to `easy`. |
-| **P3**   | Skip Control            | Optional control that bypasses round and cooldown timers so testers can fast-forward gameplay or users can quickly move through a match. |
+| **P3**   | Next Button             | Single control that starts the next round and, when pressed during stat selection or cooldown, skips the remaining timer so gameplay can move forward immediately. |
 
 **Additional Behavioral Requirements:**
 
-- Behavior on tie rounds: round ends with a message explaining the tie and an option to start the next round.
+ - Behavior on tie rounds: round ends with a message explaining the tie and an option to start the next round via the **Next** button.
 - Match start conditions: both players begin with a score of zero; player goes first by drawing their card.
   - Players have 30 seconds to select a stat; if no selection is made, the system randomly selects a stat from the drawn card. **The timer is displayed in the Info Bar and the prompt appears in a snackbar.**
 - The opponent's card must always differ from the player's card for each round.
@@ -148,12 +148,12 @@ This feedback highlights why Classic Battle is needed now: new players currently
   - Stat selection buttons sit in a center column between the two cards on screens wider than 480px; on narrow screens they appear below the cards.
   - Central score prominently displayed.
   - Tie or win/loss messages placed centrally.
-  - Clear "Next Round" button with distinct state (enabled/disabled). When disabled, the button should remain visible using the `--button-disabled-bg` token.
+  - Clear **Next** button with distinct state (enabled/disabled). When pressed while a selection or cooldown timer is active, **Next** skips the remaining time and starts the following round. When disabled, the button should remain visible using the `--button-disabled-bg` token.
   - Ensure player and opponent cards show all stats without scrolling on common desktop resolutions (e.g., 1440px width).
   - Provide a dedicated "Quit Match" button below the controls.
     Clicking it opens a confirmation modal styled like the
     **Restore Defaults** dialog from the Settings page.
-  - A small help icon (`#stat-help`) sits between the **Next Round** and
+  - A small help icon (`#stat-help`) sits between the **Next** and
     **Quit Match** buttons. It displays a tooltip explaining how to pick an
     attribute and auto-opens on first visit using the storage helper to remember the
     dismissal.
@@ -162,7 +162,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
   - **Accessibility:**
   - Minimum text contrast ratio: ≥4.5:1 (per WCAG).
   - Minimum touch target size: ≥44px. See [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness) for the full rule.
-  - Support keyboard navigation for stat selection, match progression, and quit confirmation.
+  - Support keyboard navigation for stat selection, the **Next** button (for round progression and timer skipping), and quit confirmation.
   - Provide alt text for cards and labels readable by screen readers.
   - **All Info Bar content must be accessible and responsive as described in prdBattleInfoBar.md.**
 
@@ -184,7 +184,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - [x] 1.1 Create round loop: random card draw, stat selection, comparison
   - [x] 1.2 Implement 30-second stat selection timer with auto-selection fallback (displayed in Info Bar)
   - [x] 1.3 Handle scoring updates on win, loss, and tie
-  - [x] 1.4 Add "Next Round" and "Quit Match" buttons to controls
+  - [x] 1.4 Add "Next" (round advance/timer skip) and "Quit Match" buttons to controls
   - [x] 1.5 End match after the user-selected win target (5, 10, or 15 points; default 10) or 25 rounds
 - [ ] 2.0 Add Early Quit Functionality
   - [x] 2.1 Trigger quit confirmation when the header logo is clicked


### PR DESCRIPTION
## Summary
- replace "Next Round" and "Skip" with unified "Next" button covering round advance and timer skipping
- align Info Bar accessibility notes with the new Next control

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 4 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6898768c77ac8326abf37df971c7927f