### PR TITLE
Deep clone cached settings to avoid shared mutations

### DIFF
--- a/src/helpers/settingsCache.js
+++ b/src/helpers/settingsCache.js
@@ -1,28 +1,53 @@
 import { DEFAULT_SETTINGS } from "./settingsSchema.js";
 
+/**
+ * Clone a settings object, duplicating nested structures to avoid mutations.
+ *
+ * @pseudocode
+ * 1. Shallow copy `settings`.
+ * 2. Clone nested objects: `tooltipIds`, `gameModes`, and `featureFlags`.
+ * 3. Return the cloned object.
+ *
+ * @param {import("./settingsSchema.js").Settings} settings - Settings to clone.
+ * @returns {import("./settingsSchema.js").Settings} Cloned settings.
+ */
+function cloneSettings(settings) {
+  return {
+    ...settings,
+    tooltipIds: settings.tooltipIds ? { ...settings.tooltipIds } : undefined,
+    gameModes: settings.gameModes ? { ...settings.gameModes } : undefined,
+    featureFlags: settings.featureFlags
+      ? Object.fromEntries(
+          Object.entries(settings.featureFlags).map(([name, flag]) => [name, { ...flag }])
+        )
+      : undefined
+  };
+}
+
 // Cached settings object for synchronous access
-let cachedSettings = { ...DEFAULT_SETTINGS };
+let cachedSettings = cloneSettings(DEFAULT_SETTINGS);
 
 /**
  * Replace the cached settings object.
  *
  * @pseudocode
- * 1. Assign `settings` to `cachedSettings`.
+ * 1. Clone `settings` to prevent external mutations.
+ * 2. Assign the clone to `cachedSettings`.
  *
  * @param {import("./settingsSchema.js").Settings} settings - New settings object.
  */
 export function setCachedSettings(settings) {
-  cachedSettings = settings;
+  cachedSettings = cloneSettings(settings);
 }
 
 /**
  * Reset the cache to the default settings.
  *
  * @pseudocode
- * 1. Set `cachedSettings` to a shallow copy of `DEFAULT_SETTINGS`.
+ * 1. Set `cachedSettings` to a cloned copy of `DEFAULT_SETTINGS`.
  */
 export function resetCache() {
-  cachedSettings = { ...DEFAULT_SETTINGS };
+  cachedSettings = cloneSettings(DEFAULT_SETTINGS);
 }
 
 /**

--- a/tests/helpers/settingsCache.test.js
+++ b/tests/helpers/settingsCache.test.js
@@ -1,0 +1,29 @@
+import {
+  setCachedSettings,
+  getCachedSettings,
+  resetCache
+} from "../../src/helpers/settingsCache.js";
+import { DEFAULT_SETTINGS } from "../../src/helpers/settingsSchema.js";
+
+describe("settingsCache", () => {
+  afterEach(() => {
+    resetCache();
+  });
+
+  it("clones nested structures to avoid mutation side effects", () => {
+    const source = {
+      ...DEFAULT_SETTINGS,
+      tooltipIds: { a: "b" },
+      gameModes: { demo: true },
+      featureFlags: { test: { enabled: true } }
+    };
+    setCachedSettings(source);
+    const cached = getCachedSettings();
+
+    source.tooltipIds.a = "changed";
+    source.featureFlags.test.enabled = false;
+
+    expect(cached.tooltipIds.a).toBe("b");
+    expect(cached.featureFlags.test.enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- clone nested structures in settings cache to prevent shared mutation
- reset cache and set operations now use deep copies
- add unit test ensuring settings cache resists external mutations

## Testing
- `npx prettier . --check`
- `npx eslint src/helpers/settingsCache.js tests/helpers/settingsCache.test.js`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatches and timeouts)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef35b38c8326896098e50691c2e0