### PR TITLE
test: ensure tie battle flow uses global store

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -22,10 +22,10 @@ test.describe.parallel("Classic battle flow", () => {
     const timer = page.locator("header #next-round-timer");
     await timer.waitFor();
     await page.evaluate(async () => {
-      const { createBattleStore, _resetForTest } = await import(
+      const { _resetForTest } = await import(
         new URL("/src/helpers/classicBattle.js", window.location.href)
       );
-      _resetForTest(createBattleStore());
+      _resetForTest(window.battleStore);
       document.querySelector("#next-round-timer").textContent = "Time Left: 3s";
       document.querySelector("#player-card").innerHTML =
         `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;


### PR DESCRIPTION
## Summary
- use existing `window.battleStore` when resetting classic battle store

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689ccd3d99c0832685593df065396b9d