### PR TITLE
Return cleanup from setupHamburger

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -47,7 +47,7 @@ import { buildMenu, setupHamburger } from "../helpers/api/navigation.js";
 ```
 
 - `buildMenu(gameModes, { orientation })` returns the created menu element.
-- `setupHamburger(breakpoint?)` inserts a toggle button and returns `{button, list}`.
+- `setupHamburger(breakpoint?)` inserts a toggle button and returns a cleanup function for the resize listener.
 
 ### helpers/vector search
 

--- a/src/helpers/api/navigation.js
+++ b/src/helpers/api/navigation.js
@@ -164,15 +164,15 @@ export function buildMenu(gameModes, { orientation }) {
  * 3. Define `update()` to insert the button and hide the list when the width is below the breakpoint; otherwise remove the button.
  * 4. Define `toggle()` to flip `aria-expanded` and the `.expanded` class on the list.
  * 5. Attach `click` and `resize` listeners and invoke `update()` once.
- * 6. Return the button and list elements for further wiring.
+ * 6. Return a cleanup function that removes the `resize` listener.
  *
  * @param {number} [breakpoint=480] - Maximum width to show the hamburger menu.
- * @returns {{button: HTMLButtonElement|null, list: HTMLUListElement|null}} DOM hooks.
+ * @returns {() => void} Cleanup function to remove the `resize` listener.
  */
 export function setupHamburger(breakpoint = 480) {
   const navBar = document.querySelector(".bottom-navbar");
   const list = navBar?.querySelector("ul") || null;
-  if (!navBar || !list) return { button: null, list };
+  if (!navBar || !list) return () => {};
 
   const id = list.id || "bottom-nav-menu";
   list.id = id;
@@ -209,5 +209,7 @@ export function setupHamburger(breakpoint = 480) {
   window.addEventListener("resize", update);
   update();
 
-  return { button, list };
+  return () => {
+    window.removeEventListener("resize", update);
+  };
 }

--- a/src/helpers/navigation/navMenu.js
+++ b/src/helpers/navigation/navMenu.js
@@ -35,10 +35,10 @@ export function togglePortraitTextMenu(gameModes) {
  *
  * @pseudocode
  * 1. Delegate to {@link setupHamburger} with the provided breakpoint.
- * 2. Return the DOM hooks from the API.
+ * 2. Return the cleanup function from the API.
  *
  * @param {number} [breakpoint=480] - Maximum width to show the hamburger menu.
- * @returns {{button: HTMLButtonElement|null, list: HTMLUListElement|null}} DOM hooks.
+ * @returns {() => void} Cleanup function to remove the `resize` listener.
  */
 export function setupHamburgerMenu(breakpoint = 480) {
   return setupHamburger(breakpoint);

--- a/tests/helpers/navMenuResponsive.test.js
+++ b/tests/helpers/navMenuResponsive.test.js
@@ -1,14 +1,21 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { setupHamburger } from "../../src/helpers/api/navigation.js";
 
 describe("setupHamburger", () => {
+  let cleanup;
+
   beforeEach(() => {
     document.body.innerHTML = '<nav class="bottom-navbar"><ul><li></li></ul></nav>';
     window.innerWidth = 320;
+    cleanup = () => {};
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it("creates a toggle button and toggles aria-expanded", () => {
-    setupHamburger();
+    cleanup = setupHamburger();
     const button = document.querySelector(".nav-toggle");
     const list = document.querySelector(".bottom-navbar ul");
     expect(button).toBeTruthy();
@@ -19,7 +26,7 @@ describe("setupHamburger", () => {
   });
 
   it("removes the button when resized above breakpoint", () => {
-    setupHamburger();
+    cleanup = setupHamburger();
     window.innerWidth = 1024;
     window.dispatchEvent(new Event("resize"));
     expect(document.querySelector(".nav-toggle")).toBeNull();


### PR DESCRIPTION
## Summary
- return a cleanup function from setupHamburger to remove the resize listener
- update nav menu wrapper and design docs for new API
- invoke cleanup during responsive nav tests

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: 1)*
- `npx vitest run tests/helpers/navMenuResponsive.test.js`
- `npx playwright test` *(failed: battleJudoka.spec.js, browse-judoka-navigation.spec.js, changelog.spec.js, classicBattleFlow.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a22f958c848326b09e4248f8654c27