### PR TITLE
feat: delay opponent hint with snackbar

### DIFF
--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -56,6 +56,7 @@ describe("countdown resets after stat selection", () => {
     const timer = vi.useFakeTimers();
     const showSpy = vi.spyOn(snackbar, "showSnackbar");
     const updateSpy = vi.spyOn(snackbar, "updateSnackbar");
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
     const p = battleMod.handleStatSelection(store, "power");
     await vi.advanceTimersByTimeAsync(1000);
     await p;
@@ -76,6 +77,7 @@ describe("countdown resets after stat selection", () => {
     expect(document.querySelectorAll(".snackbar").length).toBe(1);
 
     timer.clearAllTimers();
+    randomSpy.mockRestore();
     showSpy.mockRestore();
     updateSpy.mockRestore();
   });

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -76,7 +76,7 @@ describe("classicBattle opponent delay", () => {
     const store = mod.createBattleStore();
 
     showSnackbar = vi.fn();
-
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
     const promise = mod.handleStatSelection(store, mod.simulateOpponentStat());
 
     // Snackbar is delayed ~500ms; ensure it hasn't shown too early
@@ -90,5 +90,6 @@ describe("classicBattle opponent delay", () => {
     await promise;
     expect(scheduleNextRound).toHaveBeenCalled();
     timer.clearAllTimers();
+    randomSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- delay opponent choosing message and show via snackbar after 500ms
- cancel pending snackbar when round resolves
- stabilize tests by stubbing Math.random

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Scroll buttons have labels, etc.)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689c4113b84c8326a624a78a3e56b980