### PR TITLE
Reorder cardCode helper imports

### DIFF
--- a/src/helpers/cardCode.js
+++ b/src/helpers/cardCode.js
@@ -1,7 +1,8 @@
+import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
+
 const XOR_KEY = 37;
 const ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // 32 readable characters
 const CARD_CODE_VERSION = "v1";
-import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidation.js";
 
 /**
  * Encodes a string using XOR encryption.


### PR DESCRIPTION
## Summary
- move `judokaValidation` import to file top and group constants below

## Testing
- `npx prettier . --check` *(fails: playwright/fixtures/commonRoutes.js: Unexpected token (107:1))*
- `npx eslint .` *(fails: Parsing error in playwright/fixtures/commonRoutes.js)*
- `npx vitest run` *(fails: 1 failed, 127 passed)*
- `npx playwright test` *(fails: Unexpected token in playwright/fixtures/commonRoutes.js, no tests found)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689bce62438c8326bec1727b900d9f42