### PR TITLE
Ensure Node detection excludes browser contexts

### DIFF
--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -11,13 +11,15 @@ let ajvInstance;
  * Determine if the code is running in a Node environment.
  *
  * @pseudocode
- * 1. Check if `process.versions.node` exists using optional chaining.
- * 2. Return `true` when it exists; otherwise, return `false`.
+ * 1. Check that `process.versions.node` exists and `typeof window === "undefined"`.
+ * 2. Return `true` when both conditions hold; otherwise, return `false`.
  *
  * @returns {boolean} `true` if running under Node.
  */
 export function isNodeEnvironment() {
-  return Boolean(typeof process !== "undefined" && process?.versions?.node);
+  return Boolean(
+    typeof process !== "undefined" && process?.versions?.node && typeof window === "undefined"
+  );
 }
 /**
  * Lazily instantiate and return a singleton Ajv instance with format support.

--- a/tests/helpers/classicBattle/battleStateBadge.test.js
+++ b/tests/helpers/classicBattle/battleStateBadge.test.js
@@ -59,6 +59,14 @@ describe("battleStateBadge displays state transitions", () => {
     vi.doMock("../../../src/helpers/classicBattle/roundSelectModal.js", () => ({
       initRoundSelectModal: vi.fn()
     }));
+    vi.doMock("../../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn(async (path) => {
+        if (path.includes("classicBattleStates.json")) return classicBattleStates;
+        if (path.includes("battleRounds.json")) return [];
+        return {};
+      }),
+      importJsonModule: vi.fn(async () => ({}))
+    }));
 
     const header = document.createElement("header");
     header.innerHTML = `


### PR DESCRIPTION
## Summary
- require `typeof window === "undefined"` in `isNodeEnvironment`
- mock data utilities in `battleStateBadge` tests to avoid file fetches

## Testing
- `npx prettier . --check --ignore-unknown`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test tooltip.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0a1a9d4508326833599bd26fd5729