### PR TITLE
refactor: modularize browse helpers

### DIFF
--- a/design/adr/0001-browse-helpers-separation.md
+++ b/design/adr/0001-browse-helpers-separation.md
@@ -1,0 +1,19 @@
+# ADR 0001: Separate Browse Judoka Helpers
+
+## Status
+
+Accepted
+
+## Context
+
+`setupCountryToggle`, `setupCountryFilter`, and the keyboard navigation logic were previously implemented inline in `browseJudokaPage.js`. The shared state (`countriesLoaded` and `allJudoka`) made these helpers harder to test and reuse.
+
+## Decision
+
+Extracted the helpers into dedicated modules under `src/helpers/browse/` and changed data loading to return values instead of mutating outer scope variables.
+
+## Consequences
+
+- Modules can be tested in isolation.
+- State is derived from return values or DOM, avoiding hidden globals.
+- Future browse-related helpers should follow the same separation pattern.

--- a/src/helpers/browse/handleKeyboardNavigation.js
+++ b/src/helpers/browse/handleKeyboardNavigation.js
@@ -1,0 +1,27 @@
+/**
+ * Handle left/right arrow key navigation within a button container.
+ *
+ * @pseudocode
+ * 1. Get all buttons with the specified class in the container.
+ * 2. Find the index of the currently focused button.
+ * 3. If a navigational key (ArrowLeft/ArrowRight) is pressed, prevent default.
+ * 4. Calculate the next index by wrapping around.
+ * 5. Move focus to the button at the next index.
+ *
+ * @param {KeyboardEvent} event
+ * @param {Element} container
+ * @param {string} buttonClass
+ */
+export function handleKeyboardNavigation(event, container, buttonClass) {
+  const buttons = Array.from(container.querySelectorAll(`button.${buttonClass}`));
+  const current = document.activeElement;
+  const index = buttons.indexOf(current);
+  if (index !== -1) {
+    event.preventDefault();
+    const offset = event.key === "ArrowRight" ? 1 : -1;
+    const next = (index + offset + buttons.length) % buttons.length;
+    buttons[next].focus();
+  }
+}
+
+export default handleKeyboardNavigation;

--- a/src/helpers/browse/setupCountryFilter.js
+++ b/src/helpers/browse/setupCountryFilter.js
@@ -1,0 +1,99 @@
+import { toggleCountryPanel } from "../countryPanel.js";
+
+/**
+ * Update selected state on flag buttons.
+ *
+ * @pseudocode
+ * 1. Remove 'selected' class from all flag buttons in the container.
+ * 2. Add 'selected' class to the provided button.
+ *
+ * @param {Element} container
+ * @param {HTMLButtonElement} button
+ */
+function highlightSelection(container, button) {
+  const buttons = container.querySelectorAll("button.flag-button");
+  buttons.forEach((b) => b.classList.remove("selected"));
+  button.classList.add("selected");
+}
+
+/**
+ * Configure country filter interactions for the carousel.
+ *
+ * @pseudocode
+ * 1. Define helper to update aria-live region with count and country.
+ * 2. On clearButton click:
+ *    a. Deselect all country buttons.
+ *    b. Render full judoka list.
+ *    c. Update live region.
+ *    d. Close country panel.
+ * 3. On listContainer click:
+ *    a. If clicked element is a flag button:
+ *       i. Determine selected country.
+ *       ii. Highlight selection.
+ *       iii. Filter judokaList by country.
+ *       iv. Render filtered list.
+ *       v. Update live region.
+ *       vi. Remove any existing no-results message.
+ *       vii. If no results, show 'no-results-message'.
+ *       viii. Close country panel.
+ *
+ * @param {Element} listContainer
+ * @param {HTMLButtonElement} clearButton
+ * @param {Array<Judoka>} judokaList
+ * @param {Function} render
+ * @param {HTMLButtonElement} toggleButton
+ * @param {Element} panel
+ * @param {Element} carouselEl
+ * @param {Element} ariaLiveEl
+ */
+export function setupCountryFilter(
+  listContainer,
+  clearButton,
+  judokaList,
+  render,
+  toggleButton,
+  panel,
+  carouselEl,
+  ariaLiveEl
+) {
+  let liveRegion = ariaLiveEl;
+
+  function updateLiveRegion(count, country) {
+    liveRegion = carouselEl.querySelector(".carousel-aria-live") || liveRegion;
+    liveRegion.textContent = `Showing ${count} judoka for ${country}`;
+  }
+
+  clearButton.addEventListener("click", async () => {
+    const buttons = listContainer.querySelectorAll("button.flag-button");
+    buttons.forEach((b) => b.classList.remove("selected"));
+    await render(judokaList);
+    updateLiveRegion(judokaList.length, "all countries");
+    toggleCountryPanel(toggleButton, panel, false);
+  });
+
+  listContainer.addEventListener("click", async (e) => {
+    const button = e.target.closest("button.flag-button");
+    if (!button) return;
+    const selected = button.value;
+    highlightSelection(listContainer, button);
+    const filtered =
+      selected === "all" ? judokaList : judokaList.filter((j) => j.country === selected);
+    await render(filtered);
+    updateLiveRegion(filtered.length, selected === "all" ? "all countries" : selected);
+    const existingMessage = carouselEl.querySelector(".no-results-message");
+    if (existingMessage) {
+      existingMessage.remove();
+    }
+    if (filtered.length === 0) {
+      const noResultsMessage = document.createElement("div");
+      noResultsMessage.className = "no-results-message";
+      noResultsMessage.setAttribute("role", "status");
+      noResultsMessage.setAttribute("aria-live", "polite");
+      noResultsMessage.textContent = "No judoka available for this country";
+      carouselEl.appendChild(noResultsMessage);
+    }
+    toggleCountryPanel(toggleButton, panel, false);
+  });
+}
+
+export default setupCountryFilter;

--- a/src/helpers/browse/setupCountryToggle.js
+++ b/src/helpers/browse/setupCountryToggle.js
@@ -1,0 +1,46 @@
+import { createCountrySlider } from "../countrySlider.js";
+import { toggleCountryPanel } from "../countryPanel.js";
+import { handleKeyboardNavigation } from "./handleKeyboardNavigation.js";
+
+/**
+ * Set up the country selection panel toggle behavior.
+ *
+ * @pseudocode
+ * 1. On toggleButton click:
+ *    a. Toggle panel open state.
+ *    b. If opening for the first time, initialize country slider.
+ * 2. On panel keydown:
+ *    a. Close panel on 'Escape'.
+ *    b. Navigate slider buttons with ArrowLeft/ArrowRight.
+ * 3. Return a function indicating if countries are loaded.
+ *
+ * @param {HTMLButtonElement} toggleButton
+ * @param {Element} panel
+ * @param {Element} listContainer
+ * @returns {() => boolean} Function returning true when countries are loaded.
+ */
+export function setupCountryToggle(toggleButton, panel, listContainer) {
+  const countriesLoaded = () => listContainer.children.length > 0;
+
+  toggleButton.addEventListener("click", async () => {
+    const wasOpen = panel.classList.contains("open");
+    toggleCountryPanel(toggleButton, panel);
+    if (!wasOpen && !countriesLoaded()) {
+      await createCountrySlider(listContainer);
+    }
+  });
+
+  panel.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      toggleCountryPanel(toggleButton, panel, false);
+    }
+
+    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+      handleKeyboardNavigation(e, listContainer, "flag-button");
+    }
+  });
+
+  return countriesLoaded;
+}
+
+export default setupCountryToggle;

--- a/tests/helpers/browseJudokaPage.test.js
+++ b/tests/helpers/browseJudokaPage.test.js
@@ -3,11 +3,13 @@ import { describe, it, expect, vi } from "vitest";
 describe("browseJudokaPage helpers", () => {
   it("setupCountryToggle toggles panel and loads flags once", async () => {
     const toggleCountryPanel = vi.fn();
-    const createCountrySlider = vi.fn();
-
-    vi.doMock("../../src/helpers/domReady.js", () => ({
-      onDomReady: vi.fn()
-    }));
+    const createCountrySlider = vi.fn(async (container) => {
+      const first = document.createElement("button");
+      first.className = "flag-button";
+      const second = document.createElement("button");
+      second.className = "flag-button";
+      container.append(first, second);
+    });
 
     vi.doMock("../../src/helpers/countryPanel.js", () => ({
       toggleCountryPanel,
@@ -17,29 +19,27 @@ describe("browseJudokaPage helpers", () => {
       createCountrySlider
     }));
 
-    const { setupCountryToggle } = await import("../../src/helpers/browseJudokaPage.js");
+    const { setupCountryToggle } = await import("../../src/helpers/browse/setupCountryToggle.js");
 
     const toggleBtn = document.createElement("button");
     const panel = document.createElement("div");
     const list = document.createElement("div");
-    const first = document.createElement("button");
-    first.className = "flag-button";
-    const second = document.createElement("button");
-    second.className = "flag-button";
-    list.append(first, second);
     document.body.append(toggleBtn, panel, list);
 
-    setupCountryToggle(toggleBtn, panel, list);
+    const countriesLoaded = setupCountryToggle(toggleBtn, panel, list);
 
     toggleBtn.click();
     await Promise.resolve();
     expect(toggleCountryPanel).toHaveBeenCalledWith(toggleBtn, panel);
     expect(createCountrySlider).toHaveBeenCalledTimes(1);
+    expect(countriesLoaded()).toBe(true);
 
     toggleBtn.click();
     await Promise.resolve();
     expect(createCountrySlider).toHaveBeenCalledTimes(1);
 
+    const first = list.querySelectorAll("button.flag-button")[0];
+    const second = list.querySelectorAll("button.flag-button")[1];
     first.focus();
     const arrowEvent = new KeyboardEvent("keydown", { key: "ArrowRight" });
     panel.dispatchEvent(arrowEvent);
@@ -83,16 +83,12 @@ describe("browseJudokaPage helpers", () => {
   it("setupCountryFilter filters judoka and clears selection", async () => {
     const toggleCountryPanel = vi.fn();
 
-    vi.doMock("../../src/helpers/domReady.js", () => ({
-      onDomReady: vi.fn()
-    }));
-
     vi.doMock("../../src/helpers/countryPanel.js", () => ({
       toggleCountryPanel,
       toggleCountryPanelMode: vi.fn()
     }));
 
-    const { setupCountryFilter } = await import("../../src/helpers/browseJudokaPage.js");
+    const { setupCountryFilter } = await import("../../src/helpers/browse/setupCountryFilter.js");
 
     const list = document.createElement("div");
     const allBtn = document.createElement("button");


### PR DESCRIPTION
## Summary
- split browse page toggle and filter helpers into dedicated modules
- load judoka data via return values instead of mutable globals
- document browse helper separation pattern in ADR

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: locator not disabled, orientation screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6898cc385d448326a7c273655d4d53e7