### PR TITLE
refactor: modularize vector search page

### DIFF
--- a/design/adr/0002-modular-vector-search.md
+++ b/design/adr/0002-modular-vector-search.md
@@ -1,0 +1,19 @@
+# ADR 0002: Modular Vector Search Page Helpers
+
+## Status
+
+Accepted
+
+## Context
+
+`vectorSearchPage.js` previously contained query setup and result rendering, leading to a large, tightly coupled helper.
+
+## Decision
+
+Extracted `prepareSearchUi`, `getSelectedTags`, and `renderResults` into standalone modules under `src/helpers/vectorSearchPage/`. Introduced a configuration object for score classes to remove branching logic in the results table.
+
+## Consequences
+
+- Smaller helpers are easier to test and reuse.
+- Score thresholds can be adjusted without modifying core logic.
+- Future vector search enhancements can follow this modular structure.

--- a/src/helpers/vectorSearchPage/queryUi.js
+++ b/src/helpers/vectorSearchPage/queryUi.js
@@ -1,0 +1,34 @@
+/**
+ * Prepare DOM elements and query for a new search.
+ *
+ * @pseudocode
+ * 1. Locate the search input, results table body, and message element.
+ * 2. Trim the query value and clear any previous results.
+ * 3. Return the query, tbody reference, and message element.
+ *
+ * @returns {{query: string, tbody: HTMLTableSectionElement|null, messageEl: HTMLElement|null}}
+ */
+export function prepareSearchUi() {
+  const input = document.getElementById("vector-search-input");
+  const table = document.getElementById("vector-results-table");
+  const tbody = table?.querySelector("tbody");
+  const query = input.value.trim();
+  if (tbody) tbody.textContent = "";
+  const messageEl = document.getElementById("search-results-message");
+  return { query, tbody, messageEl };
+}
+
+/**
+ * Return an array containing the selected tag, if any.
+ *
+ * @pseudocode
+ * 1. Read the value from the tag filter dropdown.
+ * 2. When the value is not "all", return it in an array.
+ * 3. Otherwise, return an empty array.
+ *
+ * @returns {string[]}
+ */
+export function getSelectedTags() {
+  const tagSelect = document.getElementById("tag-filter");
+  return tagSelect && tagSelect.value && tagSelect.value !== "all" ? [tagSelect.value] : [];
+}

--- a/src/helpers/vectorSearchPage/renderResults.js
+++ b/src/helpers/vectorSearchPage/renderResults.js
@@ -1,0 +1,76 @@
+import { createSnippetElement } from "../snippetFormatter.js";
+import { formatSourcePath, formatTags } from "../api/vectorSearchPage.js";
+
+export const RESULT_TABLE_CONFIG = {
+  scoreClasses: [
+    { min: 0.8, className: "score-high" },
+    { min: 0.6, className: "score-mid" },
+    { min: 0, className: "score-low" }
+  ]
+};
+
+function buildResultRow(match, queryTerms, isTop) {
+  const row = document.createElement("tr");
+  row.classList.add("search-result-item");
+  if (isTop) row.classList.add("top-match");
+  row.dataset.id = match.id;
+  row.tabIndex = 0;
+  row.setAttribute("aria-expanded", "false");
+
+  const textCell = document.createElement("td");
+  textCell.classList.add("match-text");
+  const snippet = createSnippetElement(match.text, queryTerms);
+  textCell.appendChild(snippet);
+  if (match.qaContext) {
+    const qa = document.createElement("div");
+    qa.classList.add("qa-context", "small-text");
+    qa.textContent = match.qaContext;
+    textCell.appendChild(qa);
+  }
+  const context = document.createElement("div");
+  context.classList.add("result-context", "small-text");
+  context.setAttribute("aria-live", "polite");
+  textCell.appendChild(context);
+
+  const sourceCell = document.createElement("td");
+  sourceCell.appendChild(formatSourcePath(match.source));
+
+  const tagsCell = document.createElement("td");
+  tagsCell.textContent = formatTags(match.tags);
+
+  const scoreCell = document.createElement("td");
+  scoreCell.textContent = match.score.toFixed(2);
+  const scoreClass = RESULT_TABLE_CONFIG.scoreClasses.find((c) => match.score >= c.min)?.className;
+  if (scoreClass) scoreCell.classList.add(scoreClass);
+
+  row.append(textCell, sourceCell, tagsCell, scoreCell);
+  return row;
+}
+
+/**
+ * Render search results into the table body.
+ *
+ * @pseudocode
+ * 1. Iterate over matches to display.
+ * 2. Build a row for each match, marking the first as top match.
+ * 3. Attach click and keyboard handlers to load surrounding context.
+ * 4. Append each row to the results table body.
+ *
+ * @param {HTMLElement} tbody
+ * @param {Array} toRender
+ * @param {string[]} queryTerms
+ * @param {(el: HTMLElement) => void} loadResultContext
+ */
+export function renderResults(tbody, toRender, queryTerms, loadResultContext) {
+  for (const [idx, match] of toRender.entries()) {
+    const row = buildResultRow(match, queryTerms, idx === 0);
+    row.addEventListener("click", () => loadResultContext(row));
+    row.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        loadResultContext(row);
+      }
+    });
+    tbody?.appendChild(row);
+  }
+}

--- a/tests/helpers/vectorSearchPage.test.js
+++ b/tests/helpers/vectorSearchPage.test.js
@@ -372,3 +372,81 @@ describe("synonym expansion", () => {
     expect(findMatches.mock.calls[0][3]).toContain("seoi-nage");
   });
 });
+
+describe("search results", () => {
+  it("renders table rows when matches are found", async () => {
+    const match = {
+      id: "1",
+      text: "lorem ipsum",
+      source: "doc",
+      tags: [],
+      score: 0.9,
+      version: 1
+    };
+    const findMatches = vi.fn().mockResolvedValue([match]);
+    vi.doMock("../../src/helpers/vectorSearch/index.js", () => ({
+      default: {
+        findMatches,
+        fetchContextById: vi.fn(),
+        loadEmbeddings: vi.fn().mockResolvedValue([match]),
+        expandQueryWithSynonyms: vi.fn((q) => q),
+        CURRENT_EMBEDDING_VERSION: 1
+      }
+    }));
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ count: 1, version: 1 })
+    }));
+    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "./" }));
+    const { handleSearch, init } = await import("../../src/helpers/vectorSearchPage.js");
+    const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
+    __setExtractor(async () => ({ data: [0, 0, 0] }));
+    document.body.innerHTML = `
+      <div id="search-spinner"></div>
+      <form id="vector-search-form">
+        <input id="vector-search-input" />
+        <select id="tag-filter"><option value="all">all</option></select>
+      </form>
+      <table id="vector-results-table"><tbody></tbody></table>
+      <p id="search-results-message"></p>
+    `;
+    await init();
+    document.getElementById("vector-search-input").value = "ipsum";
+    await handleSearch(new Event("submit"));
+    expect(document.querySelectorAll("tbody tr").length).toBe(1);
+  });
+
+  it("shows a message when no matches are found", async () => {
+    const findMatches = vi.fn().mockResolvedValue([]);
+    vi.doMock("../../src/helpers/vectorSearch/index.js", () => ({
+      default: {
+        findMatches,
+        fetchContextById: vi.fn(),
+        loadEmbeddings: vi.fn().mockResolvedValue([]),
+        expandQueryWithSynonyms: vi.fn((q) => q),
+        CURRENT_EMBEDDING_VERSION: 1
+      }
+    }));
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ count: 0, version: 1 })
+    }));
+    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "./" }));
+    const { handleSearch, init } = await import("../../src/helpers/vectorSearchPage.js");
+    const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
+    __setExtractor(async () => ({ data: [0, 0, 0] }));
+    document.body.innerHTML = `
+      <div id="search-spinner"></div>
+      <form id="vector-search-form">
+        <input id="vector-search-input" />
+        <select id="tag-filter"><option value="all">all</option></select>
+      </form>
+      <table id="vector-results-table"><tbody></tbody></table>
+      <p id="search-results-message"></p>
+    `;
+    await init();
+    document.getElementById("vector-search-input").value = "test";
+    await handleSearch(new Event("submit"));
+    const msg = document.getElementById("search-results-message");
+    expect(msg.textContent).toContain("No close matches");
+    expect(document.querySelectorAll("tbody tr").length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- split query and tag helpers into `vectorSearchPage` module
- move result rendering to a separate helper with score config
- document modular vector search pattern in a new ADR

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatches)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6898d82eff948326b34c7a81881e2eb0