### PR TITLE
docs: clarify @vite-ignore loader behavior

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -15,10 +15,9 @@
 /**
  * Absolute URL to the helpers directory.
  *
- * The `@vite-ignore` directive is used here to prevent Vite from analyzing
- * or transforming the path as a static asset import. Without this directive,
- * Vite may attempt to bundle or process the directory, which is not desired
- * for runtime directory resolution.
+ * The `@vite-ignore` directive prevents Vitest's Vite-based loader from
+ * rewriting this path during tests; production serving uses the original URL
+ * and is unaffected.
  *
  * @constant {URL}
  */


### PR DESCRIPTION
## Summary
- clarify @vite-ignore comment in constants.js so Vitest's loader doesn't rewrite paths and production serving remains unchanged

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 8 failed, 2 interrupted, 58 did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a084068f2483269ec6b7bec8a61660