### PR TITLE
Reset feature flags cache on load failure

### DIFF
--- a/src/helpers/featureFlags.js
+++ b/src/helpers/featureFlags.js
@@ -1,4 +1,5 @@
 import { loadSettings, updateSetting } from "./settingsStorage.js";
+import { setCachedSettings } from "./settingsCache.js";
 import { DEFAULT_SETTINGS } from "./settingsSchema.js";
 
 /**
@@ -16,7 +17,7 @@ let cachedFlags = { ...DEFAULT_SETTINGS.featureFlags };
  *
  * @pseudocode
  * 1. Call `loadSettings()` to retrieve current settings.
- * 2. Set `cachedFlags` to `settings.featureFlags` or default feature flags.
+ * 2. Set `cachedFlags` and the global settings cache to `settings.featureFlags` or defaults.
  * 3. Dispatch a `change` event with `flag: null`.
  * 4. Return the loaded `settings`.
  *
@@ -28,8 +29,9 @@ export async function initFeatureFlags() {
     settings = await loadSettings();
     cachedFlags = settings.featureFlags || { ...DEFAULT_SETTINGS.featureFlags };
   } catch {
-    settings = { featureFlags: { ...DEFAULT_SETTINGS.featureFlags } };
+    settings = { ...DEFAULT_SETTINGS };
     cachedFlags = { ...DEFAULT_SETTINGS.featureFlags };
+    setCachedSettings(settings);
   }
   featureFlagsEmitter.dispatchEvent(new CustomEvent("change", { detail: { flag: null } }));
   return settings;

--- a/src/helpers/settings/index.js
+++ b/src/helpers/settings/index.js
@@ -4,3 +4,4 @@ export * from "./gameModeSwitches.js";
 export * from "./featureFlagSwitches.js";
 export * from "./makeHandleUpdate.js";
 export * from "./addNavResetButton.js";
+export { initFeatureFlags } from "../featureFlags.js";


### PR DESCRIPTION
## Summary
- Safely initialize feature flags: on load failure, reset global settings cache and return full defaults
- Expose `initFeatureFlags` through settings module

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a054c4c1588326a6654b6bcc011c96