### PR TITLE
Provide Ajv stub when imports fail

### DIFF
--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -59,7 +59,20 @@ export async function getAjv() {
           ajvInstance = new Ajv();
         } catch (cdnError) {
           console.error("Error loading Ajv:", localError, cdnError);
-          ajvInstance = { compile: () => () => true };
+          const message = "Ajv import failed; validation disabled";
+          ajvInstance = {
+            errors: null,
+            compile: () => {
+              const validate = () => {
+                const error = { message };
+                ajvInstance.errors = [error];
+                validate.errors = [error];
+                return false;
+              };
+              return validate;
+            },
+            errorsText: () => message
+          };
         }
       }
     }

--- a/tests/helpers/getAjvFallback.test.js
+++ b/tests/helpers/getAjvFallback.test.js
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../src/vendor/ajv6.min.js", () => {
+  throw new Error("local import failed");
+});
+
+describe("getAjv fallback stub", () => {
+  const message = "Ajv import failed; validation disabled";
+  let originalNodeVersion;
+  let errorSpy;
+
+  beforeEach(() => {
+    originalNodeVersion = process.versions.node;
+    delete process.versions.node;
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.versions.node = originalNodeVersion;
+    errorSpy.mockRestore();
+  });
+
+  it("provides stub with errorsText and sets errors", async () => {
+    const { getAjv } = await import("../../src/helpers/dataUtils.js");
+    const ajv = await getAjv();
+
+    const validate = ajv.compile({});
+    const result = validate({});
+
+    expect(result).toBe(false);
+    expect(ajv.errors).toEqual([{ message }]);
+    expect(validate.errors).toEqual([{ message }]);
+    expect(ajv.errorsText(validate.errors)).toBe(message);
+  });
+});


### PR DESCRIPTION
## Summary
- Extend `getAjv` fallback with a stub that reports validation failures and exposes `errorsText`
- Add unit test to simulate Ajv import failures and assert stub behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 12 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899d7b4d8108326a8a1abbb46d8789d