### PR TITLE
Handle missing vector search input

### DIFF
--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -156,7 +156,10 @@ function selectTopMatches(matches) {
 export async function handleSearch(event) {
   event.preventDefault();
   const { query, tbody, messageEl } = prepareSearchUi();
-  if (!query) return;
+  if (!query) {
+    finalizeSearchUi(messageEl);
+    return;
+  }
   const selected = getSelectedTags();
   showSearching(messageEl);
   try {

--- a/src/helpers/vectorSearchPage/queryUi.js
+++ b/src/helpers/vectorSearchPage/queryUi.js
@@ -3,8 +3,9 @@
  *
  * @pseudocode
  * 1. Locate the search input, results table body, and message element.
- * 2. Trim the query value and clear any previous results.
- * 3. Return the query, tbody reference, and message element.
+ * 2. When the input is missing, return early with an empty query.
+ * 3. Trim the query value and clear any previous results.
+ * 4. Return the query, tbody reference, and message element.
  *
  * @returns {{query: string, tbody: HTMLTableSectionElement|null, messageEl: HTMLElement|null}}
  */
@@ -12,9 +13,10 @@ export function prepareSearchUi() {
   const input = document.getElementById("vector-search-input");
   const table = document.getElementById("vector-results-table");
   const tbody = table?.querySelector("tbody");
+  const messageEl = document.getElementById("search-results-message");
+  if (!input) return { query: "", tbody, messageEl };
   const query = input.value.trim();
   if (tbody) tbody.textContent = "";
-  const messageEl = document.getElementById("search-results-message");
   return { query, tbody, messageEl };
 }
 


### PR DESCRIPTION
## Summary
- guard vector search UI prep against missing input
- finalize UI when query is empty before searching

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0f36fdedc8326ad3f2d89787f6b8a