### PR TITLE
Sanitize card HTML

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -5,15 +5,18 @@
  * 1. Use a `<div>` element by default or an `<a>` element when `href` is provided.
  * 2. Apply `id`, `href`, `className` and `onClick` options if present.
  * 3. Always include the `card` class plus any additional `className`.
- * 4. Insert string content with `textContent` by default, or with `innerHTML`
- *    when `html` is true.
+ * 4. Insert string content with `textContent` by default, or with sanitized
+ *    HTML when `html` is true.
  *
  * @class
  */
+import { getSanitizer } from "../helpers/sanitizeHtml.js";
+
 export class Card {
   /**
    * @param {string|Node} content - Text or HTML to place inside the card.
-   * @param {{id?: string, className?: string, href?: string, onClick?: Function, html?: boolean}} [options] - Optional settings. When `html` is true, `content` must be pre-sanitized.
+   * @param {{id?: string, className?: string, href?: string, onClick?: Function, html?: boolean}} [options] - Optional settings.
+   *    When `html` is true, the `content` string is sanitized before insertion.
    */
   constructor(content, options = {}) {
     const { id, className, href, onClick, html = false } = options;
@@ -31,7 +34,10 @@ export class Card {
     }
     if (typeof content === "string") {
       if (html) {
-        this.element.innerHTML = content;
+        // Sanitize HTML content before inserting into the DOM
+        getSanitizer().then(({ sanitize }) => {
+          this.element.innerHTML = sanitize(content);
+        });
       } else {
         this.element.textContent = content;
       }

--- a/tests/helpers/cardComponent.test.js
+++ b/tests/helpers/cardComponent.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { Card, createCard } from "../../src/components/Card.js";
+import { getSanitizer } from "../../src/helpers/sanitizeHtml.js";
 
 describe("createCard", () => {
   it("creates a div card with text content", () => {
@@ -9,8 +10,10 @@ describe("createCard", () => {
     expect(card.textContent).toBe("Hello");
   });
 
-  it("inserts HTML when the html flag is true", () => {
-    const card = createCard("<em>hi</em>", { html: true });
+  it("inserts sanitized HTML when the html flag is true", async () => {
+    const { sanitize } = await getSanitizer();
+    const card = createCard(sanitize("<em>hi</em>"), { html: true });
+    await Promise.resolve();
     expect(card.innerHTML).toBe("<em>hi</em>");
   });
 


### PR DESCRIPTION
## Summary
- sanitize Card HTML content before DOM insertion
- sanitize Card test fixture before usage

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a22a3026d48326b87696359a3e2bae