### PR TITLE
docs: document match state progress bar

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -26,6 +26,7 @@ The round message, timer, and score now sit directly inside the page header rath
 3. Ensure all messages are clearly readable, positioned responsively, and maintain usability across devices.
 4. Display fallback messages within 500ms of sync failure.
 5. Surface a round counter and a field showing the player's selected stat for the current round.
+6. **Complement header messaging with a numbered progress bar** beneath the battle area that displays the current state ID for clear, accessible progress tracking.
 
 ---
 

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -71,8 +71,10 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 ## Match Flow
 
-The Classic Battle match follows a fixed sequence of states and transitions, as illustrated in the diagram below.  
+The Classic Battle match follows a fixed sequence of states and transitions, as illustrated in the diagram below.
 Each state describes what the game is doing, what events trigger a change, and where it transitions next.
+
+- A numbered progress bar beneath the battle area shows the current state ID, giving players a clear, accessible sense of match progression.
 
 ---
 


### PR DESCRIPTION
## Summary
- Note that a numbered progress bar beneath the battle area shows the current state ID in Classic Battle's match flow
- Mention that the Battle Info Bar works with this progress bar to surface battle states

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689d9914f10883268bc2ba10563de0d0