### PR TITLE
feat: preload vector extractor

### DIFF
--- a/src/helpers/api/vectorSearchPage.js
+++ b/src/helpers/api/vectorSearchPage.js
@@ -70,6 +70,17 @@ export async function getExtractor() {
 }
 
 /**
+ * Preload the feature extractor without awaiting its result.
+ *
+ * @pseudocode
+ * 1. Call `getExtractor()` to trigger the model download.
+ * 2. Ignore any errors to avoid blocking page initialization.
+ */
+export function preloadExtractor() {
+  getExtractor().catch(() => {});
+}
+
+/**
  * Format a file path string for display in the Source column.
  * Each path segment appears on a new line.
  *

--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -5,7 +5,7 @@ import { fetchJson } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
 import { prepareSearchUi, getSelectedTags } from "./vectorSearchPage/queryUi.js";
 import { renderResults } from "./vectorSearchPage/renderResults.js";
-import { getExtractor, SIMILARITY_THRESHOLD } from "./api/vectorSearchPage.js";
+import { getExtractor, SIMILARITY_THRESHOLD, preloadExtractor } from "./api/vectorSearchPage.js";
 
 let spinner;
 
@@ -175,13 +175,15 @@ function handleNoMatches(matches, messageEl) {
  * Initialize event handlers for the Vector Search page.
  *
  * @pseudocode
- * 1. Cache the spinner element and hide it if present.
- * 2. Locate the search form element.
- * 3. Load embeddings and populate the tag filter dropdown with unique tags.
- * 4. Fetch meta stats and display the embedding count in the header.
- * 5. Attach `handleSearch` to the form and intercept Enter key submissions.
+ * 1. Begin preloading the feature extractor.
+ * 2. Cache the spinner element and hide it if present.
+ * 3. Locate the search form element.
+ * 4. Load embeddings and populate the tag filter dropdown with unique tags.
+ * 5. Fetch meta stats and display the embedding count in the header.
+ * 6. Attach `handleSearch` to the form and intercept Enter key submissions.
  */
 export async function init() {
+  preloadExtractor();
   spinner = document.getElementById("search-spinner");
   if (spinner) spinner.style.display = "none";
   const form = document.getElementById("vector-search-form");


### PR DESCRIPTION
## Summary
- preload the vector search extractor to start model download in the background
- invoke extractor preloading during Vector Search page init

## Testing
- `npx prettier src/helpers/api/vectorSearchPage.js src/helpers/vectorSearchPage.js --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: timeout in battle-orientation screenshots)*
- `npm run check:contrast` *(fails: Server start timeout)*

------
https://chatgpt.com/codex/tasks/task_e_689e13a1efa483268cf4114fdeb80073