### PR TITLE
Use markdown parser for tooltip text

### DIFF
--- a/src/helpers/markdownToHtml.js
+++ b/src/helpers/markdownToHtml.js
@@ -16,3 +16,25 @@ export function markdownToHtml(text) {
   if (!text) return "";
   return marked.parse(text);
 }
+
+/**
+ * Convert Markdown to inline HTML without wrapping paragraphs.
+ *
+ * @pseudocode
+ * 1. If `text` is empty, return an empty string.
+ * 2. Split `text` on newline characters.
+ * 3. For each line:
+ *    - Parse with `marked.parse`.
+ *    - Remove surrounding `<p>` tags.
+ * 4. Join the lines with `<br>` and return the result.
+ *
+ * @param {string} [text] - Markdown content to convert.
+ * @returns {string} Inline HTML string.
+ */
+export function markdownToInlineHtml(text) {
+  if (!text) return "";
+  return text
+    .split("\n")
+    .map((line) => marked.parse(line).replace(/^<p>|<\/p>$/g, ""))
+    .join("<br>");
+}

--- a/src/vendor/marked.esm.js
+++ b/src/vendor/marked.esm.js
@@ -8,7 +8,9 @@ export const marked = {
    */
   parse(md) {
     function renderInline(text) {
-      return text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+      return text
+        .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+        .replace(/_(.+?)_/g, "<em>$1</em>");
     }
 
     function renderList(lines) {


### PR DESCRIPTION
## Summary
- replace regex tooltip parsing with markdown parser
- support italics in vendor marked parser and add inline markdown helper
- test nested and unbalanced tooltip markup

## Testing
- `npx prettier src/helpers/tooltip.js src/helpers/markdownToHtml.js src/vendor/marked.esm.js tests/helpers/tooltip.test.js --check`
- `npx eslint src/helpers/tooltip.js src/helpers/markdownToHtml.js src/vendor/marked.esm.js tests/helpers/tooltip.test.js && echo 'ESLint passed'`
- `npx vitest run tests/helpers/tooltip.test.js`
- `npx playwright test` *(fails: Battle Judoka page, Change log page, Classic battle flow x2)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a103a9fd0c8326a1d27dbc2834c7c4