### PR TITLE
feat: add modal destroy method

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -11,6 +11,7 @@
  *    manage focus and `aria-expanded` on the trigger.
  * 6. Clicking the backdrop or pressing Escape closes the modal.
  * 7. While open, trap focus inside the modal container.
+ * 8. Provide `destroy()` to remove listeners and detach the element.
  *
  * @param {HTMLElement|DocumentFragment} content - Dialog contents.
  * @param {object} [options] - Optional configuration.
@@ -111,6 +112,16 @@ export class Modal {
       this.returnFocus.setAttribute("aria-expanded", "false");
       this.returnFocus.focus();
     }
+  }
+
+  /**
+   * Remove event listeners and detach the modal element.
+   * @returns {void}
+   */
+  destroy() {
+    this.element.removeEventListener("click", this.handleBackdropClick);
+    document.removeEventListener("keydown", this.handleEscape);
+    this.element.remove();
   }
 }
 

--- a/src/helpers/classicBattle/quitModal.js
+++ b/src/helpers/classicBattle/quitModal.js
@@ -41,6 +41,8 @@ function createQuitConfirmation(store, onConfirm) {
       await dispatchBattleEvent("abortMatch");
     }
     // Navigate to home (robust to varying base paths like GH Pages)
+    modal.destroy();
+    store.quitModal = null;
     navigateToHome();
   });
   document.body.appendChild(modal.element);

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -52,6 +52,10 @@ function getStartRound(store) {
  */
 export async function handleReplay(store) {
   resetEngineForTest();
+  if (store.quitModal) {
+    store.quitModal.destroy();
+    store.quitModal = null;
+  }
   document.querySelectorAll(".modal-backdrop").forEach((m) => {
     if (typeof m.remove === "function") m.remove();
   });
@@ -145,7 +149,7 @@ export function _resetForTest(store) {
     quitBtn.replaceWith(quitBtn.cloneNode(true));
   }
   if (store.quitModal) {
-    store.quitModal.element.remove();
+    store.quitModal.destroy();
     store.quitModal = null;
   }
   syncScoreDisplay();

--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -21,7 +21,7 @@ import { isTestModeEnabled } from "../testModeUtils.js";
  * 6. Open the modal.
  * 7. When a button is clicked:
  *    a. Call `setPointsToWin` with the round value.
- *    b. Close the modal and invoke the provided start callback.
+ *    b. Close and destroy the modal, then invoke the provided start callback.
  *
  * @param {Function} onStart - Callback to invoke after selecting rounds.
  * @returns {Promise<void>} Resolves when modal is initialized.
@@ -71,6 +71,7 @@ export async function initRoundSelectModal(onStart) {
       setPointsToWin(r.value);
       modal.close();
       if (typeof onStart === "function") onStart();
+      modal.destroy();
     });
     btnWrap.appendChild(btn);
   });

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -23,7 +23,9 @@ export function syncScoreDisplay() {
  * 1. Build title and score elements.
  * 2. Create Quit and Next buttons using `createButton`.
  * 3. Assemble the modal via `createModal` and append it to the DOM.
- * 4. Quit navigates to `index.html`; Next closes the modal and runs `onNext`.
+ * 4. Both buttons close and destroy the modal:
+ *    - Quit navigates to `index.html`.
+ *    - Next runs `onNext`.
  *
  * @param {{message: string, playerScore: number, computerScore: number}} result
  * @param {Function} onNext Callback invoked when starting the next match.
@@ -57,12 +59,14 @@ export function showMatchSummaryModal(result, onNext) {
 
   quit.addEventListener("click", () => {
     modal.close();
+    modal.destroy();
     // Navigate to home (robust base path handling)
     navigateToHome();
   });
 
   next.addEventListener("click", () => {
     modal.close();
+    modal.destroy();
     if (typeof onNext === "function") onNext();
   });
 

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -88,7 +88,7 @@ async function startRoundWrapper() {
  *
  * @pseudocode
  * 1. Create a modal dialog with an error message and a Retry button.
- * 2. When Retry is clicked, close the modal and call startRoundWrapper again.
+ * 2. When Retry is clicked, close and destroy the modal then call `startRoundWrapper` again.
  * 3. If modal is already open, do not create another.
  */
 function showRetryModal() {
@@ -107,6 +107,7 @@ function showRetryModal() {
   modal.element.id = "round-retry-modal";
   retryBtn.addEventListener("click", async () => {
     modal.close();
+    modal.destroy();
     await startRoundWrapper();
   });
   document.body.appendChild(modal.element);

--- a/tests/helpers/classicBattle/interruptHandlers.test.js
+++ b/tests/helpers/classicBattle/interruptHandlers.test.js
@@ -25,7 +25,7 @@ vi.mock("../../../src/components/Modal.js", () => ({
     modalOpenMock = vi.fn();
     modalElement = document.createElement("div");
     modalElement.append(content);
-    return { element: modalElement, open: modalOpenMock };
+    return { element: modalElement, open: modalOpenMock, close: vi.fn(), destroy: vi.fn() };
   },
   createButton: (label, { id } = {}) => {
     const btn = document.createElement("button");

--- a/tests/helpers/classicBattle/matchFlow.test.js
+++ b/tests/helpers/classicBattle/matchFlow.test.js
@@ -62,7 +62,7 @@ vi.mock("../../../src/components/Modal.js", () => ({
   createModal: (content) => {
     const el = document.createElement("div");
     if (content) el.append(content);
-    return { element: el, open: vi.fn(), close: vi.fn() };
+    return { element: el, open: vi.fn(), close: vi.fn(), destroy: vi.fn() };
   },
   createButton: (text, opts = {}) => {
     const btn = document.createElement("button");

--- a/tests/helpers/classicBattle/quitModal.test.js
+++ b/tests/helpers/classicBattle/quitModal.test.js
@@ -11,7 +11,7 @@ vi.mock("../../../src/components/Modal.js", () => ({
     const element = document.createElement("div");
     element.className = "modal-backdrop";
     element.appendChild(content);
-    return { element, open: vi.fn(), close: vi.fn() };
+    return { element, open: vi.fn(), close: vi.fn(), destroy: vi.fn() };
   }
 }));
 vi.mock("../../../src/components/Button.js", () => ({

--- a/tests/helpers/classicBattle/roundSelectModal.test.js
+++ b/tests/helpers/classicBattle/roundSelectModal.test.js
@@ -24,7 +24,7 @@ vi.mock("../../../src/components/Modal.js", () => ({
   createModal: (content) => {
     const element = document.createElement("div");
     element.appendChild(content);
-    return { element, open: mocks.modal.open, close: mocks.modal.close };
+    return { element, open: mocks.modal.open, close: mocks.modal.close, destroy: vi.fn() };
   }
 }));
 vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -409,7 +409,7 @@ describe("startRoundWrapper failures", () => {
       createModal: (content) => {
         const element = document.createElement("div");
         element.appendChild(content);
-        return { element, open, close: vi.fn() };
+        return { element, open, close: vi.fn(), destroy: vi.fn() };
       },
       createButton: (label, opts = {}) => {
         const btn = document.createElement("button");
@@ -466,7 +466,7 @@ describe("syncScoreDisplay", () => {
         const element = document.createElement("div");
         element.className = "modal-backdrop";
         element.appendChild(content);
-        return { element, open: vi.fn(), close: vi.fn() };
+        return { element, open: vi.fn(), close: vi.fn(), destroy: vi.fn() };
       }
     }));
 

--- a/tests/helpers/modalComponent.test.js
+++ b/tests/helpers/modalComponent.test.js
@@ -18,31 +18,34 @@ describe("createModal", () => {
     trigger.id = "trigger";
     document.body.appendChild(trigger);
 
-    const { element, open, close } = createModal(buildContent());
-    document.body.appendChild(element);
+    const modal = createModal(buildContent());
+    document.body.appendChild(modal.element);
 
-    open(trigger);
-    expect(element.hasAttribute("hidden")).toBe(false);
+    modal.open(trigger);
+    expect(modal.element.hasAttribute("hidden")).toBe(false);
     expect(trigger).toHaveAttribute("aria-expanded", "true");
     expect(document.activeElement.id).toBe("cancel-btn");
 
-    close();
-    expect(element.hasAttribute("hidden")).toBe(true);
+    modal.close();
+    expect(modal.element.hasAttribute("hidden")).toBe(true);
     expect(trigger).toHaveAttribute("aria-expanded", "false");
     expect(document.activeElement).toBe(trigger);
+
+    modal.destroy();
   });
 
   it("applies aria labels from options", () => {
     const heading = document.createElement("h2");
     heading.id = "modal-title";
-    const { element } = createModal(buildContent(), {
+    const modal = createModal(buildContent(), {
       labelledBy: heading,
       describedBy: "modal-desc"
     });
-    document.body.appendChild(element);
-    const dialog = element.querySelector(".modal");
+    document.body.appendChild(modal.element);
+    const dialog = modal.element.querySelector(".modal");
     expect(dialog).toHaveAttribute("aria-labelledby", "modal-title");
     expect(dialog).toHaveAttribute("aria-describedby", "modal-desc");
+    modal.destroy();
   });
 });
 
@@ -56,5 +59,13 @@ describe("Modal class", () => {
     expect(modal.element.hasAttribute("hidden")).toBe(false);
     modal.close();
     expect(modal.element.hasAttribute("hidden")).toBe(true);
+    modal.destroy();
+  });
+
+  it("removes element on destroy", () => {
+    const modal = createModal(buildContent());
+    document.body.appendChild(modal.element);
+    modal.destroy();
+    expect(document.body.contains(modal.element)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add destroy() to Modal and detach DOM listeners
- call destroy when round select and match summary modals close
- clean up quit and retry modals and battle reset logic

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a0fbe486c48326bfead29f5551effe