### PR TITLE
test: mock fetchJson by path

### DIFF
--- a/src/data/classicBattleStates.json
+++ b/src/data/classicBattleStates.json
@@ -18,7 +18,12 @@
     "id": 2,
     "name": "matchStart",
     "description": "Initialises match context. Stores selected win target, resets scores, and fixes user as first player for all rounds.",
-    "onEnter": ["init:matchContext", "store:winTargetSelection", "reset:scores", "set:firstPlayerUser"],
+    "onEnter": [
+      "init:matchContext",
+      "store:winTargetSelection",
+      "reset:scores",
+      "set:firstPlayerUser"
+    ],
     "triggers": [
       { "on": "ready", "target": "cooldown" },
       { "on": "interrupt", "target": "interruptMatch" },
@@ -120,7 +125,11 @@
     "id": 98,
     "name": "interruptRound",
     "description": "Round-level interruption (quit, navigation, or error). Performs safe rollback and offers options.",
-    "onEnter": ["timer:clearIfRunning", "rollback:roundContextIfNeeded", "log:analyticsInterruptRound"],
+    "onEnter": [
+      "timer:clearIfRunning",
+      "rollback:roundContextIfNeeded",
+      "log:analyticsInterruptRound"
+    ],
     "triggers": [
       { "on": "roundModifyFlag", "target": "roundModification", "guard": "FF_ROUND_MODIFY" },
       { "on": "restartRound", "target": "cooldown" },

--- a/tests/helpers/vectorSearchPage.test.js
+++ b/tests/helpers/vectorSearchPage.test.js
@@ -336,9 +336,14 @@ describe("synonym expansion", () => {
         }
       };
     });
-    vi.doMock("../../src/helpers/dataUtils.js", () => ({
-      fetchJson: vi.fn().mockResolvedValue(synonyms)
-    }));
+    vi.doMock("../../src/helpers/dataUtils.js", () => {
+      const fetchJson = vi.fn(async (path) => {
+        if (path.endsWith("synonyms.json")) return synonyms;
+        if (path.endsWith("client_embeddings.meta.json")) return { count: 0, version: 1 };
+        return null;
+      });
+      return { fetchJson };
+    });
     vi.doMock("../../src/helpers/constants.js", () => ({
       DATA_DIR: "./"
     }));


### PR DESCRIPTION
## Summary
- mock fetchJson in vector search misspelling test to handle specific file paths and avoid warnings
- format classic battle states JSON after running Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/vectorSearchPage.test.js -t "handles misspellings via Levenshtein check"`
- `npx vitest run` *(fails: timerService, battleStateBadge)*
- `npx playwright test` *(fails: 20 specs)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_689f7e4d0d788326bdf8705bab45dcce