### PR TITLE
Surface settings storage errors

### DIFF
--- a/src/helpers/settings/featureFlagSwitches.js
+++ b/src/helpers/settings/featureFlagSwitches.js
@@ -78,18 +78,20 @@ export function renderFeatureFlagSwitches(
         handleUpdate("featureFlags", updated, () => {
           input.checked = prev;
         })
-      ).then(() => {
-        showSnackbar(`${currentLabel} ${input.checked ? "enabled" : "disabled"}`);
-        if (flag === "viewportSimulation") {
-          toggleViewportSimulation(input.checked);
-        }
-        if (flag === "tooltipOverlayDebug") {
-          toggleTooltipOverlayDebug(input.checked);
-        }
-        if (flag === "layoutDebugPanel") {
-          toggleLayoutDebugPanel(input.checked);
-        }
-      });
+      )
+        .then(() => {
+          showSnackbar(`${currentLabel} ${input.checked ? "enabled" : "disabled"}`);
+          if (flag === "viewportSimulation") {
+            toggleViewportSimulation(input.checked);
+          }
+          if (flag === "tooltipOverlayDebug") {
+            toggleTooltipOverlayDebug(input.checked);
+          }
+          if (flag === "layoutDebugPanel") {
+            toggleLayoutDebugPanel(input.checked);
+          }
+        })
+        .catch(() => {});
     });
   });
 }

--- a/src/helpers/settings/gameModeSwitches.js
+++ b/src/helpers/settings/gameModeSwitches.js
@@ -71,9 +71,11 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
         handleUpdate("gameModes", updated, () => {
           input.checked = prev;
         })
-      ).then(() => {
-        showSnackbar(`${label} ${input.checked ? "enabled" : "disabled"}`);
-      });
+      )
+        .then(() => {
+          showSnackbar(`${label} ${input.checked ? "enabled" : "disabled"}`);
+        })
+        .catch(() => {});
       updateNavigationItemHidden(mode.id, !input.checked).catch((err) => {
         console.error("Failed to update navigation item", err);
         input.checked = prev;

--- a/src/helpers/settings/listenerUtils.js
+++ b/src/helpers/settings/listenerUtils.js
@@ -33,9 +33,11 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
       handleUpdate("sound", soundToggle.checked, () => {
         soundToggle.checked = prev;
       })
-    ).then(() => {
-      showSnackbar(`Sound ${soundToggle.checked ? "enabled" : "disabled"}`);
-    });
+    )
+      .then(() => {
+        showSnackbar(`Sound ${soundToggle.checked ? "enabled" : "disabled"}`);
+      })
+      .catch(() => {});
   });
   motionToggle?.addEventListener("change", () => {
     const prev = !motionToggle.checked;
@@ -45,9 +47,11 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
         motionToggle.checked = prev;
         applyMotionPreference(prev);
       })
-    ).then(() => {
-      showSnackbar(`Motion effects ${motionToggle.checked ? "enabled" : "disabled"}`);
-    });
+    )
+      .then(() => {
+        showSnackbar(`Motion effects ${motionToggle.checked ? "enabled" : "disabled"}`);
+      })
+      .catch(() => {});
   });
   if (displayRadios) {
     displayRadios.forEach((radio) => {
@@ -72,10 +76,12 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
               applyDisplayMode(previous);
             });
           })
-        ).then(() => {
-          const label = mode.charAt(0).toUpperCase() + mode.slice(1);
-          showSnackbar(`${label} mode enabled`);
-        });
+        )
+          .then(() => {
+            const label = mode.charAt(0).toUpperCase() + mode.slice(1);
+            showSnackbar(`${label} mode enabled`);
+          })
+          .catch(() => {});
       });
     });
   }
@@ -85,9 +91,11 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
       handleUpdate("typewriterEffect", typewriterToggle.checked, () => {
         typewriterToggle.checked = prev;
       })
-    ).then(() => {
-      showSnackbar(`Typewriter effect ${typewriterToggle.checked ? "enabled" : "disabled"}`);
-    });
+    )
+      .then(() => {
+        showSnackbar(`Typewriter effect ${typewriterToggle.checked ? "enabled" : "disabled"}`);
+      })
+      .catch(() => {});
   });
   tooltipsToggle?.addEventListener("change", () => {
     const prev = !tooltipsToggle.checked;
@@ -95,9 +103,11 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
       handleUpdate("tooltips", tooltipsToggle.checked, () => {
         tooltipsToggle.checked = prev;
       })
-    ).then(() => {
-      showSnackbar(`Tooltips ${tooltipsToggle.checked ? "enabled" : "disabled"}`);
-    });
+    )
+      .then(() => {
+        showSnackbar(`Tooltips ${tooltipsToggle.checked ? "enabled" : "disabled"}`);
+      })
+      .catch(() => {});
   });
   cardOfTheDayToggle?.addEventListener("change", () => {
     const prev = !cardOfTheDayToggle.checked;
@@ -105,9 +115,11 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
       handleUpdate("showCardOfTheDay", cardOfTheDayToggle.checked, () => {
         cardOfTheDayToggle.checked = prev;
       })
-    ).then(() => {
-      showSnackbar(`Card of the Day ${cardOfTheDayToggle.checked ? "enabled" : "disabled"}`);
-    });
+    )
+      .then(() => {
+        showSnackbar(`Card of the Day ${cardOfTheDayToggle.checked ? "enabled" : "disabled"}`);
+      })
+      .catch(() => {});
   });
   fullNavigationMapToggle?.addEventListener("change", () => {
     const prev = !fullNavigationMapToggle.checked;
@@ -115,10 +127,12 @@ export function attachToggleListeners(controls, getCurrentSettings, handleUpdate
       handleUpdate("fullNavigationMap", fullNavigationMapToggle.checked, () => {
         fullNavigationMapToggle.checked = prev;
       })
-    ).then(() => {
-      showSnackbar(
-        `Full navigation map ${fullNavigationMapToggle.checked ? "enabled" : "disabled"}`
-      );
-    });
+    )
+      .then(() => {
+        showSnackbar(
+          `Full navigation map ${fullNavigationMapToggle.checked ? "enabled" : "disabled"}`
+        );
+      })
+      .catch(() => {});
   });
 }

--- a/src/helpers/settings/makeHandleUpdate.js
+++ b/src/helpers/settings/makeHandleUpdate.js
@@ -4,7 +4,7 @@
  * @pseudocode
  * 1. Call `updateSetting` with the provided key/value.
  * 2. On success, store the returned settings via `setCurrentSettings`.
- * 3. On failure, log an error and invoke `showErrorAndRevert` with `revert`.
+ * 3. On failure, log an error, invoke `showErrorAndRevert` with `revert`, and rethrow.
  *
  * @param {(settings: object) => void} setCurrentSettings - Stores updated settings.
  * @param {(revert?: Function) => void} showErrorAndRevert - Displays an error and reverts UI state.
@@ -17,10 +17,12 @@ export function makeHandleUpdate(setCurrentSettings, showErrorAndRevert) {
     return updateSetting(key, value)
       .then((updated) => {
         setCurrentSettings(updated);
+        return updated;
       })
       .catch((err) => {
         console.error("Failed to update setting", err);
         showErrorAndRevert(revert);
+        throw err;
       });
   };
 }

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -192,7 +192,7 @@ function makeRenderSwitches(controls, getCurrentSettings, handleUpdate) {
     let next = current;
     if (radio && radio.value !== current.displayMode) {
       withViewTransition(() => applyDisplayMode(radio.value));
-      handleUpdate("displayMode", radio.value, () => {});
+      handleUpdate("displayMode", radio.value, () => {}).catch(() => {});
       next = { ...current, displayMode: radio.value };
     }
     applyInitialControlValues(controls, next, tooltipMap);

--- a/src/helpers/settingsStorage.js
+++ b/src/helpers/settingsStorage.js
@@ -19,13 +19,13 @@ const debouncedSave = debounce((settings) => {
  *
  * @pseudocode
  * 1. Invoke `debouncedSave` with `settings`.
- * 2. Ignore any rejection from `debouncedSave` and return its promise.
+ * 2. Return the resulting promise so callers can handle failures.
  *
  * @param {import("./settingsSchema.js").Settings} settings - Settings object to save.
  * @returns {Promise<void>} Resolves when the write completes.
  */
 export function saveSettings(settings) {
-  return debouncedSave(settings).catch(() => {});
+  return debouncedSave(settings);
 }
 
 /**

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -87,12 +87,12 @@ describe("settings utils", () => {
     expect(JSON.parse(localStorage.getItem("settings"))).toEqual(data);
   });
 
-  it("does not throw if localStorage is unavailable", async () => {
+  it("rejects if localStorage is unavailable", async () => {
     const original = global.localStorage;
     // Simulate localStorage being undefined
     Object.defineProperty(global, "localStorage", { value: undefined, configurable: true });
     const { saveSettings, loadSettings } = await import("../../src/helpers/settingsStorage.js");
-    await expect(saveSettings({ sound: true })).resolves.toBeUndefined();
+    await expect(saveSettings({ sound: true })).rejects.toThrow("localStorage unavailable");
     await expect(loadSettings()).rejects.toThrow();
     Object.defineProperty(global, "localStorage", { value: original, configurable: true });
   });
@@ -133,9 +133,9 @@ describe("settings utils", () => {
   });
 
   /**
-   * Should swallow errors when localStorage.setItem throws.
+   * Should reject when localStorage.setItem throws.
    */
-  it("swallows errors when localStorage.setItem throws", async () => {
+  it("rejects when localStorage.setItem throws", async () => {
     Storage.prototype.setItem = vi.fn(() => {
       throw new Error("fail");
     });
@@ -156,7 +156,7 @@ describe("settings utils", () => {
           enableCardInspector: { enabled: false }
         }
       })
-    ).resolves.toBeUndefined();
+    ).rejects.toThrow("fail");
     Storage.prototype.setItem = originalSetItem;
   });
 
@@ -214,7 +214,7 @@ describe("settings utils", () => {
     };
     const first = saveSettings(data1);
     const second = saveSettings(data2);
-    await expect(first).resolves.toBeUndefined();
+    await expect(first).rejects.toThrow("Debounced");
     await vi.advanceTimersByTimeAsync(110);
     await expect(second).resolves.toBeUndefined();
     expect(setItemSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- Let `saveSettings` propagate errors instead of silently swallowing them
- Rethrow failures from `makeHandleUpdate` and catch them in settings listeners
- Adjust tests for new rejection behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a185df33f48326b173517a1e5e23f5