### PR TITLE
Add timeout fallback for random judoka animation

### DIFF
--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -12,7 +12,7 @@
  * 6. Define `displayCard` that disables the Draw button, updates its text and `aria-busy` state while loading, verifies the
  *    card container exists, calls `generateRandomCard` with the loaded data and the user's motion preference, handles any
  *    errors by logging and showing a message, updates the history list, then restores the button once the animation completes
- *    (or immediately when motion is disabled).
+ *    (or immediately when motion is disabled) with a timeout fallback if the event never fires.
  * 7. Render a placeholder card in the card container.
  * 8. Create the "Draw Card!" button (min 64px height, 300px width, pill shape, ARIA attributes) and attach its event listener.
  * 9. If data fails to load, disable the Draw button and show an error message or fallback card.
@@ -228,9 +228,14 @@ async function displayCard({
     } else {
       const onEnd = () => {
         cardEl.removeEventListener("animationend", onEnd);
+        clearTimeout(fallbackId);
         enableButton();
       };
       cardEl.addEventListener("animationend", onEnd);
+      const fallbackId = setTimeout(() => {
+        cardEl.removeEventListener("animationend", onEnd);
+        enableButton();
+      }, 2000);
     }
   }
 }


### PR DESCRIPTION
## Summary
- restore draw button if animationend never fires by clearing with a 2s timeout
- document fallback in random card pseudocode

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef26179c8326a24ddbb6f6e3cfaa