### PR TITLE
Simplify scoreboard round counter

### DIFF
--- a/src/components/Scoreboard.js
+++ b/src/components/Scoreboard.js
@@ -203,16 +203,15 @@ export function clearTimer() {
  *
  * @pseudocode
  * 1. When the round counter element exists, set its text content to
- *    `"Round <current> of <total>"`.
+ *    `"Round <current>"`.
  *
  * @param {number} current - Current round number.
- * @param {number} total - Total number of rounds.
  * @returns {void}
  */
-export function updateRoundCounter(current, total) {
+export function updateRoundCounter(current) {
   ensureRefs();
   if (roundCounterEl) {
-    roundCounterEl.textContent = `Round ${current} of ${total}`;
+    roundCounterEl.textContent = `Round ${current}`;
   }
 }
 

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -6,7 +6,6 @@ import * as battleEngine from "../battleEngineFacade.js";
 import * as scoreboard from "../setupScoreboard.js";
 import { resetStatButtons } from "../battle/index.js";
 import { syncScoreDisplay } from "./uiService.js";
-import { CLASSIC_BATTLE_MAX_ROUNDS } from "../constants.js";
 import { handleStatSelection } from "./selectionHandler.js";
 import { quitMatch } from "./quitModal.js";
 import { cancel as cancelFrame, stop as stopScheduler } from "../../utils/scheduler.js";
@@ -68,8 +67,7 @@ export async function handleReplay(store) {
  * 1. Reset buttons and disable the Next Round button.
  * 2. Draw player and opponent cards.
  * 3. Sync the score display and show the selection prompt.
- * 4. Update the round counter using `battleEngine.getRoundsPlayed() + 1` and
- *    `CLASSIC_BATTLE_MAX_ROUNDS`.
+ * 4. Update the round counter using `battleEngine.getRoundsPlayed() + 1`.
  * 5. Start the round timer and stall timeout.
  * 6. Update the debug panel.
  *
@@ -84,7 +82,7 @@ export async function startRound(store) {
   await drawCards();
   syncScoreDisplay();
   const currentRound = battleEngine.getRoundsPlayed() + 1;
-  scoreboard.updateRoundCounter(currentRound, CLASSIC_BATTLE_MAX_ROUNDS);
+  scoreboard.updateRoundCounter(currentRound);
   showSelectionPrompt();
   await startTimer((stat, opts) => handleStatSelection(store, stat, opts));
   store.statTimeoutId = setTimeout(

--- a/tests/helpers/scoreboard.integration.test.js
+++ b/tests/helpers/scoreboard.integration.test.js
@@ -88,8 +88,8 @@ describe("Scoreboard integration without explicit init", () => {
     expect(document.getElementById("round-message").textContent).toBe("Ready to fight!");
 
     // Round counter
-    scoreboard.updateRoundCounter(1, 25);
-    expect(document.getElementById("round-counter").textContent).toBe("Round 1 of 25");
+    scoreboard.updateRoundCounter(1);
+    expect(document.getElementById("round-counter").textContent).toBe("Round 1");
 
     // Score
     scoreboard.updateScore(2, 1);


### PR DESCRIPTION
## Summary
- Show only the current round in the scoreboard counter
- Drop total round parameter from round manager and related helpers
- Adjust scoreboard integration test for single-number round display

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689f8db6529883268d9ca7741f659279