### PR TITLE
Document round data fallback in Classic Battle PRD

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -82,6 +82,12 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - The cooldown timer between rounds begins only after round results are shown in the Scoreboard and is displayed using one persistent snackbar that updates its text each second.
 - The debug panel is available when the `battleDebugPanel` feature flag is enabled and appears beside the opponent's card.
 
+### Round Data Fallback
+
+- If `battleRounds.json` fails to load, the game falls back to default round settings and surfaces an error message in the Scoreboard.
+- **QA:** Temporarily block `battleRounds.json` to confirm default rounds appear and the error message is displayed.
+
+
 ---
 
 ## Prioritized Functional Requirements Table


### PR DESCRIPTION
## Summary
- Specify fallback behavior when `battleRounds.json` fails to load and defaults are used
- Add QA steps for simulating missing round data by blocking `battleRounds.json`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 5 failed, 2 interrupted, 1 skipped, 66 did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a05838e7ac8326b1ecdf27fcf86d07