### PR TITLE
Refactor battle control buttons layout

### DIFF
--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -97,16 +97,30 @@
             </div>
 
             <p id="round-result" aria-live="polite" aria-atomic="true"></p>
-            <button id="next-button" class="disabled" data-tooltip-id="ui.next">Next</button>
-            <button
-              id="stat-help"
-              class="info-button"
-              aria-label="Stat selection help"
-              data-tooltip-id="ui.selectStat"
-            >
-              ?
-            </button>
-            <button id="quit-match-button" data-tooltip-id="ui.quitMatch">Quit Match</button>
+            <div class="action-buttons">
+              <button
+                id="next-button"
+                class="disabled battle-control-button"
+                data-tooltip-id="ui.next"
+              >
+                Next
+              </button>
+              <button
+                id="stat-help"
+                class="battle-control-button"
+                aria-label="Stat selection help"
+                data-tooltip-id="ui.selectStat"
+              >
+                ?
+              </button>
+              <button
+                id="quit-match-button"
+                class="battle-control-button"
+                data-tooltip-id="ui.quitMatch"
+              >
+                Quit Match
+              </button>
+            </div>
             <div id="debug-panel" class="debug-panel hidden">
               <pre id="debug-output" role="status" aria-live="polite"></pre>
             </div>

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -85,9 +85,13 @@
 }
 
 /* Control buttons */
-#next-button,
-#quit-match-button {
-  min-width: var(--touch-target-size, 44px);
+.action-buttons {
+  display: flex;
+  gap: var(--space-md);
+}
+
+.battle-control-button {
+  flex: 1;
   min-height: var(--touch-target-size, 44px);
   margin-top: var(--space-md);
 }

--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -85,33 +85,6 @@ button:focus-visible,
   background-color: var(--button-active-bg);
 }
 
-.info-button {
-  width: var(--touch-target-size, 44px);
-  height: var(--touch-target-size, 44px);
-  min-width: var(--touch-target-size, 44px);
-  min-height: var(--touch-target-size, 44px);
-  border-radius: 50%;
-  background-color: transparent;
-  color: var(--button-bg);
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: bold;
-}
-
-.info-button:hover,
-.info-button:focus-visible,
-.info-button:focus {
-  background-color: var(--button-hover-bg);
-  color: var(--button-text-color);
-}
-
-.info-button:active {
-  background-color: var(--button-active-bg);
-  transform: scale(0.95);
-}
-
 a:focus,
 a:focus-visible {
   outline-offset: 2px;


### PR DESCRIPTION
## Summary
- Wrap battle screen control buttons in a flex container and give them a shared class for equal width
- Add flex styles for the new container and buttons; remove obsolete info-button styles

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 9 failed, 595 passed)*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b6dfcf9388326bae4ab3e6ae36e3f