### PR TITLE
feat: improve debounce cancellation

### DIFF
--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -6,20 +6,32 @@
  * 2. Return a new function that returns a promise.
  * 3. On each call:
  *    - Clear the existing `timer`.
- *    - If a pending promise exists, reject it with `Error('Debounced')`.
+ *    - If a pending promise exists:
+ *       - Reject with `DebounceError` unless suppression is enabled.
+ *       - Invoke `onCancel` callback if provided.
  *    - Store the current promise's `resolve` and `reject` as `pending`.
  *    - Start a new timer with the provided `delay`.
  * 4. When the timer fires, invoke `fn` with the latest arguments.
  *    - Clear `pending`.
  *    - Resolve the promise with `fn`'s return value.
  *    - Reject if `fn` throws an error.
- *
+ */
+export class DebounceError extends Error {
+  /** @param {string} [message="Debounced"] */
+  constructor(message = "Debounced") {
+    super(message);
+    this.name = "DebounceError";
+  }
+}
+
+/**
  * @template {(...args: any[]) => any} F
  * @param {F} fn - Function to debounce.
  * @param {number} delay - Delay in milliseconds.
+ * @param {{suppressRejection?: boolean, onCancel?: (error: DebounceError) => void}} [options]
  * @returns {(...args: Parameters<F>) => Promise<ReturnType<F>>} Debounced function.
  */
-export function debounce(fn, delay) {
+export function debounce(fn, delay, { suppressRejection = false, onCancel } = {}) {
   let timer;
   /** @type {{resolve: (value: any) => void, reject: (reason?: any) => void} | undefined} */
   let pending;
@@ -27,7 +39,13 @@ export function debounce(fn, delay) {
     new Promise((resolve, reject) => {
       clearTimeout(timer);
       if (pending) {
-        pending.reject(new Error("Debounced"));
+        const error = new DebounceError();
+        if (suppressRejection) {
+          pending.resolve();
+        } else {
+          pending.reject(error);
+        }
+        onCancel?.(error);
       }
       pending = { resolve, reject };
       timer = setTimeout(() => {


### PR DESCRIPTION
## Summary
- add `DebounceError` for clearer cancellation signaling
- allow suppressing promise rejection and expose `onCancel` callback
- test debounce suppression and custom error behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot and network issues)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a185ea6d2483269b47471b3b68efe8