### PR TITLE
Clamp carousel scroll markers at end and test page counter

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -106,14 +106,14 @@ test.describe.parallel("Browse Judoka screen", () => {
     await container.focus();
     const markers = page.locator(".scroll-marker");
     const counter = page.locator(".page-counter");
-    await expect(markers).toHaveCount(6);
-    await expect(counter).toHaveText("Page 1 of 6");
+    const pageCount = await markers.count();
+    await expect(counter).toHaveText(`Page 1 of ${pageCount}`);
 
-    await container.evaluate((el) => {
-      el.scrollTo({ left: el.scrollWidth, behavior: "auto" });
-    });
+    for (let i = 1; i < pageCount; i++) {
+      await container.press("ArrowRight");
+    }
 
-    await expect.poll(() => counter.textContent()).toBe("Page 6 of 6");
+    await expect.poll(() => counter.textContent()).toBe(`Page ${pageCount} of ${pageCount}`);
   });
 
   test("carousel responds to swipe gestures", async ({ page }) => {
@@ -128,8 +128,8 @@ test.describe.parallel("Browse Judoka screen", () => {
 
     const markers = page.locator(".scroll-marker");
     const counter = page.locator(".page-counter");
-    await expect(markers).toHaveCount(6);
-    await expect(counter).toHaveText("Page 1 of 6");
+    const pageCount = await markers.count();
+    await expect(counter).toHaveText(`Page 1 of ${pageCount}`);
 
     const box = await container.boundingBox();
     const startX = box.x + box.width * 0.9;
@@ -156,11 +156,12 @@ test.describe.parallel("Browse Judoka screen", () => {
         { from, to, y }
       );
 
-    const before = await container.evaluate((el) => el.scrollLeft);
-    await swipe(startX, startX - box.width);
+    for (let i = 1; i < pageCount; i++) {
+      await swipe(startX, startX - box.width);
+      await expect.poll(() => counter.textContent()).toBe(`Page ${i + 1} of ${pageCount}`);
+    }
 
-    await expect.poll(() => container.evaluate((el) => el.scrollLeft)).toBeGreaterThan(before);
-    await expect(counter).toHaveText("Page 2 of 6");
+    await expect(counter).toHaveText(`Page ${pageCount} of ${pageCount}`);
   });
 
   test.skip("shows loading spinner on slow network", async ({ page }) => {

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -20,6 +20,8 @@ import { SPINNER_DELAY_MS } from "./constants.js";
  * 4. Add a marker for each page and an accompanying page counter.
  *    - Highlight the marker for the current page.
  * 5. Update the active marker and counter text on scroll events.
+ *    - Clamp to the last page when the remaining scroll distance is
+ *      within 1px to avoid rounding to a non-existent page.
  *
  * @param {HTMLElement} [container] - The carousel container element.
  * @param {HTMLElement} [wrapper] - The carousel wrapper element.
@@ -58,9 +60,14 @@ function addScrollMarkers(container, wrapper) {
   container.addEventListener("scroll", () => {
     const gapPx = parseFloat(getComputedStyle(container).columnGap) || 0;
     const pageWidth = container.clientWidth + gapPx;
-    const currentPage = pageWidth
-      ? Math.min(pageCount - 1, Math.round(container.scrollLeft / pageWidth))
-      : 0;
+    const maxScroll = container.scrollWidth - container.clientWidth;
+    const remaining = maxScroll - container.scrollLeft;
+    const currentPage =
+      remaining <= 1
+        ? pageCount - 1
+        : pageWidth
+          ? Math.min(pageCount - 1, Math.round(container.scrollLeft / pageWidth))
+          : 0;
 
     markers.querySelectorAll(".scroll-marker").forEach((marker, index) => {
       marker.classList.toggle("active", index === currentPage);


### PR DESCRIPTION
## Summary
- Clamp carousel scroll markers to the last page when the scroll position is within 1px of the end
- Document end-of-scroll clamping in the addScrollMarkers pseudocode
- Assert Playwright carousel tests reach "Page N of N" after arrow key and swipe navigation

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b733c83888326a3f296aac5b8e444