### PR TITLE
Document ES module deployment in Copilot guide

### DIFF
--- a/JU-DO-KON_Copilot_Instructions.md
+++ b/JU-DO-KON_Copilot_Instructions.md
@@ -14,6 +14,7 @@ This file guides GitHub Copilot agents contributing to the JU-DO-KON! repository
 
 ## Coding Standards
 
+- The project is deployed as static ES modules on GitHub Pages and uses no bundler; Vite is present only for Vitest.
 - Use ES modules and modern JavaScript (Node 18+ expected)
 - Format code with Prettier and lint with ESLint (`eslint.config.mjs`)
 - **Preserve all JSDoc comments and `@pseudocode` blocks**; update them when the code changes


### PR DESCRIPTION
## Summary
- note that JU-DO-KON! ships as static ES modules on GitHub Pages with Vite only used for Vitest

## Testing
- `npx prettier "**/*.{js,mjs,md,json,html,css}" --check --ignore-unknown | head -n 20 | cut -c1-200`
- `npx eslint . && echo ESLint passed`
- `npx vitest run | head -n 200`
- `npx playwright test` *(fails: Failed to load module script / EPIPE)*
- `npm run check:contrast` *(fails: requires dev server; command stalled)*

------
https://chatgpt.com/codex/tasks/task_e_68a09afd26408326b9bbcabe12047914