### PR TITLE
feat: support woff fonts in test server

### DIFF
--- a/scripts/playwrightServer.js
+++ b/scripts/playwrightServer.js
@@ -27,7 +27,9 @@ const mimeTypes = {
   ".png": "image/png",
   ".jpg": "image/jpeg",
   ".svg": "image/svg+xml",
-  ".ico": "image/x-icon"
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2"
 };
 
 function getContentType(filePath) {


### PR DESCRIPTION
## Summary
- serve woff and woff2 fonts in Playwright test server

## Testing
- `npx prettier scripts/playwrightServer.js --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test --reporter=line` *(fails: 12 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b18b8313c83269bd3af9225fb3fc0