### PR TITLE
feat: guard error display when card section missing

### DIFF
--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -125,6 +125,10 @@ function showError(msg) {
     errorEl.style.marginTop = "12px";
     errorEl.style.fontSize = "1.1rem";
     const cardSection = document.querySelector(".card-section");
+    if (!cardSection) {
+      console.warn("showError: .card-section element not found; skipping error display.");
+      return;
+    }
     cardSection.appendChild(errorEl);
   }
   errorEl.textContent = msg;


### PR DESCRIPTION
## Summary
- ensure randomJudokaPage's showError checks for missing `.card-section`
- warn and skip DOM manipulation when the container is absent

## Testing
- `npx prettier src/helpers/randomJudokaPage.js --check`
- `npx eslint src/helpers/randomJudokaPage.js`
- `npx vitest run`
- `npx playwright test` *(fails: GET https://cdn.jsdelivr.net/npm/@xenova/transformers@2.6.0/dist/transformers.min.js net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a03371e7d88326b4d73f97b8506262