### PR TITLE
test: silence debug output in settings and motion tests

### DIFF
--- a/tests/helpers/motionUtils.test.js
+++ b/tests/helpers/motionUtils.test.js
@@ -44,7 +44,9 @@ describe("motionUtils", () => {
   it("handles invalid stored settings gracefully", async () => {
     window.matchMedia = matchMediaMock(true);
     localStorage.setItem("settings", "not json");
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
     await loadSettings();
+    debugSpy.mockRestore();
     expect(shouldReduceMotionSync()).toBe(true);
   });
 

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -125,11 +125,11 @@ describe("settings utils", () => {
   it("recovers from invalid stored JSON", async () => {
     localStorage.setItem("settings", "{bad json}");
     const { loadSettings } = await import("../../src/helpers/settingsStorage.js");
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
     const settings = await loadSettings();
     expect(settings).toEqual(DEFAULT_SETTINGS);
     expect(localStorage.getItem("settings")).toBeNull();
-    warnSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 
   /**


### PR DESCRIPTION
## Summary
- use console.debug spy when recovering from invalid settings JSON
- mock console.debug in motionUtils invalid settings test

## Testing
- `npx prettier tests/helpers/settingsUtils.test.js tests/helpers/motionUtils.test.js --check`
- `npx eslint .`
- `npx vitest run` *(fails: timerService auto-select and battleStateBadge timeout)*
- `npx vitest run tests/helpers/settingsUtils.test.js tests/helpers/motionUtils.test.js`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689f7e53850c8326a8317fdcfb41a0bc