### PR TITLE
test: verify classic battle state transitions

### DIFF
--- a/tests/helpers/classicBattle/stateTransitions.test.js
+++ b/tests/helpers/classicBattle/stateTransitions.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import classicBattleStates from "../../../src/data/classicBattleStates.json";
+import { BattleStateMachine } from "../../../src/helpers/classicBattle/stateMachine.js";
+
+const statesByName = new Map(classicBattleStates.map((s) => [s.name, s]));
+
+// Generates a BattleStateMachine scoped to a single transition
+function createMachineForTransition(state, trigger) {
+  const source = { ...state, triggers: [trigger] };
+  const machineStates = new Map([[state.name, source]]);
+  if (trigger.target !== state.name) {
+    machineStates.set(
+      trigger.target,
+      statesByName.get(trigger.target) || { name: trigger.target, triggers: [] }
+    );
+  }
+  return new BattleStateMachine(machineStates, state.name, {});
+}
+
+describe("classicBattleStates.json transitions", () => {
+  for (const state of classicBattleStates) {
+    if (!Array.isArray(state.triggers)) continue;
+    for (const trigger of state.triggers) {
+      it(`${state.name} --${trigger.on}--> ${trigger.target}`, async () => {
+        const machine = createMachineForTransition(state, trigger);
+        await machine.dispatch(trigger.on);
+        expect(machine.getState()).toBe(trigger.target);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add unit tests that cover every transition from `classicBattleStates.json`, including admin/test and error branches

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_689fb16fb2608326902638ed517f8745