### PR TITLE
Defer scroll marker init until carousel insertion

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1,5 +1,5 @@
 import { fetchJson, validateData } from "./helpers/dataUtils.js";
-import { buildCardCarousel, addScrollMarkers } from "./helpers/carouselBuilder.js";
+import { buildCardCarousel, initScrollMarkers } from "./helpers/carouselBuilder.js";
 import { generateRandomCard } from "./helpers/randomCard.js";
 import { DATA_DIR } from "./helpers/constants.js";
 import { shouldReduceMotionSync } from "./helpers/motionUtils.js";
@@ -20,7 +20,7 @@ let inspectorEnabled = false;
  *    a. If the carousel is built, simply reveal `container`.
  *    b. If `container` is missing, log an error.
  *    c. Otherwise fetch and validate judoka and gokyo data.
- *    d. Build the carousel, append it to `container`, and add scroll markers.
+ *    d. Build the carousel, append it to `container`, and initialize scroll markers.
  *    e. Reveal `container` and mark the carousel as built.
  *    f. Log any errors that occur.
  *
@@ -56,12 +56,10 @@ export function setupCarouselToggle(button, container) {
       container.appendChild(carousel);
       container.classList.remove("hidden");
 
-      requestAnimationFrame(() => {
-        const containerEl = carousel.querySelector(".card-carousel");
-        if (containerEl) {
-          addScrollMarkers(containerEl, carousel);
-        }
-      });
+      const containerEl = carousel.querySelector(".card-carousel");
+      if (containerEl) {
+        initScrollMarkers(containerEl, carousel);
+      }
 
       isBuilt = true;
       console.log("Carousel displayed on demand.");

--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -1,4 +1,4 @@
-import { buildCardCarousel, addScrollMarkers, createLoadingSpinner } from "./carouselBuilder.js";
+import { buildCardCarousel, initScrollMarkers, createLoadingSpinner } from "./carouselBuilder.js";
 import { toggleCountryPanelMode } from "./countryPanel.js";
 import { fetchJson } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
@@ -76,7 +76,7 @@ export async function setupBrowseJudokaPage() {
    * @pseudocode
    * 1. Use `buildCardCarousel` to create carousel markup.
    * 2. Remove the loading spinner and clear the existing container.
-   * 3. Append the carousel to the container and add scroll markers.
+   * 3. Append the carousel to the container and initialize scroll markers.
    * 4. Apply button ripple effects.
    *
    * @param {Judoka[]} list - Judoka to display.
@@ -91,12 +91,10 @@ export async function setupBrowseJudokaPage() {
     carouselContainer.innerHTML = "";
     carouselContainer.appendChild(carousel);
 
-    requestAnimationFrame(() => {
-      const containerEl = carousel.querySelector(".card-carousel");
-      if (containerEl) {
-        addScrollMarkers(containerEl, carousel);
-      }
-    });
+    const containerEl = carousel.querySelector(".card-carousel");
+    if (containerEl) {
+      initScrollMarkers(containerEl, carousel);
+    }
 
     setupButtonEffects();
   }

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -73,6 +73,22 @@ function addScrollMarkers(container, wrapper) {
 }
 
 /**
+ * Initialize scroll markers after the carousel is attached to the document.
+ *
+ * @pseudocode
+ * 1. Exit early if `container` or `wrapper` is missing.
+ * 2. Schedule `addScrollMarkers` inside `requestAnimationFrame` to ensure
+ *    measurements occur after layout.
+ *
+ * @param {HTMLElement} [container] - The carousel container element.
+ * @param {HTMLElement} [wrapper] - The carousel wrapper element.
+ */
+export function initScrollMarkers(container, wrapper) {
+  if (!container || !wrapper) return;
+  requestAnimationFrame(() => addScrollMarkers(container, wrapper));
+}
+
+/**
  * Validates the judoka list to ensure it is a non-empty array.
  *
  * @pseudocode
@@ -155,9 +171,9 @@ export function createLoadingSpinner(wrapper) {
  * 4. For each judoka:
  *    a. Validate fields; use fallback card if invalid.
  *    b. Generate card, handle broken images, and make focusable.
- * 5. Add scroll buttons and markers, ensuring ARIA roles/labels.
+ * 5. Add scroll buttons; scroll markers are initialized after insertion.
  *    - Update button state on scroll and after scroll-snap completes.
- * 6. Use ResizeObserver to adapt card sizing and scroll marker logic on window resize.
+ * 6. Use ResizeObserver to adapt card sizing on window resize.
  * 7. Enable keyboard navigation (arrow keys), swipe gestures, and focus/hover enlargement for the center card only.
  * 8. Provide aria-live region for dynamic messages (errors, empty state).
  * 9. Return the completed wrapper element.
@@ -218,9 +234,6 @@ export async function buildCardCarousel(judokaList, gokyoData) {
   wrapper.appendChild(leftButton);
   wrapper.appendChild(container);
   wrapper.appendChild(rightButton);
-
-  // Add scroll markers below the carousel
-  addScrollMarkers(container, wrapper);
 
   const updateButtons = () => updateScrollButtonState(container, leftButton, rightButton);
 

--- a/tests/helpers/browseJudokaPage.test.js
+++ b/tests/helpers/browseJudokaPage.test.js
@@ -158,7 +158,7 @@ describe("browseJudokaPage helpers", () => {
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
     vi.doMock("../../src/helpers/carouselBuilder.js", () => ({
       buildCardCarousel,
-      addScrollMarkers: vi.fn(),
+      initScrollMarkers: vi.fn(),
       createLoadingSpinner
     }));
     vi.doMock("../../src/helpers/buttonEffects.js", () => ({ setupButtonEffects: vi.fn() }));
@@ -235,7 +235,7 @@ describe("browseJudokaPage helpers", () => {
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
     vi.doMock("../../src/helpers/carouselBuilder.js", () => ({
       buildCardCarousel,
-      addScrollMarkers: vi.fn(),
+      initScrollMarkers: vi.fn(),
       createLoadingSpinner: () => ({ spinner: document.createElement("div"), timeoutId: 0 })
     }));
     vi.doMock("../../src/helpers/buttonEffects.js", () => ({ setupButtonEffects: vi.fn() }));

--- a/tests/helpers/setupCarouselToggle.test.js
+++ b/tests/helpers/setupCarouselToggle.test.js
@@ -28,7 +28,7 @@ describe("setupCarouselToggle", () => {
     const fetchJson = vi.fn().mockResolvedValue([]);
     const validateData = vi.fn();
     const buildCardCarousel = vi.fn().mockResolvedValue(createCarousel());
-    const addScrollMarkers = vi.fn();
+    const initScrollMarkers = vi.fn();
 
     vi.doMock("../../src/helpers/dataUtils.js", async () => {
       const actual = await vi.importActual("../../src/helpers/dataUtils.js");
@@ -36,7 +36,7 @@ describe("setupCarouselToggle", () => {
     });
     vi.doMock("../../src/helpers/carouselBuilder.js", () => ({
       buildCardCarousel,
-      addScrollMarkers
+      initScrollMarkers
     }));
 
     const { setupCarouselToggle } = await import("../../src/game.js");
@@ -61,7 +61,7 @@ describe("setupCarouselToggle", () => {
     const fetchJson = vi.fn();
     const validateData = vi.fn();
     const buildCardCarousel = vi.fn();
-    const addScrollMarkers = vi.fn();
+    const initScrollMarkers = vi.fn();
 
     vi.doMock("../../src/helpers/dataUtils.js", async () => {
       const actual = await vi.importActual("../../src/helpers/dataUtils.js");
@@ -69,7 +69,7 @@ describe("setupCarouselToggle", () => {
     });
     vi.doMock("../../src/helpers/carouselBuilder.js", () => ({
       buildCardCarousel,
-      addScrollMarkers
+      initScrollMarkers
     }));
 
     const { setupCarouselToggle } = await import("../../src/game.js");


### PR DESCRIPTION
## Summary
- add `initScrollMarkers` helper to apply markers after the carousel is in the DOM
- update carousel callers to invoke `initScrollMarkers` after appending wrappers
- adjust related unit tests for new initializer

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 11 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899e5ebbcd48326b2ccddcb9d5f21ad