### PR TITLE
Sanitize tooltip HTML with DOMPurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "why-is-node-running": "^3.2.2",
     "ws": "^8.18.3",
     "xml-name-validator": "^5.0.0",
-    "xmlchars": "^2.2.0"
+    "xmlchars": "^2.2.0",
+    "dompurify": "^3.0.8"
   }
 }

--- a/src/helpers/tooltip.js
+++ b/src/helpers/tooltip.js
@@ -3,6 +3,7 @@ import { DATA_DIR } from "./constants.js";
 import { escapeHTML } from "./utils.js";
 import { loadSettings } from "./settingsStorage.js";
 import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
+import DOMPurify from "dompurify";
 
 let tooltipDataPromise;
 let cachedData;
@@ -109,7 +110,7 @@ function ensureTooltipElement() {
  * 2. Load tooltip data with `loadTooltips()`.
  * 3. Select all elements matching `[data-tooltip-id]` within `root`.
  * 4. For each element, attach hover and focus listeners.
- *    - `show` looks up the tooltip text and positions the element.
+ *    - `show` looks up the tooltip text, sanitizes it with DOMPurify, and positions the element.
  *    - `hide` hides the tooltip element.
  * 5. When an ID is missing, log a warning only once and skip display.
  *
@@ -149,7 +150,7 @@ export async function initTooltips(root = document) {
       return;
     }
     const { html, warning } = parseTooltipText(text);
-    tip.innerHTML = html;
+    tip.innerHTML = DOMPurify.sanitize(html);
     if (warning && !loggedUnbalanced.has(id)) {
       console.warn(`Unbalanced markup in tooltip id: ${id}`);
       loggedUnbalanced.add(id);


### PR DESCRIPTION
## Summary
- import DOMPurify and sanitize tooltip HTML before inserting into the DOM
- document DOMPurify sanitization in tooltip initialization pseudocode
- add DOMPurify dependency

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Cannot find package 'dompurify')*
- `npx playwright test` *(fails: 11 failed, 2 interrupted, 67 did not run)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_689c3ba1ee6c832690e42b3e9c57e81b