### PR TITLE
refactor: lazy feature flag init

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -4,9 +4,8 @@ import { generateRandomCard } from "./helpers/randomCard.js";
 import { DATA_DIR } from "./helpers/constants.js";
 import { shouldReduceMotionSync } from "./helpers/motionUtils.js";
 import { initTooltips } from "./helpers/tooltip.js";
-import { loadSettings } from "./helpers/settingsStorage.js";
 import { toggleInspectorPanels } from "./helpers/cardUtils.js";
-import { isEnabled, featureFlagsEmitter } from "./helpers/featureFlags.js";
+import { initFeatureFlags, isEnabled, featureFlagsEmitter } from "./helpers/featureFlags.js";
 import { debugLog } from "./helpers/debug.js";
 
 let inspectorEnabled = false;
@@ -158,7 +157,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   try {
-    await loadSettings();
+    await initFeatureFlags();
     inspectorEnabled = isEnabled("enableCardInspector");
   } catch {
     inspectorEnabled = false;

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -41,7 +41,7 @@ import {
   dispatchBattleEvent
 } from "./classicBattle/orchestrator.js";
 import { skipCurrentPhase, onNextButtonClick } from "./classicBattle/timerService.js";
-import { isEnabled, featureFlagsEmitter } from "./featureFlags.js";
+import { initFeatureFlags, isEnabled, featureFlagsEmitter } from "./featureFlags.js";
 
 function enableStatButtons(enable = true) {
   document.querySelectorAll("#stat-buttons button").forEach((btn) => {
@@ -107,6 +107,7 @@ function watchBattleOrientation() {
 }
 
 export async function setupClassicBattlePage() {
+  await initFeatureFlags();
   await applyStatLabels();
   const statButtons = document.querySelectorAll("#stat-buttons button");
   setupNextButton();

--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -24,14 +24,13 @@
 import { generateRandomCard } from "./randomCard.js";
 import { toggleInspectorPanels } from "./cardUtils.js";
 import { createButton } from "../components/Button.js";
-import { loadSettings } from "./settingsStorage.js";
 import { applyMotionPreference } from "./motionUtils.js";
 import { onDomReady } from "./domReady.js";
 import { initTooltips } from "./tooltip.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
 import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
 import { setTestMode } from "./testModeUtils.js";
-import { isEnabled, featureFlagsEmitter } from "./featureFlags.js";
+import { initFeatureFlags, isEnabled, featureFlagsEmitter } from "./featureFlags.js";
 import { preloadRandomCardData, createHistoryManager } from "./randomCardService.js";
 
 const DRAW_ICON =
@@ -39,7 +38,7 @@ const DRAW_ICON =
 export async function setupRandomJudokaPage() {
   let settings;
   try {
-    settings = await loadSettings();
+    settings = await initFeatureFlags();
   } catch (err) {
     console.error("Error loading settings:", err);
     // Fallback to system motion preference

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -7,7 +7,7 @@
  * 3. Toggle the `.simulate-viewport` class based on the viewport flag.
  * 4. Initialize the page controls and event listeners.
  */
-import { loadSettings, resetSettings } from "./settingsStorage.js";
+import { resetSettings } from "./settingsStorage.js";
 import { loadNavigationItems, loadGameModes } from "./gameModeUtils.js";
 import { showSettingsError } from "./showSettingsError.js";
 import { applyDisplayMode } from "./displayMode.js";
@@ -20,7 +20,7 @@ import { createButton } from "../components/Button.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
 import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
 import { toggleLayoutDebugPanel } from "./layoutDebugPanel.js";
-import { isEnabled } from "./featureFlags.js";
+import { initFeatureFlags, isEnabled } from "./featureFlags.js";
 
 import { applyInitialControlValues } from "./settings/applyInitialValues.js";
 import { attachToggleListeners } from "./settings/listenerUtils.js";
@@ -241,7 +241,7 @@ async function initializeSettingsPage() {
   try {
     const gameModesPromise = settled(loadNavigationItems());
     const tooltipMapPromise = settled(getTooltips());
-    const settings = await loadSettings();
+    const settings = await initFeatureFlags();
     const [gameModesResult, tooltipMapResult] = await Promise.all([
       gameModesPromise,
       tooltipMapPromise

--- a/src/helpers/setupDisplaySettings.js
+++ b/src/helpers/setupDisplaySettings.js
@@ -11,17 +11,16 @@
  *    e. Log any errors to the console.
  * 2. Use `onDomReady` to run `init` when the DOM is ready.
  */
-import { loadSettings } from "./settingsStorage.js";
 import { applyDisplayMode } from "./displayMode.js";
 import { applyMotionPreference } from "./motionUtils.js";
 import { onDomReady } from "./domReady.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
 import { toggleLayoutDebugPanel } from "./layoutDebugPanel.js";
-import { isEnabled } from "./featureFlags.js";
+import { initFeatureFlags, isEnabled } from "./featureFlags.js";
 
 async function init() {
   try {
-    const settings = await loadSettings();
+    const settings = await initFeatureFlags();
     applyDisplayMode(settings.displayMode);
     applyMotionPreference(settings.motionEffects);
     toggleViewportSimulation(isEnabled("viewportSimulation"));

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -35,7 +35,8 @@ describe("classicBattlePage feature flag updates", () => {
     }));
     vi.doMock("../../src/helpers/featureFlags.js", () => ({
       featureFlagsEmitter,
-      isEnabled: (flag) => currentFlags[flag]?.enabled ?? false
+      isEnabled: (flag) => currentFlags[flag]?.enabled ?? false,
+      initFeatureFlags: vi.fn().mockResolvedValue({ featureFlags: currentFlags })
     }));
     vi.doMock("../../src/helpers/stats.js", () => ({
       loadStatNames: async () => [{ name: "Power" }]

--- a/tests/helpers/gameRandom.test.js
+++ b/tests/helpers/gameRandom.test.js
@@ -28,8 +28,10 @@ describe("game.js", () => {
     const shouldReduceMotionSync = vi.fn(() => true);
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard }));
     vi.doMock("../../src/helpers/motionUtils.js", () => ({ shouldReduceMotionSync }));
-    vi.doMock("../../src/helpers/settingsStorage.js", () => ({
-      loadSettings: vi.fn().mockResolvedValue({ featureFlags: {} })
+    vi.doMock("../../src/helpers/featureFlags.js", () => ({
+      initFeatureFlags: vi.fn().mockResolvedValue({ featureFlags: {} }),
+      isEnabled: vi.fn(() => false),
+      featureFlagsEmitter: new EventTarget()
     }));
 
     await import("../../src/game.js");


### PR DESCRIPTION
## Summary
- defer feature flag setup into new `initFeatureFlags` helper that loads settings, caches flags, and emits an initial change event
- initialize feature flags during startup in main entry points
- adjust tests to mock the new initializer

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Settings page section toggle test, orientation screenshots, screenshot suite, and others)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_6899f593f7448326b4456b140129a33a