### PR TITLE
Default tooltip IDs for feature flag switches

### DIFF
--- a/src/helpers/settings/featureFlagSwitches.js
+++ b/src/helpers/settings/featureFlagSwitches.js
@@ -46,7 +46,7 @@ export function renderFeatureFlagSwitches(
       name: flag,
       checked: Boolean(getCurrentSettings().featureFlags[flag]?.enabled),
       ariaLabel: label,
-      tooltipId: info.tooltipId
+      tooltipId: tipId
     });
     const { element: wrapper, input } = toggle;
     if (input) input.dataset.flag = flag;

--- a/tests/helpers/settingsFormUtils.test.js
+++ b/tests/helpers/settingsFormUtils.test.js
@@ -35,3 +35,23 @@ describe("formUtils ARIA", () => {
     expect(input).toHaveAttribute("aria-describedby", "feature-test-flag-desc");
   });
 });
+
+describe("renderFeatureFlagSwitches", () => {
+  it("uses default tooltip id when none provided", () => {
+    const container = document.createElement("div");
+    const flags = {
+      firstFlag: { enabled: true },
+      secondFlag: { enabled: true, tooltipId: "custom.tip" }
+    };
+    renderFeatureFlagSwitches(
+      container,
+      flags,
+      () => ({ featureFlags: {} }),
+      () => {}
+    );
+    const first = container.querySelector("#feature-first-flag");
+    const second = container.querySelector("#feature-second-flag");
+    expect(first).toHaveAttribute("data-tooltip-id", "settings.firstFlag");
+    expect(second).toHaveAttribute("data-tooltip-id", "custom.tip");
+  });
+});


### PR DESCRIPTION
## Summary
- Default feature flag toggles to `settings.<flag>` tooltip IDs when none provided
- Test rendering assigns fallback tooltip IDs for feature flag toggles

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0b9fb58a48326841ebefdaaf6ca63