### PR TITLE
test: mute css parse debug

### DIFF
--- a/tests/helpers/cssVariableParser.test.js
+++ b/tests/helpers/cssVariableParser.test.js
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { parseCssVariables } from "../../src/helpers/cssVariableParser.js";
 
 describe("parseCssVariables", () => {
@@ -124,9 +124,13 @@ describe("parseCssVariables", () => {
   it("should return empty object for invalid CSS", () => {
     const css = "invalid css content {{{";
 
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
     const vars = parseCssVariables(css);
 
     expect(vars).toEqual({});
+
+    debugSpy.mockRestore();
   });
 
   it("should return empty object for CSS without :root", () => {


### PR DESCRIPTION
## Summary
- mute console.debug in css variable parser invalid CSS test to avoid noisy log

## Testing
- `npx prettier . --check` (fails: Code style issues in src/data/classicBattleStates.json)
- `npx eslint .`
- `npx vitest run` (fails: timerService.test.js, battleStateBadge.test.js)
- `npx vitest run tests/helpers/cssVariableParser.test.js`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689f7e58db508326b6b9c0e2c783974b