### PR TITLE
Guard matchMedia usage in randomJudokaPage

### DIFF
--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -38,13 +38,16 @@ const DRAW_ICON =
   '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#1f1f1f"><path d="m600-200-56-57 143-143H300q-75 0-127.5-52.5T120-580q0-75 52.5-127.5T300-760h20v80h-20q-42 0-71 29t-29 71q0 42 29 71t71 29h387L544-624l56-56 240 240-240 240Z"/></svg>';
 
 export async function initFeatureFlagState() {
+  const hasMatchMedia = typeof window !== "undefined" && typeof window.matchMedia === "function";
   let settings;
   try {
     settings = await initFeatureFlags();
   } catch (err) {
     console.error("Error loading settings:", err);
     settings = {
-      motionEffects: !window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+      motionEffects: hasMatchMedia
+        ? !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        : true,
       featureFlags: {
         viewportSimulation: { enabled: false },
         enableCardInspector: { enabled: false },
@@ -60,7 +63,8 @@ export async function initFeatureFlagState() {
   toggleTooltipOverlayDebug(isEnabled("tooltipOverlayDebug"));
 
   const prefersReducedMotion =
-    !settings.motionEffects || window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    !settings.motionEffects ||
+    (hasMatchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
   return { prefersReducedMotion };
 }
 


### PR DESCRIPTION
## Summary
- Safely detect `matchMedia` before use in randomJudokaPage and default to motion enabled when unavailable
- Add tests ensuring reduced-motion logic falls back without `matchMedia`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Failed to load tooltips: TypeError: fetch failed)*
- `npx playwright test` *(fails: 1 failed, 1 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef419be483269e739bd7aca73ebb