### PR TITLE
docs: refresh scoreboard references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Before submitting or completing a task, verify that your work:
 | Debug + Observability targets | Components with data-_, like data-tooltip-id, data-flag, data-feature-_ |
 | UI test entry points          | playwright/_.spec.js, tests/\*\*/_.test.js                              |
 | Component factories           | src/components/\*.js                                                    |
-| Battle logic and UI           | classicBattle.js, setupBattleScoreboard.js, Scoreboard.js               |
+| Battle logic and UI           | classicBattle.js, setupScoreboard.js, Scoreboard.js                     |
 
 ---
 

--- a/src/helpers/classicBattle/autoSelectStat.js
+++ b/src/helpers/classicBattle/autoSelectStat.js
@@ -5,7 +5,7 @@ import { dispatchBattleEvent } from "./orchestrator.js";
 // the outcome message to occupy that region immediately after selection.
 // Intentionally avoid showing a snackbar here to prevent racing with
 // the cooldown countdown snackbar. The auto-select announcement is
-// surfaced via the Info Bar message area instead.
+// surfaced via the Scoreboard message area instead.
 
 const AUTO_SELECT_FEEDBACK_MS = 500;
 


### PR DESCRIPTION
## Summary
- Update Battle logic and UI key files list to setupScoreboard.js and Scoreboard.js
- Replace Info Bar wording with Scoreboard in classic battle helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689f5cb7238483269b9e2202ac5a78bc