### PR TITLE
Refactor card builder with section registry and inspector helper

### DIFF
--- a/design/adr/0005-card-section-registry.md
+++ b/design/adr/0005-card-section-registry.md
@@ -1,0 +1,19 @@
+# ADR 0005: Card Section Registry
+
+## Status
+
+Accepted
+
+## Context
+
+`generateJudokaCardHTML` appended card sections one-by-one, duplicating logic and making future section ordering changes error-prone.
+
+## Decision
+
+Introduced a data-driven registry in `cardSections.js`. Each entry builds a card section, and `generateJudokaCardHTML` iterates over the registry to append sections. The inspector panel was extracted to `src/helpers/inspector/` for clearer ownership.
+
+## Consequences
+
+- Section order and composition can be adjusted by editing the registry.
+- Card assembly logic is simplified and easier to extend.
+- Inspector utilities are isolated, improving reuse.

--- a/playwright/card-inspector-accessibility.spec.js
+++ b/playwright/card-inspector-accessibility.spec.js
@@ -16,7 +16,9 @@ const JUDOKA = {
 test.describe.parallel("Card inspector accessibility", () => {
   test("summary keyboard support and ARIA state", async ({ page }) => {
     await page.setContent("<html><body></body></html>");
-    const { createInspectorPanel } = await import("../src/helpers/cardBuilder.js");
+    const { createInspectorPanel } = await import(
+      "../src/helpers/inspector/createInspectorPanel.js"
+    );
     const func = createInspectorPanel.toString();
     await page.evaluate(
       ({ judoka, funcStr }) => {
@@ -46,7 +48,9 @@ test.describe.parallel("Card inspector accessibility", () => {
 
   test("announces invalid card data on JSON failure", async ({ page }) => {
     await page.setContent("<html><body></body></html>");
-    const { createInspectorPanel } = await import("../src/helpers/cardBuilder.js");
+    const { createInspectorPanel } = await import(
+      "../src/helpers/inspector/createInspectorPanel.js"
+    );
     const func = createInspectorPanel.toString();
     await page.evaluate(
       ({ funcStr }) => {

--- a/src/components/JudokaCard.js
+++ b/src/components/JudokaCard.js
@@ -8,7 +8,7 @@ import {
   createStatsSection,
   createSignatureMoveSection
 } from "../helpers/cardSections.js";
-import { createInspectorPanel } from "../helpers/cardBuilder.js";
+import { createInspectorPanel } from "../helpers/inspector/createInspectorPanel.js";
 import { Card } from "./Card.js";
 
 /**

--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -1,13 +1,9 @@
 import { getFlagUrl } from "./country/codes.js";
-import { generateCardTopBar, createNoDataContainer } from "./cardTopBar.js";
 import { safeGenerate } from "./errorUtils.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
 import { enableCardFlip } from "./cardFlip.js";
-import {
-  createPortraitSection,
-  createStatsSection,
-  createSignatureMoveSection
-} from "./cardSections.js";
+import { cardSectionRegistry } from "./cardSections.js";
+import { createInspectorPanel } from "./inspector/createInspectorPanel.js";
 
 /**
  * Generates the "last updated" HTML for a judoka card.
@@ -36,126 +32,17 @@ import {
 // }
 
 /**
- * Generates the complete DOM structure for a judoka card.
+ * Build and return a DOM container for a judoka card.
  *
  * @pseudocode
- * 1. Validate the `judoka` object:
- *    - Ensure all required fields are present using `hasRequiredJudokaFields`.
- *
- * 2. Generate the flag URL:
- *    - Call `safeGenerate` with `getFlagUrl` and the `countryCode`.
- *    - Default to "vu" if `countryCode` is missing.
- *    - Fallback to the Vanuatu flag when an error occurs.
- *
- * 3. Determine the card type:
- *    - Use the `rarity` field to set the card type (e.g., "common").
- *
- * 4. Create the main card container:
- *    - Initialize a `<div>` with the class `card-container`.
- *    - Create a child `<div>` with the class `judoka-card` and card type.
- *
- * 5. Add gender-specific styling:
- *    - Add a class based on the `gender` field ("female-card" or "male-card").
- *
- * 6. Append the top bar:
- *    - Generate the top bar using `generateCardTopBar` and append it.
- *    - If generation fails, append a "No data available" container instead.
- *
- * 7. Append the portrait section:
- *    - Generate portrait HTML using `generateCardPortrait`.
- *    - If generation fails, append a "No data available" container.
- *    - Add weight class information to the portrait section.
- *
- * 8. Append the stats section:
- *    - Build the stats panel using `createStatsPanel` and append it.
- *    - If generation fails, append an empty stats container.
- *
- * 9. Append the signature move section:
- *    - Generate signature move HTML using `generateCardSignatureMove` and append it.
- *    - If generation fails, append an empty signature move container.
- *
- * 10. Enable card interactivity:
- *    - Attach click and keyboard handlers to toggle `.show-card-back`.
- *
- * 11. Return the complete card container:
- *    - Append the `judoka-card` to the `card-container`.
- *
- * @param {Object} judoka - The judoka object containing data for the card.
- * @param {Object} gokyo - The Gokyo data (technique information).
- * @returns {HTMLElement} The DOM element for the complete judoka card.
- */
-async function createTopBar(judoka, flagUrl) {
-  return await safeGenerate(
-    () => generateCardTopBar(judoka, flagUrl),
-    "Failed to generate top bar:",
-    createNoDataContainer()
-  );
-}
-
-function createInspectorPanel(container, judoka) {
-  let json;
-  try {
-    json = JSON.stringify(judoka, null, 2);
-  } catch {
-    const p = document.createElement("p");
-    p.textContent = "Invalid card data";
-    return p;
-  }
-
-  const panel = document.createElement("details");
-  panel.className = "debug-panel";
-  panel.setAttribute("aria-label", "Inspector panel");
-
-  const summary = document.createElement("summary");
-  summary.textContent = "Card Inspector";
-  summary.tabIndex = 0;
-  summary.style.minHeight = "44px";
-  summary.style.minWidth = "44px";
-  summary.style.display = "flex";
-  summary.style.alignItems = "center";
-  summary.style.outline = "2px solid transparent";
-  summary.style.outlineOffset = "2px";
-  summary.addEventListener("focus", () => {
-    summary.style.outlineColor = "#000";
-  });
-  summary.addEventListener("blur", () => {
-    summary.style.outlineColor = "transparent";
-  });
-  summary.addEventListener("keydown", (e) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      panel.open = !panel.open;
-      panel.dispatchEvent(new Event("toggle"));
-    }
-  });
-  panel.appendChild(summary);
-
-  const jsonPre = document.createElement("pre");
-  jsonPre.textContent = json;
-  panel.appendChild(jsonPre);
-
-  // Only show the card's JSON data. The markup preview was removed to
-  // keep the inspector output concise.
-
-  function updateDataset() {
-    summary.setAttribute("aria-expanded", panel.open ? "true" : "false");
-    if (panel.open) {
-      container.dataset.inspector = "true";
-    } else {
-      container.removeAttribute("data-inspector");
-    }
-  }
-
-  panel.addEventListener("toggle", updateDataset);
-  updateDataset();
-
-  return panel;
-}
-
-export { createInspectorPanel };
-
-/**
- * Build and return a DOM container for a judoka card.
+ * 1. Validate `judoka` and `gokyoLookup`:
+ *    - Throw when required fields are missing.
+ * 2. Resolve the flag URL via `safeGenerate(getFlagUrl)`.
+ * 3. Create container and inner card elements and apply gender styling.
+ * 4. For each builder in `cardSectionRegistry`, generate and append the section.
+ * 5. Enable flip interactivity with `enableCardFlip`.
+ * 6. Append an inspector panel when `enableInspector` is true.
+ * 7. Return the populated container.
  *
  * Validates the judoka data and gokyo lookup, generates DOM sections for the card, and assembles them into a single container. When either argument is missing, a fallback element labeled "No data available" is returned.
  *
@@ -203,17 +90,10 @@ export async function generateJudokaCardHTML(judoka, gokyoLookup, options = {}) 
   const genderClass = judoka.gender === "female" ? "female-card" : "male-card";
   judokaCard.classList.add(genderClass);
 
-  const topBarElement = await createTopBar(judoka, flagUrl);
-  judokaCard.appendChild(topBarElement);
-
-  const portraitElement = createPortraitSection(judoka);
-  judokaCard.appendChild(portraitElement);
-
-  const statsElement = await createStatsSection(judoka, cardType);
-  judokaCard.appendChild(statsElement);
-
-  const signatureMoveElement = createSignatureMoveSection(judoka, gokyoLookup, cardType);
-  judokaCard.appendChild(signatureMoveElement);
+  for (const buildSection of cardSectionRegistry) {
+    const section = await buildSection(judoka, { flagUrl, gokyoLookup, cardType });
+    judokaCard.appendChild(section);
+  }
 
   enableCardFlip(judokaCard);
 

--- a/src/helpers/cardSections.js
+++ b/src/helpers/cardSections.js
@@ -3,7 +3,28 @@ import {
   generateCardSignatureMove,
   generateCardStats
 } from "./cardRender.js";
-import { createNoDataContainer } from "./cardTopBar.js";
+import { generateCardTopBar, createNoDataContainer } from "./cardTopBar.js";
+import { safeGenerate } from "./errorUtils.js";
+
+/**
+ * Build the top bar section for a judoka card.
+ *
+ * @pseudocode
+ * 1. Generate the top bar with `safeGenerate(generateCardTopBar)`.
+ *    - On failure, return `createNoDataContainer()`.
+ * 2. Return the resulting element.
+ *
+ * @param {import("./types.js").Judoka} judoka - Judoka data object.
+ * @param {string} flagUrl - URL of the country flag.
+ * @returns {Promise<HTMLElement>} Top bar element.
+ */
+export async function createTopBarSection(judoka, flagUrl) {
+  return await safeGenerate(
+    () => generateCardTopBar(judoka, flagUrl),
+    "Failed to generate top bar:",
+    createNoDataContainer()
+  );
+}
 
 /**
  * Build the portrait section for a judoka card.
@@ -83,3 +104,10 @@ export function createSignatureMoveSection(judoka, gokyoLookup, cardType) {
     return createNoDataContainer();
   }
 }
+
+export const cardSectionRegistry = [
+  async (judoka, { flagUrl }) => await createTopBarSection(judoka, flagUrl),
+  (judoka) => createPortraitSection(judoka),
+  async (judoka, { cardType }) => await createStatsSection(judoka, cardType),
+  (judoka, { gokyoLookup, cardType }) => createSignatureMoveSection(judoka, gokyoLookup, cardType)
+];

--- a/src/helpers/cardUtils.js
+++ b/src/helpers/cardUtils.js
@@ -1,4 +1,4 @@
-import { createInspectorPanel } from "./cardBuilder.js";
+import { createInspectorPanel } from "./inspector/createInspectorPanel.js";
 import { debugLog } from "./debug.js";
 import { seededRandom } from "./testModeUtils.js";
 import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";

--- a/src/helpers/inspector/createInspectorPanel.js
+++ b/src/helpers/inspector/createInspectorPanel.js
@@ -1,0 +1,74 @@
+/**
+ * Build an expandable inspector panel showing the judoka JSON.
+ *
+ * @pseudocode
+ * 1. Attempt to serialize `judoka` to formatted JSON.
+ *    - If serialization fails, return a paragraph with "Invalid card data".
+ * 2. Create a `<details>` element with class `debug-panel` and accessible summary.
+ * 3. Append a `<pre>` element containing the JSON string.
+ * 4. On toggle, set `container.dataset.inspector` when open and remove it when closed.
+ * 5. Return the `<details>` panel.
+ *
+ * @param {HTMLElement} container - Card container element.
+ * @param {object} judoka - Judoka data to display.
+ * @returns {HTMLElement} Inspector panel element.
+ */
+export function createInspectorPanel(container, judoka) {
+  let json;
+  try {
+    json = JSON.stringify(judoka, null, 2);
+  } catch {
+    const p = document.createElement("p");
+    p.textContent = "Invalid card data";
+    return p;
+  }
+
+  const panel = document.createElement("details");
+  panel.className = "debug-panel";
+  panel.setAttribute("aria-label", "Inspector panel");
+
+  const summary = document.createElement("summary");
+  summary.textContent = "Card Inspector";
+  summary.tabIndex = 0;
+  summary.style.minHeight = "44px";
+  summary.style.minWidth = "44px";
+  summary.style.display = "flex";
+  summary.style.alignItems = "center";
+  summary.style.outline = "2px solid transparent";
+  summary.style.outlineOffset = "2px";
+  summary.addEventListener("focus", () => {
+    summary.style.outlineColor = "#000";
+  });
+  summary.addEventListener("blur", () => {
+    summary.style.outlineColor = "transparent";
+  });
+  summary.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      panel.open = !panel.open;
+      panel.dispatchEvent(new Event("toggle"));
+    }
+  });
+  panel.appendChild(summary);
+
+  const jsonPre = document.createElement("pre");
+  jsonPre.textContent = json;
+  panel.appendChild(jsonPre);
+
+  // Only show the card's JSON data. The markup preview was removed to
+  // keep the inspector output concise.
+
+  function updateDataset() {
+    summary.setAttribute("aria-expanded", panel.open ? "true" : "false");
+    if (panel.open) {
+      container.dataset.inspector = "true";
+    } else {
+      container.removeAttribute("data-inspector");
+    }
+  }
+
+  panel.addEventListener("toggle", updateDataset);
+  updateDataset();
+
+  return panel;
+}

--- a/tests/helpers/cardBuilder.test.js
+++ b/tests/helpers/cardBuilder.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { generateJudokaCardHTML } from "../../src/helpers/cardBuilder.js";
+
+const VALID_JUDOKA = {
+  id: 1,
+  firstname: "Jane",
+  surname: "Doe",
+  country: "USA",
+  countryCode: "us",
+  stats: { power: 5, speed: 5, technique: 5, kumikata: 5, newaza: 5 },
+  weightClass: "-63kg",
+  signatureMoveId: 1,
+  rarity: "common",
+  gender: "female"
+};
+
+const GOKYO_LOOKUP = { 1: { id: 1, name: "Ouchi-gari" } };
+
+describe("generateJudokaCardHTML", () => {
+  it("throws error when required fields are missing", async () => {
+    const incomplete = { ...VALID_JUDOKA };
+    delete incomplete.countryCode;
+    await expect(generateJudokaCardHTML(incomplete, GOKYO_LOOKUP)).rejects.toThrow(
+      /Missing required fields/
+    );
+  });
+
+  it("toggles inspector dataset on panel toggle", async () => {
+    const container = await generateJudokaCardHTML(VALID_JUDOKA, GOKYO_LOOKUP, {
+      enableInspector: true
+    });
+    const panel = container.querySelector(".debug-panel");
+    expect(panel).toBeTruthy();
+    expect(container.dataset.inspector).toBeUndefined();
+    panel.open = true;
+    panel.dispatchEvent(new Event("toggle"));
+    expect(container.dataset.inspector).toBe("true");
+    panel.open = false;
+    panel.dispatchEvent(new Event("toggle"));
+    expect(container.dataset.inspector).toBeUndefined();
+  });
+});

--- a/tests/helpers/createInspectorPanel.test.js
+++ b/tests/helpers/createInspectorPanel.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createInspectorPanel } from "../../src/helpers/cardBuilder.js";
+import { createInspectorPanel } from "../../src/helpers/inspector/createInspectorPanel.js";
 
 const judoka = {};
 


### PR DESCRIPTION
## Summary
- move inspector panel builder to dedicated `src/helpers/inspector/createInspectorPanel.js`
- drive card assembly via `cardSectionRegistry` to avoid sequential appends
- test card builder error handling and inspector toggle behavior
- document section registry design in ADR 0005

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle orientation screenshots, Battle Judoka page, Responsive scenarios, Settings screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6898e9847c188326b5105bb74b3ffb22