### PR TITLE
fix: serve stat names fixture early in tests

### DIFF
--- a/playwright/fixtures/commonRoutes.js
+++ b/playwright/fixtures/commonRoutes.js
@@ -97,10 +97,10 @@ export async function registerCommonRoutes(page) {
       } else {
         route.fulfill({ path: "src/assets/fonts/OpenSansRegular.woff2" });
       }
-    })
-  ]);
-}
+    }),
     // Ensure stat names are always served promptly to avoid flaky fetches
     page.route("**/src/data/statNames.json", (route) =>
       route.fulfill({ path: "src/data/statNames.json" })
-    ),
+    )
+  ]);
+}


### PR DESCRIPTION
## Summary
- serve `statNames.json` fixture before other data requests in Playwright common routes to avoid flaky fetches
- format route list

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: classicBattle opponent delay shows snackbar)*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689c309d391883268631e27cf55373d8