### PR TITLE
fix: add json import type for battle state tests

### DIFF
--- a/tests/helpers/classicBattle/battleStateBadge.test.js
+++ b/tests/helpers/classicBattle/battleStateBadge.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import classicBattleStates from "../../../src/data/classicBattleStates.json";
+import classicBattleStates from "../../../src/data/classicBattleStates.json" with { type: "json" };
 
 const coreStateIds = classicBattleStates
   .filter((s) => s.id < 90)

--- a/tests/helpers/classicBattle/stateTransitions.test.js
+++ b/tests/helpers/classicBattle/stateTransitions.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import classicBattleStates from "../../../src/data/classicBattleStates.json";
+import classicBattleStates from "../../../src/data/classicBattleStates.json" with { type: "json" };
 import { BattleStateMachine } from "../../../src/helpers/classicBattle/stateMachine.js";
 
 const statesByName = new Map(classicBattleStates.map((s) => [s.name, s]));


### PR DESCRIPTION
## Summary
- ensure classicBattleStates JSON in tests uses `with { type: "json" }`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0a0ce0ae88326abf520cf0fa52b2c