### PR TITLE
test: await PRD content before initial capture

### DIFF
--- a/playwright/prd-reader.spec.js
+++ b/playwright/prd-reader.spec.js
@@ -39,6 +39,7 @@ test.describe.parallel("PRD Reader page", () => {
   test("tab and arrow key traversal", async ({ page }) => {
     const items = page.locator(".sidebar-list li");
     const container = page.locator("#prd-content");
+    await expect(container).not.toHaveText("");
     const initial = await container.innerHTML();
     const isFirstFocused = async () =>
       await items.first().evaluate((el) => el === document.activeElement);


### PR DESCRIPTION
## Summary
- ensure PRD reader test waits for content load

## Testing
- `npx prettier . --check` *(fails: tests/helpers/classicBattle/scheduleNextRound.skip.test.js needs formatting)*
- `npx eslint .` *(fails: prettier/prettier in tests/helpers/classicBattle/scheduleNextRound.skip.test.js)*
- `npx vitest run` *(fails: JudokaCard did not render an HTMLElement)*
- `npx playwright test` *(fails: 3 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b8698f92c8326b80e0c7d9d15eb5a