### PR TITLE
Simplify carousel portrait error handling

### DIFF
--- a/src/helpers/carousel/cards.js
+++ b/src/helpers/carousel/cards.js
@@ -37,13 +37,12 @@ export async function appendCards(container, judokaList, gokyoLookup) {
       if (img) {
         // Be resilient: if a portrait 404s, fall back to the silhouette image
         // without reconstructing the entire card to avoid layout/DOM churn.
-        const onError = () => {
+        img.onerror = () => {
           // Clear handler to avoid loops and set placeholder directly.
           img.onerror = null;
           img.removeAttribute("data-portrait-src");
           img.src = "../assets/judokaPortraits/judokaPortrait-0.png";
         };
-        img.addEventListener("error", onError, { once: true });
       }
       card.tabIndex = 0;
       card.setAttribute("role", "listitem");


### PR DESCRIPTION
## Summary
- Swap the judoka portrait to a silhouette on load errors without rebuilding the card

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: JudokaCard did not render an HTMLElement)
- `npx playwright test playwright/browse-judoka-navigation.spec.js` (fails: unexpected page counter text)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b64cb122c8326a3b320d0132b2342