### PR TITLE
Fix keyboard navigation to ignore non-arrow keys

### DIFF
--- a/src/helpers/browse/handleKeyboardNavigation.js
+++ b/src/helpers/browse/handleKeyboardNavigation.js
@@ -2,10 +2,10 @@
  * Handle left/right arrow key navigation within a button container.
  *
  * @pseudocode
- * 1. Get all buttons with the specified class in the container.
- * 2. Find the index of the currently focused button.
- * 3. If a navigational key (ArrowLeft/ArrowRight) is pressed, prevent default.
- * 4. Calculate the next index by wrapping around.
+ * 1. Exit if the key is not ArrowLeft or ArrowRight.
+ * 2. Get all buttons with the specified class in the container.
+ * 3. Find the index of the currently focused button.
+ * 4. If focus is within the buttons, prevent default and calculate the next index.
  * 5. Move focus to the button at the next index.
  *
  * @param {KeyboardEvent} event
@@ -13,6 +13,10 @@
  * @param {string} buttonClass
  */
 export function handleKeyboardNavigation(event, container, buttonClass) {
+  if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+    return;
+  }
+
   const buttons = Array.from(container.querySelectorAll(`button.${buttonClass}`));
   const current = document.activeElement;
   const index = buttons.indexOf(current);

--- a/tests/helpers/handleKeyboardNavigation.test.js
+++ b/tests/helpers/handleKeyboardNavigation.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleKeyboardNavigation } from "../../src/helpers/browse/handleKeyboardNavigation.js";
+
+describe("handleKeyboardNavigation", () => {
+  it("moves focus on arrow keys", () => {
+    const container = document.createElement("div");
+    const first = document.createElement("button");
+    first.className = "flag-button";
+    first.tabIndex = 0;
+    const second = document.createElement("button");
+    second.className = "flag-button";
+    second.tabIndex = 0;
+    container.append(first, second);
+    document.body.append(container);
+
+    first.focus();
+    const event = { key: "ArrowRight", preventDefault: vi.fn() };
+    handleKeyboardNavigation(event, container, "flag-button");
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(document.activeElement).toBe(second);
+  });
+
+  it("ignores non-arrow keys", () => {
+    const container = document.createElement("div");
+    const first = document.createElement("button");
+    first.className = "flag-button";
+    first.tabIndex = 0;
+    const second = document.createElement("button");
+    second.className = "flag-button";
+    second.tabIndex = 0;
+    container.append(first, second);
+    document.body.append(container);
+
+    first.focus();
+    const event = { key: "Enter", preventDefault: vi.fn() };
+    handleKeyboardNavigation(event, container, "flag-button");
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent `handleKeyboardNavigation` from acting on non-arrow keys
- test keyboard navigation behavior for arrow and non-arrow keys

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: numerous screenshot and timeout failures)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689d096066948326b005d92d7763aa7d