### PR TITLE
refactor: statically import debugLog in stats helper

### DIFF
--- a/src/helpers/stats.js
+++ b/src/helpers/stats.js
@@ -1,5 +1,6 @@
 import { fetchJson, importJsonModule } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
+import { debugLog } from "./debug.js";
 
 let namesPromise;
 let cachedNames;
@@ -26,10 +27,7 @@ export async function loadStatNames(category = "Judo") {
     if (!namesPromise) {
       namesPromise = fetchJson(`${DATA_DIR}statNames.json`).catch(async (err) => {
         // Use debug logging to avoid noisy browser error output in tests/CI
-        try {
-          const { debugLog } = await import("./debug.js");
-          debugLog("Failed to load stat names:", err);
-        } catch {}
+        debugLog("Failed to load stat names:", err);
         // Fallback to module import so tests/dev still function when fetch fails.
         try {
           return await importJsonModule("../data/statNames.json");


### PR DESCRIPTION
## Summary
- statically import `debugLog` in `stats.js`
- invoke `debugLog` directly when stat name loading fails

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Bundle Size
- `stats.js` bundle before: 434,774 bytes
- `stats.js` bundle after: 434,399 bytes


------
https://chatgpt.com/codex/tasks/task_e_689edcb9defc8326b58c94fea17080a1