### PR TITLE
test: cover next button skipping

### DIFF
--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -69,4 +69,38 @@ describe("timerService drift handling", () => {
     expect(showMessage).toHaveBeenCalledWith("Waiting…");
     timer.clearAllTimers();
   });
+
+  it("clicking Next during cooldown skips current phase", async () => {
+    vi.resetModules();
+    document.body.innerHTML = "";
+    vi.doMock("../../../src/helpers/setupBattleInfoBar.js", () => ({
+      showMessage: vi.fn(),
+      showTemporaryMessage: () => () => {},
+      showAutoSelect: vi.fn(),
+      clearTimer: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
+      enableNextRoundButton: vi.fn(),
+      disableNextRoundButton: vi.fn(),
+      updateDebugPanel: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/battleEngine.js", () => ({
+      startCoolDown: vi.fn(),
+      stopTimer: vi.fn(),
+      STATS: []
+    }));
+    vi.doMock("../../../src/helpers/classicBattle/runTimerWithDrift.js", () => ({
+      runTimerWithDrift: () => async () => {}
+    }));
+    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const btn = document.createElement("button");
+    btn.id = "next-button";
+    document.body.appendChild(btn);
+    const timerNode = document.createElement("p");
+    timerNode.id = "next-round-timer";
+    document.body.appendChild(timerNode);
+    mod.scheduleNextRound({ matchEnded: false });
+    btn.click();
+    expect(btn.dataset.nextReady).toBe("true");
+  });
 });

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -172,7 +172,7 @@ describe("classicBattlePage simulated opponent mode", () => {
     btn.dispatchEvent(new Event("click", { bubbles: true }));
     next.dispatchEvent(new Event("click", { bubbles: true }));
     expect(handleStatSelection).toHaveBeenCalledTimes(calls);
-    expect(btn.disabled).toBe(true);
+    expect(btn.classList.contains("disabled")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- assert next-button readiness via disabled class
- verify Next skips cooldown phase

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: statReset spec timing out, battle orientation screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689876874d548326a254295463e8804b