### PR TITLE
chore: guard classic battle setup during tests

### DIFF
--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -436,4 +436,6 @@ function maybeShowStatHint() {
   }
 }
 
-onDomReady(setupClassicBattlePage);
+if (typeof process === "undefined" || process.env.NODE_ENV !== "test") {
+  onDomReady(setupClassicBattlePage);
+}


### PR DESCRIPTION
## Summary
- avoid initializing classic battle page during tests by gating `onDomReady` call

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: expected [ Array(2) ] to deeply equal [ 'waitingForMatchStart', …(3) ])
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0a71562a48326b8f8e7f9257beed2