### PR TITLE
Align carousel page width with card dimensions

### DIFF
--- a/src/helpers/carousel/metrics.js
+++ b/src/helpers/carousel/metrics.js
@@ -4,7 +4,8 @@
  * @pseudocode
  * 1. Read gap from computed styles (prefer columnGap, fallback to gap).
  * 2. Measure first card width to estimate cards per page; ensure at least 1.
- * 3. Derive pageWidth as container width plus gap and compute pageCount.
+ * 3. Compute pageCount and derive pageWidth from card widths when available,
+ *    otherwise fallback to container width plus gap.
  * 4. Return { gap, pageWidth, cardsPerPage, pageCount }.
  *
  * @param {HTMLElement} container
@@ -24,7 +25,7 @@ export function getPageMetrics(container) {
     : 1;
 
   const pageCount = Math.max(1, Math.ceil(cards.length / cardsPerPage));
-  const pageWidth = containerWidth + gap;
+  const pageWidth = cardWidth ? cardsPerPage * (cardWidth + gap) : containerWidth + gap;
 
   return { gap, pageWidth, cardsPerPage, pageCount };
 }

--- a/tests/carousel/metrics.test.js
+++ b/tests/carousel/metrics.test.js
@@ -28,7 +28,7 @@ describe("getPageMetrics", () => {
     const m = getPageMetrics(container);
     expect(m.cardsPerPage).toBe(1);
     expect(m.pageCount).toBe(6);
-    expect(m.pageWidth).toBe(336); // container + gap
+    expect(m.pageWidth).toBe(216); // 1 * (card + gap)
   });
 
   it("computes 2 cards per page on medium container", () => {
@@ -39,6 +39,6 @@ describe("getPageMetrics", () => {
     const m = getPageMetrics(container);
     expect(m.cardsPerPage).toBe(2);
     expect(m.pageCount).toBe(3);
-    expect(m.pageWidth).toBe(520);
+    expect(m.pageWidth).toBe(480); // 2 * (card + gap)
   });
 });


### PR DESCRIPTION
## Summary
- compute carousel `pageWidth` using card sizes when available to match scroll increments
- document updated `pageWidth` logic in helper pseudocode
- update carousel metrics tests for new width calculations

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0cf9564548326b4fcd905f6c23ba0