### PR TITLE
Dispatch ready event before starting next round

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -64,11 +64,11 @@ export async function onNextButtonClick() {
     btn.classList.add("disabled");
     delete btn.dataset.nextReady;
     const start = window.startRoundOverride;
-    setSkipHandler(null);
     try {
       const { dispatchBattleEvent } = await import("./orchestrator.js");
       await dispatchBattleEvent("ready");
     } catch {}
+    setSkipHandler(null);
     if (typeof start === "function") {
       await start();
     }
@@ -88,6 +88,10 @@ export async function onNextButtonClick() {
       btn.classList.add("disabled");
       delete btn.dataset.nextReady;
       const start = window.startRoundOverride;
+      try {
+        const { dispatchBattleEvent } = await import("./orchestrator.js");
+        await dispatchBattleEvent("ready");
+      } catch {}
       setSkipHandler(null);
       if (typeof start === "function") {
         await start();

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -103,7 +103,9 @@ describe("timerService drift handling", () => {
     mod.scheduleNextRound({ matchEnded: false });
     window.startRoundOverride = vi.fn();
     btn.click();
+    await vi.waitFor(() => {
+      expect(window.startRoundOverride).toHaveBeenCalled();
+    });
     expect(btn.dataset.nextReady).toBeUndefined();
-    expect(window.startRoundOverride).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Dispatch `ready` battle event before clearing skip handler and starting the next round
- Mirror the same `ready` event dispatch inside `maybeStart` helper
- Update timerService drift test to await async round start

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899a465a2208326b10ccbbfb5bf8a09