### PR TITLE
feat: add tooltip cleanup

### DIFF
--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -64,6 +64,7 @@ export async function initRoundSelectModal(onStart) {
   frag.append(title, btnWrap);
 
   const modal = createModal(frag, { labelledBy: title });
+  let cleanupTooltips = () => {};
   rounds.forEach((r) => {
     const btn = createButton(r.label, { id: `round-select-${r.id}` });
     btn.dataset.tooltipId = `ui.round${r.label}`;
@@ -71,6 +72,7 @@ export async function initRoundSelectModal(onStart) {
       setPointsToWin(r.value);
       modal.close();
       if (typeof onStart === "function") onStart();
+      cleanupTooltips();
       modal.destroy();
     });
     btnWrap.appendChild(btn);
@@ -78,7 +80,7 @@ export async function initRoundSelectModal(onStart) {
 
   document.body.appendChild(modal.element);
   try {
-    await initTooltips(modal.element);
+    cleanupTooltips = await initTooltips(modal.element);
   } catch (err) {
     console.error("Failed to initialize tooltips:", err);
   }

--- a/src/helpers/mockupViewerPage.js
+++ b/src/helpers/mockupViewerPage.js
@@ -13,11 +13,11 @@ import { SidebarList } from "../components/SidebarList.js";
  * 4. Implement `showImage(index)` to update the image, alt text, filename, and sidebar highlight.
  * 5. Define event handlers; remove existing listeners and attach click and keydown handlers to cycle images with wraparound.
  * 6. Show the first image and apply button ripple effects.
- * 7. Return a teardown function that removes event listeners.
+ * 7. Return a teardown function that removes event listeners and tooltip listeners.
  *
- * @returns {void}
+ * @returns {Promise<() => void>} Teardown function.
  */
-export function setupMockupViewerPage() {
+export async function setupMockupViewerPage() {
   const imgEl = document.getElementById("mockup-image");
   const filenameEl = document.getElementById("mockup-filename");
   const prevBtn = document.getElementById("prev-btn");
@@ -110,12 +110,13 @@ export function setupMockupViewerPage() {
 
   showImage(0);
   setupButtonEffects();
-  initTooltips();
+  const cleanupTooltips = await initTooltips();
 
   return () => {
     prevBtn.removeEventListener("click", handlePrevClick);
     nextBtn.removeEventListener("click", handleNextClick);
     document.removeEventListener("keydown", handleKeydown);
+    cleanupTooltips();
   };
 }
 

--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -261,12 +261,13 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
     selectDocSync(i, true, true, !opts.fromListNav);
   });
 
+  let cleanupTooltips = () => {};
   // Ensure the initially visible document is reflected in the sidebar
   // selection and accessibility state before any navigation.
   // This keeps aria-current/selected in sync with the rendered content.
   listSelect(startIndex);
-
   function renderDoc(i) {
+    cleanupTooltips();
     container.innerHTML = DOMPurify.sanitize(documents[i] || "");
     container.classList.remove("fade-in");
     void container.offsetWidth;
@@ -277,7 +278,9 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
       const percent = total ? Math.round((completed / total) * 100) : 0;
       summaryEl.textContent = `Tasks: ${completed}/${total} (${percent}%)`;
     }
-    initTooltips();
+    initTooltips(container).then((fn) => {
+      cleanupTooltips = fn;
+    });
   }
 
   // Attempt to fill a document synchronously when possible (docsMap or cached).

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -177,7 +177,12 @@ function clearToggles(container) {
 }
 
 function makeRenderSwitches(controls, getCurrentSettings, handleUpdate) {
+  let cleanupTooltips;
   return function renderSwitches(gameModes, tooltipMap) {
+    if (cleanupTooltips) {
+      cleanupTooltips();
+      cleanupTooltips = undefined;
+    }
     // Apply current settings once toggles are available.
     const current = getCurrentSettings();
     const radio = document.querySelector('input[name="display-mode"]:checked');
@@ -212,7 +217,9 @@ function makeRenderSwitches(controls, getCurrentSettings, handleUpdate) {
       });
       navCacheToggle.dataset.listenerBound = "true";
     }
-    initTooltips();
+    initTooltips().then((fn) => {
+      cleanupTooltips = fn;
+    });
   };
 }
 

--- a/tests/helpers/browseJudokaPage.test.js
+++ b/tests/helpers/browseJudokaPage.test.js
@@ -162,7 +162,9 @@ describe("browseJudokaPage helpers", () => {
       createLoadingSpinner
     }));
     vi.doMock("../../src/helpers/buttonEffects.js", () => ({ setupButtonEffects: vi.fn() }));
-    vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips: vi.fn() }));
+    vi.doMock("../../src/helpers/tooltip.js", () => ({
+      initTooltips: vi.fn().mockResolvedValue(() => {})
+    }));
     const toggleCountryPanel = vi.fn();
     const toggleCountryPanelMode = vi.fn();
     vi.doMock("../../src/helpers/countryPanel.js", () => ({
@@ -239,7 +241,9 @@ describe("browseJudokaPage helpers", () => {
       createLoadingSpinner: () => ({ spinner: document.createElement("div"), timeoutId: 0 })
     }));
     vi.doMock("../../src/helpers/buttonEffects.js", () => ({ setupButtonEffects: vi.fn() }));
-    vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips: vi.fn() }));
+    vi.doMock("../../src/helpers/tooltip.js", () => ({
+      initTooltips: vi.fn().mockResolvedValue(() => {})
+    }));
     const toggleCountryPanel = vi.fn();
     const toggleCountryPanelMode = vi.fn();
     vi.doMock("../../src/helpers/countryPanel.js", () => ({

--- a/tests/helpers/changeLogPage.test.js
+++ b/tests/helpers/changeLogPage.test.js
@@ -38,7 +38,9 @@ describe("changeLogPage", () => {
       fetchJson: vi.fn().mockResolvedValue([sample[0]])
     }));
     vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
-    vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips: vi.fn() }));
+    vi.doMock("../../src/helpers/tooltip.js", () => ({
+      initTooltips: vi.fn().mockResolvedValue(() => {})
+    }));
 
     const { setupChangeLogPage } = await import("../../src/helpers/changeLogPage.js");
 

--- a/tests/helpers/classicBattle/mocks.js
+++ b/tests/helpers/classicBattle/mocks.js
@@ -73,7 +73,7 @@ export function mockShowSnackbar() {
 
 export function mockTooltips() {
   vi.doMock("../../../src/helpers/tooltip.js", () => ({
-    initTooltips: vi.fn()
+    initTooltips: vi.fn().mockResolvedValue(() => {})
   }));
 }
 

--- a/tests/helpers/classicBattle/roundSelectModal.test.js
+++ b/tests/helpers/classicBattle/roundSelectModal.test.js
@@ -39,7 +39,8 @@ describe("initRoundSelectModal", () => {
     document.body.innerHTML = "";
     vi.clearAllMocks();
     mocks.fetchJson.mockResolvedValue(rounds);
-    mocks.initTooltips.mockResolvedValue();
+    mocks.cleanup = vi.fn();
+    mocks.initTooltips.mockResolvedValue(mocks.cleanup);
   });
 
   it("renders three options from battleRounds.json", async () => {
@@ -56,6 +57,7 @@ describe("initRoundSelectModal", () => {
     first.click();
     expect(mocks.setPointsToWin).toHaveBeenCalledWith(rounds[0].value);
     expect(onStart).toHaveBeenCalled();
+    expect(mocks.cleanup).toHaveBeenCalled();
   });
 
   it("opens modal and starts match even if tooltip init fails", async () => {

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -56,7 +56,9 @@ describe("classicBattlePage feature flag updates", () => {
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard: vi.fn() }));
     vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar: vi.fn() }));
-    vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips: vi.fn() }));
+    vi.doMock("../../src/helpers/tooltip.js", () => ({
+      initTooltips: vi.fn().mockResolvedValue(() => {})
+    }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({
       setTestMode: vi.fn(),
       isTestModeEnabled: () => currentFlags.enableTestMode?.enabled ?? false

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -19,7 +19,7 @@ describe("classicBattlePage stat button interactions", () => {
     const handleStatSelection = vi.fn();
     const store = {};
     const loadSettings = vi.fn().mockResolvedValue({ featureFlags: {} });
-    const initTooltips = vi.fn().mockResolvedValue();
+    const initTooltips = vi.fn().mockResolvedValue(() => {});
     const setTestMode = vi.fn();
     const showSnackbar = vi.fn();
 
@@ -89,7 +89,7 @@ describe("classicBattlePage stat button interactions", () => {
     const handleStatSelection = vi.fn();
     const store = {};
     const loadSettings = vi.fn().mockResolvedValue({ featureFlags: {} });
-    const initTooltips = vi.fn().mockResolvedValue();
+    const initTooltips = vi.fn().mockResolvedValue(() => {});
     const setTestMode = vi.fn();
 
     vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
@@ -158,7 +158,7 @@ describe("classicBattlePage stat help tooltip", () => {
     const startRound = vi.fn();
     const waitForComputerCard = vi.fn();
     const loadSettings = vi.fn().mockResolvedValue({ featureFlags: {} });
-    const initTooltips = vi.fn().mockResolvedValue();
+    const initTooltips = vi.fn().mockResolvedValue(() => {});
     const setTestMode = vi.fn();
 
     const store = {};
@@ -209,7 +209,7 @@ describe("classicBattlePage test mode flag", () => {
         }
       }
     });
-    const initTooltips = vi.fn().mockResolvedValue();
+    const initTooltips = vi.fn().mockResolvedValue(() => {});
     const setTestMode = vi.fn();
 
     const store = {};
@@ -252,7 +252,7 @@ describe("classicBattlePage test mode flag", () => {
     const updateSetting = vi
       .fn()
       .mockResolvedValue({ featureFlags: { enableTestMode: { enabled: true } } });
-    const initTooltips = vi.fn().mockResolvedValue();
+    const initTooltips = vi.fn().mockResolvedValue(() => {});
     const setTestMode = vi.fn();
 
     const store = {};
@@ -296,7 +296,7 @@ describe("classicBattlePage battle state progress", () => {
     const waitForComputerCard = vi.fn();
     const handleStatSelection = vi.fn();
     const loadSettings = vi.fn().mockResolvedValue({ featureFlags: {} });
-    const initTooltips = vi.fn().mockResolvedValue();
+    const initTooltips = vi.fn().mockResolvedValue(() => {});
     const setTestMode = vi.fn();
     const showSnackbar = vi.fn();
     const cleanup = vi.fn();
@@ -372,7 +372,7 @@ describe("startRoundWrapper failures", () => {
       showMessage
     }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({
-      initTooltips: vi.fn().mockResolvedValue()
+      initTooltips: vi.fn().mockResolvedValue(() => {})
     }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode: vi.fn() }));
     vi.doMock("../../src/helpers/stats.js", () => ({

--- a/tests/helpers/mockupViewerPage.test.js
+++ b/tests/helpers/mockupViewerPage.test.js
@@ -13,7 +13,7 @@ describe("mockupViewerPage", () => {
     globalThis.SKIP_MOCKUP_AUTO_INIT = true;
     const { setupMockupViewerPage } = await import("../../src/helpers/mockupViewerPage.js");
 
-    setupMockupViewerPage();
+    await setupMockupViewerPage();
 
     const list = document.getElementById("mockup-list");
     const img = document.getElementById("mockup-image");
@@ -38,7 +38,7 @@ describe("mockupViewerPage", () => {
     globalThis.SKIP_MOCKUP_AUTO_INIT = true;
     const { setupMockupViewerPage } = await import("../../src/helpers/mockupViewerPage.js");
 
-    setupMockupViewerPage();
+    await setupMockupViewerPage();
 
     const list = document.getElementById("mockup-list");
     const img = document.getElementById("mockup-image");

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -55,7 +55,7 @@ beforeEach(() => {
   resetDom();
   document.body.appendChild(createSettingsDom());
   vi.doMock("../../src/helpers/tooltip.js", () => ({
-    initTooltips: vi.fn(),
+    initTooltips: vi.fn().mockResolvedValue(() => {}),
     getTooltips: vi.fn()
   }));
   vi.doMock("../../src/helpers/displayMode.js", () => ({ applyDisplayMode: vi.fn() }));
@@ -83,7 +83,7 @@ describe("loadSettingsData", () => {
     }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({
       getTooltips: vi.fn().mockResolvedValue({}),
-      initTooltips: vi.fn()
+      initTooltips: vi.fn().mockResolvedValue(() => {})
     }));
     vi.doMock("../../src/helpers/featureFlags.js", () => ({
       initFeatureFlags: vi.fn().mockRejectedValue(new Error("fail")),
@@ -273,7 +273,7 @@ describe("initializeSettingsPage", () => {
       isEnabled: vi.fn()
     }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({
-      initTooltips: vi.fn(),
+      initTooltips: vi.fn().mockResolvedValue(() => {}),
       getTooltips: vi.fn().mockResolvedValue({})
     }));
     vi.doMock("../../src/helpers/displayMode.js", () => ({

--- a/tests/helpers/tooltip.test.js
+++ b/tests/helpers/tooltip.test.js
@@ -148,6 +148,31 @@ describe("initTooltips", () => {
     await initTooltips();
     expect(document.body.classList.contains("tooltip-overlay-debug")).toBe(false);
   });
+
+  it("returns cleanup function that removes listeners", async () => {
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ stat: { test: "text" } })
+    }));
+
+    const { initTooltips } = await import("../../src/helpers/tooltip.js");
+
+    const el = document.createElement("div");
+    el.dataset.tooltipId = "stat.test";
+    document.body.appendChild(el);
+
+    const cleanup = await initTooltips();
+
+    const tip = document.querySelector(".tooltip");
+    el.dispatchEvent(new Event("mouseenter"));
+    expect(tip.style.display).toBe("block");
+    el.dispatchEvent(new Event("mouseleave"));
+    expect(tip.style.display).toBe("none");
+
+    cleanup();
+
+    el.dispatchEvent(new Event("mouseenter"));
+    expect(tip.style.display).toBe("none");
+  });
 });
 
 describe("flattenTooltips", () => {


### PR DESCRIPTION
## Summary
- return cleanup from initTooltips and remove listeners
- use tooltip cleanup when tearing down UI fragments
- test tooltip cleanup and update mocks

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: environment issue)*
- `npx playwright test` *(fails: 3 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a18544b8c8832689cdb80aada73f27