### PR TITLE
Refactor tooltip viewer helpers

### DIFF
--- a/design/adr/0004-preview-toggle-component.md
+++ b/design/adr/0004-preview-toggle-component.md
@@ -1,0 +1,24 @@
+# ADR 0004: Tooltip Viewer Componentization
+
+## Status
+
+Accepted
+
+## Context
+
+`tooltipViewerPage.js` mixed tooltip list rendering, JSON parse helpers and DOM
+logic for expanding the preview. This made the helper large and difficult to
+test in isolation.
+
+## Decision
+
+Moved JSON parsing and list rendering into `src/helpers/tooltipViewer/` and
+introduced a reusable `PreviewToggle` component to manage preview expansion.
+`tooltipViewerPage.js` now composes these utilities instead of holding the
+implementation details.
+
+## Consequences
+
+- Tooltip viewer logic is smaller and more modular.
+- Preview expansion behaviour can be reused elsewhere.
+- JSON parsing helpers are available for unit testing.

--- a/src/components/PreviewToggle.js
+++ b/src/components/PreviewToggle.js
@@ -1,0 +1,53 @@
+/**
+ * Expandable preview container with a toggle button.
+ *
+ * @pseudocode
+ * 1. Wrap the given element in a `.preview-container` div and insert a toggle button after it.
+ * 2. Clicking the button toggles an `expanded` class and updates `aria-expanded` and label text.
+ * 3. Hide the button when the content height is 300px or less.
+ * 4. Expose `update()` to recompute button visibility and `reset()` to collapse the view.
+ */
+export class PreviewToggle {
+  /**
+   * @param {HTMLElement} previewEl - Element containing preview content.
+   */
+  constructor(previewEl) {
+    this.previewEl = previewEl;
+    this.container = document.createElement("div");
+    this.container.className = "preview-container";
+    previewEl.parentNode?.insertBefore(this.container, previewEl);
+    this.container.appendChild(previewEl);
+
+    this.button = document.createElement("button");
+    this.button.id = "toggle-preview-btn";
+    this.button.className = "secondary-button preview-toggle";
+    this.button.type = "button";
+    this.button.textContent = "Expand";
+    this.button.setAttribute("aria-expanded", "false");
+    this.container.after(this.button);
+
+    this.expanded = false;
+    this.button.addEventListener("click", () => this.toggle());
+    this.update();
+  }
+
+  toggle() {
+    this.expanded = !this.expanded;
+    this.container.classList.toggle("expanded", this.expanded);
+    this.button.textContent = this.expanded ? "Collapse" : "Expand";
+    this.button.setAttribute("aria-expanded", String(this.expanded));
+  }
+
+  update() {
+    const needsToggle = this.previewEl.scrollHeight > 300;
+    this.button.hidden = !needsToggle;
+    if (!needsToggle) this.reset();
+  }
+
+  reset() {
+    this.expanded = false;
+    this.container.classList.remove("expanded");
+    this.button.setAttribute("aria-expanded", "false");
+    this.button.textContent = "Expand";
+  }
+}

--- a/src/helpers/tooltipViewer/extractLineAndColumn.js
+++ b/src/helpers/tooltipViewer/extractLineAndColumn.js
@@ -1,0 +1,32 @@
+/**
+ * Extract line and column numbers from a JSON parse error.
+ *
+ * @pseudocode
+ * 1. Run a regex on `error.message` to capture `line` and `column` digits.
+ * 2. When both numbers exist, return them as an object.
+ * 3. Otherwise, attempt to parse a position and return it as `column`.
+ * 4. If no numbers can be found, return `null`.
+ *
+ * @param {SyntaxError} error - SyntaxError thrown during JSON parsing.
+ * @returns {{ line: number|null, column: number|null } | null} Parsed line/column or `null`.
+ */
+export function extractLineAndColumn(error) {
+  const message = error?.message ?? "";
+  let match = /line (\d+)[^\d]+column (\d+)/i.exec(message);
+  if (match) {
+    return { line: Number(match[1]), column: Number(match[2]) };
+  }
+  match = /at line (\d+)[^\d]+column (\d+)/i.exec(message);
+  if (match) {
+    return { line: Number(match[1]), column: Number(match[2]) };
+  }
+  match = /at position (\d+)/i.exec(message);
+  if (match) {
+    return { line: null, column: Number(match[1]) };
+  }
+  match = /in JSON at position (\d+)/i.exec(message);
+  if (match) {
+    return { line: null, column: Number(match[1]) };
+  }
+  return null;
+}

--- a/src/helpers/tooltipViewer/renderList.js
+++ b/src/helpers/tooltipViewer/renderList.js
@@ -1,0 +1,76 @@
+import { parseTooltipText } from "../tooltip.js";
+import { SidebarList } from "../../components/SidebarList.js";
+
+export const INVALID_TOOLTIP_MSG = "Empty or whitespace-only content";
+export const MALFORMED_TOOLTIP_MSG = "Unbalanced markup detected";
+export const INVALID_KEY_MSG = "Invalid key format (prefix.name)";
+const KEY_PATTERN = /^[a-z]+\.[\w-]+$/;
+
+/**
+ * Render a list of tooltip entries filtered by search terms.
+ *
+ * @pseudocode
+ * 1. Build an array of list item configs from matching tooltip entries.
+ * 2. Use {@link SidebarList} to create a list and wire selection to `select`.
+ * 3. Append a warning icon and screen-reader text for invalid or malformed entries.
+ * 4. Replace the previous list element and return the new element and select binding.
+ *
+ * @param {Record<string,string>} data - Flattened tooltips map.
+ * @param {string} filter - Search filter string.
+ * @param {(key: string) => void} select - Callback when an item is selected.
+ * @param {HTMLElement} listPlaceholder - Current list element to replace.
+ * @returns {{ element: HTMLElement, listSelect: (index: number) => void }}
+ */
+export function renderList(data, filter, select, listPlaceholder) {
+  const items = [];
+  const terms = filter.toLowerCase().split(/\s+/).filter(Boolean);
+  Object.entries(data).forEach(([key, body]) => {
+    const haystack = `${key} ${body}`.toLowerCase();
+    const match = terms.every((t) => haystack.includes(t));
+    if (match) {
+      const bodyValid = typeof body === "string" && body.trim().length > 0;
+      const keyValid = KEY_PATTERN.test(key);
+      const valid = bodyValid && keyValid;
+      const { warning } = parseTooltipText(body);
+      const prefix = key.split(".")[0];
+      items.push({
+        label: key,
+        className: prefix,
+        dataset: {
+          key,
+          body,
+          valid: String(valid),
+          warning: String(warning),
+          keyValid: String(keyValid)
+        }
+      });
+    }
+  });
+  const list = new SidebarList(items, (_, el) => {
+    select(el.dataset.key);
+  });
+  Array.from(list.element.children).forEach((li) => {
+    let message = null;
+    if (li.dataset.keyValid === "false") {
+      message = INVALID_KEY_MSG;
+    } else if (li.dataset.valid === "false") {
+      message = INVALID_TOOLTIP_MSG;
+    } else if (li.dataset.warning === "true") {
+      message = MALFORMED_TOOLTIP_MSG;
+    }
+    if (message) {
+      const icon = document.createElement("span");
+      icon.className = "tooltip-invalid-icon";
+      icon.textContent = "!";
+      icon.title = message;
+      icon.setAttribute("aria-hidden", "true");
+      const sr = document.createElement("span");
+      sr.className = "tooltip-invalid-text";
+      sr.textContent = message;
+      li.append(" ", icon, sr);
+    }
+  });
+  list.element.id = "tooltip-list";
+  if (listPlaceholder) listPlaceholder.replaceWith(list.element);
+  return { element: list.element, listSelect: list.select.bind(list) };
+}


### PR DESCRIPTION
## Summary
- modularize tooltip viewer JSON parsing and list rendering
- add reusable PreviewToggle component for expandable preview
- extend tooltip viewer tests for copy buttons and invalid keys
- document component extraction in ADR 0004

## Testing
- `npx prettier src/components/PreviewToggle.js src/helpers/tooltipViewerPage.js src/helpers/tooltipViewer/extractLineAndColumn.js src/helpers/tooltipViewer/renderList.js tests/helpers/tooltipViewerPage.test.js design/adr/0004-preview-toggle-component.md --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: browse-judoka navigation, responsive high-contrast toggle, settings screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6898e57beb608326a0c745c411f2c4de