### PR TITLE
Refactor classic battle tests with DOM helpers

### DIFF
--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
+import { createRoundMessage, createSnackbarContainer, createTimerNodes } from "./domUtils.js";
 import * as snackbar from "../../../src/helpers/showSnackbar.js";
 vi.mock("../../../src/utils/scheduler.js", () => ({
   onFrame: (cb) => {
@@ -36,17 +37,12 @@ describe("countdown resets after stat selection", () => {
     document.body.innerHTML = "";
     const { playerCard, computerCard } = createBattleCardContainers();
     const header = createBattleHeader();
-    const roundResult = document.createElement("p");
-    roundResult.id = "round-result";
-    const nextBtn = document.createElement("button");
-    nextBtn.id = "next-button";
-    document.body.append(playerCard, computerCard, header, roundResult, nextBtn);
+    header.querySelector("#next-round-timer")?.remove();
+    document.body.append(playerCard, computerCard, header);
+    createRoundMessage("round-result");
+    createTimerNodes();
     document.body.innerHTML += '<div id="stat-buttons"><button data-stat="power"></button></div>';
-    const container = document.createElement("div");
-    container.id = "snackbar-container";
-    container.setAttribute("role", "status");
-    container.setAttribute("aria-live", "polite");
-    document.body.append(container);
+    createSnackbarContainer();
     battleMod = await import("../../../src/helpers/classicBattle.js");
     store = battleMod.createBattleStore();
     battleMod._resetForTest(store);

--- a/tests/helpers/classicBattle/domUtils.js
+++ b/tests/helpers/classicBattle/domUtils.js
@@ -1,0 +1,30 @@
+export function createSnackbarContainer() {
+  const container = document.createElement("div");
+  container.id = "snackbar-container";
+  container.setAttribute("role", "status");
+  container.setAttribute("aria-live", "polite");
+  document.body.appendChild(container);
+  return container;
+}
+
+export function createRoundMessage(id = "round-message") {
+  const el = document.createElement("p");
+  el.id = id;
+  el.setAttribute("aria-live", "polite");
+  el.setAttribute("aria-atomic", "true");
+  el.setAttribute("role", "status");
+  document.body.appendChild(el);
+  return el;
+}
+
+export function createTimerNodes() {
+  const nextButton = document.createElement("button");
+  nextButton.id = "next-button";
+  const nextRoundTimer = document.createElement("p");
+  nextRoundTimer.id = "next-round-timer";
+  nextRoundTimer.setAttribute("aria-live", "polite");
+  nextRoundTimer.setAttribute("aria-atomic", "true");
+  nextRoundTimer.setAttribute("role", "status");
+  document.body.append(nextButton, nextRoundTimer);
+  return { nextButton, nextRoundTimer };
+}

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createRoundMessage, createTimerNodes } from "./domUtils.js";
 
 vi.mock("../../../src/helpers/classicBattle/quitModal.js", () => ({
   quitMatch: () => {
@@ -10,12 +11,14 @@ vi.mock("../../../src/helpers/classicBattle/quitModal.js", () => ({
 
 describe("classicBattle match controls", () => {
   beforeEach(() => {
-    document.body.innerHTML = `
-      <div id="round-message"></div>
-      <button id="next-button" disabled></button>
-      <button id="quit-match-button"></button>
-      <header></header>
-    `;
+    document.body.innerHTML = "";
+    createRoundMessage();
+    const { nextButton } = createTimerNodes();
+    nextButton.disabled = true;
+    const quitBtn = document.createElement("button");
+    quitBtn.id = "quit-match-button";
+    const header = document.createElement("header");
+    document.body.append(quitBtn, header);
     window.location.href = "http://localhost/src/pages/battleJudoka.html";
     vi.resetModules();
   });

--- a/tests/helpers/classicBattle/pauseTimer.test.js
+++ b/tests/helpers/classicBattle/pauseTimer.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
+import { createRoundMessage } from "./domUtils.js";
 import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
@@ -44,10 +45,7 @@ describe("classicBattle timer pause", () => {
     document.body.innerHTML = "";
     const { playerCard, computerCard } = createBattleCardContainers();
     const header = createBattleHeader();
-    const roundResult = document.createElement("p");
-    roundResult.id = "round-result";
-    roundResult.setAttribute("aria-live", "polite");
-    roundResult.setAttribute("aria-atomic", "true");
+    const roundResult = createRoundMessage("round-result");
     const statButtons = document.createElement("div");
     statButtons.id = "stat-buttons";
     statButtons.dataset.tooltipId = "ui.selectStat";

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setupClassicBattleDom } from "./utils.js";
+import { createTimerNodes } from "./domUtils.js";
 import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
@@ -76,10 +77,9 @@ afterEach(() => {
 
 describe("classicBattle scheduleNextRound", () => {
   it("auto-dispatches ready after cooldown", async () => {
-    const nextBtn = document.createElement("button");
-    nextBtn.id = "next-button";
-    nextBtn.disabled = true;
-    document.body.appendChild(nextBtn);
+    document.getElementById("next-round-timer")?.remove();
+    const { nextButton } = createTimerNodes();
+    nextButton.disabled = true;
 
     fetchJsonMock.mockImplementation(async (url) => {
       if (String(url).includes("gameTimers.json")) {

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { createNextButton, createNextRoundTimer } from "./utils.js";
+import { createTimerNodes } from "./domUtils.js";
 
 describe("timerService drift handling", () => {
   it("startTimer shows fallback on drift", async () => {
@@ -58,8 +58,7 @@ describe("timerService drift handling", () => {
     });
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
     const timer = vi.useFakeTimers();
-    createNextButton();
-    createNextRoundTimer();
+    createTimerNodes();
     mod.scheduleNextRound({ matchEnded: false });
     timer.advanceTimersByTime(2000);
     onDrift(1);

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createNextButton, createNextRoundTimer } from "./utils.js";
+import { createTimerNodes } from "./domUtils.js";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
 import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
 
@@ -31,16 +31,15 @@ describe("timerService next round handling", () => {
       dispatchBattleEvent
     }));
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
-    const btn = createNextButton();
-    btn.addEventListener("click", mod.onNextButtonClick);
-    createNextRoundTimer();
+    const { nextButton } = createTimerNodes();
+    nextButton.addEventListener("click", mod.onNextButtonClick);
     mod.scheduleNextRound({ matchEnded: false });
-    btn.click();
+    nextButton.click();
     await vi.waitFor(() => {
       expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
     });
     expect(dispatchBattleEvent).toHaveBeenCalledTimes(2);
-    expect(btn.dataset.nextReady).toBeUndefined();
+    expect(nextButton.dataset.nextReady).toBeUndefined();
   });
 
   it("auto-dispatches ready when cooldown finishes", async () => {
@@ -72,8 +71,7 @@ describe("timerService next round handling", () => {
       dispatchBattleEvent
     }));
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
-    createNextButton();
-    createNextRoundTimer();
+    createTimerNodes();
     mod.scheduleNextRound({ matchEnded: false });
     await vi.waitFor(() => {
       expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
@@ -138,10 +136,10 @@ describe("scheduleNextRound early click", () => {
     document.body.innerHTML = "";
     const { playerCard, computerCard } = createBattleCardContainers();
     const header = createBattleHeader();
+    header.querySelector("#next-round-timer")?.remove();
     document.body.append(playerCard, computerCard, header);
-    const btn = createNextButton();
-    btn.disabled = true;
-    createNextRoundTimer();
+    const { nextButton } = createTimerNodes();
+    nextButton.disabled = true;
     timerSpy = vi.useFakeTimers();
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/tests/helpers/classicBattle/utils.js
+++ b/tests/helpers/classicBattle/utils.js
@@ -41,17 +41,3 @@ export function setupClassicBattleDom() {
     currentFlags
   };
 }
-
-export function createNextButton() {
-  const btn = document.createElement("button");
-  btn.id = "next-button";
-  document.body.appendChild(btn);
-  return btn;
-}
-
-export function createNextRoundTimer() {
-  const timerNode = document.createElement("p");
-  timerNode.id = "next-round-timer";
-  document.body.appendChild(timerNode);
-  return timerNode;
-}


### PR DESCRIPTION
## Summary
- add `domUtils` test helpers for snackbar, round messages, and timer nodes
- refactor classic battle tests to reuse shared DOM helpers

## Testing
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`
- `npx prettier . --check`


------
https://chatgpt.com/codex/tasks/task_e_68a21a8fa39883269c3eb0ef8ee8e42f