### PR TITLE
feat: handle settings updates without localStorage

### DIFF
--- a/src/helpers/settingsStorage.js
+++ b/src/helpers/settingsStorage.js
@@ -86,11 +86,12 @@ export async function loadSettings() {
  * Update a single setting and persist the result.
  *
  * @pseudocode
- * 1. Load current settings via `loadSettings`.
- * 2. Merge `key`/`value` into the settings object.
- * 3. Validate with the schema.
- * 4. Persist using `saveSettings`.
- * 5. Update the cache and return the updated settings.
+ * 1. Ensure the settings schema is loaded.
+ * 2. Retrieve current settings from `localStorage` when available; otherwise use the cache.
+ * 3. Merge `key`/`value` into the settings object.
+ * 4. Validate with the schema.
+ * 5. Persist using `localStorage` when available.
+ * 6. Update the cache and return the updated settings.
  *
  * @param {string} key - Name of the setting to update.
  * @param {*} value - Value to assign to the setting.
@@ -98,13 +99,11 @@ export async function loadSettings() {
  */
 export async function updateSetting(key, value) {
   await getSettingsSchema();
-  const current = await loadSettings();
+  const current = typeof localStorage !== "undefined" ? await loadSettings() : getCachedSettings();
   const updated = { ...current, [key]: value };
   await validateWithSchema(updated, await getSettingsSchema());
   if (typeof localStorage !== "undefined") {
     localStorage.setItem(SETTINGS_KEY, JSON.stringify(updated));
-  } else {
-    await saveSettings(updated);
   }
   setCachedSettings(updated);
   return updated;

--- a/tests/helpers/settingsStorage.test.js
+++ b/tests/helpers/settingsStorage.test.js
@@ -1,0 +1,37 @@
+import { updateSetting, resetSettings } from "../../src/helpers/settingsStorage.js";
+import { getCachedSettings, resetCache } from "../../src/helpers/settingsCache.js";
+
+/**
+ * @vitest-environment jsdom
+ */
+describe("updateSetting", () => {
+  beforeEach(() => {
+    resetSettings();
+    localStorage.clear();
+  });
+
+  it("persists changes when localStorage is available", async () => {
+    await updateSetting("sound", false);
+    const stored = JSON.parse(localStorage.getItem("settings"));
+    expect(stored.sound).toBe(false);
+    expect(getCachedSettings().sound).toBe(false);
+  });
+
+  it("updates cache when localStorage is unavailable", async () => {
+    const original = globalThis.localStorage;
+    // Simulate environment without localStorage
+    Object.defineProperty(globalThis, "localStorage", {
+      value: undefined,
+      configurable: true
+    });
+    resetCache();
+
+    await updateSetting("sound", false);
+    expect(getCachedSettings().sound).toBe(false);
+
+    Object.defineProperty(globalThis, "localStorage", {
+      value: original,
+      configurable: true
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fall back to cached settings when updating without `localStorage`
- add tests for `updateSetting` with and without `localStorage`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/settingsStorage.test.js`
- `npx playwright test` *(fails: homepage navigation link tests interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899d7b9d6688326beb5a2412d79fad8