### PR TITLE
fix: restore defaults button

### DIFF
--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -102,7 +102,7 @@ Pages should query `featureFlags.isEnabled` rather than reading
 - **View Tooltip Descriptions:** Link opens `tooltipViewer.html` for exploring tooltip text.
 - **Vector Search for RAG:** Link opens `vectorSearch.html` to explore the vector database.
 - Links in this fieldset are arranged in a responsive three-column grid, collapsing to a single column below 768px.
-- **Restore Defaults:** Button opens a confirmation modal to clear stored settings, reset feature flags, and reapply defaults.
+- **Restore Defaults:** Button opens a confirmation modal to clear stored settings, reset feature flags, reapply defaults, and display a snackbar confirmation.
 
 ---
 

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -191,4 +191,15 @@ test.describe.parallel("Settings page", () => {
       expect(box?.height).toBeGreaterThanOrEqual(44);
     }
   });
+
+  test("restore defaults resets settings", async ({ page }) => {
+    const sound = page.getByRole("checkbox", { name: "Sound" });
+    await sound.click();
+    await expect(sound).not.toBeChecked();
+    await page.getByRole("button", { name: "Restore Defaults" }).click();
+    await page.getByRole("button", { name: "Yes" }).click();
+    await expect(sound).toBeChecked();
+    const stored = await page.evaluate(() => localStorage.getItem("settings"));
+    expect(JSON.parse(stored).sound).toBe(true);
+  });
 });

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -20,6 +20,7 @@ import { toggleViewportSimulation } from "./viewportDebug.js";
 import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
 import { toggleLayoutDebugPanel } from "./layoutDebugPanel.js";
 import { initFeatureFlags, isEnabled } from "./featureFlags.js";
+import { showSnackbar } from "./showSnackbar.js";
 
 import { applyInitialControlValues } from "./settings/applyInitialValues.js";
 import { attachToggleListeners } from "./settings/listenerUtils.js";
@@ -109,8 +110,8 @@ function initializeControls(settings) {
   const renderSwitches = makeRenderSwitches(controls, () => currentSettings, handleUpdate);
 
   const resetModal = createResetConfirmation(async () => {
-    currentSettings = resetSettings();
-    await initFeatureFlags();
+    resetSettings();
+    currentSettings = await initFeatureFlags();
     withViewTransition(() => {
       applyDisplayMode(currentSettings.displayMode);
     });
@@ -120,6 +121,7 @@ function initializeControls(settings) {
     toggleLayoutDebugPanel(isEnabled("layoutDebugPanel"));
     renderSwitches(latestGameModes, latestTooltipMap);
     expandAllSections();
+    showSnackbar("Settings restored to defaults");
   });
 
   resetButton?.addEventListener("click", () => {

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -182,8 +182,9 @@ describe("renderSettingsControls", () => {
   });
 
   it("restores defaults when confirmed", async () => {
-    const resetSettings = vi.fn().mockReturnValue(baseSettings);
+    const resetSettings = vi.fn();
     const initFeatureFlags = vi.fn().mockResolvedValue(baseSettings);
+    const showSnackbar = vi.fn();
     vi.doMock("../../src/helpers/settingsStorage.js", () => ({
       updateSetting: vi.fn(),
       loadSettings: vi.fn(),
@@ -193,6 +194,7 @@ describe("renderSettingsControls", () => {
       isEnabled: vi.fn().mockReturnValue(false),
       initFeatureFlags
     }));
+    vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar }));
     const { renderSettingsControls } = await import("../../src/helpers/settingsPage.js");
     renderSettingsControls(baseSettings, [], tooltipMap);
     document.getElementById("reset-settings-button").dispatchEvent(new Event("click"));
@@ -200,5 +202,6 @@ describe("renderSettingsControls", () => {
     await Promise.resolve();
     expect(resetSettings).toHaveBeenCalled();
     expect(initFeatureFlags).toHaveBeenCalled();
+    expect(showSnackbar).toHaveBeenCalledWith("Settings restored to defaults");
   });
 });


### PR DESCRIPTION
## Summary
- reload feature flags and show snackbar when restoring defaults
- test reset flow and ensure UI resets after confirmation
- document Restore Defaults snackbar behavior

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a03523baa88326bbab4ab9007ccc49