### PR TITLE
chore: skip battle phase in stat reset test

### DIFF
--- a/playwright/statReset.spec.js
+++ b/playwright/statReset.spec.js
@@ -11,6 +11,7 @@ test.describe.parallel("Classic battle button reset", () => {
     await timer.waitFor();
     await page.locator("#stat-buttons button[data-stat='power']").click();
     await page.locator("#next-button").click();
+    await page.evaluate(() => window.skipBattlePhase?.());
     await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
     await expect(page.locator("#stat-buttons .selected")).toHaveCount(0);
   });
@@ -23,6 +24,7 @@ test.describe.parallel("Classic battle button reset", () => {
     const btn = page.locator("#stat-buttons button[data-stat='power']");
     await btn.click();
     await page.locator("#next-button").click();
+    await page.evaluate(() => window.skipBattlePhase?.());
     await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
     const highlight = await btn.evaluate((el) => getComputedStyle(el).webkitTapHighlightColor);
     expect(highlight).toBe("rgba(0, 0, 0, 0)");


### PR DESCRIPTION
## Summary
- ensure stat reset spec skips battle phase after advancing the round so snackbar reappears quickly

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689ccd3e6dd483268eaa6a5ee9649aef