### PR TITLE
refactor: drop legacy settings section styles

### DIFF
--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -22,8 +22,12 @@
 /* Reset fieldset styles inside settings forms */
 .settings-form fieldset {
   border: none;
-  margin: 0;
+  margin: 0 0 var(--space-lg);
   padding: var(--space-sm);
+}
+
+.settings-form fieldset:last-of-type {
+  margin-block-end: 0;
 }
 
 .settings-form {
@@ -147,36 +151,6 @@
 
 .slider.round::before {
   border-radius: 50%;
-}
-
-.settings-section {
-  margin-block-end: var(--space-lg);
-}
-
-.settings-section-toggle {
-  width: 100%;
-  text-align: left;
-  padding: var(--space-sm) var(--space-md);
-  background: var(--button-bg);
-  color: var(--button-text-color);
-  border: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  min-height: var(--touch-target-size);
-}
-
-.settings-section-toggle:hover {
-  background: var(--button-hover-bg);
-}
-
-.settings-section-toggle:focus-visible {
-  outline: 2px solid var(--button-hover-bg);
-  outline-offset: 2px;
-}
-
-.settings-section-content {
-  padding-block-start: var(--space-sm);
-  transition: height var(--transition-fast);
 }
 
 /* Display mode radio group */


### PR DESCRIPTION
## Summary
- remove legacy `.settings-section` styling and related toggles
- rely on `.settings-form fieldset` spacing with margin and last-of-type reset

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 8 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b210f71c083268ea770f3b7cbe96d