### PR TITLE
Sanitize tooltip preview output

### DIFF
--- a/src/helpers/tooltipViewerPage.js
+++ b/src/helpers/tooltipViewerPage.js
@@ -6,6 +6,7 @@ import { showSnackbar } from "./showSnackbar.js";
 import { PreviewToggle } from "../components/PreviewToggle.js";
 import { extractLineAndColumn } from "./tooltipViewer/extractLineAndColumn.js";
 import { renderList, MALFORMED_TOOLTIP_MSG } from "./tooltipViewer/renderList.js";
+import DOMPurify from "dompurify";
 
 const FILE_NOT_FOUND_MSG = "File not found";
 const LOAD_ERROR_MSG = "Error loading tooltips.";
@@ -150,7 +151,7 @@ export async function setupTooltipViewerPage() {
       if (index !== -1) listSelect(index);
     }
     const { html, warning } = parseTooltipText(body);
-    previewEl.innerHTML = html;
+    previewEl.innerHTML = DOMPurify.sanitize(html);
     rawEl.textContent = body;
     if (warning) {
       warningEl.textContent = MALFORMED_TOOLTIP_MSG;


### PR DESCRIPTION
## Summary
- import DOMPurify in tooltip viewer page
- sanitize tooltip preview HTML before rendering

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689c4867e1308326bb92fe88d335923c