### PR TITLE
Add battle state progress indicator

### DIFF
--- a/src/helpers/battleStateProgress.js
+++ b/src/helpers/battleStateProgress.js
@@ -1,0 +1,64 @@
+/**
+ * Render Classic Battle state progress list and sync active state.
+ *
+ * @pseudocode
+ * 1. Fetch `classicBattleStates.json` using `fetchJson`.
+ * 2. Filter for core states (IDs below 90).
+ * 3. Render each state as an `<li>` with `data-state` inside `#battle-state-progress`.
+ * 4. Define `updateActive(state)` to toggle the `active` class on matching items.
+ * 5. Observe `#machine-state` for text changes; on each change call `updateActive`.
+ * 6. If `#machine-state` is missing, poll `window.__classicBattleState` via `requestAnimationFrame`.
+ *
+ * @returns {Promise<void>} Resolves when the list is initialized.
+ */
+import { fetchJson } from "./dataUtils.js";
+import { DATA_DIR } from "./constants.js";
+
+export async function initBattleStateProgress() {
+  const list = document.getElementById("battle-state-progress");
+  if (!list) return;
+
+  let states = [];
+  try {
+    states = await fetchJson(`${DATA_DIR}classicBattleStates.json`);
+  } catch {
+    // ignore fetch errors; list remains empty
+  }
+
+  const core = Array.isArray(states) ? states.filter((s) => s.id < 90) : [];
+  const frag = document.createDocumentFragment();
+  core.forEach((s) => {
+    const li = document.createElement("li");
+    li.dataset.state = s.name;
+    frag.appendChild(li);
+  });
+  list.appendChild(frag);
+
+  const items = Array.from(list.querySelectorAll("li"));
+  const updateActive = (state) => {
+    items.forEach((li) => {
+      li.classList.toggle("active", li.dataset.state === state);
+    });
+  };
+
+  const machine = document.getElementById("machine-state");
+  if (machine && typeof MutationObserver !== "undefined") {
+    const observer = new MutationObserver(() => {
+      updateActive(machine.textContent.trim());
+    });
+    observer.observe(machine, { childList: true, characterData: true, subtree: true });
+    updateActive(machine.textContent.trim());
+    return;
+  }
+
+  let prev;
+  const tick = () => {
+    const state = window.__classicBattleState;
+    if (state !== prev) {
+      prev = state;
+      updateActive(state);
+    }
+    requestAnimationFrame(tick);
+  };
+  tick();
+}

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -48,6 +48,7 @@ import {
 import { onNextButtonClick } from "./classicBattle/timerService.js";
 import { skipCurrentPhase } from "./classicBattle/skipHandler.js";
 import { initFeatureFlags, isEnabled, featureFlagsEmitter } from "./featureFlags.js";
+import { initBattleStateProgress } from "./battleStateProgress.js";
 import {
   start as startScheduler,
   stop as stopScheduler,
@@ -214,6 +215,7 @@ export async function setupClassicBattlePage() {
 
   window.startRoundOverride = () => startRoundWrapper();
   await initClassicBattleOrchestrator(battleStore, startRoundWrapper);
+  await initBattleStateProgress();
   // In Test Mode, auto-start the match to avoid blocking on the round select modal
   try {
     if (isEnabled("enableTestMode")) {

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -136,6 +136,7 @@
  -->
           </div>
         </section>
+        <ul id="battle-state-progress" class="battle-state-progress" aria-label="Match states"></ul>
       </main>
 
       <footer>

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -143,3 +143,23 @@
   flex: 1;
   text-align: center;
 }
+
+.battle-state-progress {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-sm);
+  list-style: none;
+  padding: 0;
+  margin-top: var(--space-lg);
+}
+
+.battle-state-progress li {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background-color: color-mix(in srgb, var(--color-primary) 40%, white);
+}
+
+.battle-state-progress li.active {
+  background-color: var(--color-primary);
+}


### PR DESCRIPTION
## Summary
- show match state progress below battle area
- visualize current state via helper that syncs with state machine
- style battle state progress dots

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689d9006279c832687e959bc63647a1a