### PR TITLE
Add tooltip hooks to settings toggles

### DIFF
--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -117,6 +117,7 @@
                   name="sound"
                   aria-label="Sound"
                   aria-describedby="sound-desc"
+                  data-tooltip-id="settings.sound"
                 />
                 <div class="slider round"></div>
                 <span>Sound</span>
@@ -131,6 +132,7 @@
                   name="motion"
                   aria-label="Motion Effects"
                   aria-describedby="motion-desc"
+                  data-tooltip-id="settings.motionEffects"
                 />
                 <div class="slider round"></div>
                 <span>Motion Effects</span>
@@ -147,6 +149,7 @@
                   name="typewriter"
                   aria-label="Typewriter Effect"
                   aria-describedby="typewriter-desc"
+                  data-tooltip-id="settings.typewriterEffect"
                 />
                 <div class="slider round"></div>
                 <span>Typewriter Effect</span>
@@ -163,6 +166,7 @@
                   name="tooltips"
                   aria-label="Tooltips"
                   aria-describedby="tooltips-desc"
+                  data-tooltip-id="settings.tooltips"
                 />
                 <div class="slider round"></div>
                 <span>Tooltips</span>
@@ -177,6 +181,7 @@
                   name="cardOfTheDay"
                   aria-label="Card of the Day"
                   aria-describedby="card-of-the-day-desc"
+                  data-tooltip-id="settings.showCardOfTheDay"
                 />
                 <div class="slider round"></div>
                 <span>Card of the Day</span>
@@ -193,6 +198,7 @@
                   name="fullNavigationMap"
                   aria-label="Full Navigation Map"
                   aria-describedby="full-navigation-map-desc"
+                  data-tooltip-id="settings.fullNavigationMap"
                 />
                 <div class="slider round"></div>
                 <span>Full Navigation Map</span>


### PR DESCRIPTION
## Summary
- connect sound, motion, typewriter, tooltips, card-of-the-day and navigation map toggles to their tooltip entries

## Testing
- `npx prettier src/pages/settings.html --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 20 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0b9f53e2c8326b7e601fbd9410c12