### PR TITLE
Use console helpers to mute noisy test output

### DIFF
--- a/tests/helpers/carouselBuilder.test.js
+++ b/tests/helpers/carouselBuilder.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { withMutedConsole } from "../utils/console.js";
 
 vi.mock("../../src/helpers/carousel/index.js", async () => {
   const actual = await vi.importActual("../../src/helpers/carousel/index.js");
@@ -19,18 +20,14 @@ import { buildCardCarousel } from "../../src/helpers/carouselBuilder.js";
 
 describe("buildCardCarousel", () => {
   it("returns message when judoka list is empty", async () => {
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const wrapper = await buildCardCarousel([], []);
-    errorSpy.mockRestore();
+    const wrapper = await withMutedConsole(() => buildCardCarousel([], []));
     expect(wrapper.textContent).toContain("No cards available.");
   });
 
   it("updates scroll button state on scroll", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const wrapper = await buildCardCarousel([{ id: 1 }, { id: 2 }, { id: 3 }], []);
-    warnSpy.mockRestore();
-    errorSpy.mockRestore();
+    const wrapper = await withMutedConsole(() =>
+      buildCardCarousel([{ id: 1 }, { id: 2 }, { id: 3 }], [])
+    );
 
     const container = wrapper.querySelector(".card-carousel");
     const [leftBtn, rightBtn] = wrapper.querySelectorAll(".scroll-button");

--- a/tests/helpers/randomJudokaPage.test.js
+++ b/tests/helpers/randomJudokaPage.test.js
@@ -4,6 +4,7 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 import { parseCssVariables } from "../../src/helpers/cssVariableParser.js";
 import { hex } from "wcag-contrast";
+import { withMutedConsole } from "../utils/console.js";
 
 const baseSettings = {
   motionEffects: true,
@@ -312,7 +313,6 @@ describe("randomJudokaPage module", () => {
       if (opts.id) btn.id = opts.id;
       return btn;
     });
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
     vi.doMock("../../src/helpers/randomCard.js", () => ({ generateRandomCard: vi.fn() }));
     vi.doMock("../../src/components/Button.js", () => ({ createButton }));
@@ -326,9 +326,11 @@ describe("randomJudokaPage module", () => {
     const { section, container, placeholderTemplate } = createRandomCardDom();
     document.body.append(section, container, placeholderTemplate);
 
-    await import("../../src/helpers/randomJudokaPage.js");
-    document.dispatchEvent(new Event("DOMContentLoaded"));
-    await vi.runAllTimersAsync();
+    await withMutedConsole(async () => {
+      await import("../../src/helpers/randomJudokaPage.js");
+      document.dispatchEvent(new Event("DOMContentLoaded"));
+      await vi.runAllTimersAsync();
+    });
 
     const button = document.getElementById("draw-card-btn");
     expect(button.disabled).toBe(true);
@@ -336,7 +338,6 @@ describe("randomJudokaPage module", () => {
     const errorEl = document.getElementById("draw-error-message");
     expect(errorEl?.textContent).toMatch(/Unable to load judoka data/);
     fetchSpy.mockRestore();
-    consoleError.mockRestore();
   });
 
   it("storage event toggles card inspector", async () => {

--- a/tests/helpers/updateCodes.test.js
+++ b/tests/helpers/updateCodes.test.js
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
+import { withMutedConsole } from "../utils/console.js";
 
 const sampleJudoka = [
   {
@@ -68,7 +69,10 @@ vi.mock("fs", () => ({
 
 describe("updateCodes script", () => {
   it("assigns card codes and falls back for invalid entries", async () => {
-    await import("../../updateCodes.mjs");
+    await withMutedConsole(
+      () => import("../../updateCodes.mjs"),
+      ["log", "debug", "error", "warn"]
+    );
     const updated = JSON.parse(writtenData);
 
     expect(updated).toHaveLength(sampleJudoka.length);


### PR DESCRIPTION
## Summary
- replace manual console spies in carouselBuilder and randomJudokaPage tests with `withMutedConsole`
- silence updateCodes script logs in tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689eebb5f21c8326bc026c0d2dc9198c