### PR TITLE
test: dynamically import BattleEngine in tests

### DIFF
--- a/tests/helpers/BattleEngine.test.js
+++ b/tests/helpers/BattleEngine.test.js
@@ -89,8 +89,8 @@ describe("createDriftWatcher", () => {
 
 describe("BattleEngine robustness scenarios", () => {
   let engine;
-  beforeEach(() => {
-    const { BattleEngine } = require("../../src/helpers/BattleEngine.js");
+  beforeEach(async () => {
+    const { BattleEngine } = await import("../../src/helpers/BattleEngine.js");
     engine = new BattleEngine();
     engine._resetForTest();
   });
@@ -124,8 +124,8 @@ describe("BattleEngine robustness scenarios", () => {
 
 describe("BattleEngine timer pause/resume and drift correction", () => {
   let engine;
-  beforeEach(() => {
-    const { BattleEngine } = require("../../src/helpers/BattleEngine.js");
+  beforeEach(async () => {
+    const { BattleEngine } = await import("../../src/helpers/BattleEngine.js");
     engine = new BattleEngine();
     engine._resetForTest();
   });


### PR DESCRIPTION
## Summary
- dynamically import `BattleEngine` in BattleEngine helper tests to ensure async resolution before tests run

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689fbaed47f88326af5cc68e5576e89d