### PR TITLE
Handle round readiness change before observer registration

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -56,6 +56,11 @@ export async function onNextButtonClick() {
   });
   obs.observe(btn, { attributes: true, attributeFilter: ["data-next-ready", "disabled"] });
 
+  if (await maybeStart()) {
+    obs.disconnect();
+    return;
+  }
+
   // Safety timeout to avoid leaking the observer if nothing happens.
   setTimeout(() => obs.disconnect(), 10000);
 }


### PR DESCRIPTION
## Summary
- Re-run `maybeStart` after attaching the observer in `onNextButtonClick`
- Disconnect observer and exit early if the button becomes ready before observation

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689ceb4823a48326bab84eda229cd1f8