### PR TITLE
Prevent lingering settings error popup

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -29,6 +29,8 @@ import { renderFeatureFlagSwitches } from "./settings/featureFlagSwitches.js";
 import { makeHandleUpdate } from "./settings/makeHandleUpdate.js";
 import { addNavResetButton } from "./settings/addNavResetButton.js";
 
+let errorPopupTimeoutId;
+
 /**
  * Build a confirmation modal for restoring default settings.
  *
@@ -164,9 +166,11 @@ function makeErrorPopupHandler(errorPopup) {
     if (errorPopup) {
       errorPopup.textContent = "Failed to update settings. Please try again.";
       errorPopup.style.display = "block";
-      setTimeout(() => {
+      if (errorPopupTimeoutId) clearTimeout(errorPopupTimeoutId);
+      errorPopupTimeoutId = setTimeout(() => {
         errorPopup.style.display = "none";
         errorPopup.textContent = "";
+        errorPopupTimeoutId = undefined;
       }, 3000);
     }
   };


### PR DESCRIPTION
## Summary
- track and clear a pending timeout for the settings update error popup to avoid lingering messages

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a103b813bc8326955d2f6e9bb35755