### PR TITLE
fix: restore defaults resets feature flags

### DIFF
--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -102,7 +102,7 @@ Pages should query `featureFlags.isEnabled` rather than reading
 - **View Tooltip Descriptions:** Link opens `tooltipViewer.html` for exploring tooltip text.
 - **Vector Search for RAG:** Link opens `vectorSearch.html` to explore the vector database.
 - Links in this fieldset are arranged in a responsive three-column grid, collapsing to a single column below 768px.
-- **Restore Defaults:** Button opens a confirmation modal to clear stored settings and reapply defaults.
+- **Restore Defaults:** Button opens a confirmation modal to clear stored settings, reset feature flags, and reapply defaults.
 
 ---
 

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -82,7 +82,8 @@ function createResetConfirmation(onConfirm) {
  * 1. Store a mutable copy of `settings` for updates.
  * 2. Query DOM elements for each control and container.
  * 3. Provide helpers to read/persist settings and show errors.
- * 4. Attach listeners for existing controls.
+ * 4. Attach listeners for existing controls and the Restore Defaults button.
+ *    - Reset confirms with a modal, reloads feature flags, reapplies defaults, and rerenders switches.
  * 5. Return `renderSwitches` to inject game-mode/feature-flag toggles and apply initial values later.
  *
  * @param {Settings} settings - Current settings object.
@@ -107,8 +108,9 @@ function initializeControls(settings) {
 
   const renderSwitches = makeRenderSwitches(controls, () => currentSettings, handleUpdate);
 
-  const resetModal = createResetConfirmation(() => {
+  const resetModal = createResetConfirmation(async () => {
     currentSettings = resetSettings();
+    await initFeatureFlags();
     withViewTransition(() => {
       applyDisplayMode(currentSettings.displayMode);
     });

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -180,4 +180,25 @@ describe("renderSettingsControls", () => {
     expect(populateNavbar).toHaveBeenCalled();
     expect(showSnackbar).toHaveBeenCalledWith("Navigation cache cleared");
   });
+
+  it("restores defaults when confirmed", async () => {
+    const resetSettings = vi.fn().mockReturnValue(baseSettings);
+    const initFeatureFlags = vi.fn().mockResolvedValue(baseSettings);
+    vi.doMock("../../src/helpers/settingsStorage.js", () => ({
+      updateSetting: vi.fn(),
+      loadSettings: vi.fn(),
+      resetSettings
+    }));
+    vi.doMock("../../src/helpers/featureFlags.js", () => ({
+      isEnabled: vi.fn().mockReturnValue(false),
+      initFeatureFlags
+    }));
+    const { renderSettingsControls } = await import("../../src/helpers/settingsPage.js");
+    renderSettingsControls(baseSettings, [], tooltipMap);
+    document.getElementById("reset-settings-button").dispatchEvent(new Event("click"));
+    document.getElementById("confirm-reset-button").dispatchEvent(new Event("click"));
+    await Promise.resolve();
+    expect(resetSettings).toHaveBeenCalled();
+    expect(initFeatureFlags).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure Restore Defaults reinitializes feature flags and reapplies default UI
- document that Restore Defaults resets feature flags
- test Restore Defaults flow

## Testing
- `npx prettier . --check`
- `npx eslint .` (fails: Cannot find package '@eslint/js')
- `npx vitest run` (fails: 403 Forbidden)
- `npx playwright test` (fails: 403 Forbidden)
- `npm run check:contrast` (fails: spawn pa11y ENOENT)


------
https://chatgpt.com/codex/tasks/task_e_68a025d117a08326b06234f8a2035a8f