### PR TITLE
Refactor carousel swipe tests

### DIFF
--- a/playwright/browse-judoka-navigation.spec.js
+++ b/playwright/browse-judoka-navigation.spec.js
@@ -78,20 +78,16 @@ test.describe.parallel("Browse Judoka navigation", () => {
         { from, to, y }
       );
 
-    await swipe(startX, startX - 600);
-    await swipe(startX, startX - 600);
-    await swipe(startX, startX - 600);
-    await swipe(startX, startX - 600);
-    await swipe(startX, startX - 600);
-    await expect(counter).toHaveText("Page 6 of 6");
+    for (let page = 2; page <= 6; page++) {
+      await swipe(startX, startX - 600);
+      await expect(counter).toHaveText(`Page ${page} of 6`);
+    }
     await expect(right).toBeDisabled();
 
-    await swipe(endX, endX + 600);
-    await swipe(endX, endX + 600);
-    await swipe(endX, endX + 600);
-    await swipe(endX, endX + 600);
-    await swipe(endX, endX + 600);
-    await expect(counter).toHaveText("Page 1 of 6");
+    for (let page = 5; page >= 1; page--) {
+      await swipe(endX, endX + 600);
+      await expect(counter).toHaveText(`Page ${page} of 6`);
+    }
     await expect(left).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary
- replace repetitive swipe assertions with loops in browse judoka navigation test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689ccd3f67ac83268863ba0cb9aa3c51