### PR TITLE
refactor: add random card service

### DIFF
--- a/design/adr/0003-random-card-service.md
+++ b/design/adr/0003-random-card-service.md
@@ -1,0 +1,19 @@
+# ADR 0003: Random Card Service Extraction
+
+## Status
+
+Accepted
+
+## Context
+
+`randomJudokaPage.js` mixed data loading, history state, and DOM updates, making the helper hard to test and reuse.
+
+## Decision
+
+Extracted data preload and history management into `randomCardService.js`. The service returns plain data and exposes a history manager so page helpers handle all DOM rendering.
+
+## Consequences
+
+- Presentation logic is separated from data handling.
+- The service functions are reusable across potential pages that need random card data.
+- History behavior can be unit tested without touching the DOM.

--- a/src/helpers/randomCardService.js
+++ b/src/helpers/randomCardService.js
@@ -1,0 +1,57 @@
+/**
+ * Service utilities for the Random Judoka feature.
+ *
+ * @pseudocode
+ * preloadRandomCardData
+ * 1. Fetch `judoka.json` and `gokyo.json` in parallel.
+ * 2. Return both datasets when successful.
+ * 3. On error, log the issue and return the error for the caller.
+ *
+ * createHistoryManager
+ * 1. Maintain an internal array of recent judoka draws.
+ * 2. `add` prepends a judoka and trims the array to `limit` entries.
+ * 3. `get` returns a shallow copy of the history array.
+ */
+import { fetchJson } from "./dataUtils.js";
+import { DATA_DIR } from "./constants.js";
+
+/**
+ * Preload judoka and gokyo data required for random card generation.
+ *
+ * @returns {Promise<{judokaData: any[]|null, gokyoData: any[]|null, error: Error|null}>}
+ *   Resolves with the datasets or an error when loading fails.
+ */
+export async function preloadRandomCardData() {
+  try {
+    const [judokaData, gokyoData] = await Promise.all([
+      fetchJson(`${DATA_DIR}judoka.json`),
+      fetchJson(`${DATA_DIR}gokyo.json`)
+    ]);
+    return { judokaData, gokyoData, error: null };
+  } catch (error) {
+    console.error("Error preloading data:", error);
+    return { judokaData: null, gokyoData: null, error };
+  }
+}
+
+/**
+ * Create a manager for recent judoka history.
+ *
+ * @param {number} [limit=5] - Maximum history entries to retain.
+ * @returns {{ add: (j: any) => any[], get: () => any[] }}
+ *   Functions to add to and retrieve the history list.
+ */
+export function createHistoryManager(limit = 5) {
+  const history = [];
+  return {
+    add(judoka) {
+      if (!judoka) return history;
+      history.unshift(judoka);
+      if (history.length > limit) history.pop();
+      return history;
+    },
+    get() {
+      return [...history];
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- extract preload and history logic into randomCardService
- handle error fallback and history limit on random judoka page
- document service pattern in ADR 0003

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: settings screenshots)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6898dd217a388326b2e2ffe63802ef11