### PR TITLE
refactor: import createButton from Button component

### DIFF
--- a/src/helpers/classicBattle/interruptHandlers.js
+++ b/src/helpers/classicBattle/interruptHandlers.js
@@ -3,7 +3,8 @@ import { dispatchBattleEvent } from "./orchestrator.js";
 import { showMessage, clearTimer } from "../setupScoreboard.js";
 import { stop as stopScheduler, cancel as cancelFrame } from "../../utils/scheduler.js";
 import { resetSkipState } from "./skipHandler.js";
-import { createModal, createButton } from "../../components/Modal.js";
+import { createModal } from "../../components/Modal.js";
+import { createButton } from "../../components/Button.js";
 
 let errorModal;
 


### PR DESCRIPTION
## Summary
- import `createButton` from `Button.js` and keep `createModal` from `Modal.js`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a083a7795083269aacb536855165fc