### PR TITLE
test: verify feature flag defaults on load failure

### DIFF
--- a/tests/helpers/featureFlags.test.js
+++ b/tests/helpers/featureFlags.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "../../src/helpers/settingsSchema.js";
+
+/**
+ * @fileoverview
+ * Unit tests for feature flag initialization.
+ * Ensures defaults are used when settings fail to load and that change events fire.
+ */
+
+describe("initFeatureFlags", () => {
+  it("falls back to defaults and emits change on load failure", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/helpers/settingsStorage.js", () => ({
+      loadSettings: vi.fn().mockRejectedValue(new Error("fail")),
+      updateSetting: vi.fn()
+    }));
+    const { initFeatureFlags, featureFlagsEmitter, isEnabled } = await import(
+      "../../src/helpers/featureFlags.js"
+    );
+
+    const changeSpy = vi.fn();
+    featureFlagsEmitter.addEventListener("change", changeSpy);
+
+    const settings = await initFeatureFlags();
+    expect(settings).toEqual(DEFAULT_SETTINGS);
+    expect(changeSpy).toHaveBeenCalledTimes(1);
+    expect(changeSpy.mock.calls[0][0].detail.flag).toBeNull();
+
+    for (const flag of Object.keys(DEFAULT_SETTINGS.featureFlags)) {
+      expect(isEnabled(flag)).toBe(DEFAULT_SETTINGS.featureFlags[flag].enabled);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- test feature flag initialization when settings load fails
- ensure default settings and change event
- verify cached flags mirror `DEFAULT_SETTINGS`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a058466e548326a417573a49a9a7a8