### PR TITLE
feat(agent): introduce animation scheduler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ npx playwright test # run Playwright UI tests
 - Confirm that any new or modified functions include JSDoc with an `@pseudocode` block so documentation stays complete.
 - Playwright tests clear localStorage at startup. If a manual run fails unexpectedly, clear it in your browser and ensure [http://localhost:5000](http://localhost:5000) is served (start it with `npm start`).
 - Use `src/helpers/storage.js` for persistent data access instead of direct `localStorage` calls.
+- Use the shared scheduler (`src/utils/scheduler.js`) for all timing-sensitive work instead of standalone timers.
 
 **For UI-related changes (styles, components, layout):**
 

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -12,18 +12,19 @@
  *    c. Waits for the Mystery card to render using `waitForComputerCard` then
  *       re-enables stat buttons.
  * 5. Define `setupClassicBattlePage` to:
- *    a. Initialize the battle info bar.
- *    b. Load feature flags, apply them to `#battle-area` and react to changes.
- *    c. Initialize stat buttons, attach listeners, and display a snackbar with
+ *    a. Start the shared scheduler.
+ *    b. Initialize the battle info bar.
+ *    c. Load feature flags, apply them to `#battle-area` and react to changes.
+ *    d. Initialize stat buttons, attach listeners, and display a snackbar with
  *       the chosen stat.
- *    d. Set `window.startRoundOverride` to `startRoundWrapper` so the battle
+ *    e. Set `window.startRoundOverride` to `startRoundWrapper` so the battle
  *       module uses it for subsequent rounds.
- *    e. Toggle the debug panel.
- *    f. Show a round selection modal that sets points-to-win and starts the first round.
- *    g. Initialize tooltips and show the stat help tooltip once for new users.
- *    h. Watch for orientation changes and update the battle header's
+ *    f. Toggle the debug panel.
+ *    g. Show a round selection modal that sets points-to-win and starts the first round.
+ *    h. Initialize tooltips and show the stat help tooltip once for new users.
+ *    i. Watch for orientation changes and update the battle header's
  *       `data-orientation` attribute.
- *    i. Listen for `storage` events and update the Test Mode banner and
+ *    j. Listen for `storage` events and update the Test Mode banner and
  *       `data-test-mode` attribute when settings change.
  * 6. Execute `setupClassicBattlePage` with `onDomReady`.
  */
@@ -46,6 +47,7 @@ import {
 import { onNextButtonClick } from "./classicBattle/timerService.js";
 import { skipCurrentPhase } from "./classicBattle/skipHandler.js";
 import { initFeatureFlags, isEnabled, featureFlagsEmitter } from "./featureFlags.js";
+import { start as startScheduler } from "../utils/scheduler.js";
 
 const battleStore = createBattleStore();
 window.battleStore = battleStore;
@@ -139,6 +141,7 @@ function watchBattleOrientation() {
 }
 
 export async function setupClassicBattlePage() {
+  if (!(typeof process !== "undefined" && process.env.VITEST)) startScheduler();
   setupBattleInfoBar();
   // Apply orientation ASAP so tests observing the header don't block
   // behind async initialization (flags, data fetches, tooltips, etc.).

--- a/src/utils/scheduler.js
+++ b/src/utils/scheduler.js
@@ -1,0 +1,106 @@
+/**
+ * Shared animation scheduler built on `requestAnimationFrame`.
+ *
+ * @pseudocode
+ * 1. Store callbacks for per-frame and per-second events in Maps.
+ * 2. `start()` initializes a RAF loop that:
+ *    a. Updates `currentTime` on each frame.
+ *    b. Executes frame callbacks.
+ *    c. When a new second is detected, executes second callbacks.
+ * 3. `onFrame(cb)` and `onSecondTick(cb)` register callbacks and return ids.
+ * 4. `cancel(id)` removes callbacks by id.
+ */
+let nextId = 0;
+const frameCallbacks = new Map();
+const secondCallbacks = new Map();
+let running = false;
+let lastSecond;
+let currentTime = 0;
+
+/**
+ * Begin the animation loop.
+ *
+ * @pseudocode
+ * 1. If already running, do nothing.
+ * 2. Define `loop(time)`:
+ *    a. Save `time` to `currentTime`.
+ *    b. Call each frame callback with `time`.
+ *    c. If the integer second changed, call second callbacks.
+ *    d. Request the next frame via `requestAnimationFrame`.
+ * 3. Kick off the loop with `requestAnimationFrame(loop)`.
+ */
+export function start() {
+  if (running) return;
+  running = true;
+  const loop = (time) => {
+    currentTime = time;
+    frameCallbacks.forEach((cb) => {
+      try {
+        cb(currentTime);
+      } catch {
+        // ignore callback errors to keep the scheduler running
+      }
+    });
+    const sec = Math.floor(currentTime / 1000);
+    if (sec !== lastSecond) {
+      lastSecond = sec;
+      secondCallbacks.forEach((cb) => {
+        try {
+          cb(time);
+        } catch {
+          // ignore callback errors to keep the scheduler running
+        }
+      });
+    }
+    requestAnimationFrame(loop);
+  };
+  requestAnimationFrame(loop);
+}
+
+/**
+ * Register a callback to run every animation frame.
+ *
+ * @pseudocode
+ * 1. Generate a unique id.
+ * 2. Store `cb` in `frameCallbacks` under the id.
+ * 3. Return the id for cancellation.
+ *
+ * @param {(time: number) => void} cb - Callback invoked each frame.
+ * @returns {number} Identifier for the scheduled callback.
+ */
+export function onFrame(cb) {
+  const id = ++nextId;
+  frameCallbacks.set(id, cb);
+  return id;
+}
+
+/**
+ * Register a callback that fires once per second.
+ *
+ * @pseudocode
+ * 1. Generate a unique id.
+ * 2. Store `cb` in `secondCallbacks` under the id.
+ * 3. Return the id for cancellation.
+ *
+ * @param {(time: number) => void} cb - Callback invoked on each second.
+ * @returns {number} Identifier for the scheduled callback.
+ */
+export function onSecondTick(cb) {
+  const id = ++nextId;
+  secondCallbacks.set(id, cb);
+  return id;
+}
+
+/**
+ * Cancel a previously scheduled callback.
+ *
+ * @pseudocode
+ * 1. Remove `id` from `frameCallbacks`.
+ * 2. Remove `id` from `secondCallbacks`.
+ *
+ * @param {number} id - Identifier returned by `onFrame` or `onSecondTick`.
+ */
+export function cancel(id) {
+  frameCallbacks.delete(id);
+  secondCallbacks.delete(id);
+}


### PR DESCRIPTION
## Summary
- add shared requestAnimationFrame scheduler with frame and second callbacks
- boot scheduler during classic battle initialization
- document scheduler requirement for timing-sensitive code

## Testing
- `npx prettier src/utils/scheduler.js src/helpers/classicBattlePage.js CONTRIBUTING.md --check`
- `npx eslint .` (warning: 'selectDoc' is defined but never used)
- `npx vitest run` *(fails: No "resetGame" export defined in roundManager mock)*
- `npx playwright test` *(fails: screenshot mismatch and fetch errors)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689b9e895300832687d5de90f68ebab8