### PR TITLE
test: cover tooltip fallback cases

### DIFF
--- a/tests/helpers/tooltip.test.js
+++ b/tests/helpers/tooltip.test.js
@@ -34,7 +34,7 @@ describe("initTooltips", () => {
     expect(tip.style.display).toBe("none");
   });
 
-  it("warns once for unknown ids", async () => {
+  it("shows fallback text and warns once for unknown ids", async () => {
     const fetchJson = vi.fn().mockResolvedValue({});
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -47,12 +47,36 @@ describe("initTooltips", () => {
 
     await initTooltips();
 
+    const tip = document.querySelector(".tooltip");
+
     el.dispatchEvent(new Event("mouseenter"));
+    expect(tip.textContent).toBe("More info coming…");
     el.dispatchEvent(new Event("mouseleave"));
     el.dispatchEvent(new Event("mouseenter"));
 
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
+  });
+
+  it("falls back to leaf keys for parent ids", async () => {
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({
+        settings: { theme: { description: "Theme description" } }
+      })
+    }));
+
+    const { initTooltips } = await import("../../src/helpers/tooltip.js");
+
+    const el = document.createElement("div");
+    el.dataset.tooltipId = "settings.theme";
+    document.body.appendChild(el);
+
+    await initTooltips();
+
+    const tip = document.querySelector(".tooltip");
+    el.dispatchEvent(new Event("mouseenter"));
+
+    expect(tip.textContent).toBe("Theme description");
   });
 
   it("positions tooltip within viewport for zero-size targets", async () => {


### PR DESCRIPTION
## Summary
- assert unknown tooltip ids display fallback text
- add coverage for parent id leaf key resolution

## Testing
- `node_modules/.bin/prettier . --check` *(fails: `/usr/bin/env: ‘node’: No such file or directory`)*
- `node_modules/.bin/eslint .` *(fails: `/usr/bin/env: ‘node’: No such file or directory`)*
- `node_modules/.bin/vitest run` *(fails: `/usr/bin/env: ‘node’: No such file or directory`)*
- `node_modules/.bin/playwright test` *(fails: `/usr/bin/env: ‘node’: No such file or directory`)*
- `npm run check:contrast` *(fails: `bash: npm: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ca29cfe08326a4e5ea91d8e1b3ca