### PR TITLE
refactor: prevent duplicate nav reset listeners

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -201,9 +201,13 @@ function makeRenderSwitches(controls, getCurrentSettings, handleUpdate) {
       );
     }
     queueMicrotask(addNavResetButton);
-    document.getElementById("feature-nav-cache-reset-button")?.addEventListener("change", () => {
-      setTimeout(addNavResetButton);
-    });
+    const navCacheToggle = document.getElementById("feature-nav-cache-reset-button");
+    if (navCacheToggle && !navCacheToggle.dataset.listenerBound) {
+      navCacheToggle.addEventListener("change", () => {
+        setTimeout(addNavResetButton);
+      });
+      navCacheToggle.dataset.listenerBound = "true";
+    }
     initTooltips();
   };
 }


### PR DESCRIPTION
## Summary
- avoid re-binding nav cache reset feature flag listener in settings page

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0e75b07e083268e86b6d897303570