### PR TITLE
refactor: relocate imports to top of data utils

### DIFF
--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -1,11 +1,11 @@
+import { getMissingJudokaFields } from "./judokaValidation.js";
+import { debugLog } from "./debug.js";
+
 // In-memory cache for data fetched from URLs
 const dataCache = new Map();
 
 // Lazily instantiated Ajv singleton
 let ajvInstance;
-
-import { getMissingJudokaFields } from "./judokaValidation.js";
-import { debugLog } from "./debug.js";
 
 /**
  * Determine if the code is running in a Node environment.


### PR DESCRIPTION
## Summary
- move `judokaValidation` and `debug` imports to the top of `dataUtils`

## Testing
- `npx prettier . --check` *(fails: SyntaxError: Unexpected token (107:1) in playwright/fixtures/commonRoutes.js)*
- `npx eslint .` *(fails: Parsing error in playwright/fixtures/commonRoutes.js)*
- `npx vitest run` *(fails: AssertionError in classicBattle opponent delay test)*
- `npx playwright test` *(fails: SyntaxError in playwright/fixtures/commonRoutes.js)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_689bce513278832682d411402a9f114a