### PR TITLE
refactor: use static orchestrator import in quit modal

### DIFF
--- a/src/helpers/classicBattle/quitModal.js
+++ b/src/helpers/classicBattle/quitModal.js
@@ -3,6 +3,7 @@ import { createButton } from "../../components/Button.js";
 import * as battleEngine from "../battleEngineFacade.js";
 import { showResult } from "../battle/index.js";
 import { navigateToHome } from "../navUtils.js";
+import { dispatchBattleEvent } from "./orchestrator.js";
 
 function createQuitConfirmation(store, onConfirm) {
   const title = document.createElement("h2");
@@ -31,13 +32,9 @@ function createQuitConfirmation(store, onConfirm) {
   quit.addEventListener("click", () => {
     onConfirm();
     modal.close();
-    try {
-      // Drive state machine to interruption path
-      import("./orchestrator.js").then(({ dispatchBattleEvent }) => {
-        dispatchBattleEvent("interrupt");
-        dispatchBattleEvent("finalize");
-      });
-    } catch {}
+    // Drive state machine to interruption path
+    dispatchBattleEvent("interrupt");
+    dispatchBattleEvent("finalize");
     // Navigate to home (robust to varying base paths like GH Pages)
     navigateToHome();
   });


### PR DESCRIPTION
## Summary
- statically import `dispatchBattleEvent` in Classic Battle quit modal
- synchronously dispatch `interrupt` and `finalize` events when quitting

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Bundle Size
- `npx vite build` before: 596K total / 54.74 kB main chunk
- `npx vite build` after: 596K total / 54.74 kB main chunk


------
https://chatgpt.com/codex/tasks/task_e_689edb59b83c83269beeb339384f4e22