### PR TITLE
Respect Random Stat Mode when timer expires

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -73,7 +73,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 - Classic Battle logic must reuse shared random card draw module (`generateRandomCard`).
 - Card reveal and result animations should use hardware-accelerated CSS for smooth performance on low-end devices.
-- Stat selection timer (30s) must be displayed in the Scoreboard; if timer expires, a random stat is auto-selected. Timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see prdBattleScoreboard.md).
+- Stat selection timer (30s) must be displayed in the Scoreboard; if timer expires, a random stat is auto-selected. This auto-select behavior is controlled by Random Stat Mode (`FF_AUTO_SELECT`), enabled by default. Timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see prdBattleScoreboard.md).
 - Stat selection timer halts immediately once the player picks a stat.
 - Detect timer drift by comparing engine state with real time; if drift exceeds 2s, display "Waiting…" and restart the countdown.
 - Opponent stat selection runs entirely on the client. After the player picks a stat (or the timer auto-chooses), the opponent's choice is revealed after a short artificial delay to mimic turn-taking.
@@ -88,7 +88,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 | Priority | Feature                 | Description                                                                                                                                                                      |
 | -------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **P1**   | Random Card Draw        | Draw one random card per player each round; the opponent card must differ from the player's.                                                                                     |
-| **P1**   | Stat Selection Timer    | Player selects stat within 30 seconds; otherwise, random stat is chosen. Default timer is fixed at 30s. Timer is displayed in the Scoreboard and pauses/resumes on tab inactivity. |
+| **P1**   | Stat Selection Timer    | Player selects stat within 30 seconds; otherwise, random stat is chosen. Auto-select is controlled by Random Stat Mode (`FF_AUTO_SELECT`), enabled by default. Timer is displayed in the Scoreboard and pauses/resumes on tab inactivity. |
 | **P1**   | Scoring                 | Increase score by one for each round win.                                                                                                                                        |
 | **P1**   | Match End Condition     | End match when either player reaches a user-selected win target of 5, 10, or 15 points (default 10) or after 25 rounds.                                                                                                                                       |
 | **P2**   | Tie Handling            | Show tie message; round ends without score change; continue to next round.                                                                                                       |

--- a/design/productRequirementsDocuments/prdClassicBattleEngine.md
+++ b/design/productRequirementsDocuments/prdClassicBattleEngine.md
@@ -40,7 +40,8 @@ A well-defined engine will enable consistent gameplay, predictable UI updates th
 ## Defaults (Developer Configurable)
 
 - **Stat Selection Timer:** 30 seconds, or another value
-- **Win Target:** User-selected at match start (5, 10, or 15 round wins)  
+- **Win Target:** User-selected at match start (5, 10, or 15 round wins)
+- **Random Stat Mode (`FF_AUTO_SELECT`):** Enabled by default
 
 ---
 
@@ -59,7 +60,7 @@ A well-defined engine will enable consistent gameplay, predictable UI updates th
 |----------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
 | **P1**   | State Machine                | Implements all match states and transitions as defined in `classicBattleStates.json`. Exposes current state to UI and tests.       |
 | **P1**   | Round Logic                  | Handles round start, stat selection, comparison, scoring, and round end.                                                          |
-| **P1**   | Stat Selection Timer         | 30s timer for stat selection, with pause/resume and auto-select fallback (if `FF_AUTO_SELECT` enabled).                           |
+| **P1**   | Stat Selection Timer         | 30s timer for stat selection, with pause/resume and auto-select fallback (Random Stat Mode, `FF_AUTO_SELECT`, enabled by default). |
 | **P1**   | Scoring                      | Updates player and opponent scores after each round.                                                                               |
 | **P1**   | Match End Condition          | Ends match when user-selected win target is reached; exposes final result and score.                                               |
 | **P2**   | Interrupt Handling           | Supports early quit, navigation, or error interrupts; rolls back or ends match as appropriate.                                    |
@@ -79,8 +80,8 @@ A well-defined engine will enable consistent gameplay, predictable UI updates th
    - **Given** the player is in `waitingForPlayerAction`  
    - **When** the timer reaches zero  
    - **Then**  
-     - If `FF_AUTO_SELECT` is enabled → system auto-selects the highest stat allowed by rules, and match proceeds to `roundDecision`.  
-     - If `FF_AUTO_SELECT` is disabled → match proceeds to `interruptRound` or a defined grace extension.
+    - If `FF_AUTO_SELECT` (Random Stat Mode) is enabled → system auto-selects the highest stat allowed by rules, and match proceeds to `roundDecision`.
+    - If `FF_AUTO_SELECT` is disabled → match proceeds to `interruptRound` or a defined grace extension.
 
 3. **Timer Drift Handling**  
    - **Given** the tab is inactive or device clock drifts by >200ms  
@@ -101,7 +102,7 @@ A well-defined engine will enable consistent gameplay, predictable UI updates th
 
 ## Edge Cases / Failure States
 
-- **Timeout Auto-Select:** If enabled via `FF_AUTO_SELECT`, the engine auto-selects highest stat by ruleset; otherwise follow fallback path.  
+- **Timeout Auto-Select:** If enabled via `FF_AUTO_SELECT` (Random Stat Mode), the engine auto-selects highest stat by ruleset; otherwise follow fallback path.
 - **Tab Inactivity / App Backgrounding:** Timers pause; state resumes accurately on return.  
 - **Error Injection (Testing):** Engine must recover from simulated logic or UI hook errors without corrupting match state.
 


### PR DESCRIPTION
## Summary
- Check `FF_AUTO_SELECT` (Random Stat Mode) in timer service to interrupt round when disabled
- Document Random Stat Mode default in Classic Battle PRDs
- Add unit tests covering timer expiry with Random Stat Mode on or off

## Testing
- `npx prettier src/helpers/classicBattle/timerService.js tests/helpers/classicBattle/matchFlow.test.js design/productRequirementsDocuments/prdClassicBattleEngine.md design/productRequirementsDocuments/prdClassicBattle.md --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/matchFlow.test.js`
- `npx playwright test` *(fails: createButton export missing; some tests interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689f7881455c832687c317a4f82016d5