### PR TITLE
Handle missing card container on random draw

### DIFF
--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -9,9 +9,9 @@
  * 3. Initialize a draw history manager with a 5-entry limit.
  * 4. Toggle the `.simulate-viewport` class based on the stored feature flag.
  * 5. Create a hidden slide-out history panel and a toggle button.
- * 6. Define `displayCard` that disables the Draw button, updates its text and `aria-busy` state while loading, calls
- *    `generateRandomCard` with the loaded data and the user's motion preference, updates the history list, then restores
- *    the button once the animation completes (or immediately when motion is disabled).
+ * 6. Define `displayCard` that disables the Draw button, updates its text and `aria-busy` state while loading, verifies the
+ *    card container exists, calls `generateRandomCard` with the loaded data and the user's motion preference, updates the
+ *    history list, then restores the button once the animation completes (or immediately when motion is disabled).
  * 7. Render a placeholder card in the card container.
  * 8. Create the "Draw Card!" button (min 64px height, 300px width, pill shape, ARIA attributes) and attach its event listener.
  * 9. If data fails to load, disable the Draw button and show an error message or fallback card.
@@ -183,14 +183,6 @@ async function displayCard({
   const errorEl = document.getElementById("draw-error-message");
   if (errorEl) errorEl.textContent = "";
   const cardContainer = document.getElementById("card-container");
-  await generateRandomCard(
-    cachedJudokaData,
-    cachedGokyoData,
-    cardContainer,
-    prefersReducedMotion,
-    onSelect,
-    { enableInspector: isEnabled("enableCardInspector") }
-  );
   function enableButton() {
     drawButton.disabled = false;
     drawButton.removeAttribute("aria-disabled");
@@ -202,6 +194,19 @@ async function displayCard({
     }
     drawButton.removeAttribute("aria-busy");
   }
+  if (!cardContainer) {
+    showError("Card area missing. Please refresh the page.");
+    enableButton();
+    return;
+  }
+  await generateRandomCard(
+    cachedJudokaData,
+    cachedGokyoData,
+    cardContainer,
+    prefersReducedMotion,
+    onSelect,
+    { enableInspector: isEnabled("enableCardInspector") }
+  );
   if (prefersReducedMotion) {
     enableButton();
   } else {


### PR DESCRIPTION
## Summary
- guard against missing card container in `randomJudokaPage`
- surface error and re-enable draw button when container is absent
- note container check in pseudocode documentation

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689f8e06e5a88326b9701316f8999cc4