### PR TITLE
test: show snackbars in classic battle flow

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -6,13 +6,16 @@ import { resolve } from "path";
 const rounds = JSON.parse(readFileSync(resolve("src/data/battleRounds.json"), "utf8"));
 
 test.describe.parallel("Classic battle flow", () => {
-  test("shows countdown before first round", async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem(
         "settings",
         JSON.stringify({ featureFlags: { enableTestMode: { enabled: false } } })
       );
     });
+  });
+
+  test("shows countdown before first round", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
     const roundOptions = page.locator(".round-select-buttons button");
     await roundOptions.first().waitFor();


### PR DESCRIPTION
## Summary
- ensure classic battle flow E2E tests run with snackbars enabled by disabling test mode before each test

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden retrieving vitest)*
- `npx playwright test` *(fails: 403 Forbidden retrieving playwright)*
- `npm run check:contrast` *(fails: spawn pa11y ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ca8f018c832689b5e4c03accfc3a