### PR TITLE
feat(tooltip): use markdown parser

### DIFF
--- a/src/helpers/tooltip.js
+++ b/src/helpers/tooltip.js
@@ -1,6 +1,7 @@
 import { fetchJson, importJsonModule } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
 import { escapeHTML } from "./utils.js";
+import { marked } from "../vendor/marked.esm.js";
 import { loadSettings } from "./settingsStorage.js";
 import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
 import { getSanitizer } from "./sanitizeHtml.js";
@@ -81,10 +82,9 @@ export function getTooltips() {
  * @pseudocode
  * 1. Escape HTML in `text` using `escapeHTML`.
  * 2. Count occurrences of `**` and `_` to detect unbalanced markers.
- * 3. Replace newline characters with `<br>`.
- * 4. Replace `**bold**` with `<strong>` elements.
- * 5. Replace `_italic_` with `<em>` elements.
- * 6. Return an object with `html` and a `warning` flag when markers are unbalanced.
+ * 3. Parse the markdown with `marked.parseInline`.
+ * 4. Replace newline characters with `<br>`.
+ * 5. Return an object with `html` and a `warning` flag when markers are unbalanced.
  *
  * @param {string} text - Raw tooltip text to parse.
  * @returns {{ html: string, warning: boolean }} Parsed HTML and warning flag.
@@ -95,10 +95,7 @@ export function parseTooltipText(text) {
   const italicPairMatches = safe.match(/_(.*?)_/g) || [];
   const totalUnderscores = (safe.match(/_/g) || []).length;
   const warning = boldCount % 2 !== 0 || totalUnderscores !== italicPairMatches.length * 2;
-  const html = safe
-    .replace(/\n/g, "<br>")
-    .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
-    .replace(/_(.*?)_/g, "<em>$1</em>");
+  const html = marked.parseInline(safe).replace(/\n/g, "<br>");
   return { html, warning };
 }
 

--- a/src/vendor/marked.esm.js
+++ b/src/vendor/marked.esm.js
@@ -1,16 +1,17 @@
+function renderInline(text) {
+  return text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>").replace(/_(.+?)_/g, "<em>$1</em>");
+}
+
 export const marked = {
   /**
-   * Very small markdown parser supporting headings, bold text paragraphs, lists,
-   * tables and horizontal rules (each rule followed by a line break for spacing).
+   * Very small markdown parser supporting headings, bold and italic text,
+   * paragraphs, lists, tables and horizontal rules (each rule followed by a
+   * line break for spacing).
    *
    * @param {string} md - Markdown string.
    * @returns {string} HTML string.
    */
   parse(md) {
-    function renderInline(text) {
-      return text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
-    }
-
     function renderList(lines) {
       let html = "";
       const stack = [];
@@ -109,5 +110,14 @@ export const marked = {
         return `<p>${renderInline(block.trim())}</p>`;
       })
       .join("");
+  },
+  /**
+   * Parse inline markdown (no block handling).
+   *
+   * @param {string} md - Markdown string.
+   * @returns {string} HTML string.
+   */
+  parseInline(md) {
+    return renderInline(md);
   }
 };

--- a/tests/helpers/parseTooltipText.test.js
+++ b/tests/helpers/parseTooltipText.test.js
@@ -24,4 +24,16 @@ describe("parseTooltipText", () => {
     const { warning } = parseTooltipText("**Bold");
     expect(warning).toBe(true);
   });
+
+  it("renders nested markup", () => {
+    const { html, warning } = parseTooltipText("**bold _italic_**");
+    expect(html).toBe("<strong>bold <em>italic</em></strong>");
+    expect(warning).toBe(false);
+  });
+
+  it("warns on edge-case markup", () => {
+    const { html, warning } = parseTooltipText("**bold _italic**");
+    expect(html).toBe("<strong>bold _italic</strong>");
+    expect(warning).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- use small markdown parser for tooltip rendering
- extend minimal parser with italics and inline parsing
- cover nested and edge-case markup in tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a23698234c832688b4dab2584739eb