### PR TITLE
test: harden settings page game mode flows

### DIFF
--- a/tests/helpers/gameModeUtils.test.js
+++ b/tests/helpers/gameModeUtils.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+
+describe("loadNavigationItems", () => {
+  it("returns static fallback when cache and import fail", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/helpers/navigationCache.js", () => ({
+      load: vi.fn().mockRejectedValue(new Error("cache fail")),
+      save: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue([]),
+      validateWithSchema: vi.fn(),
+      importJsonModule: vi.fn(async (path) => {
+        if (path.includes("navigationItems.json")) throw new Error("import fail");
+        return [];
+      })
+    }));
+    vi.doMock("../../src/helpers/storage.js", () => ({
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn()
+    }));
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { loadNavigationItems } = await import("../../src/helpers/gameModeUtils.js");
+    const result = await loadNavigationItems();
+    const { default: navFallback } = await import("../../src/data/navigationItems.json");
+    expect(result).toEqual(navFallback);
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for settings page init failure and nav cache fallback
- ensure loadNavigationItems falls back to static data on import failure

## Testing
- `npx prettier . --check`
- `npx eslint tests/helpers/settingsPage.test.js tests/helpers/gameModeUtils.test.js`
- `npx vitest run tests/helpers/settingsPage.test.js tests/helpers/gameModeUtils.test.js`
- `npx playwright test` *(fails: 12 failed, 1 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a078ffd3088326a9b2ee55c4cdc263