### PR TITLE
refactor: init feature flags from entry point

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -4,9 +4,8 @@ import { generateRandomCard } from "./helpers/randomCard.js";
 import { DATA_DIR } from "./helpers/constants.js";
 import { shouldReduceMotionSync } from "./helpers/motionUtils.js";
 import { initTooltips } from "./helpers/tooltip.js";
-import { loadSettings } from "./helpers/settingsStorage.js";
 import { toggleInspectorPanels } from "./helpers/cardUtils.js";
-import { isEnabled, featureFlagsEmitter } from "./helpers/featureFlags.js";
+import { initFeatureFlags, isEnabled, featureFlagsEmitter } from "./helpers/featureFlags.js";
 
 let inspectorEnabled = false;
 
@@ -140,10 +139,11 @@ export function setupRandomCardButton(button, container) {
  * @pseudocode
  * 1. Wait for the `DOMContentLoaded` event.
  * 2. Query elements used by the game (buttons, containers).
- * 3. Call `setupCarouselToggle` with the carousel button and container.
- * 4. Call `setupHideCardButton` with the hide-card button.
- * 5. Call `setupRandomCardButton` with the random button and game area.
- * 6. Call `initTooltips` to initialize tooltips.
+ * 3. Call `initFeatureFlags` and set `inspectorEnabled` via `isEnabled`.
+ * 4. Call `setupCarouselToggle` with the carousel button and container.
+ * 5. Call `setupHideCardButton` with the hide-card button.
+ * 6. Call `setupRandomCardButton` with the random button and game area.
+ * 7. Call `initTooltips` to initialize tooltips.
  */
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -158,12 +158,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
-  try {
-    await loadSettings();
-    inspectorEnabled = isEnabled("enableCardInspector");
-  } catch {
-    inspectorEnabled = false;
-  }
+  await initFeatureFlags();
+  inspectorEnabled = isEnabled("enableCardInspector");
   toggleInspectorPanels(inspectorEnabled);
 
   featureFlagsEmitter.addEventListener("change", () => {

--- a/src/helpers/featureFlags.js
+++ b/src/helpers/featureFlags.js
@@ -8,11 +8,25 @@ import { loadSettings, updateSetting } from "./settingsStorage.js";
 export const featureFlagsEmitter = new EventTarget();
 
 let cachedFlags = {};
-try {
-  const settings = await loadSettings();
-  cachedFlags = settings.featureFlags || {};
-} catch {
-  cachedFlags = {};
+
+/**
+ * Initialize feature flags cache.
+ *
+ * @pseudocode
+ * 1. Call `loadSettings()` to retrieve current settings.
+ * 2. Set `cachedFlags` to `settings.featureFlags` or `{}`.
+ * 3. Dispatch a `change` event on `featureFlagsEmitter`.
+ *
+ * @returns {Promise<void>} Resolves once flags are loaded.
+ */
+export async function initFeatureFlags() {
+  try {
+    const settings = await loadSettings();
+    cachedFlags = settings.featureFlags || {};
+  } catch {
+    cachedFlags = {};
+  }
+  featureFlagsEmitter.dispatchEvent(new CustomEvent("change", { detail: { flag: null } }));
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace top-level feature flag load with `initFeatureFlags` helper
- initialize feature flags during game startup

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: classicBattlePage test mode flag, game.js motion preference)*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899e5df2a3c8326b64e6cc3fcc85ea3