### PR TITLE
chore: guard carousel log

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -7,6 +7,7 @@ import { initTooltips } from "./helpers/tooltip.js";
 import { loadSettings } from "./helpers/settingsStorage.js";
 import { toggleInspectorPanels } from "./helpers/cardUtils.js";
 import { isEnabled, featureFlagsEmitter } from "./helpers/featureFlags.js";
+import { debugLog } from "./helpers/debug.js";
 
 let inspectorEnabled = false;
 
@@ -64,7 +65,7 @@ export function setupCarouselToggle(button, container) {
       });
 
       isBuilt = true;
-      console.log("Carousel displayed on demand.");
+      debugLog("Carousel displayed on demand.");
     } catch (error) {
       console.error("Failed to build carousel:", error);
     }


### PR DESCRIPTION
## Summary
- conditionally log carousel display using debugLog

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: 11 failed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899e5f8c2948326b22b8fb81696c8cf