### PR TITLE
feat(card): support sanitized HTML

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -5,17 +5,18 @@
  * 1. Use a `<div>` element by default or an `<a>` element when `href` is provided.
  * 2. Apply `id`, `href`, `className` and `onClick` options if present.
  * 3. Always include the `card` class plus any additional `className`.
- * 4. Insert string content via `innerHTML` or append a DOM node directly.
+ * 4. Insert string content with `textContent` by default, or with `innerHTML`
+ *    when `html` is true.
  *
  * @class
  */
 export class Card {
   /**
-   * @param {string|Node} content - Markup string or DOM node to place inside the card.
-   * @param {{id?: string, className?: string, href?: string, onClick?: Function}} [options] - Optional settings.
+   * @param {string|Node} content - Text or HTML to place inside the card.
+   * @param {{id?: string, className?: string, href?: string, onClick?: Function, html?: boolean}} [options] - Optional settings. When `html` is true, `content` must be pre-sanitized.
    */
   constructor(content, options = {}) {
-    const { id, className, href, onClick } = options;
+    const { id, className, href, onClick, html = false } = options;
     this.element = href ? document.createElement("a") : document.createElement("div");
     if (id) this.element.id = id;
     if (href) this.element.href = href;
@@ -29,7 +30,11 @@ export class Card {
       this.element.addEventListener("click", onClick);
     }
     if (typeof content === "string") {
-      this.element.innerHTML = content;
+      if (html) {
+        this.element.innerHTML = content;
+      } else {
+        this.element.textContent = content;
+      }
     } else if (content instanceof Node) {
       this.element.append(content);
     }
@@ -39,7 +44,7 @@ export class Card {
 /**
  * Factory wrapper for backward compatibility with function callers.
  *
- * @param {string|Node} content - Markup string or DOM node to place inside the card.
+ * @param {string|Node} content - Text or HTML to place inside the card.
  * @param {object} [options] - Optional settings passed to the `Card` constructor.
  * @returns {HTMLElement} The card element.
  */

--- a/tests/helpers/cardComponent.test.js
+++ b/tests/helpers/cardComponent.test.js
@@ -6,7 +6,12 @@ describe("createCard", () => {
     const card = createCard("Hello");
     expect(card).toBeInstanceOf(HTMLDivElement);
     expect(card.classList.contains("card")).toBe(true);
-    expect(card.innerHTML).toBe("Hello");
+    expect(card.textContent).toBe("Hello");
+  });
+
+  it("inserts HTML when the html flag is true", () => {
+    const card = createCard("<em>hi</em>", { html: true });
+    expect(card.innerHTML).toBe("<em>hi</em>");
   });
 
   it("creates an anchor card when href provided", () => {


### PR DESCRIPTION
## Summary
- allow Card to render either raw text or sanitized HTML via `html` flag
- document expectation for sanitized content
- verify card component renders HTML when requested

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: module specifier "dompurify" not resolved)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689c505c45ac8326895c7b7c2543fbea