### PR TITLE
Guard displayJudokaCard against missing container

### DIFF
--- a/src/helpers/cardUtils.js
+++ b/src/helpers/cardUtils.js
@@ -52,13 +52,13 @@ export function getRandomJudoka(data) {
  * Displays a judoka card in the specified game area.
  *
  * @pseudocode
- * 1. Validate the `judoka` object:
- *    - Ensure `judoka` contains all required fields.
- *    - If invalid, log an error and display a fallback message in the `gameArea`.
- *
- * 2. Validate the `gameArea` element:
+ * 1. Validate the `gameArea` element:
  *    - Ensure `gameArea` is not `null` or `undefined`.
  *    - If invalid, log an error and exit the function.
+ *
+ * 2. Validate the `judoka` object:
+ *    - Ensure `judoka` contains all required fields.
+ *    - If invalid, log an error and display a fallback message in the `gameArea`.
  *
  * 3. Clear the `gameArea`:
  *    - Set its `innerHTML` to an empty string to remove existing content.
@@ -78,16 +78,15 @@ export function getRandomJudoka(data) {
  */
 export async function displayJudokaCard(judoka, gokyo, gameArea) {
   debugLog("Judoka passed to displayJudokaCard:", judoka);
+  if (!gameArea) {
+    console.error("Game area is not available.");
+    return;
+  }
 
   if (!hasRequiredJudokaFields(judoka)) {
     console.error("Invalid judoka object:", judoka);
     const missing = getMissingJudokaFields(judoka).join(", ");
     gameArea.innerHTML = `<p>⚠️ Invalid judoka data. Missing fields: ${missing}</p>`;
-    return;
-  }
-
-  if (!gameArea) {
-    console.error("Game area is not available.");
     return;
   }
 

--- a/tests/helpers/cardUtils.test.js
+++ b/tests/helpers/cardUtils.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { displayJudokaCard } from "../../src/helpers/cardUtils.js";
+
+const validJudoka = {
+  firstname: "A",
+  surname: "B",
+  country: "C",
+  countryCode: "cc",
+  stats: { power: 1, speed: 1, technique: 1, kumikata: 1, newaza: 1 },
+  weightClass: "-60",
+  signatureMoveId: 1,
+  rarity: 1
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("displayJudokaCard", () => {
+  it("returns early with console error when gameArea is null", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(displayJudokaCard(validJudoka, {}, null)).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith("Game area is not available.");
+  });
+
+  it("handles null gameArea even when judoka is invalid", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(displayJudokaCard({}, {}, null)).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith("Game area is not available.");
+  });
+});


### PR DESCRIPTION
## Summary
- guard displayJudokaCard with early gameArea check and error
- note pseudocode reflects game area validation first
- add tests confirming null gameArea exits without throwing

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689af2d0108c83268642a54fc8bc8b22