### PR TITLE
test: cover startRoundWrapper failures

### DIFF
--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -283,6 +283,96 @@ describe("classicBattlePage test mode flag", () => {
   });
 });
 
+describe("startRoundWrapper failures", () => {
+  it("shows error message, opens retry modal, and re-enables stat buttons", async () => {
+    const showMessage = vi.fn();
+    const startRound = vi.fn().mockRejectedValue(new Error("fail"));
+    const waitForComputerCard = vi.fn().mockResolvedValue();
+
+    vi.doMock("../../src/helpers/domReady.js", () => ({ onDomReady: () => {} }));
+    vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+      createBattleStore: () => ({}),
+      startRound
+    }));
+    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
+    vi.doMock("../../src/helpers/classicBattle/selectionHandler.js", () => ({
+      handleStatSelection: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/setupScoreboard.js", () => ({
+      setupScoreboard: vi.fn(),
+      showMessage
+    }));
+    vi.doMock("../../src/helpers/tooltip.js", () => ({
+      initTooltips: vi.fn().mockResolvedValue()
+    }));
+    vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode: vi.fn() }));
+    vi.doMock("../../src/helpers/stats.js", () => ({
+      loadStatNames: vi.fn().mockResolvedValue([])
+    }));
+    vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar: vi.fn() }));
+    vi.doMock("../../src/helpers/featureFlags.js", () => ({
+      initFeatureFlags: vi.fn(),
+      isEnabled: vi.fn().mockReturnValue(false),
+      featureFlagsEmitter: new EventTarget()
+    }));
+    vi.doMock("../../src/helpers/battleStateProgress.js", () => ({
+      initBattleStateProgress: vi.fn().mockResolvedValue()
+    }));
+    vi.doMock("../../src/helpers/classicBattle/interruptHandlers.js", () => ({
+      initInterruptHandlers: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/cardUtils.js", () => ({ toggleInspectorPanels: vi.fn() }));
+    vi.doMock("../../src/helpers/viewportDebug.js", () => ({ toggleViewportSimulation: vi.fn() }));
+    vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+      pauseTimer: vi.fn(),
+      resumeTimer: vi.fn(),
+      STATS: []
+    }));
+    vi.doMock("../../src/helpers/classicBattle/timerService.js", () => ({
+      onNextButtonClick: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/classicBattle/skipHandler.js", () => ({
+      skipCurrentPhase: vi.fn()
+    }));
+
+    const open = vi.fn();
+    vi.doMock("../../src/components/Modal.js", () => ({
+      createModal: (content) => {
+        const element = document.createElement("div");
+        element.appendChild(content);
+        return { element, open, close: vi.fn() };
+      },
+      createButton: (label, opts = {}) => {
+        const btn = document.createElement("button");
+        btn.textContent = label;
+        Object.assign(btn, opts);
+        return btn;
+      }
+    }));
+
+    const container = document.createElement("div");
+    container.id = "stat-buttons";
+    const btn = document.createElement("button");
+    btn.disabled = true;
+    container.appendChild(btn);
+    const battleArea = document.createElement("div");
+    battleArea.id = "battle-area";
+    document.body.append(container, battleArea);
+
+    const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
+    await setupClassicBattlePage();
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    await window.startRoundOverride();
+
+    expect(showMessage).toHaveBeenCalledWith("Round start error. Please retry.");
+    expect(open).toHaveBeenCalled();
+    expect(btn.disabled).toBe(false);
+    consoleError.mockRestore();
+    vi.doUnmock("../../src/helpers/setupScoreboard.js");
+  });
+});
+
 describe("syncScoreDisplay", () => {
   it("keeps scoreboard and summary in sync", async () => {
     window.matchMedia = () => ({ matches: true, addListener() {}, removeListener() {} });


### PR DESCRIPTION
## Summary
- add test for startRoundWrapper error path to ensure user messaging, retry modal, and button state reset

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: The requested module '../../components/Modal.js' does not provide an export named 'createButton')*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_689fbea99c8883269985f7a6f80600fb