### PR TITLE
Guard classic battle helpers against missing DOM APIs

### DIFF
--- a/src/helpers/battleJudokaPage.js
+++ b/src/helpers/battleJudokaPage.js
@@ -8,13 +8,17 @@
  * @pseudocode
  * 1. Fetch the `#computer-card` container.
  * 2. Resolve immediately if missing or a `.judoka-card` is already present.
- * 3. Otherwise observe mutations and resolve once a `.judoka-card` appears.
- * 4. Set a timeout that disconnects the observer and resolves after `timeoutMs`.
+ * 3. Resolve immediately if `MutationObserver` is unavailable.
+ * 4. Otherwise observe mutations and resolve once a `.judoka-card` appears.
+ * 5. Set a timeout that disconnects the observer and resolves after `timeoutMs`.
  */
 export function waitForComputerCard(timeoutMs = 5000) {
   const container = document.getElementById("computer-card");
   if (!container) return Promise.resolve();
   if (container.querySelector(".judoka-card")) {
+    return Promise.resolve();
+  }
+  if (typeof MutationObserver === "undefined") {
     return Promise.resolve();
   }
   return new Promise((resolve) => {

--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -104,6 +104,7 @@ function pickOpponent(available, playerJudoka) {
 }
 
 async function renderComputerPlaceholder(container, placeholder, enableInspector) {
+  if (!container) return;
   const judokaCard = new JudokaCard(placeholder, gokyoLookup, {
     useObscuredStats: true,
     enableInspector

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -63,7 +63,7 @@ window.skipBattlePhase = skipCurrentPhase;
 export const getBattleStore = () => battleStore;
 let statButtonControls;
 async function startRoundWrapper() {
-  statButtonControls.disable();
+  statButtonControls?.disable();
   try {
     await startRound(battleStore);
     await waitForComputerCard(5000);
@@ -74,7 +74,7 @@ async function startRoundWrapper() {
     } catch {}
     await dispatchBattleEvent("interrupt");
   } finally {
-    statButtonControls.enable();
+    statButtonControls?.enable();
   }
 }
 


### PR DESCRIPTION
## Summary
- Avoid constructing MutationObserver when unavailable in `waitForComputerCard`
- Skip computer placeholder rendering if the container is missing
- Guard stat button controls with optional chaining in classic battle page

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689ddcec77988326b64fd997403133ea