### PR TITLE
Sanitize quote content before rendering

### DIFF
--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -22,6 +22,7 @@
  */
 import { DATA_DIR } from "./constants.js";
 import { seededRandom } from "./testModeUtils.js";
+import { escapeHTML } from "./utils.js";
 
 /**
  * @typedef {Object} QuoteLoadState
@@ -102,9 +103,10 @@ function renderQuote(fable) {
   if (!quoteDiv) {
     return;
   }
-  const formattedStory = formatFableStory(fable.story);
+  const formattedStory = formatFableStory(escapeHTML(fable.story));
+  const safeTitle = escapeHTML(fable.title);
   quoteDiv.innerHTML = `
-      <div class="quote-heading" id="quote-heading">${fable.title}</div>
+      <div class="quote-heading" id="quote-heading">${safeTitle}</div>
       <div class="quote-content long-form" id="quote-content">${formattedStory}</div>
     `;
 }


### PR DESCRIPTION
## Summary
- import `escapeHTML` utility into `quoteBuilder`
- sanitize fable title and story before injecting into DOM

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: unused variables)*
- `npx vitest run` *(fails: classicBattle opponent delay shows snackbar)*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689c3bad05208326bb6ec964e8ccc8c4