### PR TITLE
Refactor timer service with shared skip handler and auto-select helpers

### DIFF
--- a/src/helpers/classicBattle/autoSelectStat.js
+++ b/src/helpers/classicBattle/autoSelectStat.js
@@ -1,0 +1,26 @@
+import { seededRandom } from "../testModeUtils.js";
+import { STATS } from "../battleEngineFacade.js";
+import * as infoBar from "../setupBattleInfoBar.js";
+import { showSnackbar } from "../showSnackbar.js";
+
+const AUTO_SELECT_FEEDBACK_MS = 500;
+
+/**
+ * Automatically select a random stat and provide UI feedback.
+ *
+ * @param {(stat: string, opts?: { delayOpponentMessage?: boolean }) => Promise<void>|void} onSelect
+ * - Callback to handle the chosen stat.
+ * @returns {Promise<void>} Resolves after feedback completes.
+ */
+export async function autoSelectStat(onSelect) {
+  const randomStat = STATS[Math.floor(seededRandom() * STATS.length)];
+  const btn = document.querySelector(`#stat-buttons button[data-stat="${randomStat}"]`);
+  const label = btn?.textContent || randomStat;
+  if (btn) {
+    btn.classList.add("selected");
+  }
+  infoBar.showAutoSelect(label);
+  showSnackbar(`Time's up! Auto-selecting ${label}`);
+  await new Promise((resolve) => setTimeout(resolve, AUTO_SELECT_FEEDBACK_MS));
+  await onSelect(randomStat, { delayOpponentMessage: true });
+}

--- a/src/helpers/classicBattle/skipHandler.js
+++ b/src/helpers/classicBattle/skipHandler.js
@@ -1,0 +1,45 @@
+// Skip handler management utilities shared across timer orchestration
+// and cooldown scheduling.
+
+let skipHandler = null;
+let pendingSkip = false;
+
+/**
+ * Set the current skip handler and notify listeners of its presence.
+ * If a skip was requested before a handler existed, invoking this with
+ * a function will immediately trigger it and clear the pending state.
+ *
+ * @param {null|function(): void|Promise<void>} fn - Handler to invoke when skipping.
+ * @returns {void}
+ */
+export function setSkipHandler(fn) {
+  skipHandler = typeof fn === "function" ? fn : null;
+  window.dispatchEvent(
+    new CustomEvent("skip-handler-change", {
+      detail: { active: Boolean(skipHandler) }
+    })
+  );
+  if (pendingSkip && skipHandler) {
+    pendingSkip = false;
+    const current = skipHandler;
+    skipHandler = null;
+    window.dispatchEvent(new CustomEvent("skip-handler-change", { detail: { active: false } }));
+    current();
+  }
+}
+
+/**
+ * Skip the current timer phase if a handler is set. When no handler is
+ * available, mark the skip as pending so it runs once a handler is provided.
+ *
+ * @returns {void}
+ */
+export function skipCurrentPhase() {
+  if (skipHandler) {
+    const fn = skipHandler;
+    setSkipHandler(null);
+    fn();
+  } else {
+    pendingSkip = true;
+  }
+}

--- a/tests/helpers/classicBattle/timerService.skip.test.js
+++ b/tests/helpers/classicBattle/timerService.skip.test.js
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 describe("timerService pending skip", () => {
   it("fires handler once registered after pending skip", async () => {
     vi.resetModules();
-    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const mod = await import("../../../src/helpers/classicBattle/skipHandler.js");
     const handler = vi.fn();
     mod.skipCurrentPhase();
     mod.setSkipHandler(handler);

--- a/tests/helpers/timerService.test.js
+++ b/tests/helpers/timerService.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("timerService", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("enables next round when skipped before cooldown starts", async () => {
+    const btn = document.createElement("button");
+    btn.id = "next-button";
+    btn.classList.add("disabled");
+    document.body.appendChild(btn);
+    const timerEl = document.createElement("div");
+    timerEl.id = "next-round-timer";
+    document.body.appendChild(timerEl);
+
+    const skip = await import("../../src/helpers/classicBattle/skipHandler.js");
+    skip.skipCurrentPhase();
+
+    const runSpy = vi.fn();
+    vi.mock("../../src/helpers/classicBattle/runTimerWithDrift.js", () => ({
+      runTimerWithDrift: vi.fn(() => runSpy)
+    }));
+    vi.mock("../../src/helpers/uiHelpers.js", () => ({
+      updateDebugPanel: vi.fn()
+    }));
+    vi.mock("../../src/helpers/showSnackbar.js", () => ({
+      showSnackbar: vi.fn(),
+      updateSnackbar: vi.fn()
+    }));
+    vi.mock("../../src/helpers/setupBattleInfoBar.js", () => ({
+      clearTimer: vi.fn(),
+      showMessage: vi.fn(),
+      showAutoSelect: vi.fn(),
+      showTemporaryMessage: () => () => {}
+    }));
+    vi.mock("../../src/helpers/battleEngineFacade.js", () => ({
+      startCoolDown: vi.fn(),
+      startRound: vi.fn(),
+      stopTimer: vi.fn(),
+      STATS: ["a", "b"]
+    }));
+
+    const mod = await import("../../src/helpers/classicBattle/timerService.js");
+    mod.scheduleNextRound({ matchEnded: false });
+
+    expect(btn.dataset.nextReady).toBe("true");
+    expect(runSpy).not.toHaveBeenCalled();
+  });
+
+  it("auto-selects a stat after the round timer expires", async () => {
+    const timerEl = document.createElement("div");
+    timerEl.id = "next-round-timer";
+    document.body.appendChild(timerEl);
+    const statButtons = document.createElement("div");
+    statButtons.id = "stat-buttons";
+    const btnA = document.createElement("button");
+    btnA.dataset.stat = "a";
+    btnA.textContent = "A";
+    statButtons.appendChild(btnA);
+    document.body.appendChild(statButtons);
+
+    vi.mock("../../src/helpers/classicBattle/runTimerWithDrift.js", () => ({
+      runTimerWithDrift: vi.fn(() => async (_d, _t, onExpired) => {
+        await onExpired();
+      })
+    }));
+    vi.mock("../../src/helpers/showSnackbar.js", () => ({
+      showSnackbar: vi.fn(),
+      updateSnackbar: vi.fn()
+    }));
+    vi.mock("../../src/helpers/setupBattleInfoBar.js", () => ({
+      clearTimer: vi.fn(),
+      showAutoSelect: vi.fn(),
+      showMessage: vi.fn(),
+      showTemporaryMessage: () => () => {}
+    }));
+    vi.mock("../../src/helpers/uiHelpers.js", () => ({
+      updateDebugPanel: vi.fn()
+    }));
+    vi.mock("../../src/helpers/battleEngineFacade.js", () => ({
+      startRound: vi.fn(),
+      startCoolDown: vi.fn(),
+      stopTimer: vi.fn(),
+      STATS: ["a", "b"]
+    }));
+    vi.mock("../../src/helpers/testModeUtils.js", () => ({
+      seededRandom: () => 0
+    }));
+    vi.mock("../../src/helpers/timerUtils.js", () => ({
+      getDefaultTimer: vi.fn(() => Promise.resolve(30))
+    }));
+    vi.mock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+      dispatchBattleEvent: vi.fn()
+    }));
+
+    const mod = await import("../../src/helpers/classicBattle/timerService.js");
+    const onSelect = vi.fn();
+    const promise = mod.startTimer(onSelect);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(onSelect).toHaveBeenCalledWith("a", { delayOpponentMessage: true });
+    expect(btnA.classList.contains("selected")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- extract skip handler utilities into `skipHandler.js`
- move stat auto-selection & feedback into `autoSelectStat.js`
- refactor timerService to use new helpers and respect early skips
- add coverage for skipping before cooldown and auto-selection after timer

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689a26d9d8448326b01cf271e26f5126