### PR TITLE
Add toggle layout tooltip entry

### DIFF
--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -21,7 +21,8 @@
     "roundQuick": "**Quick**\\nFirst to 5 points wins.",
     "roundMedium": "**Medium**\\nFirst to 10 points wins.",
     "roundLong": "**Long**\\nFirst to 15 points wins.",
-    "next": "**Next**\nStart the next round or skip the current phase."
+    "next": "**Next**\nStart the next round or skip the current phase.",
+    "toggleLayout": "**Toggle layout**\nSwitch between grid and carousel."
   },
   "mode": {
     "classicBattle": "**Classic Battle Mode** pits you against an opponent.\nFirst to 10 round‑wins becomes the champion.",

--- a/tests/data/tooltipsEntries.test.js
+++ b/tests/data/tooltipsEntries.test.js
@@ -19,7 +19,8 @@ describe("tooltips.json", () => {
       "card.flag",
       "ui.roundQuick",
       "ui.roundMedium",
-      "ui.roundLong"
+      "ui.roundLong",
+      "ui.toggleLayout"
     ];
     for (const key of keys) {
       expect(get(tooltips, key)).toBeDefined();


### PR DESCRIPTION
## Summary
- add tooltip for toggling layout
- verify tooltip entry is included in data test

## Testing
- `npm run validate:data`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed to load tooltips: fetch failed)*
- `npx playwright test` *(fails: screenshot mismatch and other errors)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0b9ec23f083268dca6d7c3b672054