### PR TITLE
Rename battle info bars to scoreboard

### DIFF
--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -219,8 +219,8 @@ function setBattleStateBadgeEnabled(enable) {
   }
   if (!badge) {
     const headerRight =
-      document.getElementById("info-bar-right") ||
-      document.querySelector(".battle-header .info-right");
+      document.getElementById("scoreboard-right") ||
+      document.querySelector(".battle-header .scoreboard-right");
     badge = document.createElement("p");
     badge.id = "battle-state-badge";
     badge.dataset.flag = "battleStateBadge";

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -29,7 +29,7 @@
   <body>
     <div class="home-screen">
       <header class="header battle-header" role="banner">
-        <div class="info-left" id="info-bar-left">
+        <div class="scoreboard-left" id="scoreboard-left">
           <p id="round-message" aria-live="polite" aria-atomic="true" role="status"></p>
           <p id="next-round-timer" aria-live="polite" aria-atomic="true" role="status"></p>
           <p id="round-counter" aria-live="polite" aria-atomic="true"></p>
@@ -39,7 +39,7 @@
             <img src="../assets/images/judokonLogoSmall.png" alt="JU-DO-KON! Logo" class="logo" />
           </a>
         </div>
-        <div class="info-right" id="info-bar-right">
+        <div class="scoreboard-right" id="scoreboard-right">
           <p id="score-display" aria-live="polite" aria-atomic="true">
             <span>You: 0</span>
             <span>Opponent: 0</span>

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -1,6 +1,6 @@
 /* Battle header info elements */
-.battle-header .info-left,
-.battle-header .info-right {
+.battle-header .scoreboard-left,
+.battle-header .scoreboard-right {
   display: flex;
   flex-direction: column;
   padding: 1vh 1.5rem;
@@ -12,12 +12,12 @@
   contain: layout paint;
 }
 
-.battle-header .info-left {
+.battle-header .scoreboard-left {
   grid-column: 1;
   align-items: flex-start;
 }
 
-.battle-header .info-right {
+.battle-header .scoreboard-right {
   grid-column: 3;
   justify-self: end;
   align-items: flex-end;
@@ -54,7 +54,7 @@
   text-align: center;
 }
 
-.battle-header[data-orientation="portrait"] .info-left {
+.battle-header[data-orientation="portrait"] .scoreboard-left {
   grid-row: 1;
   align-items: center;
 }
@@ -63,7 +63,7 @@
   grid-row: 2;
 }
 
-.battle-header[data-orientation="portrait"] .info-right {
+.battle-header[data-orientation="portrait"] .scoreboard-right {
   grid-row: 3;
   justify-self: center;
   align-items: center;

--- a/tests/helpers/classicBattle/battleStateBadge.test.js
+++ b/tests/helpers/classicBattle/battleStateBadge.test.js
@@ -66,7 +66,7 @@ describe("battleStateBadge displays state transitions", () => {
       <p id="next-round-timer" aria-live="polite" aria-atomic="true" role="status"></p>
       <p id="round-counter" aria-live="polite" aria-atomic="true"></p>
       <p id="score-display" aria-live="polite" aria-atomic="true"></p>
-      <div id="info-bar-right"></div>
+      <div class="scoreboard-right" id="scoreboard-right"></div>
     `;
     const battleArea = document.createElement("div");
     battleArea.id = "battle-area";

--- a/tests/helpers/scoreboard.integration.test.js
+++ b/tests/helpers/scoreboard.integration.test.js
@@ -17,14 +17,16 @@ describe("Scoreboard integration without explicit init", () => {
     const header = document.createElement("header");
     header.className = "header battle-header";
     const left = document.createElement("div");
-    left.className = "info-left";
+    left.className = "scoreboard-left";
+    left.id = "scoreboard-left";
     left.innerHTML = `
       <p id="round-message" aria-live="polite" aria-atomic="true" role="status"></p>
       <p id="next-round-timer" aria-live="polite" aria-atomic="true" role="status"></p>
       <p id="round-counter" aria-live="polite" aria-atomic="true"></p>
     `;
     const right = document.createElement("div");
-    right.className = "info-right";
+    right.className = "scoreboard-right";
+    right.id = "scoreboard-right";
     right.innerHTML = `
       <p id="score-display" aria-live="polite" aria-atomic="true">
         <span>You: 0</span>


### PR DESCRIPTION
## Summary
- rename battle header info bars to `scoreboard-left`/`scoreboard-right`
- update CSS and JS selectors for new scoreboard ids/classes
- adjust tests to reference new scoreboard containers

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689f5489d4408326970441aa79a06ec7