### PR TITLE
feat: add tooltip fallback text

### DIFF
--- a/src/helpers/tooltip.js
+++ b/src/helpers/tooltip.js
@@ -122,7 +122,7 @@ function ensureTooltipElement() {
  * 5. For each element, attach hover and focus listeners.
  *    - `show` looks up the tooltip text, sanitizes it with DOMPurify, and positions the element.
  *    - `hide` hides the tooltip element.
- * 6. When an ID is missing, log a warning only once and skip display.
+ * 6. When an ID is missing, log a warning only once and show the fallback text "More info coming…".
  *
  * @param {ParentNode} [root=globalThis.document] - Scope to search for tooltip targets.
  * @returns {Promise<void>} Resolves when listeners are attached.
@@ -159,7 +159,7 @@ export async function initTooltips(root = globalThis.document) {
         console.warn(`Unknown tooltip id: ${id}`);
         loggedMissing.add(id);
       }
-      return;
+      text = "More info coming…";
     }
     const { html, warning } = parseTooltipText(text);
     tip.innerHTML = DOMPurify.sanitize(html);

--- a/tests/helpers/tooltip.test.js
+++ b/tests/helpers/tooltip.test.js
@@ -34,7 +34,7 @@ describe("initTooltips", () => {
     expect(tip.style.display).toBe("none");
   });
 
-  it("warns once for unknown ids", async () => {
+  it("shows fallback text and warns once for unknown ids", async () => {
     const fetchJson = vi.fn().mockResolvedValue({});
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -48,6 +48,8 @@ describe("initTooltips", () => {
     await initTooltips();
 
     el.dispatchEvent(new Event("mouseenter"));
+    const tip = document.querySelector(".tooltip");
+    expect(tip.textContent).toBe("More info coming…");
     el.dispatchEvent(new Event("mouseleave"));
     el.dispatchEvent(new Event("mouseenter"));
 


### PR DESCRIPTION
## Summary
- show placeholder text when a tooltip id has no definition
- warn once for missing tooltip ids
- test fallback tooltip text and warning behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0ca24379883269ee08845c881303b