### PR TITLE
Avoid duplicate reset listener on settings page

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -89,6 +89,7 @@ function createResetConfirmation(onConfirm) {
  * 3. Provide helpers to read/persist settings and show errors.
  * 4. Attach listeners for existing controls and the Restore Defaults button.
  *    - Reset confirms with a modal, reloads feature flags, reapplies defaults, and rerenders switches.
+ *    - Guard against duplicate reset listeners when controls reinitialize.
  * 5. Return `renderSwitches` to inject game-mode/feature-flag toggles and apply initial values later.
  *
  * @param {Settings} settings - Current settings object.
@@ -128,9 +129,12 @@ function initializeControls(settings) {
     showSnackbar("Settings restored to defaults");
   });
 
-  resetButton?.addEventListener("click", () => {
-    resetModal.open(resetButton);
-  });
+  if (resetButton && !resetButton.dataset.resetListenerAttached) {
+    resetButton.addEventListener("click", () => {
+      resetModal.open(resetButton);
+    });
+    resetButton.dataset.resetListenerAttached = "true";
+  }
 
   return {
     renderSwitches: (gameModes, tooltipMap) => {

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -204,6 +204,16 @@ describe("renderSettingsControls", () => {
     expect(initFeatureFlags).toHaveBeenCalled();
     expect(showSnackbar).toHaveBeenCalledWith("Settings restored to defaults");
   });
+
+  it("does not duplicate reset listener on reinit", async () => {
+    const { renderSettingsControls } = await import("../../src/helpers/settingsPage.js");
+    renderSettingsControls(baseSettings, [], tooltipMap);
+    const resetButton = document.getElementById("reset-settings-button");
+    const addSpy = vi.spyOn(resetButton, "addEventListener");
+    renderSettingsControls(baseSettings, [], tooltipMap);
+    expect(addSpy).not.toHaveBeenCalled();
+    addSpy.mockRestore();
+  });
 });
 
 describe("initializeSettingsPage", () => {


### PR DESCRIPTION
## Summary
- prevent multiple reset button listeners by tracking when one is attached
- add test verifying reinitialization doesn't duplicate reset listener

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a1039eb0c4832698a426e116c3fc99