### PR TITLE
test: cover missing tooltip id fallback

### DIFF
--- a/tests/helpers/tooltip.test.js
+++ b/tests/helpers/tooltip.test.js
@@ -58,6 +58,30 @@ describe("initTooltips", () => {
     warn.mockRestore();
   });
 
+  it("shows fallback text and warns once when id is missing", async () => {
+    const fetchJson = vi.fn().mockResolvedValue({});
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { initTooltips } = await import("../../src/helpers/tooltip.js");
+
+    const el = document.createElement("div");
+    el.setAttribute("data-tooltip-id", "");
+    document.body.appendChild(el);
+
+    await initTooltips();
+
+    const tip = document.querySelector(".tooltip");
+
+    el.dispatchEvent(new Event("mouseenter"));
+    expect(tip.textContent).toBe("More info coming…");
+    el.dispatchEvent(new Event("mouseleave"));
+    el.dispatchEvent(new Event("mouseenter"));
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
   it("falls back to leaf keys for parent ids", async () => {
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- add regression test for empty `data-tooltip-id` showing default text

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a23850e21c832699265df330d0d634