### PR TITLE
Sort Classic Battle state progress steps

### DIFF
--- a/design/productRequirementsDocuments/prdBattleInfoBar.md
+++ b/design/productRequirementsDocuments/prdBattleInfoBar.md
@@ -26,7 +26,7 @@ The round message, timer, and score now sit directly inside the page header rath
 3. Ensure all messages are clearly readable, positioned responsively, and maintain usability across devices.
 4. Display fallback messages within 500ms of sync failure.
 5. Surface a round counter and a field showing the player's selected stat for the current round.
-6. **Complement header messaging with a numbered progress bar** beneath the battle area that displays the current state ID for clear, accessible progress tracking.
+6. **Complement header messaging with a numbered progress bar** beneath the battle area that displays the current state ID in ascending order for clear, accessible progress tracking.
 
 ---
 

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -74,7 +74,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 The Classic Battle match follows a fixed sequence of states and transitions, as illustrated in the diagram below.
 Each state describes what the game is doing, what events trigger a change, and where it transitions next.
 
-- A numbered progress bar beneath the battle area shows the current state ID, giving players a clear, accessible sense of match progression.
+- A numbered progress bar beneath the battle area shows the current state ID in ascending order, giving players a clear, accessible sense of match progression.
 
 ---
 

--- a/playwright/battleJudoka.spec.js
+++ b/playwright/battleJudoka.spec.js
@@ -47,7 +47,10 @@ test.describe.parallel("Battle Judoka page", () => {
     const ariaLiveCount = await page.locator('[role="status"][aria-live]').count();
     expect(ariaLiveCount).toBeGreaterThan(0);
 
-    const expectedIds = classicBattleStates.filter((s) => s.id < 90).map((s) => String(s.id));
+    const expectedIds = classicBattleStates
+      .filter((s) => s.id < 90)
+      .sort((a, b) => a.id - b.id)
+      .map((s) => String(s.id));
     const ids = await page.$$eval("#battle-state-progress li", (lis) =>
       lis.map((li) => li.textContent.trim())
     );

--- a/src/helpers/battleStateProgress.js
+++ b/src/helpers/battleStateProgress.js
@@ -4,10 +4,11 @@
  * @pseudocode
  * 1. Fetch `classicBattleStates.json` using `fetchJson`.
  * 2. Filter for core states (IDs below 90).
- * 3. Render each state as an `<li>` with `data-state` and its numeric ID as text inside `#battle-state-progress`.
- * 4. Define `updateActive(state)` to toggle the `active` class on matching items.
- * 5. Observe `#machine-state` for text changes; on each change call `updateActive`.
- * 6. If `#machine-state` is missing, poll `window.__classicBattleState` via `requestAnimationFrame`.
+ * 3. Sort core states by `id` in ascending order.
+ * 4. Render each state as an `<li>` with `data-state` and its numeric ID inside `#battle-state-progress`.
+ * 5. Define `updateActive(state)` to toggle the `active` class on matching items.
+ * 6. Observe `#machine-state` for text changes; on each change call `updateActive`.
+ * 7. If `#machine-state` is missing, poll `window.__classicBattleState` via `requestAnimationFrame`.
  *
  * @returns {Promise<void>} Resolves when the list is initialized.
  */
@@ -25,7 +26,9 @@ export async function initBattleStateProgress() {
     // ignore fetch errors; list remains empty
   }
 
-  const core = Array.isArray(states) ? states.filter((s) => s.id < 90) : [];
+  const core = Array.isArray(states)
+    ? states.filter((s) => s.id < 90).sort((a, b) => a.id - b.id)
+    : [];
   const frag = document.createDocumentFragment();
   core.forEach((s) => {
     const li = document.createElement("li");

--- a/tests/helpers/classicBattle/battleStateBadge.test.js
+++ b/tests/helpers/classicBattle/battleStateBadge.test.js
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import classicBattleStates from "../../../src/data/classicBattleStates.json";
 
-const coreStateIds = classicBattleStates.filter((s) => s.id < 90).map((s) => String(s.id));
+const coreStateIds = classicBattleStates
+  .filter((s) => s.id < 90)
+  .sort((a, b) => a.id - b.id)
+  .map((s) => String(s.id));
 
 vi.mock("../../../src/utils/scheduler.js", () => ({
   start: vi.fn(),


### PR DESCRIPTION
## Summary
- Sort Classic Battle progress indicator IDs numerically for predictable order
- Document progress bar's ascending order in Classic Battle and Info Bar PRDs
- Adjust tests to expect sorted state IDs

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_689dcd5c6bec8326bd74ea7d1cbfea1a