### PR TITLE
Await stat selection events

### DIFF
--- a/src/helpers/classicBattle/autoSelectStat.js
+++ b/src/helpers/classicBattle/autoSelectStat.js
@@ -1,5 +1,6 @@
 import { seededRandom } from "../testModeUtils.js";
 import { STATS } from "../battleEngineFacade.js";
+import { dispatchBattleEvent } from "./orchestrator.js";
 // Avoid writing to the header message area during auto-select; tests expect
 // the outcome message to occupy that region immediately after selection.
 // Intentionally avoid showing a snackbar here to prevent racing with
@@ -18,8 +19,8 @@ const AUTO_SELECT_FEEDBACK_MS = 500;
 export async function autoSelectStat(onSelect) {
   const randomStat = STATS[Math.floor(seededRandom() * STATS.length)];
   const btn = document.querySelector(`#stat-buttons button[data-stat="${randomStat}"]`);
-  const label = btn?.textContent || randomStat;
   if (btn) btn.classList.add("selected");
   await new Promise((resolve) => setTimeout(resolve, AUTO_SELECT_FEEDBACK_MS));
+  await dispatchBattleEvent("statSelected");
   await onSelect(randomStat, { delayOpponentMessage: true });
 }

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -270,23 +270,23 @@ function initStatButtons(store) {
   }
 
   statButtons.forEach((btn) => {
-    btn.addEventListener("click", () => {
+    btn.addEventListener("click", async () => {
       if (!btn.disabled) {
         setEnabled(false);
         btn.classList.add("selected");
         showSnackbar(`You Picked: ${btn.textContent}`);
-        dispatchBattleEvent("statSelected");
-        handleStatSelection(store, btn.dataset.stat);
+        await dispatchBattleEvent("statSelected");
+        await handleStatSelection(store, btn.dataset.stat);
       }
     });
-    btn.addEventListener("keydown", (e) => {
+    btn.addEventListener("keydown", async (e) => {
       if ((e.key === "Enter" || e.key === " ") && !btn.disabled) {
         e.preventDefault();
         setEnabled(false);
         btn.classList.add("selected");
         showSnackbar(`You Picked: ${btn.textContent}`);
-        dispatchBattleEvent("statSelected");
-        handleStatSelection(store, btn.dataset.stat);
+        await dispatchBattleEvent("statSelected");
+        await handleStatSelection(store, btn.dataset.stat);
       }
     });
   });

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -6,6 +6,10 @@ beforeEach(() => {
   localStorage.clear();
   vi.resetModules();
   vi.doUnmock("../../src/helpers/settingsStorage.js");
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn(),
+    dispatchBattleEvent: vi.fn().mockResolvedValue()
+  }));
   vi.doMock("../../src/helpers/classicBattle/roundSelectModal.js", () => ({
     initRoundSelectModal: (cb) => cb()
   }));
@@ -53,6 +57,7 @@ describe("classicBattlePage stat button interactions", () => {
     const [first, second, third] = container.querySelectorAll("button");
 
     first.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
     expect(handleStatSelection).toHaveBeenCalledWith(store, "power");
     expect(showSnackbar).toHaveBeenCalledWith("You Picked: Power");
 
@@ -64,6 +69,7 @@ describe("classicBattlePage stat button interactions", () => {
     showSnackbar.mockClear();
 
     second.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await Promise.resolve();
     expect(handleStatSelection).toHaveBeenCalledWith(store, "speed");
     expect(showSnackbar).toHaveBeenCalledWith("You Picked: Speed");
 
@@ -75,6 +81,7 @@ describe("classicBattlePage stat button interactions", () => {
     showSnackbar.mockClear();
 
     third.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    await Promise.resolve();
     expect(handleStatSelection).toHaveBeenCalledWith(store, "technique");
     expect(showSnackbar).toHaveBeenCalledWith("You Picked: Technique");
   });


### PR DESCRIPTION
## Summary
- ensure stat button handlers wait for `statSelected` before evaluating the round
- auto-select routines dispatch and await `statSelected`
- adjust tests for async stat selection flow

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689dd867854c8326951f5067a0781ff9