### PR TITLE
fix: restore match start modal

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -72,6 +72,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 ## Technical Considerations
 
 - Classic Battle logic must reuse shared random card draw module (`generateRandomCard`).
+- Round selection modal must use shared `Modal` and `Button` components for consistent accessibility.
 - Card reveal and result animations should use hardware-accelerated CSS for smooth performance on low-end devices.
 - Stat selection timer (30s) must be displayed in the Scoreboard; if timer expires, a random stat is auto-selected. This auto-select behavior is controlled by Random Stat Mode (`FF_AUTO_SELECT`), enabled by default. Timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see prdBattleScoreboard.md).
 - Stat selection timer halts immediately once the player picks a stat.

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -57,7 +57,8 @@ import {
   onFrame as scheduleFrame,
   cancel as cancelFrame
 } from "../utils/scheduler.js";
-import { createModal, createButton } from "../components/Modal.js";
+import { createModal } from "../components/Modal.js";
+import { createButton } from "../components/Button.js";
 
 const battleStore = createBattleStore();
 window.battleStore = battleStore;

--- a/tests/helpers/classicBattle/classicBattlePage.import.test.js
+++ b/tests/helpers/classicBattle/classicBattlePage.import.test.js
@@ -1,0 +1,8 @@
+import { describe, it, expect } from "vitest";
+
+describe("classicBattlePage module", () => {
+  it("loads without missing exports", async () => {
+    const mod = await import("../../../src/helpers/classicBattlePage.js");
+    expect(typeof mod.setupClassicBattlePage).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- fix classic battle page import so match start modal appears
- document modal's use of shared UI components
- add regression test for classic battle page module loading

## Testing
- `npx prettier src/helpers/classicBattlePage.js tests/helpers/classicBattle/classicBattlePage.import.test.js design/productRequirementsDocuments/prdClassicBattle.md --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a0350362348326bd176e14167e5e32