### PR TITLE
Refactor carousel builder into modular helpers

### DIFF
--- a/src/helpers/carousel/accessibility.js
+++ b/src/helpers/carousel/accessibility.js
@@ -1,3 +1,7 @@
+import { setupFocusHandlers } from "./focus.js";
+import { setupKeyboardNavigation, setupSwipeNavigation } from "./navigation.js";
+import { setupLazyPortraits } from "../lazyPortrait.js";
+
 const MIN_TOUCH_TARGET_SIZE = 48;
 
 /**
@@ -40,3 +44,22 @@ export function applyAccessibilityImprovements(wrapper) {
 }
 
 export { ensureTouchTargetSize };
+
+/**
+ * Initialize carousel accessibility and interaction helpers.
+ *
+ * @pseudocode
+ * 1. Setup focus handlers for cards.
+ * 2. Enable keyboard and swipe navigation.
+ * 3. Apply accessibility improvements and lazy portrait loading.
+ *
+ * @param {HTMLElement} container - Carousel container element.
+ * @param {HTMLElement} wrapper - Carousel wrapper element.
+ */
+export function initAccessibility(container, wrapper) {
+  setupFocusHandlers(container);
+  setupKeyboardNavigation(container);
+  setupSwipeNavigation(container);
+  applyAccessibilityImprovements(wrapper);
+  setupLazyPortraits(container);
+}

--- a/src/helpers/carousel/index.js
+++ b/src/helpers/carousel/index.js
@@ -4,3 +4,4 @@ export * from "./accessibility.js";
 export * from "./responsive.js";
 export * from "./cards.js";
 export * from "./focus.js";
+export * from "./structure.js";

--- a/src/helpers/carousel/navigation.js
+++ b/src/helpers/carousel/navigation.js
@@ -1,4 +1,5 @@
 import { CAROUSEL_SWIPE_THRESHOLD } from "../constants.js";
+import { createScrollButton, updateScrollButtonState } from "./scroll.js";
 /**
  * Sets up keyboard navigation for the carousel container.
  *
@@ -94,4 +95,40 @@ export function setupSwipeNavigation(container) {
       scrollFromDelta(swipeDistance);
     }
   });
+}
+
+/**
+ * Create scroll buttons and synchronize their disabled state with the
+ * container's scroll position.
+ *
+ * @pseudocode
+ * 1. Build a `buttons` map with `left` and `right` using `createScrollButton`.
+ * 2. Append `left`, `container`, and `right` to `wrapper` in that order.
+ * 3. Define `updateButtons` via `updateScrollButtonState`.
+ * 4. Call `updateButtons` initially, on `scroll` (with a delayed recheck) and
+ *    on `resize`.
+ *
+ * @param {HTMLElement} container - Carousel container element.
+ * @param {HTMLElement} wrapper - Wrapper element to hold buttons and container.
+ */
+export function wireCarouselNavigation(container, wrapper) {
+  const buttons = {
+    left: createScrollButton("left", container),
+    right: createScrollButton("right", container)
+  };
+
+  wrapper.append(buttons.left, container, buttons.right);
+
+  const updateButtons = () => updateScrollButtonState(container, buttons.left, buttons.right);
+
+  let scrollTimeout;
+  const handleScroll = () => {
+    updateButtons();
+    clearTimeout(scrollTimeout);
+    scrollTimeout = setTimeout(updateButtons, 100);
+  };
+
+  updateButtons();
+  container.addEventListener("scroll", handleScroll);
+  window.addEventListener("resize", updateButtons);
 }

--- a/src/helpers/carousel/structure.js
+++ b/src/helpers/carousel/structure.js
@@ -1,0 +1,32 @@
+/**
+ * Create base DOM elements for a card carousel.
+ *
+ * @pseudocode
+ * 1. Create a wrapper `<div>` with class `carousel-container`.
+ * 2. Create an `aria-live` region and append it to the wrapper.
+ * 3. Create the scrolling container with required roles and styles.
+ * 4. Return the `wrapper`, `container` and `ariaLive` elements.
+ *
+ * @returns {{wrapper: HTMLElement, container: HTMLElement, ariaLive: HTMLElement}}
+ */
+export function createCarouselStructure() {
+  const wrapper = document.createElement("div");
+  wrapper.className = "carousel-container";
+
+  const ariaLive = document.createElement("div");
+  ariaLive.setAttribute("aria-live", "polite");
+  ariaLive.className = "carousel-aria-live";
+  wrapper.appendChild(ariaLive);
+
+  const container = document.createElement("div");
+  container.className = "card-carousel";
+  container.dataset.testid = "carousel";
+  container.setAttribute("role", "list");
+  container.setAttribute("aria-label", "Judoka card carousel");
+  container.style.scrollSnapType = "x mandatory";
+  container.style.overflowX = "auto";
+  container.style.display = "flex";
+  container.style.gap = "var(--carousel-gap, 1rem)";
+
+  return { wrapper, container, ariaLive };
+}

--- a/tests/helpers/carouselBuilder.test.js
+++ b/tests/helpers/carouselBuilder.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../src/helpers/carousel/index.js", async () => {
+  const actual = await vi.importActual("../../src/helpers/carousel/index.js");
+  return {
+    ...actual,
+    appendCards: vi.fn(async (container, list) => {
+      list.forEach(() => {
+        const card = document.createElement("div");
+        card.className = "judoka-card";
+        container.appendChild(card);
+      });
+    }),
+    setupResponsiveSizing: vi.fn()
+  };
+});
+
+import { buildCardCarousel } from "../../src/helpers/carouselBuilder.js";
+
+describe("buildCardCarousel", () => {
+  it("returns message when judoka list is empty", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const wrapper = await buildCardCarousel([], []);
+    errorSpy.mockRestore();
+    expect(wrapper.textContent).toContain("No cards available.");
+  });
+
+  it("updates scroll button state on scroll", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const wrapper = await buildCardCarousel([{ id: 1 }, { id: 2 }, { id: 3 }], []);
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+
+    const container = wrapper.querySelector(".card-carousel");
+    const [leftBtn, rightBtn] = wrapper.querySelectorAll(".scroll-button");
+
+    Object.defineProperty(container, "clientWidth", { value: 100, configurable: true });
+    Object.defineProperty(container, "scrollWidth", { value: 300, configurable: true });
+
+    container.scrollLeft = 0;
+    container.dispatchEvent(new Event("scroll"));
+    expect(leftBtn.disabled).toBe(true);
+    expect(rightBtn.disabled).toBe(false);
+
+    container.scrollLeft = 200;
+    container.dispatchEvent(new Event("scroll"));
+    expect(leftBtn.disabled).toBe(false);
+    expect(rightBtn.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract carousel structure, navigation wiring, and accessibility setup into dedicated helpers
- Orchestrate helpers in `buildCardCarousel` using a direction map for scroll buttons
- Add tests for empty carousel output and scroll button state changes

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 11 failed)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_689a19c1d32083268061e7317fa86d24