### PR TITLE
chore: adjust navigation json import

### DIFF
--- a/src/helpers/gameModeUtils.js
+++ b/src/helpers/gameModeUtils.js
@@ -2,7 +2,7 @@ import { fetchJson, validateWithSchema, importJsonModule } from "./dataUtils.js"
 import { DATA_DIR } from "./constants.js";
 import { load as loadNavCache, save as saveNavCache } from "./navigationCache.js";
 import { getItem, setItem, removeItem } from "./storage.js";
-import navFallback from "../data/navigationItems.json";
+import navFallback from "../data/navigationItems.json" with { type: "json" };
 
 /**
  * The game modes JSON schema is loaded on demand. This avoids fetching the


### PR DESCRIPTION
## Summary
- ensure nav fallback uses import attributes for JSON

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 22 failed, 69 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0a0c8d9b883269d8b126aac16a9c0