### PR TITLE
chore: remove unused build deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
         "@eslint/js": "^9.32.0",
         "@playwright/test": "^1.54.2",
         "es-module-lexer": "^1.7.0",
-        "esbuild": "^0.25.8",
         "eslint": "^9.32.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.3",
@@ -87,9 +86,7 @@
         "magic-string": "^0.30.17",
         "pa11y": "^9.0.0",
         "prettier": "^3.6.2",
-        "rollup": "^4.46.2",
         "vite": "^7.0.6",
-        "vite-node": "^3.2.4",
         "vitest": "^3.2.4",
         "wcag-contrast": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@eslint/js": "^9.32.0",
     "@playwright/test": "^1.54.2",
     "es-module-lexer": "^1.7.0",
-    "esbuild": "^0.25.8",
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.3",
@@ -37,9 +36,7 @@
     "magic-string": "^0.30.17",
     "pa11y": "^9.0.0",
     "prettier": "^3.6.2",
-    "rollup": "^4.46.2",
     "vite": "^7.0.6",
-    "vite-node": "^3.2.4",
     "vitest": "^3.2.4",
     "wcag-contrast": "^3.0.0"
   },


### PR DESCRIPTION
## Summary
- drop esbuild, rollup, and vite-node from devDependencies
- refresh lockfile

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a09b0ffa348326abcf589a63f65a89