### PR TITLE
Use shared scheduler for battle timers

### DIFF
--- a/src/helpers/TimerController.js
+++ b/src/helpers/TimerController.js
@@ -1,4 +1,5 @@
 import { getDefaultTimer, createCountdownTimer } from "./timerUtils.js";
+import { onSecondTick as scheduleSecond, cancel as cancelSchedule } from "../utils/scheduler.js";
 
 const FALLBACKS = {
   roundTimer: 30,
@@ -20,12 +21,14 @@ const FALLBACKS = {
  * 5. `getState` returns `{ remaining, paused }`.
  */
 export class TimerController {
-  constructor() {
+  constructor({ onSecondTick = scheduleSecond, cancel = cancelSchedule } = {}) {
     this.currentTimer = null;
     this.remaining = 0;
     this.paused = false;
     this.onTickCb = null;
     this.onExpiredCb = null;
+    this.onSecondTick = onSecondTick;
+    this.cancel = cancel;
   }
 
   async #start(category, onTick, onExpired, duration, pauseOnHidden) {
@@ -50,7 +53,9 @@ export class TimerController {
       onExpired: async () => {
         if (this.onExpiredCb) await this.onExpiredCb();
       },
-      pauseOnHidden
+      pauseOnHidden,
+      onSecondTick: this.onSecondTick,
+      cancel: this.cancel
     });
     this.currentTimer.start();
   }


### PR DESCRIPTION
## Summary
- Drive countdown timers from the shared scheduler instead of individual intervals
- Subscribe drift watcher to the scheduler and allow unsubscription
- Inject scheduler hooks into TimerController and runTimerWithDrift
- Update timer tests to mock the scheduler

## Testing
- `npx prettier src/helpers/BattleEngine.js src/helpers/TimerController.js src/helpers/classicBattle/runTimerWithDrift.js src/helpers/timerUtils.js tests/helpers/BattleEngine.test.js tests/helpers/countdownTimer.test.js tests/helpers/createCountdownTimer.test.js --check`
- `npx eslint .`
- `npx vitest run` *(fails: InfoBar component countdown, swipeNavigation scroll behavior, countdown reset, classicBattle match flow)*
- `npx playwright test` *(fails: multiple screenshot and page tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689ba1b7d7cc8326a7ba5da16bf72f67