### PR TITLE
refactor: encapsulate modal behavior in class

### DIFF
--- a/src/helpers/classicBattle/quitModal.js
+++ b/src/helpers/classicBattle/quitModal.js
@@ -26,7 +26,7 @@ function createQuitConfirmation(store, onConfirm) {
   frag.append(title, desc, actions);
 
   const modal = createModal(frag, { labelledBy: title, describedBy: desc });
-  cancel.addEventListener("click", modal.close);
+  cancel.addEventListener("click", () => modal.close());
   quit.addEventListener("click", () => {
     onConfirm();
     modal.close();

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -68,7 +68,7 @@ function createResetConfirmation(onConfirm) {
   frag.append(title, desc, actions);
 
   const modal = createModal(frag, { labelledBy: title, describedBy: desc });
-  cancel.addEventListener("click", modal.close);
+  cancel.addEventListener("click", () => modal.close());
   yes.addEventListener("click", () => {
     onConfirm();
     modal.close();

--- a/tests/helpers/modalComponent.test.js
+++ b/tests/helpers/modalComponent.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createModal } from "../../src/components/Modal.js";
+import { createModal, Modal } from "../../src/components/Modal.js";
 
 function buildContent() {
   const frag = document.createDocumentFragment();
@@ -43,5 +43,18 @@ describe("createModal", () => {
     const dialog = element.querySelector(".modal");
     expect(dialog).toHaveAttribute("aria-labelledby", "modal-title");
     expect(dialog).toHaveAttribute("aria-describedby", "modal-desc");
+  });
+});
+
+describe("Modal class", () => {
+  it("allows direct instantiation", () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    const modal = new Modal(buildContent());
+    document.body.appendChild(modal.element);
+    modal.open(trigger);
+    expect(modal.element.hasAttribute("hidden")).toBe(false);
+    modal.close();
+    expect(modal.element.hasAttribute("hidden")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- migrate `createModal` to a `Modal` class with instance methods
- wrap legacy `createModal` and bind modal methods for safe callbacks
- fix call sites to invoke modal close through arrow handlers and add class tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: No "resetGame" export defined on mock)*
- `npx playwright test` *(fails: screenshots and navigation expectations)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_6899bd8d8a44832691c6cf6e7d7c6478