### PR TITLE
Ensure settings section toggles always attach

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -206,4 +206,25 @@ test.describe.parallel("Settings page", () => {
       expect(box?.height).toBeGreaterThanOrEqual(44);
     }
   });
+
+  test("section toggles reveal content", async ({ page }) => {
+    const sections = [
+      { toggle: "#general-settings-toggle", content: "#general-settings-content" },
+      { toggle: "#game-modes-toggle", content: "#game-modes-content" },
+      { toggle: "#advanced-settings-toggle", content: "#advanced-settings-content" }
+    ];
+
+    for (const { toggle, content } of sections) {
+      const toggleLocator = page.locator(toggle);
+      const contentLocator = page.locator(content);
+
+      // Collapse if opened by beforeEach
+      await toggleLocator.click();
+      await expect(contentLocator).toHaveAttribute("hidden", "");
+
+      // Click again to expand and verify visibility
+      await toggleLocator.click();
+      await expect(contentLocator).not.toHaveAttribute("hidden", "");
+    }
+  });
 });

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -225,19 +225,20 @@ export function renderSettingsUI(settings, gameModes, tooltipMap) {
  * Load data and render the Settings page UI.
  *
  * @pseudocode
- * 1. Start loading navigation items and tooltips in parallel.
- * 2. Load saved settings.
- * 3. Resolve navigation items and tooltips with `Promise.all` on wrapped promises.
- * 4. Invoke `renderSettingsUI` with the retrieved data.
- * 5. On error, show a fallback message to the user.
+ * 1. Enable section toggles immediately.
+ * 2. Start loading navigation items and tooltips in parallel.
+ * 3. Load saved settings.
+ * 4. Resolve navigation items and tooltips with `Promise.all` on wrapped promises.
+ * 5. Invoke `renderSettingsUI` with the retrieved data.
+ * 6. On error, show a fallback message to the user.
  *
  * @returns {Promise<void>}
  */
 async function initializeSettingsPage() {
+  // Enable section toggles immediately so handlers attach even if
+  // subsequent initialization fails.
+  setupSectionToggles();
   try {
-    // Enable section toggles immediately so the UI is responsive
-    // even if data loading is slow or fails.
-    setupSectionToggles();
     const gameModesPromise = settled(loadNavigationItems());
     const tooltipMapPromise = settled(getTooltips());
     const settings = await loadSettings();


### PR DESCRIPTION
## Summary
- Call `setupSectionToggles` before data loading so toggles work even when other initialization fails
- Add Playwright test that verifies each section toggle reveals its content
- Confirm settings page includes `settingsPage.js` via correct script path

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Settings page fixtures not found, screenshot and settings specs error)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899a1f7a3108326bc7aa0c55a6e3852