### PR TITLE
docs: clarify sanitizer module resolution comment

### DIFF
--- a/src/helpers/sanitizeHtml.js
+++ b/src/helpers/sanitizeHtml.js
@@ -25,7 +25,7 @@ export async function getSanitizer() {
     return null;
   }
 
-  // Prefer bare specifier (works in Vite/Vitest and modern bundlers)
+  // Prefer bare specifier (compatible with Vitest; production static servers use native module resolution)
   const viaBare = await tryLoad("dompurify");
   if (viaBare) return (cached = viaBare);
 


### PR DESCRIPTION
## Summary
- clarify sanitizer comment for Vitest compatibility and production static server resolution

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: process produced extremely long output; truncated)*
- `npx playwright test` *(fails: module load and screenshot mismatches)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0840507ec832698e1ce8a2a03b175