### PR TITLE
feat: add tooltip ids for game mode switches

### DIFF
--- a/src/helpers/settings/gameModeSwitches.js
+++ b/src/helpers/settings/gameModeSwitches.js
@@ -2,13 +2,14 @@ import { ToggleSwitch } from "../../components/ToggleSwitch.js";
 import { updateNavigationItemHidden } from "../gameModeUtils.js";
 import { showSettingsError } from "../showSettingsError.js";
 import { showSnackbar } from "../showSnackbar.js";
+import { navTooltipKey } from "../api/navigation.js";
 
 /**
  * Render game mode toggle switches within the settings page.
  *
  * @pseudocode
  * 1. If `container` is missing or `gameModes` is not an array, warn and exit.
- * 2. Sort `gameModes` by `order`, warn on missing `name`, skip malformed entries, create a toggle for each, and attach debug data attributes.
+ * 2. Sort `gameModes` by `order`, warn on missing `name`, skip malformed entries, create a toggle for each with a tooltip id, and attach debug data attributes.
  * 3. When toggled, update navigation visibility via `updateNavigationItemHidden`.
  * 4. Persist the updated `gameModes` setting using `handleUpdate`.
  * 5. Show a snackbar confirming the new mode state.
@@ -40,10 +41,12 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
       }
       label = mode.id;
     }
+    const tooltipId = `nav.${navTooltipKey(label)}`;
     const toggle = new ToggleSwitch(label, {
       id: `mode-${mode.id}`,
       name: mode.id,
-      checked: isChecked
+      checked: isChecked,
+      tooltipId
     });
     const { element: wrapper, input } = toggle;
     if (mode.category) wrapper.dataset.category = mode.category;

--- a/tests/helpers/settingsFormUtils.test.js
+++ b/tests/helpers/settingsFormUtils.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { renderGameModeSwitches } from "../../src/helpers/settings/gameModeSwitches.js";
 import { renderFeatureFlagSwitches } from "../../src/helpers/settings/featureFlagSwitches.js";
+import { navTooltipKey } from "../../src/helpers/api/navigation.js";
 
 describe("formUtils ARIA", () => {
   it("adds aria-describedby for game mode descriptions", () => {
@@ -33,5 +34,18 @@ describe("formUtils ARIA", () => {
     const desc = container.querySelector("#feature-test-flag-desc");
     expect(desc).toBeTruthy();
     expect(input).toHaveAttribute("aria-describedby", "feature-test-flag-desc");
+  });
+
+  it("adds data-tooltip-id for game mode switches", () => {
+    const container = document.createElement("div");
+    const modes = [{ id: "classicBattle", name: "Classic Battle", order: 1 }];
+    renderGameModeSwitches(
+      container,
+      modes,
+      () => ({ gameModes: {} }),
+      () => {}
+    );
+    const input = container.querySelector("#mode-classicBattle");
+    expect(input).toHaveAttribute("data-tooltip-id", `nav.${navTooltipKey(modes[0].name)}`);
   });
 });


### PR DESCRIPTION
## Summary
- generate navigation-style tooltip IDs for each game mode switch
- test that game mode switches expose matching `data-tooltip-id`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 8 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0b9ff0a1c83269ba4ac46548cd263