### PR TITLE
refactor: move debugLog import to top

### DIFF
--- a/src/helpers/cardRender.js
+++ b/src/helpers/cardRender.js
@@ -4,6 +4,7 @@ const GENERIC_PLACEHOLDER_ID = 1;
 
 import { escapeHTML, decodeHTML } from "./utils.js";
 import { createStatsPanel } from "../components/StatsPanel.js";
+import { debugLog } from "./debug.js";
 
 /**
  * Generates the portrait HTML for a judoka card.
@@ -134,8 +135,6 @@ export async function generateCardStats(card, cardType = "common") {
  * @param {string} cardType - The type of card (e.g., "common", "rare").
  * @returns {string} The HTML string for the signature move.
  */
-import { debugLog } from "./debug.js";
-
 function resolveTechnique(judoka, gokyoLookup) {
   const safeJudoka = judoka ?? {};
   const id = Number(safeJudoka.signatureMoveId ?? PLACEHOLDER_ID);


### PR DESCRIPTION
## Summary
- move debugLog import to top of cardRender helper

## Testing
- `npx prettier . --check` *(fails: playwright/fixtures/commonRoutes.js SyntaxError)*
- `npx eslint .` *(fails: Unexpected token in playwright/fixtures/commonRoutes.js)*
- `npx vitest run` *(fails: opponentDelay test assertion)*
- `npx playwright test` *(fails: syntax error in playwright/fixtures/commonRoutes.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689bce5974508326824a1c14f239061a