### PR TITLE
refactor battle timer into controller

### DIFF
--- a/design/adr/classic-battle-refactor.md
+++ b/design/adr/classic-battle-refactor.md
@@ -17,6 +17,7 @@ Split the original helper into dedicated modules:
 - `roundManager.js` — handles round setup and timer coordination.
 - `selectionHandler.js` — manages stat selection and evaluation.
 - `quitModal.js` — encapsulates quit confirmation modal creation.
+- `TimerController.js` — centralizes countdown timer logic for rounds and cooldowns.
 
 A lightweight `classicBattle.js` file now re-exports these modules for backward
 compatibility. Page code such as `classicBattlePage.js` imports the new modules

--- a/src/helpers/TimerController.js
+++ b/src/helpers/TimerController.js
@@ -1,0 +1,90 @@
+import { getDefaultTimer, createCountdownTimer } from "./timerUtils.js";
+
+const FALLBACKS = {
+  roundTimer: 30,
+  coolDownTimer: 3
+};
+
+/**
+ * Control countdown timers for battle phases.
+ *
+ * @pseudocode
+ * 1. Maintain internal state: `currentTimer`, `remaining`, `paused`, and callbacks.
+ * 2. `startRound`/`startCoolDown` delegate to a shared `#start` helper that:
+ *    a. Resolves a default duration when none provided, with fallbacks.
+ *    b. Stops any existing timer and resets state.
+ *    c. Creates a countdown timer with `createCountdownTimer`.
+ *    d. Updates `remaining` on each tick and invokes provided callbacks.
+ * 3. `pause` and `resume` update the `paused` flag and forward to the timer.
+ * 4. `stop` halts the active timer and clears it.
+ * 5. `getState` returns `{ remaining, paused }`.
+ */
+export class TimerController {
+  constructor() {
+    this.currentTimer = null;
+    this.remaining = 0;
+    this.paused = false;
+    this.onTickCb = null;
+    this.onExpiredCb = null;
+  }
+
+  async #start(category, onTick, onExpired, duration, pauseOnHidden) {
+    if (duration === undefined) {
+      try {
+        duration = await getDefaultTimer(category);
+      } catch {
+        duration = FALLBACKS[category];
+      }
+      if (typeof duration !== "number") duration = FALLBACKS[category];
+    }
+    this.stop();
+    this.remaining = duration;
+    this.paused = false;
+    this.onTickCb = onTick;
+    this.onExpiredCb = onExpired;
+    this.currentTimer = createCountdownTimer(duration, {
+      onTick: (r) => {
+        this.remaining = r;
+        if (this.onTickCb) this.onTickCb(r);
+      },
+      onExpired: async () => {
+        if (this.onExpiredCb) await this.onExpiredCb();
+      },
+      pauseOnHidden
+    });
+    this.currentTimer.start();
+  }
+
+  startRound(onTick, onExpired, duration) {
+    return this.#start("roundTimer", onTick, onExpired, duration, true);
+  }
+
+  startCoolDown(onTick, onExpired, duration) {
+    return this.#start("coolDownTimer", onTick, onExpired, duration, false);
+  }
+
+  pause() {
+    this.paused = true;
+    if (this.currentTimer) this.currentTimer.pause();
+  }
+
+  resume() {
+    this.paused = false;
+    if (this.currentTimer) this.currentTimer.resume();
+  }
+
+  stop() {
+    if (this.currentTimer) {
+      this.currentTimer.stop();
+      this.currentTimer = null;
+    }
+  }
+
+  getState() {
+    return { remaining: this.remaining, paused: this.paused };
+  }
+
+  hasActiveTimer() {
+    return Boolean(this.currentTimer);
+  }
+}

--- a/tests/helpers/battleEngine.test.js
+++ b/tests/helpers/battleEngine.test.js
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("BattleEngine timer interactions", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("delegates timer control to TimerController", async () => {
+    const startRound = vi.fn();
+    const startCoolDown = vi.fn();
+    const pause = vi.fn();
+    const resume = vi.fn();
+    const getState = vi.fn().mockReturnValue({ remaining: 0, paused: false });
+
+    vi.doMock("../../src/helpers/TimerController.js", () => ({
+      TimerController: vi.fn().mockImplementation(() => ({
+        startRound,
+        startCoolDown,
+        pause,
+        resume,
+        stop: vi.fn(),
+        getState,
+        hasActiveTimer: vi.fn()
+      }))
+    }));
+
+    const {
+      startRound: start,
+      startCoolDown: cool,
+      pauseTimer,
+      resumeTimer,
+      getTimerState
+    } = await import("../../src/helpers/battleEngine.js");
+
+    await start(vi.fn(), vi.fn(), 10);
+    expect(startRound).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), 10);
+
+    await cool(vi.fn(), vi.fn(), 5);
+    expect(startCoolDown).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), 5);
+
+    pauseTimer();
+    expect(pause).toHaveBeenCalled();
+
+    resumeTimer();
+    expect(resume).toHaveBeenCalled();
+
+    expect(getTimerState()).toEqual({ remaining: 0, paused: false });
+  });
+});


### PR DESCRIPTION
## Summary
- add TimerController module for reusable round and cooldown timers
- streamline BattleEngine timer usage and stat selection branching
- cover battle engine timer delegation with new tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: settings screenshot diff, battle orientation, browse judoka nav, responsive contrast)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6898d82421948326a34f17740a529105