### PR TITLE
Decode Playwright server request paths

### DIFF
--- a/scripts/playwrightServer.js
+++ b/scripts/playwrightServer.js
@@ -35,7 +35,8 @@ function getContentType(filePath) {
 }
 
 const server = http.createServer((req, res) => {
-  const requestPath = req.url.replace(/^\/+/, "");
+  const { pathname } = new URL(req.url, `http://${req.headers.host}`);
+  const requestPath = decodeURIComponent(pathname).replace(/^\/+/, "");
   let filePath = path.resolve(rootDir, requestPath === "" ? "index.html" : requestPath);
   if (path.relative(rootDir, filePath).startsWith("..")) {
     res.statusCode = 403;


### PR DESCRIPTION
## Summary
- normalize server request paths by decoding URL pathname before resolving files

## Testing
- `npx prettier . --check` *(fails: src/pages/battleJudoka.html)*
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 12 tests failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b155e2afc8326934ec8211f60b9e7