### PR TITLE
test: cover early next round skip

### DIFF
--- a/tests/helpers/classicBattle/scheduleNextRound.skip.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.skip.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
+vi.mock("../../../src/helpers/motionUtils.js", () => ({
+  shouldReduceMotionSync: () => true
+}));
+
+let generateRandomCardMock;
+vi.mock("../../../src/helpers/randomCard.js", () => ({
+  generateRandomCard: (...args) => generateRandomCardMock(...args)
+}));
+
+let getRandomJudokaMock;
+let renderMock;
+let JudokaCardMock;
+vi.mock("../../../src/helpers/cardUtils.js", () => ({
+  getRandomJudoka: (...args) => getRandomJudokaMock(...args)
+}));
+vi.mock("../../../src/components/JudokaCard.js", () => {
+  renderMock = vi.fn();
+  JudokaCardMock = vi.fn().mockImplementation(() => ({ render: renderMock }));
+  return { JudokaCard: JudokaCardMock };
+});
+
+let fetchJsonMock;
+vi.mock("../../../src/helpers/dataUtils.js", () => ({
+  fetchJson: (...args) => fetchJsonMock(...args),
+  importJsonModule: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/utils.js", () => ({
+  createGokyoLookup: () => ({})
+}));
+
+describe("scheduleNextRound early click", () => {
+  let timerSpy;
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    const { playerCard, computerCard } = createBattleCardContainers();
+    const header = createBattleHeader();
+    const btn = document.createElement("button");
+    btn.id = "next-button";
+    btn.className = "disabled";
+    document.body.append(playerCard, computerCard, header, btn);
+    timerSpy = vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    fetchJsonMock = vi.fn(async (url) => {
+      if (String(url).includes("gameTimers.json")) {
+        return [{ id: 1, value: 30, default: true, category: "roundTimer" }];
+      }
+      if (String(url).includes("classicBattleStates.json")) {
+        return [
+          { name: "cooldown", triggers: [{ on: "ready", target: "roundStart" }] },
+          {
+            name: "roundStart",
+            triggers: [{ on: "cardsRevealed", target: "waitingForPlayerAction" }]
+          },
+          { name: "waitingForPlayerAction", triggers: [] }
+        ];
+      }
+      if (String(url).includes("judoka.json")) return [{ id: 1 }, { id: 2 }];
+      if (String(url).includes("gokyo.json")) return [];
+      return [];
+    });
+    generateRandomCardMock = vi.fn(async (_d, _g, container, _pm, cb) => {
+      container.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
+      cb?.({ id: 1 });
+    });
+    getRandomJudokaMock = vi.fn(() => ({ id: 2 }));
+    renderMock = vi.fn(async () => {
+      const el = document.createElement("div");
+      el.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
+      return el;
+    });
+  });
+
+  afterEach(() => {
+    timerSpy.clearAllTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("transitions from cooldown to waitingForPlayerAction when skipping", async () => {
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const orchestrator = await import("../../../src/helpers/classicBattle/orchestrator.js");
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+    await orchestrator.initClassicBattleOrchestrator(store, async () => {});
+    const machine = orchestrator.getBattleStateMachine();
+
+    await battleMod.startRound(store);
+    expect(generateRandomCardMock).toHaveBeenCalledTimes(1);
+    machine.current = "cooldown";
+
+    window.startRoundOverride = async () => {
+      await orchestrator.dispatchBattleEvent("ready");
+      await battleMod.startRound(store);
+    };
+
+    battleMod.scheduleNextRound({ matchEnded: false });
+    document.getElementById("next-button").click();
+    await vi.runAllTimersAsync();
+
+    expect(machine.getState()).toBe("waitingForPlayerAction");
+    expect(generateRandomCardMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- test scheduleNextRound when clicking Next before cooldown ends
- verify transition to waitingForPlayerAction and new card draw

## Testing
- `npx prettier tests/helpers/classicBattle/scheduleNextRound.skip.test.js --check`
- `npx eslint tests/helpers/classicBattle/scheduleNextRound.skip.test.js`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899a48694c483269801013b9cf8ad18