### PR TITLE
fix: respect early display mode interactions

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -172,7 +172,14 @@ function makeRenderSwitches(controls, getCurrentSettings, handleUpdate) {
   return function renderSwitches(gameModes, tooltipMap) {
     // Apply current settings once toggles are available.
     const current = getCurrentSettings();
-    applyInitialControlValues(controls, current, tooltipMap);
+    const radio = document.querySelector('input[name="display-mode"]:checked');
+    let next = current;
+    if (radio && radio.value !== current.displayMode) {
+      withViewTransition(() => applyDisplayMode(radio.value));
+      handleUpdate("displayMode", radio.value, () => {});
+      next = { ...current, displayMode: radio.value };
+    }
+    applyInitialControlValues(controls, next, tooltipMap);
     const modesContainerEl = document.getElementById("game-mode-toggle-container");
     if (modesContainerEl && Array.isArray(gameModes)) {
       clearToggles(modesContainerEl);


### PR DESCRIPTION
## Summary
- handle initial display mode selection before reinitializing settings controls

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: expected string to contain src attribute)*
- `npx playwright test` *(fails: multiple screenshot mismatches)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b47de00a4832690aefbd3c37d3d27