### PR TITLE
feat: add scheduler stop and cleanup

### DIFF
--- a/src/helpers/BattleEngine.js
+++ b/src/helpers/BattleEngine.js
@@ -7,7 +7,11 @@
 
 import { CLASSIC_BATTLE_POINTS_TO_WIN, CLASSIC_BATTLE_MAX_ROUNDS } from "./constants.js";
 import { TimerController } from "./TimerController.js";
-import { onSecondTick as scheduleSecond, cancel as cancelSchedule } from "../utils/scheduler.js";
+import {
+  onSecondTick as scheduleSecond,
+  cancel as cancelSchedule,
+  stop as stopScheduler
+} from "../utils/scheduler.js";
 
 export const STATS = ["power", "speed", "technique", "kumikata", "newaza"];
 const DRIFT_THRESHOLD = 2;
@@ -329,6 +333,7 @@ export class BattleEngine {
   }
 
   _resetForTest() {
+    stopScheduler();
     this.pointsToWin = CLASSIC_BATTLE_POINTS_TO_WIN;
     this.playerScore = 0;
     this.computerScore = 0;

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -9,7 +9,7 @@ import { syncScoreDisplay } from "./uiService.js";
 import { CLASSIC_BATTLE_MAX_ROUNDS } from "../constants.js";
 import { handleStatSelection } from "./selectionHandler.js";
 import { quitMatch } from "./quitModal.js";
-import { cancel as cancelFrame } from "../../utils/scheduler.js";
+import { cancel as cancelFrame, stop as stopScheduler } from "../../utils/scheduler.js";
 import { resetSkipState } from "./skipHandler.js";
 
 /**
@@ -125,6 +125,7 @@ export function _resetForTest(store) {
   resetSkipState();
   resetSelection();
   battleEngine._resetForTest();
+  stopScheduler();
   if (typeof window !== "undefined") {
     delete window.startRoundOverride;
   }

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -50,6 +50,7 @@ import { skipCurrentPhase } from "./classicBattle/skipHandler.js";
 import { initFeatureFlags, isEnabled, featureFlagsEmitter } from "./featureFlags.js";
 import {
   start as startScheduler,
+  stop as stopScheduler,
   onFrame as scheduleFrame,
   cancel as cancelFrame
 } from "../utils/scheduler.js";
@@ -187,7 +188,10 @@ function setBattleStateBadgeEnabled(enable) {
 }
 
 export async function setupClassicBattlePage() {
-  if (!(typeof process !== "undefined" && process.env.VITEST)) startScheduler();
+  if (!(typeof process !== "undefined" && process.env.VITEST)) {
+    startScheduler();
+    window.addEventListener("pagehide", stopScheduler, { once: true });
+  }
   setupBattleInfoBar();
   // Apply orientation ASAP so tests observing the header don't block
   // behind async initialization (flags, data fetches, tooltips, etc.).

--- a/src/helpers/timerUtils.js
+++ b/src/helpers/timerUtils.js
@@ -1,6 +1,10 @@
 import { fetchJson, importJsonModule } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
-import { onSecondTick as scheduleSecond, cancel as cancelSchedule } from "../utils/scheduler.js";
+import {
+  onSecondTick as scheduleSecond,
+  cancel as cancelSchedule,
+  stop as stopScheduler
+} from "../utils/scheduler.js";
 
 let timersPromise;
 let cachedTimers;
@@ -32,6 +36,7 @@ export async function getDefaultTimer(category) {
 export function _resetForTest() {
   timersPromise = undefined;
   cachedTimers = undefined;
+  stopScheduler();
 }
 
 /**

--- a/src/utils/scheduler.js
+++ b/src/utils/scheduler.js
@@ -9,6 +9,7 @@
  *    c. When a new second is detected, executes second callbacks.
  * 3. `onFrame(cb)` and `onSecondTick(cb)` register callbacks and return ids.
  * 4. `cancel(id)` removes callbacks by id.
+ * 5. `stop()` cancels the RAF loop and clears pending callbacks.
  */
 let nextId = 0;
 const frameCallbacks = new Map();
@@ -16,6 +17,7 @@ const secondCallbacks = new Map();
 let running = false;
 let lastSecond;
 let currentTime = 0;
+let rafId = 0;
 
 /**
  * Begin the animation loop.
@@ -52,9 +54,9 @@ export function start() {
         }
       });
     }
-    requestAnimationFrame(loop);
+    rafId = requestAnimationFrame(loop);
   };
-  requestAnimationFrame(loop);
+  rafId = requestAnimationFrame(loop);
 }
 
 /**
@@ -103,4 +105,23 @@ export function onSecondTick(cb) {
 export function cancel(id) {
   frameCallbacks.delete(id);
   secondCallbacks.delete(id);
+}
+
+/**
+ * Halt the animation loop and clear all callbacks.
+ *
+ * @pseudocode
+ * 1. If not running, do nothing.
+ * 2. Set `running` to false and cancel the scheduled frame via `cancelAnimationFrame`.
+ * 3. Clear both callback maps and reset timing state.
+ */
+export function stop() {
+  if (!running) return;
+  running = false;
+  cancelAnimationFrame(rafId);
+  rafId = 0;
+  frameCallbacks.clear();
+  secondCallbacks.clear();
+  lastSecond = undefined;
+  currentTime = 0;
 }

--- a/tests/components/InfoBar.test.js
+++ b/tests/components/InfoBar.test.js
@@ -19,7 +19,8 @@ vi.mock("../../src/utils/scheduler.js", () => ({
     clearTimeout(id);
     clearInterval(id);
   },
-  start: vi.fn()
+  start: vi.fn(),
+  stop: vi.fn()
 }));
 import {
   createInfoBar,

--- a/tests/helpers/BattleEngine.test.js
+++ b/tests/helpers/BattleEngine.test.js
@@ -9,7 +9,8 @@ vi.mock("../../src/utils/scheduler.js", () => ({
   },
   cancel: (id) => {
     delete callbacks[id];
-  }
+  },
+  stop: vi.fn()
 }));
 vi.spyOn(Date, "now").mockImplementation(() => now);
 import { compareStats, createDriftWatcher } from "../../src/helpers/BattleEngine.js";

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -14,7 +14,8 @@ vi.mock("../../../src/utils/scheduler.js", () => ({
     clearTimeout(id);
     clearInterval(id);
   },
-  start: vi.fn()
+  start: vi.fn(),
+  stop: vi.fn()
 }));
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -17,7 +17,8 @@ vi.mock("../../../src/utils/scheduler.js", () => ({
     clearTimeout(id);
     clearInterval(id);
   },
-  start: vi.fn()
+  start: vi.fn(),
+  stop: vi.fn()
 }));
 
 let generateRandomCardMock;

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -17,7 +17,8 @@ vi.mock("../../../src/utils/scheduler.js", () => ({
     clearTimeout(id);
     clearInterval(id);
   },
-  start: vi.fn()
+  start: vi.fn(),
+  stop: vi.fn()
 }));
 
 let generateRandomCardMock;

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("../../src/utils/scheduler.js", () => ({
+  start: vi.fn(),
+  stop: vi.fn(),
+  onFrame: vi.fn(),
+  cancel: vi.fn(),
+  onSecondTick: vi.fn()
+}));
+
 describe("classicBattlePage feature flag updates", () => {
   beforeEach(() => {
     document.body.innerHTML = "";

--- a/tests/helpers/countdownTimer.test.js
+++ b/tests/helpers/countdownTimer.test.js
@@ -7,7 +7,8 @@ vi.mock("../../src/utils/scheduler.js", () => ({
   },
   cancel: (id) => {
     delete callbacks[id];
-  }
+  },
+  stop: vi.fn()
 }));
 import { createCountdownTimer } from "../../src/helpers/timerUtils.js";
 

--- a/tests/helpers/createCountdownTimer.test.js
+++ b/tests/helpers/createCountdownTimer.test.js
@@ -8,7 +8,8 @@ vi.mock("../../src/utils/scheduler.js", () => ({
   },
   cancel: (id) => {
     delete callbacks[id];
-  }
+  },
+  stop: vi.fn()
 }));
 import { createCountdownTimer } from "../../src/helpers/timerUtils.js";
 

--- a/tests/helpers/showSettingsError.test.js
+++ b/tests/helpers/showSettingsError.test.js
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("../../src/utils/scheduler.js", () => ({
   onFrame: (cb) => cb(),
-  cancel: () => {}
+  cancel: () => {},
+  stop: vi.fn()
 }));
 import { showSettingsError } from "../../src/helpers/showSettingsError.js";
 import { SETTINGS_FADE_MS, SETTINGS_REMOVE_MS } from "../../src/helpers/constants.js";

--- a/tests/helpers/showSnackbar.test.js
+++ b/tests/helpers/showSnackbar.test.js
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("../../src/utils/scheduler.js", () => ({
   onFrame: (cb) => cb(),
-  cancel: () => {}
+  cancel: () => {},
+  stop: vi.fn()
 }));
 import { showSnackbar, updateSnackbar } from "../../src/helpers/showSnackbar.js";
 import { SNACKBAR_FADE_MS, SNACKBAR_REMOVE_MS } from "../../src/helpers/constants.js";


### PR DESCRIPTION
## Summary
- add `stop()` to shared RAF scheduler and clear callbacks
- halt scheduler on classic battle teardown and test resets
- adjust tests for new scheduler API

## Testing
- `npx prettier src/utils/scheduler.js src/helpers/classicBattlePage.js src/helpers/classicBattle/roundManager.js src/helpers/timerUtils.js src/helpers/BattleEngine.js tests/components/InfoBar.test.js tests/helpers/BattleEngine.test.js tests/helpers/classicBattle/countdownReset.test.js tests/helpers/classicBattle/matchFlow.test.js tests/helpers/classicBattle/statSelection.test.js tests/helpers/classicBattleFlags.test.js tests/helpers/countdownTimer.test.js tests/helpers/createCountdownTimer.test.js tests/helpers/showSettingsError.test.js tests/helpers/showSnackbar.test.js --check`
- `npx eslint src/utils/scheduler.js src/helpers/classicBattlePage.js src/helpers/classicBattle/roundManager.js src/helpers/timerUtils.js src/helpers/BattleEngine.js tests/components/InfoBar.test.js tests/helpers/BattleEngine.test.js tests/helpers/classicBattle/countdownReset.test.js tests/helpers/classicBattle/matchFlow.test.js tests/helpers/classicBattle/statSelection.test.js tests/helpers/classicBattleFlags.test.js tests/helpers/countdownTimer.test.js tests/helpers/createCountdownTimer.test.js tests/helpers/showSettingsError.test.js tests/helpers/showSnackbar.test.js`
- `npx vitest run` *(fails: testing process did not complete)*
- `npx playwright test --reporter=line` *(interrupted: tests did not complete)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689d09515c20832687f6b7c6e4c1e2da