### PR TITLE
Handle null story input in quote builder

### DIFF
--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -62,27 +62,29 @@ async function fetchFables() {
  * Formats a fable's story by replacing newline characters with HTML tags for proper rendering.
  *
  * @pseudocode
- * 1. Normalize newline characters:
+ * 1. Coerce the story to a string.
+ *
+ * 2. Normalize newline characters:
  *    - Replace escaped newline characters (`\\n`) with actual newline characters (`\n`).
  *
- * 2. Split the story into paragraphs:
+ * 3. Split the story into paragraphs:
  *    - Use `.split(/\n{2,}/)` to divide the story into paragraphs based on double or more consecutive newlines.
  *    - Trim each paragraph and filter out empty paragraphs.
  *
- * 3. Format each paragraph:
+ * 4. Format each paragraph:
  *    - Wrap each paragraph in `<p>` tags.
  *    - Replace single newline characters (`\n`) within paragraphs with `<br>` tags for line breaks.
  *
- * 4. Combine formatted paragraphs:
+ * 5. Combine formatted paragraphs:
  *    - Join the paragraphs into a single HTML string.
  *
- * 5. Return the formatted story.
+ * 6. Return the formatted story.
  *
  * @param {string} story - The fable's story text to format.
  * @returns {string} The formatted story with HTML tags for rendering.
  */
-function formatFableStory(story) {
-  story = story.replace(/\\n/g, "\n");
+export function formatFableStory(story) {
+  story = String(story ?? "").replace(/\\n/g, "\n");
 
   return story
     .trim()

--- a/tests/helpers/quoteBuilder.test.js
+++ b/tests/helpers/quoteBuilder.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { loadQuote } from "../../src/helpers/quoteBuilder.js";
+import { loadQuote, formatFableStory } from "../../src/helpers/quoteBuilder.js";
 
 const originalFetch = global.fetch;
 
@@ -97,5 +97,12 @@ describe("loadQuote", () => {
     await loadQuote();
     await vi.runAllTimersAsync();
     // Should not throw even if #quote, #quote-loader, or #language-toggle are missing
+  });
+});
+
+describe("formatFableStory", () => {
+  it("returns empty string for null or undefined", () => {
+    expect(formatFableStory(null)).toBe("");
+    expect(formatFableStory(undefined)).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- Safely coerce fable story text to a string before formatting
- Test formatFableStory with null and undefined inputs

## Testing
- `npx prettier src/helpers/quoteBuilder.js tests/helpers/quoteBuilder.test.js --check`
- `npx eslint .`
- `npx vitest run --reporter=basic`
- `npx playwright test` *(fails: screenshot diffs and interrupted tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a22f8af2f483269e9457cba9210754