### PR TITLE
fix: robust URL resolution for browser fallbacks

### DIFF
--- a/tests/helpers/dataUtils.test.js
+++ b/tests/helpers/dataUtils.test.js
@@ -31,6 +31,22 @@ describe("resolveUrl and readData", () => {
     expect(result).toEqual(data);
     expect(fetchMock).toHaveBeenCalled();
   });
+
+  it("falls back to window.location.href when origin is unavailable", async () => {
+    const originalWindow = global.window;
+    const originalProcess = global.process;
+    vi.resetModules();
+    global.window = { location: { href: "https://example.com/subdir/page.html" } };
+    // Simulate non-Node environment
+    // @ts-ignore
+    delete global.process;
+    const { resolveUrl } = await import("../../src/helpers/dataUtils.js");
+    const parsed = await resolveUrl("data/file.json");
+    expect(parsed.href).toBe("https://example.com/subdir/data/file.json");
+    global.window = originalWindow;
+    global.process = originalProcess;
+    vi.resetModules();
+  });
 });
 
 describe("fetchJson", () => {


### PR DESCRIPTION
## Summary
- improve resolveUrl fallback to handle missing window.location.origin
- add coverage ensuring href-based resolution in tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a03f24bfd4832692ffcd1bd746a09c