### PR TITLE
Use real settings in dataUtils mocks

### DIFF
--- a/tests/helpers/battleEngineTimer.test.js
+++ b/tests/helpers/battleEngineTimer.test.js
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import defaultSettings from "../../src/data/settings.json" with { type: "json" };
 
 const mockTimers = [{ id: 1, value: 42, default: true, category: "roundTimer" }];
 
@@ -7,7 +8,7 @@ beforeEach(() => {
   vi.resetModules();
   vi.doMock("../../src/helpers/dataUtils.js", () => ({
     fetchJson: vi.fn().mockResolvedValue(mockTimers),
-    importJsonModule: vi.fn()
+    importJsonModule: vi.fn().mockResolvedValue(defaultSettings)
   }));
 });
 

--- a/tests/helpers/classicBattle/autoSelect.test.js
+++ b/tests/helpers/classicBattle/autoSelect.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setupClassicBattleDom } from "./utils.js";
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -41,7 +42,7 @@ vi.mock("../../../src/components/JudokaCard.js", () => {
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
   fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn()
+  importJsonModule: vi.fn().mockResolvedValue(defaultSettings)
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers, resetDom } from "../../utils/testUtils.js";
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
@@ -26,7 +27,7 @@ vi.mock("../../../src/components/JudokaCard.js", () => {
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
   fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn()
+  importJsonModule: vi.fn().mockResolvedValue(defaultSettings)
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/interrupt.test.js
+++ b/tests/helpers/classicBattle/interrupt.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setupClassicBattleDom } from "./utils.js";
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -41,7 +42,7 @@ vi.mock("../../../src/components/JudokaCard.js", () => {
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
   fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn()
+  importJsonModule: vi.fn().mockResolvedValue(defaultSettings)
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/matchEnd.test.js
+++ b/tests/helpers/classicBattle/matchEnd.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setupClassicBattleDom } from "./utils.js";
 import { CLASSIC_BATTLE_POINTS_TO_WIN } from "../../../src/helpers/constants.js";
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -42,7 +43,7 @@ vi.mock("../../../src/components/JudokaCard.js", () => {
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
   fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn()
+  importJsonModule: vi.fn().mockResolvedValue(defaultSettings)
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/mocks.js
+++ b/tests/helpers/classicBattle/mocks.js
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 import classicBattleStates from "../../../src/data/classicBattleStates.json" with { type: "json" };
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 
 export function mockScheduler() {
   vi.mock("../../../src/utils/scheduler.js", () => ({
@@ -34,7 +35,7 @@ export function mockDataUtils(fetchImplementation) {
 
   vi.doMock("../../../src/helpers/dataUtils.js", () => ({
     fetchJson: vi.fn(fetchImplementation || defaultFetch),
-    importJsonModule: vi.fn(async () => ({}))
+    importJsonModule: vi.fn(async () => defaultSettings)
   }));
 }
 

--- a/tests/helpers/classicBattle/pauseTimer.test.js
+++ b/tests/helpers/classicBattle/pauseTimer.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -25,7 +26,7 @@ vi.mock("../../../src/components/JudokaCard.js", () => {
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
   fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn()
+  importJsonModule: vi.fn().mockResolvedValue(defaultSettings)
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setupClassicBattleDom } from "./utils.js";
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -41,7 +42,7 @@ vi.mock("../../../src/components/JudokaCard.js", () => {
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
   fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn()
+  importJsonModule: vi.fn().mockResolvedValue(defaultSettings)
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/selectionPrompt.test.js
+++ b/tests/helpers/classicBattle/selectionPrompt.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setupClassicBattleDom } from "./utils.js";
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -41,7 +42,7 @@ vi.mock("../../../src/components/JudokaCard.js", () => {
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
   fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn()
+  importJsonModule: vi.fn().mockResolvedValue(defaultSettings)
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
@@ -33,7 +34,7 @@ vi.mock("../../../src/components/JudokaCard.js", () => {
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
   fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn()
+  importJsonModule: vi.fn().mockResolvedValue(defaultSettings)
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
-import { STATS } from "../../../src/helpers/battleEngineFacade.js";
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
@@ -43,7 +43,7 @@ vi.mock("../../../src/components/JudokaCard.js", () => {
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
   fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn()
+  importJsonModule: vi.fn().mockResolvedValue(defaultSettings)
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({
@@ -216,7 +216,8 @@ describe("classicBattle stat selection", () => {
     expect(orchestrator.__getStateLog()).toEqual(["roundOver", "matchDecision"]);
   });
 
-  it("simulateOpponentStat returns a valid stat", () => {
+  it("simulateOpponentStat returns a valid stat", async () => {
+    const { STATS } = await import("../../../src/helpers/battleEngineFacade.js");
     const stat = simulateOpponentStat();
     expect(STATS.includes(stat)).toBe(true);
   });

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createNextButton, createNextRoundTimer } from "./utils.js";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 
 describe("timerService next round handling", () => {
   it("clicking Next during cooldown skips current phase", async () => {
@@ -101,7 +102,7 @@ vi.mock("../../../src/components/JudokaCard.js", () => {
 let fetchJsonMock;
 vi.mock("../../../src/helpers/dataUtils.js", () => ({
   fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn()
+  importJsonModule: vi.fn().mockResolvedValue(defaultSettings)
 }));
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({

--- a/tests/helpers/gameModeUtils.test.js
+++ b/tests/helpers/gameModeUtils.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import defaultSettings from "../../src/data/settings.json" with { type: "json" };
 
 describe("loadNavigationItems", () => {
   it("returns static fallback when cache and import fail", async () => {
@@ -12,7 +13,7 @@ describe("loadNavigationItems", () => {
       validateWithSchema: vi.fn(),
       importJsonModule: vi.fn(async (path) => {
         if (path.includes("navigationItems.json")) throw new Error("import fail");
-        return [];
+        return defaultSettings;
       })
     }));
     vi.doMock("../../src/helpers/storage.js", () => ({

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createSettingsDom, resetDom } from "../utils/testUtils.js";
+import defaultSettings from "../../src/data/settings.json" with { type: "json" };
 
 const baseSettings = {
   sound: true,
@@ -270,7 +271,7 @@ describe("initializeSettingsPage", () => {
       importJsonModule: vi.fn(async (path) => {
         if (path.includes("navigationItems.json")) return navItems;
         if (path.includes("gameModes.json")) return modes;
-        return {};
+        return defaultSettings;
       })
     }));
     vi.doMock("../../src/helpers/storage.js", () => ({


### PR DESCRIPTION
## Summary
- ensure tests mocking `dataUtils` resolve real settings
- update classic battle test helper to return default settings

## Testing
- `npx prettier . --check` *(fails: Code style issues found in 7 files)*
- `npx eslint .` *(fails: prettier/prettier errors in existing files)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a20eea4ec48326ad470f1c9d43a564