### PR TITLE
feat: route animations through scheduler

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -9,6 +9,7 @@ import { syncScoreDisplay } from "./uiService.js";
 import { CLASSIC_BATTLE_MAX_ROUNDS } from "../constants.js";
 import { handleStatSelection } from "./selectionHandler.js";
 import { quitMatch } from "./quitModal.js";
+import { cancel as cancelFrame } from "../../utils/scheduler.js";
 
 /**
  * Create a new battle state store and attach button handlers.
@@ -130,7 +131,7 @@ export function _resetForTest(store) {
   store.statTimeoutId = null;
   store.autoSelectId = null;
   store.selectionMade = false;
-  cancelAnimationFrame(store.compareRaf);
+  cancelFrame(store.compareRaf);
   store.compareRaf = 0;
   const timerEl = document.getElementById("next-round-timer");
   if (timerEl) timerEl.textContent = "";

--- a/src/helpers/showSettingsError.js
+++ b/src/helpers/showSettingsError.js
@@ -10,6 +10,7 @@
  *    - After `SETTINGS_REMOVE_MS`, remove the popup element.
  */
 import { SETTINGS_FADE_MS, SETTINGS_REMOVE_MS } from "./constants.js";
+import { onFrame as scheduleFrame } from "../utils/scheduler.js";
 
 export function showSettingsError() {
   const existing = document.querySelector(".settings-error-popup");
@@ -20,7 +21,7 @@ export function showSettingsError() {
   popup.setAttribute("aria-live", "assertive");
   popup.textContent = "Failed to update settings.";
   document.body.appendChild(popup);
-  requestAnimationFrame(() => popup.classList.add("show"));
+  scheduleFrame(() => popup.classList.add("show"));
   setTimeout(() => {
     popup.classList.remove("show");
   }, SETTINGS_FADE_MS);

--- a/src/helpers/showSnackbar.js
+++ b/src/helpers/showSnackbar.js
@@ -10,6 +10,7 @@
  * @param {string} message - Text content to display in the snackbar.
  */
 import { SNACKBAR_FADE_MS, SNACKBAR_REMOVE_MS } from "./constants.js";
+import { onFrame as scheduleFrame } from "../utils/scheduler.js";
 
 let bar;
 let fadeId;
@@ -38,7 +39,7 @@ export function showSnackbar(message) {
   bar.setAttribute("role", "status");
   bar.setAttribute("aria-live", "polite");
   document.body.appendChild(bar);
-  requestAnimationFrame(() => bar?.classList.add("show"));
+  scheduleFrame(() => bar?.classList.add("show"));
   resetTimers();
 }
 

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -6,6 +6,21 @@ vi.mock("../../src/helpers/showSnackbar.js", () => ({
   showSnackbar: vi.fn(),
   updateSnackbar: vi.fn()
 }));
+vi.mock("../../src/utils/scheduler.js", () => ({
+  onFrame: (cb) => {
+    const id = setTimeout(() => cb(performance.now()), 16);
+    return id;
+  },
+  onSecondTick: (cb) => {
+    const id = setInterval(() => cb(performance.now()), 1000);
+    return id;
+  },
+  cancel: (id) => {
+    clearTimeout(id);
+    clearInterval(id);
+  },
+  start: vi.fn()
+}));
 import {
   createInfoBar,
   initInfoBar,

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -5,17 +5,19 @@ import {
   getStatButtons,
   getRoundMessageEl
 } from "../../src/helpers/battle/battleUI.js";
+import * as scheduler from "../../src/utils/scheduler.js";
 
 describe("battleUI helpers", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
+    vi.restoreAllMocks();
   });
 
   it("resetStatButtons clears selection and re-enables buttons", () => {
     document.body.innerHTML =
       '<div id="stat-buttons" data-tooltip-id="ui.selectStat"><button class="selected" style="background-color:red"></button><button class="selected"></button></div>';
     vi.useFakeTimers();
-    vi.stubGlobal("requestAnimationFrame", (cb) => setTimeout(cb, 0));
+    vi.spyOn(scheduler, "onFrame").mockImplementation((cb) => setTimeout(cb, 0));
     const buttons = getStatButtons();
     resetStatButtons();
     buttons.forEach((btn) => {
@@ -32,8 +34,10 @@ describe("battleUI helpers", () => {
   it("showResult updates text and fades after delay", () => {
     document.body.innerHTML = '<p id="round-message" class="fading"></p>';
     vi.useFakeTimers();
-    vi.stubGlobal("requestAnimationFrame", (cb) => setTimeout(() => cb(performance.now()), 16));
-    vi.stubGlobal("cancelAnimationFrame", (id) => clearTimeout(id));
+    vi.spyOn(scheduler, "onFrame").mockImplementation((cb) =>
+      setTimeout(() => cb(performance.now()), 16)
+    );
+    vi.spyOn(scheduler, "cancel").mockImplementation((id) => clearTimeout(id));
     showResult("You win!");
     const el = getRoundMessageEl();
     expect(el.textContent).toBe("You win!");
@@ -46,8 +50,10 @@ describe("battleUI helpers", () => {
   it("showResult cancels previous fade when new text appears", () => {
     document.body.innerHTML = '<p id="round-message" class="fading"></p>';
     vi.useFakeTimers();
-    vi.stubGlobal("requestAnimationFrame", (cb) => setTimeout(() => cb(performance.now()), 16));
-    vi.stubGlobal("cancelAnimationFrame", (id) => clearTimeout(id));
+    vi.spyOn(scheduler, "onFrame").mockImplementation((cb) =>
+      setTimeout(() => cb(performance.now()), 16)
+    );
+    vi.spyOn(scheduler, "cancel").mockImplementation((id) => clearTimeout(id));
     showResult("First");
     vi.advanceTimersByTime(1000);
     showResult("Second");

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -1,6 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
 import * as snackbar from "../../../src/helpers/showSnackbar.js";
+vi.mock("../../../src/utils/scheduler.js", () => ({
+  onFrame: (cb) => {
+    const id = setTimeout(() => cb(performance.now()), 16);
+    return id;
+  },
+  onSecondTick: (cb) => {
+    const id = setInterval(() => cb(performance.now()), 1000);
+    return id;
+  },
+  cancel: (id) => {
+    clearTimeout(id);
+    clearInterval(id);
+  },
+  start: vi.fn()
+}));
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -4,6 +4,21 @@ import { CLASSIC_BATTLE_POINTS_TO_WIN } from "../../../src/helpers/constants.js"
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
+vi.mock("../../../src/utils/scheduler.js", () => ({
+  onFrame: (cb) => {
+    const id = setTimeout(() => cb(performance.now()), 16);
+    return id;
+  },
+  onSecondTick: (cb) => {
+    const id = setInterval(() => cb(performance.now()), 1000);
+    return id;
+  },
+  cancel: (id) => {
+    clearTimeout(id);
+    clearInterval(id);
+  },
+  start: vi.fn()
+}));
 
 let generateRandomCardMock;
 

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -4,6 +4,21 @@ import { STATS } from "../../../src/helpers/battleEngineFacade.js";
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
+vi.mock("../../../src/utils/scheduler.js", () => ({
+  onFrame: (cb) => {
+    const id = setTimeout(() => cb(performance.now()), 16);
+    return id;
+  },
+  onSecondTick: (cb) => {
+    const id = setInterval(() => cb(performance.now()), 1000);
+    return id;
+  },
+  cancel: (id) => {
+    clearTimeout(id);
+    clearInterval(id);
+  },
+  start: vi.fn()
+}));
 
 let generateRandomCardMock;
 

--- a/tests/helpers/showSettingsError.test.js
+++ b/tests/helpers/showSettingsError.test.js
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+vi.mock("../../src/utils/scheduler.js", () => ({
+  onFrame: (cb) => cb(),
+  cancel: () => {}
+}));
 import { showSettingsError } from "../../src/helpers/showSettingsError.js";
 import { SETTINGS_FADE_MS, SETTINGS_REMOVE_MS } from "../../src/helpers/constants.js";
 
@@ -9,7 +13,6 @@ beforeEach(() => {
 describe("showSettingsError", () => {
   it("shows and then removes the error popup", () => {
     vi.useFakeTimers();
-    vi.stubGlobal("requestAnimationFrame", (cb) => cb());
 
     showSettingsError();
     let popup = document.querySelector(".settings-error-popup");

--- a/tests/helpers/showSnackbar.test.js
+++ b/tests/helpers/showSnackbar.test.js
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+vi.mock("../../src/utils/scheduler.js", () => ({
+  onFrame: (cb) => cb(),
+  cancel: () => {}
+}));
 import { showSnackbar, updateSnackbar } from "../../src/helpers/showSnackbar.js";
 import { SNACKBAR_FADE_MS, SNACKBAR_REMOVE_MS } from "../../src/helpers/constants.js";
 
@@ -9,7 +13,6 @@ beforeEach(() => {
 describe("showSnackbar", () => {
   it("updates text and resets timers", () => {
     vi.useFakeTimers();
-    vi.stubGlobal("requestAnimationFrame", (cb) => cb());
 
     showSnackbar("Hello");
     updateSnackbar("World");


### PR DESCRIPTION
## Summary
- replace direct requestAnimationFrame usage with shared scheduler
- track scheduled comparison frame IDs for cleanup
- mock scheduler in tests to drive animations and countdowns

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689ba99fe238832697c837ce72150a26