### PR TITLE
Refactor country list helpers and add tests

### DIFF
--- a/tests/helpers/populateCountryList.test.js
+++ b/tests/helpers/populateCountryList.test.js
@@ -94,7 +94,7 @@ describe("populateCountryList", () => {
     });
   });
 
-  it("lazy loads additional countries on scroll", async () => {
+  it("lazy loads country batches on scroll", async () => {
     const judoka = Array.from({ length: 60 }, (_, i) => ({
       id: i,
       firstname: "A",
@@ -182,7 +182,7 @@ describe("populateCountryList", () => {
     expect(names).toEqual(["All", "Japan"]);
   });
 
-  it("shows a message if no countries are found", async () => {
+  it("renders 'No countries available.' when no active countries exist", async () => {
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue([])
     }));


### PR DESCRIPTION
## Summary
- centralize country data loading in new `fetchActiveCountries`
- extract helpers for rendering country list and flag lazy-loading
- add tests for empty country list messaging and scroll-based batch loading

## Testing
- `npx prettier src/helpers/country/list.js tests/helpers/populateCountryList.test.js --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 11 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b557e97208326852f748cbde6738f