### PR TITLE
refactor: use textContent for section errors

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -282,7 +282,13 @@ export function renderSettingsControls(settings, gameModes, tooltipMap) {
 function showSectionError(containerId, message) {
   const container = document.getElementById(containerId);
   if (container) {
-    container.innerHTML = `<div class="settings-section-error" role="alert" aria-live="assertive">${message}</div>`;
+    container.textContent = "";
+    const errorEl = document.createElement("div");
+    errorEl.className = "settings-section-error";
+    errorEl.setAttribute("role", "alert");
+    errorEl.setAttribute("aria-live", "assertive");
+    errorEl.textContent = message;
+    container.append(errorEl);
   }
 }
 


### PR DESCRIPTION
## Summary
- avoid innerHTML when displaying settings section errors

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0f37935bc8326b8f1ff5ba201df1d