### PR TITLE
refactor randomCard error handling with try-catch

### DIFF
--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -65,7 +65,7 @@ export async function createCardForJudoka(judoka, gokyoLookup, containerEl, pref
  *    with the chosen judoka when provided.
  * 4. Generate and display the card with `createCardForJudoka`.
  * 5. On any error, log the issue and load the fallback judoka using
- *    `getFallbackJudoka()` before displaying its card.
+ *    `getFallbackJudoka()`, then display its card and log any display error.
  *
  * @param {Judoka[]} [activeCards] - Preloaded judoka data.
  * @param {GokyoEntry[]} [gokyoData] - Preloaded gokyo data.
@@ -120,10 +120,10 @@ export async function generateRandomCard(
     if (typeof onSelect === "function") {
       onSelect(fallbackJudoka);
     }
-    await createCardForJudoka(fallbackJudoka, gokyoLookup, containerEl, prefersReducedMotion).catch(
-      (fallbackError) => {
-        console.error("Error displaying fallback card:", fallbackError);
-      }
-    );
+    try {
+      await createCardForJudoka(fallbackJudoka, gokyoLookup, containerEl, prefersReducedMotion);
+    } catch (fallbackError) {
+      console.error("Error displaying fallback card:", fallbackError);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- simplify fallback card generation by using a try/catch instead of `await … .catch`
- mention error logging in random card pseudocode

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a22f800b9c8326bb5d68974c6b2a22