### PR TITLE
Document post-round countdown flow in PRD

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -311,7 +311,7 @@ flowchart TD
 - After selection, the correct comparison is made, and the score updates based on round outcome.
 - After the player selects a stat, the Info Bar shows "Opponent is choosing..." until the opponent's stat is revealed.
 - If the selected stats are equal, a tie message displays and the round ends.
-- Cooldown timer to enable the next round starts only after round results are shown.
+- After round results, there is a brief (~2s) pause before a 3s countdown is displayed via snackbar (`Next round in: Xs`). The **Next** button becomes active once the countdown ends or when skipped. Reference [timerService.js](../../src/helpers/classicBattle/timerService.js) for exact durations to keep design and code aligned.
 - After the match ends, a modal appears showing the final result and score with **Quit Match** and **Next Match** buttons; **Quit Match** exits to the main menu and **Next Match** starts a new match.
 - Player can quit mid-match; confirmation prompt appears; if confirmed, match ends with player loss recorded.
 - After confirming the quit action, the player is returned to the main menu (index.html).


### PR DESCRIPTION
## Summary
- document 2s pause and 3s countdown before next round and link to timerService for durations

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-header-landscape screenshot diff)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68990d4cfa98832688945ab6bf915f8d