### PR TITLE
Ensure Classic Battle checkbox visibility

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -24,17 +24,15 @@ test.describe.parallel("Settings page", () => {
       route.fulfill({ path: "tests/fixtures/tooltips.json" })
     );
     await page.goto("/src/pages/settings.html", { waitUntil: "domcontentloaded" });
-    try {
-      await page
-        .getByRole("checkbox", { name: "Classic Battle" })
-        .waitFor({ state: "attached", timeout: 5000 });
-    } catch (e) {
-      const content = await page.content();
-      console.error("Classic Battle label not found. Page content:\n", content);
-      throw e;
-    }
     await page.locator("#general-settings-toggle").click();
     await page.locator("#game-modes-toggle").click();
+    await page.getByRole("checkbox", { name: "Classic Battle" }).waitFor({ state: "visible" });
+    if (await page.locator("#general-settings-content").getAttribute("hidden")) {
+      await page.locator("#general-settings-toggle").click();
+    }
+    if (await page.locator("#game-modes-content").getAttribute("hidden")) {
+      await page.locator("#game-modes-toggle").click();
+    }
     const advancedContent = page.locator("#advanced-settings-content");
     if (await advancedContent.getAttribute("hidden")) {
       await page.locator("#advanced-settings-toggle").click();


### PR DESCRIPTION
## Summary
- wait for Classic Battle checkbox after opening General and Game Modes sections
- ensure section toggles open if hidden

## Testing
- `npx prettier . --check`
- `npx eslint playwright/settings.spec.js`
- `npx vitest run` *(fails: JudokaCard did not render an HTMLElement, etc.)*
- `npx playwright test playwright/settings.spec.js` *(fails: section toggles reveal content, etc.)*
- `npx playwright test` *(fails: multiple tests including browse-judoka-navigation, screenshot suite, settings screenshots, section toggles reveal content)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899abb4d0f08326ac86d949c8d029e2