### PR TITLE
Handle missing scheduler ID in countdown timer

### DIFF
--- a/src/helpers/timerUtils.js
+++ b/src/helpers/timerUtils.js
@@ -110,7 +110,7 @@ export function createCountdownTimer(
         console.error("Error in countdown timer tick:", err);
       }
     });
-    if (typeof subId !== "number") {
+    if (subId === undefined || subId === null) {
       const intervalId = setInterval(async () => {
         try {
           await tick();


### PR DESCRIPTION
## Summary
- use nullish check for scheduler subscription in `createCountdownTimer`
- preserve existing stop logic for canceling active timer

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689f822f8c38832689e9e16c81ec2a94