### PR TITLE
chore: rename battle info bar PRD to scoreboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Before submitting or completing a task, verify that your work:
 | Debug + Observability targets | Components with data-_, like data-tooltip-id, data-flag, data-feature-_ |
 | UI test entry points          | playwright/_.spec.js, tests/\*\*/_.test.js                              |
 | Component factories           | src/components/\*.js                                                    |
-| Battle logic and UI           | classicBattle.js, setupBattleInfoBar.js, InfoBar.js                     |
+| Battle logic and UI           | classicBattle.js, setupBattleScoreboard.js, Scoreboard.js               |
 
 ---
 

--- a/design/productRequirementsDocuments/prdBattleScoreboard.md
+++ b/design/productRequirementsDocuments/prdBattleScoreboard.md
@@ -1,4 +1,4 @@
-# Battle Info Bar PRD
+# Battle Scoreboard PRD
 
 ## TL;DR
 
@@ -10,7 +10,7 @@ Displays round messages, stat selection timer, and live match score in the page 
 
 In battle game modes (e.g. Classic Battle), players have a real need to receive clear visual feedback between or after rounds. Without this info, it will leave users uncertain about match state, leading to confusion, reduced immersion, and increased risk of game abandonment. Players could feel "lost" due to a lack of timely updates about round outcomes, next steps, or overall progress.
 
-The round message, timer, and score now sit directly inside the page header rather than in a separate bar. The Info Bar also displays the stat selection timer (30 seconds by default), and triggers auto-selection if the timer expires, as specified in [Classic Battle PRD](prdClassicBattle.md) and [Random Stat Mode PRD](prdRandomStatMode.md). The timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see [Classic Battle PRD](prdClassicBattle.md)).
+The round message, timer, and score now sit directly inside the page header rather than in a separate bar. The Scoreboard also displays the stat selection timer (30 seconds by default), and triggers auto-selection if the timer expires, as specified in [Classic Battle PRD](prdClassicBattle.md) and [Random Stat Mode PRD](prdRandomStatMode.md). The timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see [Classic Battle PRD](prdClassicBattle.md)).
 
 ---
 
@@ -52,7 +52,7 @@ The round message, timer, and score now sit directly inside the page header rath
 - Action prompt appears via snackbar during user input phases and disappears after interaction. <!-- Implemented: see showMessage and stat selection logic -->
 - **Stat selection timer (30s) is displayed during stat selection phase; if timer expires, a random stat is auto-selected. Timer stops immediately once a stat is picked and pauses/resumes on tab inactivity.** <!-- Implemented: see startRound in battleEngine.js and [Classic Battle PRD](prdClassicBattle.md) -->
 - Auto-select messages are only shown if no stat was chosen before the timer runs out.
-- After the player selects a stat, the Info Bar shows "Opponent is choosing..." until the opponent's stat is revealed.
+- After the player selects a stat, the Scoreboard shows "Opponent is choosing..." until the opponent's stat is revealed.
 - Top bar content adapts responsively to different screen sizes and orientations. <!-- Partially implemented: stacking/truncation CSS present, but some edge cases pending -->
 - All messages meet minimum contrast ratio of **4.5:1** and are screen reader compatible. Run `npm run check:contrast` to audit these colors. <!-- Implemented: screen reader labels via `aria-live` and `role="status"`; contrast via CSS variables -->
 - **All interactive elements, including stat, Next, and Quit buttons, meet minimum touch target size (≥44px) and support keyboard navigation with Enter or Space. The Next button doubles as the timer skip and round progression control.** <!-- Implemented: see CSS min-width/min-height and stat button logic -->
@@ -120,7 +120,7 @@ The round message, timer, and score now sit directly inside the page header rath
   - [ ] 3.2 Truncate or stack content if resolution causes display issues (edge cases, pending)
   - [x] 3.3 Adaptive font sizing for all states (partially via clamp(), may need review) <!-- Implemented: font-size clamp() in battle.css -->
   - [x] 3.4 Handle orientation changes and reflow layout accordingly <!-- Implemented: orientation watcher in classicBattlePage.js -->
-  - [x] 3.5 Validate Info Bar on ultra-narrow screens (<320px) <!-- Implemented: narrow viewport test in playwright/battleJudoka.spec.js -->
+  - [x] 3.5 Validate Scoreboard on ultra-narrow screens (<320px) <!-- Implemented: narrow viewport test in playwright/battleJudoka.spec.js -->
 
 - [ ] 4.0 Implement Accessibility Features
 
@@ -129,7 +129,7 @@ The round message, timer, and score now sit directly inside the page header rath
   - [x] 4.3 Ensure all interactive elements have minimum 44px touch targets (CSS min-width/min-height present)
   - [x] 4.4 Ensure all interactive elements support keyboard navigation; tests cover stat, Next, and Quit controls
   - [x] 4.5 Announce score and timer updates via `aria-live` for screen readers (see [Classic Battle PRD](prdClassicBattle.md)) <!-- Implemented: aria-live regions in battleJudoka.html -->
-  - [x] 4.6 Provide high-contrast theme for Info Bar elements <!-- Implemented: `[data-theme="high-contrast"]` in base.css -->
+  - [x] 4.6 Provide high-contrast theme for Scoreboard elements <!-- Implemented: `[data-theme="high-contrast"]` in base.css -->
 
 - [ ] 5.0 Edge Case Handling and Fallbacks
 
@@ -141,7 +141,7 @@ The round message, timer, and score now sit directly inside the page header rath
 - [ ] 6.0 Testing and Validation
 
 - [ ] 6.1 Add/expand unit tests for timer pause/resume, auto-select, and fallback logic
-- [ ] 6.2 Add/expand Playwright UI tests for info bar responsiveness, accessibility, and edge cases
+- [ ] 6.2 Add/expand Playwright UI tests for scoreboard responsiveness, accessibility, and edge cases
 
 ---
 

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -35,7 +35,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - ≥70% of new players complete a Classic Battle within their first session.
 - Give new players an approachable mode to learn how judoka stats impact outcomes.
 - Reduce frustration by providing immediate, clear feedback on round results.
-- Ensure round result messages, stat selection timer, and score are surfaced via the Info Bar (see prdBattleInfoBar.md) for clarity and accessibility. The "Select your move" prompt and the countdown to the next round are shown in snackbars that update their text each second.
+- Ensure round result messages, stat selection timer, and score are surfaced via the Scoreboard (see prdBattleScoreboard.md) for clarity and accessibility. The "Select your move" prompt and the countdown to the next round are shown in snackbars that update their text each second.
 
 ---
 
@@ -115,7 +115,7 @@ The game waits for the player to choose a stat (or the AI to choose if it’s th
   - `statSelected` → **`roundDecision`**
   - `timeout` (statAutoSelect) → **`roundDecision`**
   - `interrupt` → **`interruptRound`**
-- **Notes:** Info Bar shows the stat-selection timer and prompt (see [prdBattleInfoBar.md](prdBattleInfoBar.md)). The UI highlights selectable stats.
+- **Notes:** Scoreboard shows the stat-selection timer and prompt (see [prdBattleScoreboard.md](prdBattleScoreboard.md)). The UI highlights selectable stats.
 
 ---
 
@@ -125,7 +125,7 @@ Compares the selected stat values and determines the round’s winner.
 - **Triggers:**
   - `outcome=winP1 / outcome=winP2 / outcome=draw` → **`roundOver`**
   - `interrupt` → **`interruptRound`**
-- **Notes:** Info Bar surfaces the win/loss/tie message and reveals the chosen stats (see [prdBattleInfoBar.md](prdBattleInfoBar.md)).
+- **Notes:** Scoreboard surfaces the win/loss/tie message and reveals the chosen stats (see [prdBattleScoreboard.md](prdBattleScoreboard.md)).
 
 ---
 
@@ -136,7 +136,7 @@ Executes card transfers, updates the score, and sets the next starting player.
   - `matchPointReached` (winner hits win target or no cards left) → **`matchDecision`**
   - `continue` → **`cooldown`**
   - `interrupt` → **`interruptRound`**
-- **Notes:** Info Bar updates the score and round summary, including streaks (see [prdBattleInfoBar.md](prdBattleInfoBar.md)).
+- **Notes:** Scoreboard updates the score and round summary, including streaks (see [prdBattleScoreboard.md](prdBattleScoreboard.md)).
 
 ---
 
@@ -146,7 +146,7 @@ A short pacing pause between rounds.
 - **Triggers:**
   - `done` → **`roundStart`**
   - `interrupt` → **`interruptRound`**
-- **Notes:** Info Bar and snackbar show a countdown to the next round (see [prdBattleInfoBar.md](prdBattleInfoBar.md)).
+- **Notes:** Scoreboard and snackbar show a countdown to the next round (see [prdBattleScoreboard.md](prdBattleScoreboard.md)).
 
 ---
 
@@ -156,7 +156,7 @@ Determines the overall winner based on score or remaining cards.
 - **Triggers:**
   - `finalize` → **`matchOver`**
   - `interrupt` → **`interruptMatch`**
-- **Notes:** Info Bar announces the final match result (see [prdBattleInfoBar.md](prdBattleInfoBar.md)).
+- **Notes:** Scoreboard announces the final match result (see [prdBattleScoreboard.md](prdBattleScoreboard.md)).
 
 ---
 
@@ -166,7 +166,7 @@ Match completed; player chooses next action.
 - **Triggers:**
   - `rematch` → **`matchStart`**
   - `home` → **`waitingForMatchStart`**
-- **Notes:** Info Bar keeps the final score visible until the player exits or rematches (see [prdBattleInfoBar.md](prdBattleInfoBar.md)).
+- **Notes:** Scoreboard keeps the final score visible until the player exits or rematches (see [prdBattleScoreboard.md](prdBattleScoreboard.md)).
 
 ---
 ### 10. `interruptRound`
@@ -175,7 +175,7 @@ Round interrupted due to quit, navigation, or error. Rolls back round context an
 - **Triggers:**
   - `resumeLobby` → **`waitingForMatchStart`**
   - `abortMatch` → **`matchOver`**
-- **Notes:** Info Bar displays an interruption message and current score (see [prdBattleInfoBar.md](prdBattleInfoBar.md)).
+- **Notes:** Scoreboard displays an interruption message and current score (see [prdBattleScoreboard.md](prdBattleScoreboard.md)).
 
 ---
 
@@ -184,7 +184,7 @@ Match interrupted from lobby or critical error. Tears down match context.
 
 - **Triggers:**
   - `toLobby` → **`waitingForMatchStart`**
-- **Notes:** Info Bar announces that the match was aborted (see [prdBattleInfoBar.md](prdBattleInfoBar.md)).
+- **Notes:** Scoreboard announces that the match was aborted (see [prdBattleScoreboard.md](prdBattleScoreboard.md)).
 
 ---
 
@@ -276,12 +276,12 @@ flowchart TD
 
 - Classic Battle logic must reuse shared random card draw module (`generateRandomCard`).
 - Card reveal and result animations should use hardware-accelerated CSS for smooth performance on low-end devices.
-- Stat selection timer (30s) must be displayed in the Info Bar; if timer expires, a random stat is auto-selected. Timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see prdBattleInfoBar.md).
+- Stat selection timer (30s) must be displayed in the Scoreboard; if timer expires, a random stat is auto-selected. Timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see prdBattleScoreboard.md).
 - Stat selection timer halts immediately once the player picks a stat.
 - Detect timer drift by comparing engine state with real time; if drift exceeds 2s, display "Waiting…" and restart the countdown.
 - Opponent stat selection runs entirely on the client. After the player picks a stat (or the timer auto-chooses), the opponent's choice is revealed after a short artificial delay to mimic turn-taking.
-- During this delay, the Info Bar displays "Opponent is choosing..." to reinforce turn flow.
-- The cooldown timer between rounds begins only after round results are shown in the Info Bar and is displayed using one persistent snackbar that updates its text each second.
+- During this delay, the Scoreboard displays "Opponent is choosing..." to reinforce turn flow.
+- The cooldown timer between rounds begins only after round results are shown in the Scoreboard and is displayed using one persistent snackbar that updates its text each second.
 - The debug panel is available when the `battleDebugPanel` feature flag is enabled and appears beside the opponent's card.
 
 ---
@@ -291,7 +291,7 @@ flowchart TD
 | Priority | Feature                 | Description                                                                                                                                                                      |
 | -------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **P1**   | Random Card Draw        | Draw one random card per player each round; the opponent card must differ from the player's.                                                                                     |
-| **P1**   | Stat Selection Timer    | Player selects stat within 30 seconds; otherwise, random stat is chosen. Default timer is fixed at 30s. Timer is displayed in the Info Bar and pauses/resumes on tab inactivity. |
+| **P1**   | Stat Selection Timer    | Player selects stat within 30 seconds; otherwise, random stat is chosen. Default timer is fixed at 30s. Timer is displayed in the Scoreboard and pauses/resumes on tab inactivity. |
 | **P1**   | Scoring                 | Increase score by one for each round win.                                                                                                                                        |
 | **P1**   | Match End Condition     | End match when either player reaches a user-selected win target of 5, 10, or 15 points (default 10) or after 25 rounds.                                                                                                                                       |
 | **P2**   | Tie Handling            | Show tie message; round ends without score change; continue to next round.                                                                                                       |
@@ -303,7 +303,7 @@ flowchart TD
 
  - Behavior on tie rounds: round ends with a message explaining the tie and an option to start the next round via the **Next** button.
 - Match start conditions: both players begin with a score of zero; player goes first by drawing their card.
-  - Players have 30 seconds to select a stat; if no selection is made, the system randomly selects a stat from the drawn card. **The timer is displayed in the Info Bar and the prompt appears in a snackbar.**
+  - Players have 30 seconds to select a stat; if no selection is made, the system randomly selects a stat from the drawn card. **The timer is displayed in the Scoreboard and the prompt appears in a snackbar.**
 - The opponent's card must always differ from the player's card for each round.
 - **Default:** 30-second timer is fixed (not adjustable by the player at launch), but can be reviewed for future difficulty settings.
 
@@ -313,11 +313,11 @@ flowchart TD
 
 - Cards are revealed in the correct sequence each round.
 - The opponent card displays a placeholder ("Mystery Judoka") until the player selects a stat ([prdMysteryCard.md](prdMysteryCard.md)).
-- Player can select a stat within 30 seconds; if not, the system auto-selects a random stat automatically. **Timer is surfaced in the Info Bar, and the "Select your move" prompt appears in a snackbar.**
+- Player can select a stat within 30 seconds; if not, the system auto-selects a random stat automatically. **Timer is surfaced in the Scoreboard, and the "Select your move" prompt appears in a snackbar.**
 - Stat-selection timer stops the moment a stat is chosen.
 - "Time's up! Auto-selecting <stat>" appears only if no stat was chosen before the timer expires.
 - After selection, the correct comparison is made, and the score updates based on round outcome.
-- After the player selects a stat, the Info Bar shows "Opponent is choosing..." until the opponent's stat is revealed.
+- After the player selects a stat, the Scoreboard shows "Opponent is choosing..." until the opponent's stat is revealed.
 - If the selected stats are equal, a tie message displays and the round ends.
 - After round results, a 3s countdown is displayed via snackbar (`Next round in: Xs`). The **Next** button becomes active once the countdown ends or when skipped. Reference [timerService.js](../../src/helpers/classicBattle/timerService.js) for exact durations to keep design and code aligned.
 - After the match ends, a modal appears showing the final result and score with **Quit Match** and **Next Match** buttons; **Quit Match** exits to the main menu and **Next Match** starts a new match.
@@ -327,14 +327,14 @@ flowchart TD
 - Animation flow: transitions between card reveal, stat selection, and result screens complete smoothly without stalling.
 - Stat buttons reset between rounds so no previous selection remains highlighted. The `battle.css` rule `#stat-buttons button { -webkit-tap-highlight-color: transparent; }` combined with a reflow ensures Safari clears the red touch overlay.
 - If the Judoka dataset fails to load, an error message appears with option to reload.
-- **All Info Bar content (messages, timer, score) must meet accessibility and responsiveness requirements as described in prdBattleInfoBar.md.**
+- **All Scoreboard content (messages, timer, score) must meet accessibility and responsiveness requirements as described in prdBattleScoreboard.md.**
 
 ---
 
 ## Edge Cases / Failure States
 
-- **Judoka or Gokyo dataset fails to load:** error message surfaces in the Info Bar and an error dialog offers a "Retry" button to reload data or the page.
-- **Player does not make a stat selection within 30 seconds:** system randomly selects a stat automatically. **Info Bar updates the timer, and the snackbar prompt informs the player.**
+- **Judoka or Gokyo dataset fails to load:** error message surfaces in the Scoreboard and an error dialog offers a "Retry" button to reload data or the page.
+- **Player does not make a stat selection within 30 seconds:** system randomly selects a stat automatically. **Scoreboard updates the timer, and the snackbar prompt informs the player.**
 - **AI fails to select a stat (if difficulty logic implemented):** fallback to random stat selection.
 
 ---
@@ -361,13 +361,13 @@ flowchart TD
     attribute and auto-opens on first visit using the storage helper to remember the
     dismissal.
   - Tooltips on stat names, country flags, weight indicators, and navigation icons provide accessible explanations.
-  - The Info Bar includes a round counter and a field showing the player's selected stat for the current round.
+  - The Scoreboard includes a round counter and a field showing the player's selected stat for the current round.
   - **Accessibility:**
   - Minimum text contrast ratio: ≥4.5:1 (per WCAG).
   - Minimum touch target size: ≥44px. See [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness) for the full rule.
   - Support keyboard navigation for stat selection, the **Next** button (for round progression and timer skipping), and quit confirmation.
   - Provide alt text for cards and labels readable by screen readers.
-  - **All Info Bar content must be accessible and responsive as described in prdBattleInfoBar.md.**
+  - **All Scoreboard content must be accessible and responsive as described in prdBattleScoreboard.md.**
 
 ---
 
@@ -377,7 +377,7 @@ flowchart TD
 - Only judoka with `isHidden` set to `false` are eligible for battle.
 - Uses the shared random card draw module (`generateRandomCard`) as detailed in [prdDrawRandomCard.md](prdDrawRandomCard.md) (see `src/helpers/randomCard.js`).
 - Uses the Mystery Card placeholder outlined in [prdMysteryCard.md](prdMysteryCard.md), which relies on the `useObscuredStats` flag added to `renderJudokaCard()`.
-- **Relies on Info Bar (see prdBattleInfoBar.md) for all round messages, timer, and score display.**
+- **Relies on Scoreboard (see prdBattleScoreboard.md) for all round messages, timer, and score display.**
 
 ---
 
@@ -385,7 +385,7 @@ flowchart TD
 
 - [x] 1.0 Implement Classic Battle Match Flow
 - [x] 1.1 Create round loop: random card draw, stat selection, comparison
-  - [x] 1.2 Implement 30-second stat selection timer with auto-selection fallback (displayed in Info Bar)
+  - [x] 1.2 Implement 30-second stat selection timer with auto-selection fallback (displayed in Scoreboard)
   - [x] 1.3 Handle scoring updates on win, loss, and tie
   - [x] 1.4 Add "Next" (round advance/timer skip) and "Quit Match" buttons to controls
   - [x] 1.5 End match after the user-selected win target (5, 10, or 15 points; default 10) or 25 rounds
@@ -399,7 +399,7 @@ flowchart TD
 - [x] 4.0 Polish UX and Accessibility
   - [x] 4.1 Integrate consistent color coding (blue for player, red for AI)
   - [x] 4.2 Apply WCAG-compliant contrast ratios
-  - [x] 4.3 Ensure touch targets ≥44px and support keyboard navigation (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness) and prdBattleInfoBar.md; implemented in [buttons.css](../../src/styles/buttons.css))
+  - [x] 4.3 Ensure touch targets ≥44px and support keyboard navigation (see [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness) and prdBattleScoreboard.md; implemented in [buttons.css](../../src/styles/buttons.css))
   - [x] 4.4 Add alt text to cards and UI elements (see [cardSelection.js](../../src/helpers/classicBattle/cardSelection.js))
 - [x] 5.0 Optimize Animations
   - [x] 5.1 Implement card reveal, stat selection, and result transitions using transform/opacity for GPU acceleration
@@ -408,4 +408,4 @@ flowchart TD
 
 **See also:**
 
-- [Battle Info Bar PRD](prdBattleInfoBar.md) for Info Bar UI, timer, and accessibility requirements.
+- [Battle Scoreboard PRD](prdBattleScoreboard.md) for Scoreboard UI, timer, and accessibility requirements.

--- a/design/productRequirementsDocuments/prdIndex.json
+++ b/design/productRequirementsDocuments/prdIndex.json
@@ -1,6 +1,6 @@
 [
   "prdBattleDebugPanel.md",
-  "prdBattleInfoBar.md",
+  "prdBattleScoreboard.md",
   "prdBrowseJudoka.md",
   "prdCardCarousel.md",
   "prdCardCodes.md",


### PR DESCRIPTION
## Summary
- rename Battle Info Bar PRD to Battle Scoreboard PRD and update terminology
- update Classic Battle PRD, index, and AGENTS guide to reference the new Scoreboard

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689f45b8a5208326b980256e108c62e0