### PR TITLE
refactor: convert stats panel factory to class

### DIFF
--- a/src/components/StatsPanel.js
+++ b/src/components/StatsPanel.js
@@ -1,63 +1,88 @@
 /**
- * Create a stats panel element using the `.card-stats` structure.
+ * StatsPanel builds a stats list using the `.card-stats` structure.
  *
  * @pseudocode
+ * constructor(stats, options)
  * 1. Validate the `stats` object and throw an error when invalid.
  * 2. Resolve panel classes from the provided `type` and `className` options.
- * 3. Load stat labels via `loadStatNames()` and pair them with the
- *    corresponding values from the `stats` object.
- * 4. Build a `<div>` with class `card-stats` containing a `<ul>` list.
- *    - For each loaded label create an `<li>` with the label, value and
- *      tooltip id.
- * 5. Apply an accessible `aria-label` to the panel when provided.
- * 6. Return the completed panel element.
+ * 3. Create the root `<div>` with class `card-stats` and append an empty `<ul>`.
  *
- * @param {object} stats - Object with stat values.
- * @param {object} [options] - Optional configuration.
- * @param {string} [options.type="common"] - Card rarity or panel type.
- * @param {string} [options.className] - Additional class name to apply.
- * @param {string} [options.ariaLabel="Judoka Stats"] - Optional ARIA label.
- * @returns {HTMLDivElement} The stats panel element.
+ * update(stats)
+ * 1. Store incoming `stats` or reuse existing ones.
+ * 2. Load stat labels via `loadStatNames()` and pair them with the
+ *    corresponding values.
+ * 3. Clear the current list and populate it with `<li>` items containing
+ *    the label, value and tooltip id.
+ *
+ * createStatsPanel(stats, options)
+ * 1. Instantiate `StatsPanel` and call `update`.
+ * 2. Return the panel's root element for backwards compatibility.
  */
 import { escapeHTML } from "../helpers/utils.js";
 import { loadStatNames } from "../helpers/stats.js";
 import { STATS } from "../helpers/battleEngineFacade.js";
+
+export class StatsPanel {
+  /**
+   * @param {object} stats - Object with stat values.
+   * @param {object} [options] - Optional configuration.
+   * @param {string} [options.type="common"] - Card rarity or panel type.
+   * @param {string} [options.className] - Additional class name to apply.
+   * @param {string} [options.ariaLabel="Judoka Stats"] - Optional ARIA label.
+   */
+  constructor(stats, options = {}) {
+    if (!stats || typeof stats !== "object") {
+      throw new Error("Stats object is required");
+    }
+
+    const { type = "common", className, ariaLabel = "Judoka Stats" } = options;
+
+    this.stats = stats;
+    this.element = document.createElement("div");
+    this.element.className = `card-stats ${type}`.trim();
+    if (className) this.element.classList.add(className);
+    if (ariaLabel) this.element.setAttribute("aria-label", ariaLabel);
+
+    this.list = document.createElement("ul");
+    this.element.appendChild(this.list);
+  }
+
+  /**
+   * Populate the stats list with current values.
+   *
+   * @param {object} [stats] - Updated stat values.
+   * @returns {Promise<void>}
+   */
+  async update(stats = this.stats) {
+    this.stats = stats || {};
+    const { power = "?", speed = "?", technique = "?", kumikata = "?", newaza = "?" } = this.stats;
+
+    this.list.textContent = "";
+
+    const names = await loadStatNames();
+    const values = [power, speed, technique, kumikata, newaza];
+    const statsEntries = STATS.map((key, index) => ({
+      label: names[index]?.name || key,
+      value: values[index],
+      id: key
+    }));
+
+    statsEntries.forEach(({ label, value, id }) => {
+      const li = document.createElement("li");
+      li.className = "stat";
+      const strong = document.createElement("strong");
+      strong.textContent = label;
+      if (id) strong.dataset.tooltipId = `stat.${id}`;
+      const span = document.createElement("span");
+      span.innerHTML = escapeHTML(value);
+      li.append(strong, span);
+      this.list.appendChild(li);
+    });
+  }
+}
+
 export async function createStatsPanel(stats, options = {}) {
-  if (!stats || typeof stats !== "object") {
-    throw new Error("Stats object is required");
-  }
-
-  const { type = "common", className, ariaLabel = "Judoka Stats" } = options;
-  const { power = "?", speed = "?", technique = "?", kumikata = "?", newaza = "?" } = stats;
-
-  const panel = document.createElement("div");
-  panel.className = `card-stats ${type}`.trim();
-  if (className) panel.classList.add(className);
-  if (ariaLabel) panel.setAttribute("aria-label", ariaLabel);
-
-  const list = document.createElement("ul");
-
-  function addItem(label, value, id) {
-    const li = document.createElement("li");
-    li.className = "stat";
-    const strong = document.createElement("strong");
-    strong.textContent = label;
-    if (id) strong.dataset.tooltipId = `stat.${id}`;
-    const span = document.createElement("span");
-    span.innerHTML = escapeHTML(value);
-    li.append(strong, span);
-    list.appendChild(li);
-  }
-
-  const names = await loadStatNames();
-  const values = [power, speed, technique, kumikata, newaza];
-  const statsEntries = STATS.map((key, index) => ({
-    label: names[index]?.name || key,
-    key: values[index],
-    id: key
-  }));
-
-  statsEntries.forEach(({ label, key, id }) => addItem(label, key, id));
-  panel.appendChild(list);
-  return panel;
+  const panel = new StatsPanel(stats, options);
+  await panel.update();
+  return panel.element;
 }

--- a/tests/components/StatsPanel.test.js
+++ b/tests/components/StatsPanel.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createStatsPanel } from "../../src/components/StatsPanel.js";
+import { StatsPanel, createStatsPanel } from "../../src/components/StatsPanel.js";
 
 vi.mock("../../src/helpers/stats.js", () => ({
   loadStatNames: () =>
@@ -49,5 +49,17 @@ describe("createStatsPanel", () => {
 
   it("throws when stats is missing", async () => {
     await expect(createStatsPanel(null)).rejects.toThrowError("Stats object is required");
+  });
+});
+
+describe("StatsPanel", () => {
+  it("updates stat values", async () => {
+    const panel = new StatsPanel({ power: 1 });
+    await panel.update();
+    let items = panel.element.querySelectorAll("li.stat");
+    expect(items[0].textContent).toContain("1");
+    await panel.update({ power: 9 });
+    items = panel.element.querySelectorAll("li.stat");
+    expect(items[0].textContent).toContain("9");
   });
 });


### PR DESCRIPTION
## Summary
- add `StatsPanel` class with async `update` for DOM rendering
- keep `createStatsPanel` wrapper for existing callers
- test direct usage of `StatsPanel` updates

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899bd7cc00083269e9bd4165c2f3bed