### PR TITLE
Handle immediate countdown expiration for non-positive durations

### DIFF
--- a/src/helpers/timerUtils.js
+++ b/src/helpers/timerUtils.js
@@ -38,8 +38,11 @@ export function _resetForTest() {
  *
  * @pseudocode
  * 1. Store the initial duration and callbacks.
- * 2. `start()` resets the remaining time and begins a 1s interval.
- *    - Invoke `onTick` immediately with the starting value.
+ * 2. `start()` resets the remaining time and handles immediate expiration.
+ *    - If the duration is non-positive, invoke `onTick(0)` and `onExpired`
+ *      without starting an interval.
+ *    - Otherwise, begin a 1s interval and invoke `onTick` immediately with
+ *      the starting value.
  *    - On each tick, decrement `remaining` and call `onTick`.
  *    - When the value reaches 0, stop the interval and call `onExpired`.
  *    - When `pauseOnHidden` is true, attach a `visibilitychange` listener that
@@ -82,6 +85,11 @@ export function createCountdownTimer(duration, { onTick, onExpired, pauseOnHidde
     stop();
     remaining = duration;
     paused = false;
+    if (remaining <= 0) {
+      if (typeof onTick === "function") onTick(0);
+      if (typeof onExpired === "function") onExpired();
+      return;
+    }
     if (typeof onTick === "function") onTick(remaining);
     intervalId = setInterval(async () => {
       try {

--- a/tests/helpers/createCountdownTimer.test.js
+++ b/tests/helpers/createCountdownTimer.test.js
@@ -45,4 +45,19 @@ describe("createCountdownTimer", () => {
     expect(onExpired).toHaveBeenCalled();
     vi.useRealTimers();
   });
+
+  it.each([0, -1])("expires immediately for non-positive duration %i", (dur) => {
+    vi.useFakeTimers();
+    const onTick = vi.fn();
+    const onExpired = vi.fn();
+    const timer = createCountdownTimer(dur, { onTick, onExpired });
+    timer.start();
+    expect(onTick).toHaveBeenCalledOnce();
+    expect(onTick).toHaveBeenCalledWith(0);
+    expect(onExpired).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(1000);
+    expect(onTick).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure countdown timer expires instantly for zero or negative duration
- test immediate expiry and absence of lingering intervals

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689af703cd208326b9e71ef9b7bd3144