### PR TITLE
Start next round after skipping

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -60,7 +60,6 @@ export async function onNextButtonClick() {
   if (!btn) return;
   if (skipHandler) {
     skipCurrentPhase();
-    return;
   }
   if (btn.dataset.nextReady === "true") {
     btn.classList.add("disabled");

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -100,7 +100,9 @@ describe("timerService drift handling", () => {
     timerNode.id = "next-round-timer";
     document.body.appendChild(timerNode);
     mod.scheduleNextRound({ matchEnded: false });
+    window.startRoundOverride = vi.fn();
     btn.click();
-    expect(btn.dataset.nextReady).toBe("true");
+    expect(btn.dataset.nextReady).toBeUndefined();
+    expect(window.startRoundOverride).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Start the next round automatically when skipping cooldown if the button is ready
- Update timerService drift test for new next-round behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npm run check:contrast`
- `npx playwright test playwright/statReset.spec.js` *(fails: waiting for snackbar "Select your move")*

------
https://chatgpt.com/codex/tasks/task_e_68988cdefd348326bda9c39ea20ca5e4