### PR TITLE
feat: extract test stats script

### DIFF
--- a/.github/workflows/playwrightBaseline.yml
+++ b/.github/workflows/playwrightBaseline.yml
@@ -52,37 +52,10 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-      # 🧮 Collect Test Suite Stats
-      - name: Get Test Suite Stats
+      # 🧮 Collect Test Suite Stats and Roll Dice
+      - name: Collect Test Suite Stats
         id: stats
-        run: |
-          SNAPSHOTS=$(find test-results -type f -name "*.png" 2>/dev/null | wc -l)
-          PLAYWRIGHT_TESTS=$(find playwright -type f \( -name "*.spec.js" -o -name "*.spec.ts" \) | wc -l)
-          VITEST_TESTS=$(find tests -type f \( -name "*.test.js" -o -name "*.spec.js" -o -name "*.test.ts" -o -name "*.spec.ts" \) | wc -l)
-          TESTFILES=$((PLAYWRIGHT_TESTS + VITEST_TESTS))
-
-          TESTCASES=$(grep -rE "test\\(|it\\(" tests playwright --include="*.js" --include="*.ts" | wc -l)
-          UPDATED_SNAPSHOTS=$(git diff --name-only | grep -E 'test-results/.+\.png$' | wc -l)
-
-          echo "snapshots=$SNAPSHOTS" >> $GITHUB_OUTPUT
-          echo "testfiles=$TESTFILES" >> $GITHUB_OUTPUT
-          echo "testcases=$TESTCASES" >> $GITHUB_OUTPUT
-          echo "updated=$UPDATED_SNAPSHOTS" >> $GITHUB_OUTPUT
-
-      # 🎲 Random Dice Roll
-      - name: Generate Judo Throw Dice Roll
-        id: dice
-        run: |
-          DICE=$(( RANDOM % 6 + 1 ))
-          case $DICE in
-            1) MOOD="🎲 Roll: 1 — *Seoi Nage* lightning strike! ⚡️ Shoulder throw supremacy." ;;
-            2) MOOD="🎲 Roll: 2 — *Osoto Gari* sweep! 🌪 The ground says hello." ;;
-            3) MOOD="🎲 Roll: 3 — *Uchi Mata* whirl! 🌀 You’re airborne now." ;;
-            4) MOOD="🎲 Roll: 4 — *Harai Goshi* slash! 🌊 A clean hip-and-leg combo." ;;
-            5) MOOD="🎲 Roll: 5 — *Tai Otoshi* drop! 💥 Straight to the tatami." ;;
-            6) MOOD="🎲 Roll: 6 — *Kouchi Gari* trip! 🎯 Small but deadly." ;;
-          esac
-          echo "mood=$MOOD" >> $GITHUB_OUTPUT
+        run: node scripts/collectTestStats.mjs
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
@@ -102,7 +75,7 @@ jobs:
             - 🖋️ Snapshots updated in this PR: ${{ steps.stats.outputs.updated }}
 
             **Let The Die Roll!**
-            ${{ steps.dice.outputs.mood }}
+            ${{ steps.stats.outputs.mood }}
           branch: ${{ env.BRANCH_NAME }}
           labels: |
             automated

--- a/design/adr/0006-workflow-simplification-node-script.md
+++ b/design/adr/0006-workflow-simplification-node-script.md
@@ -1,0 +1,26 @@
+# ADR 0006: Node Script for Test Stats and Dice Roll
+
+## Status
+
+Accepted
+
+## Context
+
+The Playwright baseline workflow used long inline Bash blocks to gather test
+statistics and generate a random "judo throw" message. The logic was hard to
+reuse and difficult to test.
+
+## Decision
+
+Moved stats gathering and dice-roll logic into `scripts/collectTestStats.mjs`.
+The workflow now invokes `node scripts/collectTestStats.mjs` and reads the
+outputs. This script is unit tested and can be reused in other workflows. We
+considered extracting the repeated setup steps of the workflow into a composite
+action but deferred until more workflows need the same setup.
+
+## Consequences
+
+- Workflow YAML is shorter and easier to maintain.
+- Test stats and dice-roll logic are reusable across workflows.
+- Future consolidation of setup steps can use the shared script as a building
+  block.

--- a/scripts/collectTestStats.mjs
+++ b/scripts/collectTestStats.mjs
@@ -1,0 +1,98 @@
+/* eslint-env node */
+/**
+ * Collect test statistics and generate a random judo throw message.
+ *
+ * @pseudocode
+ * 1. Count snapshot PNGs and test files.
+ * 2. Count Vitest and Playwright test cases.
+ * 3. Get changed snapshot files from git.
+ * 4. Roll a six-sided die to select a judo throw message.
+ * 5. Write all results to `$GITHUB_OUTPUT` for workflow consumption.
+ */
+import { glob } from "glob";
+import { readFile, appendFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+function defaultExec(cmd, options) {
+  return execSync(cmd, { encoding: "utf8", ...options }).trim();
+}
+
+/**
+ * Collect stats for tests and snapshots within a project directory.
+ *
+ * @pseudocode
+ * 1. Count snapshot images in `test-results/`.
+ * 2. Count Playwright and Vitest test files.
+ * 3. Scan test source files for `test(` or `it(` invocations.
+ * 4. Use `git diff` to count updated snapshots.
+ * 5. Return all collected counts.
+ *
+ * @param {string} [root=process.cwd()] - Directory to search.
+ * @param {(cmd: string, options?: object) => string} [execFn=defaultExec] - Function to execute shell commands.
+ * @returns {Promise<{snapshots:number, testfiles:number, testcases:number, updated:number}>}
+ */
+export async function collectTestStats(root = process.cwd(), execFn = defaultExec) {
+  const snapshots = (await glob("test-results/**/*.png", { cwd: root })).length;
+  const playwrightTests = (await glob("playwright/**/*.spec.@(js|ts)", { cwd: root })).length;
+  const vitestTests = (await glob("tests/**/*.{test,spec}.@(js|ts)", { cwd: root })).length;
+  const testfiles = playwrightTests + vitestTests;
+
+  const sourceFiles = await glob(["tests/**/*.@(js|ts)", "playwright/**/*.@(js|ts)"], {
+    cwd: root
+  });
+  let testcases = 0;
+  for (const file of sourceFiles) {
+    const content = await readFile(path.join(root, file), "utf8");
+    testcases += (content.match(/\b(?:test|it)\s*\(/g) || []).length;
+  }
+
+  const diff = execFn("git diff --name-only", { cwd: root });
+  const updated = diff.split("\n").filter((f) => /^test-results\/.*\.png$/.test(f.trim())).length;
+
+  return { snapshots, testfiles, testcases, updated };
+}
+
+const moods = {
+  1: "🎲 Roll: 1 — *Seoi Nage* lightning strike! ⚡️ Shoulder throw supremacy.",
+  2: "🎲 Roll: 2 — *Osoto Gari* sweep! 🌪 The ground says hello.",
+  3: "🎲 Roll: 3 — *Uchi Mata* whirl! 🌀 You’re airborne now.",
+  4: "🎲 Roll: 4 — *Harai Goshi* slash! 🌊 A clean hip-and-leg combo.",
+  5: "🎲 Roll: 5 — *Tai Otoshi* drop! 💥 Straight to the tatami.",
+  6: "🎲 Roll: 6 — *Kouchi Gari* trip! 🎯 Small but deadly."
+};
+
+/**
+ * Roll a six-sided die and return a judo throw description.
+ *
+ * @pseudocode
+ * 1. Generate a random integer from 1 to 6.
+ * 2. Map the number to a predefined judo throw message.
+ * 3. Return the selected message.
+ *
+ * @param {() => number} [rand=Math.random] - Random number generator.
+ * @returns {string}
+ */
+export function rollDice(rand = Math.random) {
+  const value = Math.floor(rand() * 6) + 1;
+  return moods[value];
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const stats = await collectTestStats();
+  const mood = rollDice();
+  const lines = [
+    `snapshots=${stats.snapshots}`,
+    `testfiles=${stats.testfiles}`,
+    `testcases=${stats.testcases}`,
+    `updated=${stats.updated}`,
+    `mood=${mood}`
+  ];
+  const output = process.env.GITHUB_OUTPUT;
+  if (output) {
+    await appendFile(output, lines.join("\n") + "\n");
+  } else {
+    console.log(lines.join("\n"));
+  }
+}

--- a/tests/scripts/collectTestStats.test.js
+++ b/tests/scripts/collectTestStats.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { collectTestStats, rollDice } from "../../scripts/collectTestStats.mjs";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+async function setupTempProject() {
+  const root = await mkdtemp(path.join(tmpdir(), "stats-"));
+  await mkdir(path.join(root, "test-results"), { recursive: true });
+  await writeFile(path.join(root, "test-results", "a.png"), "");
+  await writeFile(path.join(root, "test-results", "b.png"), "");
+  await mkdir(path.join(root, "playwright"), { recursive: true });
+  await writeFile(path.join(root, "playwright", "a.spec.js"), "test('a', () => {})");
+  await writeFile(path.join(root, "playwright", "b.spec.ts"), "it('b', () => {})");
+  await mkdir(path.join(root, "tests"), { recursive: true });
+  await writeFile(
+    path.join(root, "tests", "c.test.js"),
+    "test('c1', () => {}); it('c2', () => {})"
+  );
+  return root;
+}
+
+describe("rollDice", () => {
+  it("maps random values to judo throws", () => {
+    const results = [0, 0.2, 0.4, 0.6, 0.8, 0.99].map((n) => rollDice(() => n));
+    expect(results).toEqual([
+      "🎲 Roll: 1 — *Seoi Nage* lightning strike! ⚡️ Shoulder throw supremacy.",
+      "🎲 Roll: 2 — *Osoto Gari* sweep! 🌪 The ground says hello.",
+      "🎲 Roll: 3 — *Uchi Mata* whirl! 🌀 You’re airborne now.",
+      "🎲 Roll: 4 — *Harai Goshi* slash! 🌊 A clean hip-and-leg combo.",
+      "🎲 Roll: 5 — *Tai Otoshi* drop! 💥 Straight to the tatami.",
+      "🎲 Roll: 6 — *Kouchi Gari* trip! 🎯 Small but deadly."
+    ]);
+  });
+});
+
+describe("collectTestStats", () => {
+  it("counts files, cases and updated snapshots", async () => {
+    const root = await setupTempProject();
+    const stats = await collectTestStats(root, () => "test-results/a.png\ntest-results/b.png\n");
+    expect(stats).toEqual({
+      snapshots: 2,
+      testfiles: 3,
+      testcases: 4,
+      updated: 2
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace inline bash in Playwright baseline workflow with `collectTestStats.mjs`
- add unit tests for stats script
- record workflow simplification in ADR

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 3 tests)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_6898f3584d248326bb99375f14f927e1