### PR TITLE
test: handle round select in battle flow

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -3,7 +3,17 @@ import { test, expect } from "./fixtures/commonSetup.js";
 
 test.describe.parallel("Classic battle flow", () => {
   test("shows countdown before first round", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "settings",
+        JSON.stringify({ featureFlags: { enableTestMode: { enabled: false } } })
+      );
+    });
     await page.goto("/src/pages/battleJudoka.html");
+    const roundOptions = page.locator(".round-select-buttons button");
+    await roundOptions.first().waitFor();
+    await expect(roundOptions).toHaveText([/5/, /10/, /15/]);
+    await roundOptions.first().click();
     const snackbar = page.locator(".snackbar");
     await expect(snackbar).toHaveText(/Next round in: \d+s/);
     await page.evaluate(() => window.freezeBattleHeader?.());


### PR DESCRIPTION
## Summary
- ensure round-select modal is handled before battle flow begins
- verify win-target options 5/10/15 show and choose one before asserting countdown

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a05834ec4883268f9aa1f0668d43e7