### PR TITLE
fix: ensure quit confirmation navigates home reliably

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -322,7 +322,7 @@ flowchart TD
 - After round results, a 3s countdown is displayed via snackbar (`Next round in: Xs`). The **Next** button becomes active once the countdown ends or when skipped. Reference [timerService.js](../../src/helpers/classicBattle/timerService.js) for exact durations to keep design and code aligned.
 - After the match ends, a modal appears showing the final result and score with **Quit Match** and **Next Match** buttons; **Quit Match** exits to the main menu and **Next Match** starts a new match.
 - Player can quit mid-match; confirmation prompt appears; if confirmed, match ends with player loss recorded.
-- After confirming the quit action, the player is returned to the main menu (index.html).
+- After confirming the quit action, return the player to the main menu (index.html) using a path that works in local and deployed builds.
 - If AI difficulty affects stat selection, AI uses correct logic per difficulty setting.
 - Animation flow: transitions between card reveal, stat selection, and result screens complete smoothly without stalling.
 - Stat buttons reset between rounds so no previous selection remains highlighted. The `battle.css` rule `#stat-buttons button { -webkit-tap-highlight-color: transparent; }` combined with a reflow ensures Safari clears the red touch overlay.

--- a/src/helpers/classicBattle/quitModal.js
+++ b/src/helpers/classicBattle/quitModal.js
@@ -37,12 +37,15 @@ function createQuitConfirmation(store, onConfirm) {
         dispatchBattleEvent("finalize");
       });
     } catch {}
-    // In browsers, navigate to home; in jsdom, history.replaceState avoids Not Implemented errors
+    // Navigate back to the main menu. Compute the target so it works from
+    // both local `src/pages/` paths and deployed root builds.
+    const target =
+      window.location.origin +
+      window.location.pathname.replace(/\/(?:src\/pages\/)?[^/]*$/, "/index.html");
     try {
-      window.location.href = "../../index.html";
+      window.location.assign(target);
     } catch {
       try {
-        const target = new URL("../../index.html", window.location.href).href;
         if (typeof history !== "undefined" && typeof history.replaceState === "function") {
           history.replaceState(null, "", target);
         }


### PR DESCRIPTION
## Summary
- compute a robust navigation target for the quit confirmation modal so the match exits to the main menu across environments
- document quit confirmation behavior in PRD

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_689dce210a508326b1140e014ed603ba