### PR TITLE
Remove collapsible settings section guidelines

### DIFF
--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -31,6 +31,9 @@ To ensure the **Settings** page remains consistent, visually appealing, and acce
 - **Navigation and Tab Order**
   Place controls in top-down, left-to-right order in the HTML to preserve logical keyboard navigation.
 
+- **Simultaneous Sections**
+  Display all settings sections at once to simplify UI testing; avoid collapsible containers.
+
 ### Settings Item Structure
 
 Each toggle or control should display a label followed by a short description.
@@ -157,63 +160,6 @@ Reuse the following markup for general settings, game modes, and feature flags:
 
 ---
 
-## Collapsible Settings Sections (Recommended Pattern)
-
-To improve organization and reduce visual clutter, each major settings area (e.g., General Settings, Game Modes) should be collapsed by default and expandable via click or keyboard toggle. This pattern enhances accessibility and scalability as more settings are added.
-
-### Markup Example
-
-```html
-<div class="settings-section">
-  <button
-    type="button"
-    class="settings-section-toggle"
-    aria-expanded="false"
-    aria-controls="general-settings-content"
-    id="general-settings-toggle"
-  >
-    General Settings
-  </button>
-  <div
-    class="settings-section-content"
-    id="general-settings-content"
-    role="region"
-    aria-labelledby="general-settings-toggle"
-    hidden
-  >
-    <fieldset>...settings controls...</fieldset>
-  </div>
-</div>
-```
-
-- Repeat for each section (e.g., Game Modes).
-- The toggle button must be keyboard-focusable and operable (Enter/Space).
-- Toggle buttons must use `type="button"` to avoid submitting the form.
-- Use `aria-expanded`, `aria-controls`, and `aria-labelledby` for accessibility.
-- The content div should be hidden by default (`hidden` attribute or `display: none;`).
-
-### Interaction & Accessibility
-
-- Clicking or pressing Enter/Space on the toggle expands/collapses the section and updates `aria-expanded`.
-- Only one or multiple sections may be open at a time (choose per UX needs).
-- All controls inside the section remain tabbable and accessible when expanded.
-- Use CSS transitions for smooth expand/collapse if desired.
-
-### Styling
-
-- Use `.settings-section`, `.settings-section-toggle`, and `.settings-section-content` classes for structure and styling.
-- Ensure toggle buttons and content meet touch target and contrast requirements.
-
-### Testing Checklist (add to existing)
-
-- [ ] Section toggles are keyboard and screen reader accessible
-- [ ] Collapsed sections hide content from screen readers and tab order
-- [ ] Expanding a section reveals its controls in tab order
-
----
-
----
-
 ## Feature Flags & Agent Observability
 
 To support AI-assisted testing, variant gameplay modes, and scalable development, JU-DO-KON! uses a **feature flag system** exposed via the `settings.html` page. Feature flags allow agents and users to toggle experimental or optional features without altering code. Components should also expose their internal state in the DOM for real-time observability. For player-facing instructions see the [README section on Settings & Feature Flags](../../README.md#settings--feature-flags).
@@ -240,32 +186,12 @@ To support AI-assisted testing, variant gameplay modes, and scalable development
   - UI must reflect the saved state on load and provide immediate visual feedback on toggle
 
 - **Grouping**
-  - Place all feature flags in a dedicated `<fieldset>` titled `Feature Flags`
-  - For advanced/experimental features, nest under `Advanced Settings` with appropriate section toggling
+  - Place all feature flags in a dedicated `<fieldset>` titled `Feature Flags`.
   - Markup example:
     ```html
-    <div class="settings-section">
-      <button
-        type="button"
-        class="settings-section-toggle"
-        id="advanced-settings-toggle"
-        aria-expanded="false"
-        aria-controls="advanced-settings-content"
-      >
-        Advanced Settings
-      </button>
-      <div
-        class="settings-section-content"
-        id="advanced-settings-content"
-        role="region"
-        aria-labelledby="advanced-settings-toggle"
-        hidden
-      >
-        <fieldset id="feature-flags-container" class="game-mode-toggle-container settings-form">
-          ...
-        </fieldset>
-      </div>
-    </div>
+    <fieldset id="feature-flags-container" class="game-mode-toggle-container settings-form">
+      ...
+    </fieldset>
     ```
   - When a flag changes, display a short confirmation using `showSnackbar()` to inform the user of the new state.
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -187,7 +187,7 @@ Pages should query `featureFlags.isEnabled` rather than reading
 
 ### Advanced Settings & Feature Flag Info
 
-- Experimental and debug flags are grouped under a collapsible **Advanced Settings** section.
+  - Experimental and debug flags are grouped under an **Advanced Settings** section that remains visible to simplify testing.
 - When a flag is toggled, a snackbar appears with text from `tooltips.json` keyed by `settings.<flagName>`.
 - The snackbar confirms the change and hides itself after a short delay.
 - Debug-focused flags remain tucked away so younger players do not accidentally enable them.
@@ -211,32 +211,6 @@ Pages should query `featureFlags.isEnabled` rather than reading
 - AC-8.3 Color contrast of text and controls meets WCAG 2.1 minimum (4.5:1) in all display modes.
 - AC-8.4 Touch targets meet or exceed a 44px minimum size (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness)).
 - AC-8.5 All settings, including feature flags, show a label and brief description using the same markup as the Advanced Settings section (see [Settings Item Structure](../codeStandards/settingsPageDesignGuidelines.md#settings-item-structure)).
-
----
-
-## Collapsible Settings Sections
-
-To improve organization and reduce visual clutter, the Settings Menu should present each major area (e.g., General Settings, Game Modes) as a collapsible section. By default, all sections are collapsed; users can expand a section by clicking or using the keyboard. This approach supports accessibility, scalability, and a cleaner user experience as more settings are added.
-
-### Functional Requirement
-
-- Each settings area is collapsed by default and can be expanded/collapsed by the user.
-- Section headers are keyboard-focusable and operable (Enter/Space).
-- ARIA attributes (`aria-expanded`, `aria-controls`, `aria-labelledby`) are used for accessibility.
-- Only expanded sections are included in the tab order.
-- The implementation must meet all accessibility and performance requirements outlined elsewhere in this PRD.
-
-### Acceptance Criteria
-
-- AC-9.1 All settings areas are collapsed by default on page load.
-- AC-9.2 Clicking or pressing Enter/Space on a section header toggles its expanded/collapsed state and updates `aria-expanded`.
-- AC-9.3 When collapsed, section content is hidden from both view and tab order.
-- AC-9.4 When expanded, section content is visible and all controls are accessible via keyboard and screen reader.
-- AC-9.5 Section toggles and content meet touch target and color contrast requirements.
-
-### Rationale
-
-This pattern keeps the settings page organized and accessible, especially as more options are added. It also aligns with modern accessibility and responsive design standards.
 
 ---
 
@@ -268,6 +242,7 @@ This pattern keeps the settings page organized and accessible, especially as mor
   - Tab order should proceed top-to-bottom: **display mode → sound → motion → game mode toggles**.
   - Users can navigate and activate each control without needing a mouse.
   - **Section layout:** The page begins with an `h1` heading followed by two `fieldset` sections—**General Settings** and **Game Modes**—each using the `.game-mode-toggle-container` grid. The second fieldset keeps `id="game-mode-toggle-container"` so scripts can find it.
+  - To simplify UI testing, all settings sections are displayed simultaneously.
 
   | **Settings Menu Mockup 1**                                         | **Settings Menu Mockup 2**                                         | **Settings Menu Mockup 2**                                         |
   | ------------------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
@@ -363,9 +338,9 @@ The page begins with an `h1` heading labeled "Settings". Two `fieldset` sections
   - [ ] 11.1 Run Pa11y or equivalent accessibility audit on the settings page and resolve any issues.
   - [ ] 11.2 Verify all color contrast ratios meet WCAG 2.1 (4.5:1) in all display modes.
   - [ ] 11.3 Verify all touch targets are ≥44px and add Playwright tests if needed.
-  - [ ] 11.4 Add Playwright UI tests for keyboard navigation, ARIA attributes, and section collapse/expand accessibility.
+  - [ ] 11.4 Add Playwright UI tests for keyboard navigation and ARIA attributes.
 - [ ] 12.0 Visual Regression
-  - [ ] 12.1 Add Playwright screenshot tests for the settings page in all display modes and collapsed/expanded states.
+  - [ ] 12.1 Add Playwright screenshot tests for the settings page in all display modes.
 
 ---
 


### PR DESCRIPTION
## Summary
- drop Collapsible Settings Sections from settings PRD and design guidelines
- document that all settings sections stay visible to ease UI testing
- clean up examples and tasks to match new always-visible layout

## Testing
- `npx prettier design/productRequirementsDocuments/prdSettingsMenu.md design/codeStandards/settingsPageDesignGuidelines.md --check`
- `npx eslint .` *(fails: Delete `⏎··⏎⏎··` at playwright/settings.spec.js:193:3)*
- `npx vitest run`
- `npx playwright test` *(fails: screenshot diffs in playwright/settings-screenshot.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b2f2cc6bc8326b57bd3f6d5316d93