### PR TITLE
refactor battle engine stat comparison and drift watcher

### DIFF
--- a/tests/helpers/BattleEngine.test.js
+++ b/tests/helpers/BattleEngine.test.js
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { compareStats, createDriftWatcher } from "../../src/helpers/BattleEngine.js";
+
+describe("compareStats", () => {
+  it("detects player win", () => {
+    expect(compareStats(5, 3)).toEqual({ delta: 2, winner: "player" });
+  });
+
+  it("detects computer win", () => {
+    expect(compareStats(3, 5)).toEqual({ delta: -2, winner: "computer" });
+  });
+
+  it("detects tie", () => {
+    expect(compareStats(4, 4)).toEqual({ delta: 0, winner: "tie" });
+  });
+});
+
+describe("createDriftWatcher", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("invokes callback when drift exceeds threshold", () => {
+    vi.useFakeTimers();
+    const timer = {
+      hasActiveTimer: vi.fn().mockReturnValue(true),
+      getState: vi.fn().mockReturnValue({ remaining: 13, paused: false })
+    };
+    const onDrift = vi.fn();
+    const watch = createDriftWatcher(timer);
+    watch(10, onDrift);
+    vi.advanceTimersByTime(1000);
+    expect(onDrift).toHaveBeenCalledWith(13);
+  });
+});


### PR DESCRIPTION
## Summary
- add `compareStats` helper returning delta and winner
- refactor `handleStatSelection` to use lookup table
- extract drift monitoring to `createDriftWatcher`
- test stat comparisons and drift watcher callback

## Testing
- `npx vitest run tests/helpers/BattleEngine.test.js`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689a49ee344083268b64cc9fe3098877