### PR TITLE
fix hidden attribute checks in settings test

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -27,14 +27,14 @@ test.describe.parallel("Settings page", () => {
     await page.locator("#general-settings-toggle").click();
     await page.locator("#game-modes-toggle").click();
     await page.getByRole("checkbox", { name: "Classic Battle" }).waitFor({ state: "visible" });
-    if (await page.locator("#general-settings-content").getAttribute("hidden")) {
+    if ((await page.locator("#general-settings-content").getAttribute("hidden")) !== null) {
       await page.locator("#general-settings-toggle").click();
     }
-    if (await page.locator("#game-modes-content").getAttribute("hidden")) {
+    if ((await page.locator("#game-modes-content").getAttribute("hidden")) !== null) {
       await page.locator("#game-modes-toggle").click();
     }
     const advancedContent = page.locator("#advanced-settings-content");
-    if (await advancedContent.getAttribute("hidden")) {
+    if ((await advancedContent.getAttribute("hidden")) !== null) {
       await page.locator("#advanced-settings-toggle").click();
     }
   });


### PR DESCRIPTION
## Summary
- check for `hidden` attribute presence explicitly in settings tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/settings.spec.js`
- `npx playwright test` *(fails: screenshot diffs in unrelated tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b1bc446848326b4fe3cc544d6e7d4