### PR TITLE
fix: remove duplicate round select modal

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -59,7 +59,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 
 ## Gameplay Basics
 
-- On first visit to `battleJudoka.html`, a modal prompts the player to select a win target of **5, 10, or 15 points** (default 10).
+ - On first visit to `battleJudoka.html`, a modal prompts the player to select a win target of **5, 10, or 15 points** (default 10). After a choice is made, the modal closes and the match begins.
 - The standard deck contains **99 unique cards**.
 - Each match begins with both sides receiving **25 random cards**.
 - At the start of each round, both players draw their top card.

--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -14,6 +14,7 @@ test.describe.parallel("Classic battle flow", () => {
     await roundOptions.first().waitFor();
     await expect(roundOptions).toHaveText([/5/, /10/, /15/]);
     await roundOptions.first().click();
+    await expect(page.locator(".modal-backdrop:not([hidden])")).toHaveCount(0);
     const snackbar = page.locator(".snackbar");
     await expect(snackbar).toHaveText(/Next round in: \d+s/);
     await page.evaluate(() => window.freezeBattleHeader?.());

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -21,7 +21,9 @@
  *    e. Set `window.startRoundOverride` to `startRoundWrapper` so the battle
  *       module uses it for subsequent rounds.
  *    f. Toggle the debug panel.
- *    g. Show a round selection modal that sets points-to-win and starts the first round.
+ *    g. Initialize the battle state progress list, then let the orchestrator
+ *       present the round selection modal to set points-to-win and start the
+ *       first round.
  *    h. Initialize tooltips and show the stat help tooltip once for new users.
  *    i. Watch for orientation changes and update the battle header's
  *       `data-orientation` attribute.
@@ -49,7 +51,6 @@ import {
 import { onNextButtonClick } from "./classicBattle/timerService.js";
 import { skipCurrentPhase } from "./classicBattle/skipHandler.js";
 import { initFeatureFlags, isEnabled, featureFlagsEmitter } from "./featureFlags.js";
-// Removed unused import for initBattleStateProgress
 import { initInterruptHandlers } from "./classicBattle/interruptHandlers.js";
 import {
   start as startScheduler,
@@ -59,7 +60,6 @@ import {
 } from "../utils/scheduler.js";
 import { createModal } from "../components/Modal.js";
 import { createButton } from "../components/Button.js";
-import { initRoundSelectModal } from "./classicBattle/roundSelectModal.js";
 import { initBattleStateProgress } from "./battleStateProgress.js";
 
 const battleStore = createBattleStore();
@@ -275,14 +275,8 @@ export async function setupClassicBattlePage() {
   initDebugPanel();
 
   window.startRoundOverride = () => startRoundWrapper();
+  initBattleStateProgress();
   await initClassicBattleOrchestrator(battleStore, startRoundWrapper);
-  // Initialize battle state progress list before round select modal
-  initBattleStateProgress(battleStore);
-  // Show round selection modal immediately after orchestrator initializes
-  await initRoundSelectModal(async (rounds) => {
-    battleStore.winTarget = rounds;
-    await dispatchBattleEvent("startClicked");
-  });
   // Non-critical UI enhancements can load after the orchestrator begins
   applyStatLabels().catch(() => {});
   await initTooltips();

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -10,9 +10,6 @@ beforeEach(() => {
     initClassicBattleOrchestrator: vi.fn(),
     dispatchBattleEvent: vi.fn().mockResolvedValue()
   }));
-  vi.doMock("../../src/helpers/classicBattle/roundSelectModal.js", () => ({
-    initRoundSelectModal: (cb) => cb()
-  }));
 });
 
 describe("classicBattlePage stat button interactions", () => {
@@ -142,6 +139,16 @@ describe("classicBattlePage stat button interactions", () => {
     expect(document.activeElement).toBe(next);
     tab();
     expect(document.activeElement).toBe(quit);
+  });
+
+  it("does not invoke round select modal directly", async () => {
+    const initRoundSelectModal = vi.fn();
+    vi.doMock("../../src/helpers/classicBattle/roundSelectModal.js", () => ({
+      initRoundSelectModal
+    }));
+    const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
+    await setupClassicBattlePage();
+    expect(initRoundSelectModal).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- rely on orchestrator to present round-select modal and avoid duplicate dialogs
- assert modal closes before countdown in classic battle flow
- document that match starts once after selecting win target

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a09c2ee7c883268306b7c0510813f7