### PR TITLE
Fix default flag usage and timer fallback

### DIFF
--- a/src/helpers/featureFlags.js
+++ b/src/helpers/featureFlags.js
@@ -1,4 +1,5 @@
 import { loadSettings, updateSetting } from "./settingsStorage.js";
+import { DEFAULT_SETTINGS } from "./settingsSchema.js";
 
 /**
  * Event emitter broadcasting feature flag changes.
@@ -7,14 +8,15 @@ import { loadSettings, updateSetting } from "./settingsStorage.js";
  */
 export const featureFlagsEmitter = new EventTarget();
 
-let cachedFlags = {};
+// Initialize with defaults so flags have expected values before loading settings.
+let cachedFlags = { ...DEFAULT_SETTINGS.featureFlags };
 
 /**
  * Initialize feature flags from persisted settings.
  *
  * @pseudocode
  * 1. Call `loadSettings()` to retrieve current settings.
- * 2. Set `cachedFlags` to `settings.featureFlags` or `{}`.
+ * 2. Set `cachedFlags` to `settings.featureFlags` or default feature flags.
  * 3. Dispatch a `change` event with `flag: null`.
  * 4. Return the loaded `settings`.
  *
@@ -24,10 +26,10 @@ export async function initFeatureFlags() {
   let settings;
   try {
     settings = await loadSettings();
-    cachedFlags = settings.featureFlags || {};
+    cachedFlags = settings.featureFlags || { ...DEFAULT_SETTINGS.featureFlags };
   } catch {
-    settings = { featureFlags: {} };
-    cachedFlags = {};
+    settings = { featureFlags: { ...DEFAULT_SETTINGS.featureFlags } };
+    cachedFlags = { ...DEFAULT_SETTINGS.featureFlags };
   }
   featureFlagsEmitter.dispatchEvent(new CustomEvent("change", { detail: { flag: null } }));
   return settings;


### PR DESCRIPTION
## Summary
- initialize feature flags from default settings so Random Stat Mode works before flags load
- add setInterval fallback in countdown timer when scheduler isn't active

## Testing
- `npx prettier src/helpers/featureFlags.js src/helpers/timerUtils.js --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_689f7d48055483268793fd6580022529