### PR TITLE
Check container before building carousel

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -18,10 +18,11 @@ let inspectorEnabled = false;
  * 2. Maintain an `isBuilt` flag inside the closure.
  * 3. On click:
  *    a. If the carousel is built, simply reveal `container`.
- *    b. Otherwise fetch and validate judoka and gokyo data.
- *    c. Build the carousel, append it to `container`, and add scroll markers.
- *    d. Reveal `container` and mark the carousel as built.
- *    e. Log any errors that occur.
+ *    b. If `container` is missing, log an error.
+ *    c. Otherwise fetch and validate judoka and gokyo data.
+ *    d. Build the carousel, append it to `container`, and add scroll markers.
+ *    e. Reveal `container` and mark the carousel as built.
+ *    f. Log any errors that occur.
  *
  * @param {HTMLElement} button - Button to show the carousel.
  * @param {HTMLElement} container - Container for the carousel.
@@ -39,6 +40,11 @@ export function setupCarouselToggle(button, container) {
       return;
     }
 
+    if (!container) {
+      console.error("Carousel container not found.");
+      return;
+    }
+
     try {
       const judokaData = await fetchJson(`${DATA_DIR}judoka.json`);
       const gokyoData = await fetchJson(`${DATA_DIR}gokyo.json`);
@@ -47,8 +53,8 @@ export function setupCarouselToggle(button, container) {
       validateData(gokyoData, "gokyo");
 
       const carousel = await buildCardCarousel(judokaData, gokyoData);
-      container?.appendChild(carousel);
-      container?.classList.remove("hidden");
+      container.appendChild(carousel);
+      container.classList.remove("hidden");
 
       requestAnimationFrame(() => {
         const containerEl = carousel.querySelector(".card-carousel");

--- a/tests/helpers/setupCarouselToggle.test.js
+++ b/tests/helpers/setupCarouselToggle.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+function createCarousel() {
+  const wrapper = document.createElement("div");
+  const inner = document.createElement("div");
+  inner.className = "card-carousel";
+  wrapper.appendChild(inner);
+  return wrapper;
+}
+
+async function flush() {
+  return await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  document.body.innerHTML = "";
+});
+
+describe("setupCarouselToggle", () => {
+  it("marks carousel as built only after successful insertion", async () => {
+    const button = document.createElement("button");
+    const container = document.createElement("div");
+    container.classList.add("hidden");
+    document.body.append(button, container);
+
+    const fetchJson = vi.fn().mockResolvedValue([]);
+    const validateData = vi.fn();
+    const buildCardCarousel = vi.fn().mockResolvedValue(createCarousel());
+    const addScrollMarkers = vi.fn();
+
+    vi.doMock("../../src/helpers/dataUtils.js", async () => {
+      const actual = await vi.importActual("../../src/helpers/dataUtils.js");
+      return { ...actual, fetchJson, validateData };
+    });
+    vi.doMock("../../src/helpers/carouselBuilder.js", () => ({
+      buildCardCarousel,
+      addScrollMarkers
+    }));
+
+    const { setupCarouselToggle } = await import("../../src/game.js");
+
+    setupCarouselToggle(button, container);
+
+    button.dispatchEvent(new Event("click"));
+    await flush();
+
+    expect(buildCardCarousel).toHaveBeenCalledTimes(1);
+
+    button.dispatchEvent(new Event("click"));
+    await flush();
+
+    expect(buildCardCarousel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mark built when container is missing", async () => {
+    const button = document.createElement("button");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const fetchJson = vi.fn();
+    const validateData = vi.fn();
+    const buildCardCarousel = vi.fn();
+    const addScrollMarkers = vi.fn();
+
+    vi.doMock("../../src/helpers/dataUtils.js", async () => {
+      const actual = await vi.importActual("../../src/helpers/dataUtils.js");
+      return { ...actual, fetchJson, validateData };
+    });
+    vi.doMock("../../src/helpers/carouselBuilder.js", () => ({
+      buildCardCarousel,
+      addScrollMarkers
+    }));
+
+    const { setupCarouselToggle } = await import("../../src/game.js");
+
+    setupCarouselToggle(button, null);
+
+    button.dispatchEvent(new Event("click"));
+    await flush();
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(buildCardCarousel).not.toHaveBeenCalled();
+
+    button.dispatchEvent(new Event("click"));
+    await flush();
+
+    expect(consoleError).toHaveBeenCalledTimes(2);
+    expect(buildCardCarousel).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure carousel container exists before building to avoid marking built when missing
- Add tests confirming carousel marks built only on successful insertion

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: settings screenshots and navigation tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899d7bf5fcc8326884c44031d45c271