### PR TITLE
Reject superseded debounced promises

### DIFF
--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -2,11 +2,15 @@
  * Create a debounced version of a function.
  *
  * @pseudocode
- * 1. Maintain an internal `timer` variable.
+ * 1. Maintain internal `timer` and `pending` (resolve and reject handlers).
  * 2. Return a new function that returns a promise.
- * 3. Each call clears the existing `timer`.
- * 4. Start a new timer with the provided `delay`.
- * 5. When the timer fires, invoke `fn` with the latest arguments.
+ * 3. On each call:
+ *    - Clear the existing `timer`.
+ *    - If a pending promise exists, reject it with `Error('Debounced')`.
+ *    - Store the current promise's `resolve` and `reject` as `pending`.
+ *    - Start a new timer with the provided `delay`.
+ * 4. When the timer fires, invoke `fn` with the latest arguments.
+ *    - Clear `pending`.
  *    - Resolve the promise with `fn`'s return value.
  *    - Reject if `fn` throws an error.
  *
@@ -17,10 +21,18 @@
  */
 export function debounce(fn, delay) {
   let timer;
+  /** @type {{resolve: (value: any) => void, reject: (reason?: any) => void} | undefined} */
+  let pending;
   return (...args) =>
     new Promise((resolve, reject) => {
       clearTimeout(timer);
+      if (pending) {
+        pending.reject(new Error("Debounced"));
+      }
+      pending = { resolve, reject };
       timer = setTimeout(() => {
+        const { resolve, reject } = pending;
+        pending = undefined;
         try {
           resolve(fn(...args));
         } catch (error) {

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -211,9 +211,11 @@ describe("settings utils", () => {
         enableCardInspector: { enabled: false }
       }
     };
-    saveSettings(data1);
-    saveSettings(data2);
+    const first = saveSettings(data1);
+    const second = saveSettings(data2);
+    await expect(first).rejects.toThrow("Debounced");
     await vi.advanceTimersByTimeAsync(110);
+    await expect(second).resolves.toBeUndefined();
     expect(JSON.parse(localStorage.getItem("settings"))).toEqual(data2);
   });
 

--- a/tests/utils/debounce.test.js
+++ b/tests/utils/debounce.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+import { debounce } from "../../src/utils/debounce.js";
+
+describe("debounce", () => {
+  it("resolves with latest call after delay", async () => {
+    vi.useFakeTimers();
+    const fn = vi.fn().mockReturnValue("done");
+    const debounced = debounce(fn, 100);
+    const promise = debounced("first");
+    vi.advanceTimersByTime(100);
+    await expect(promise).resolves.toBe("done");
+    expect(fn).toHaveBeenCalledWith("first");
+    vi.useRealTimers();
+  });
+
+  it("rejects previous promise when a new call is made", async () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+    const first = debounced("a");
+    const second = debounced("b");
+    await expect(first).rejects.toThrow("Debounced");
+    vi.advanceTimersByTime(100);
+    await expect(second).resolves.toBeUndefined();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("b");
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- reject previous debounced calls by storing resolve/reject handlers and rejecting with `Error('Debounced')`
- add unit tests confirming debounced promise rejection behavior and update settings utils test accordingly

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899c13963fc8326bf11e9526c127753