### PR TITLE
Retry synonym loading after fetch failures

### DIFF
--- a/src/helpers/vectorSearchQuery.js
+++ b/src/helpers/vectorSearchQuery.js
@@ -10,7 +10,10 @@ let synonymsPromise;
  */
 async function loadSynonyms() {
   if (!synonymsPromise) {
-    synonymsPromise = fetchJson(`${DATA_DIR}synonyms.json`).catch(() => null);
+    synonymsPromise = fetchJson(`${DATA_DIR}synonyms.json`).catch(() => {
+      synonymsPromise = undefined;
+      return null;
+    });
   }
   return synonymsPromise;
 }

--- a/tests/helpers/vectorSearchQuery.test.js
+++ b/tests/helpers/vectorSearchQuery.test.js
@@ -1,0 +1,27 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../src/helpers/dataUtils.js", () => ({
+  fetchJson: vi.fn()
+}));
+
+let fetchJsonMock;
+
+beforeEach(async () => {
+  vi.resetModules();
+  fetchJsonMock = (await import("../../src/helpers/dataUtils.js")).fetchJson;
+  fetchJsonMock.mockReset();
+});
+
+describe("loadSynonyms", () => {
+  it("retries after a transient failure", async () => {
+    fetchJsonMock.mockRejectedValueOnce(new Error("fail"));
+    fetchJsonMock.mockResolvedValueOnce({ judoka: ["fighter"] });
+    const { expandQueryWithSynonyms } = await import("../../src/helpers/vectorSearchQuery.js");
+    const first = await expandQueryWithSynonyms("judoka");
+    expect(first).toBe("judoka");
+    const second = await expandQueryWithSynonyms("judoka");
+    expect(second).toBe("judoka fighter");
+    expect(fetchJsonMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Reset cached synonyms when the JSON fetch fails so later calls retry
- Add a regression test confirming a second call loads synonyms after a transient failure

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 13 failed, 82 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899d3aecce083268e812dbfec580295