### PR TITLE
Resume battle header before viewport change

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -114,6 +114,7 @@ test.describe.parallel(
       await expect(page.locator(".battle-header")).toHaveScreenshot(
         `battle-header-portrait${osSuffix}.png`
       );
+      await page.evaluate(() => window.resumeBattleHeader?.());
 
       await page.setViewportSize({ width: 480, height: 320 });
       await page.waitForFunction(


### PR DESCRIPTION
## Summary
- Resume frozen battle header after portrait screenshot so orientation updates on resize

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689cd16bcf8483268b550d9f0453489a