### PR TITLE
feat: add deep merge utility

### DIFF
--- a/src/utils/deepMerge.js
+++ b/src/utils/deepMerge.js
@@ -1,0 +1,37 @@
+/**
+ * Deep merge two plain objects.
+ * Arrays are replaced, not merged, and inputs are not mutated.
+ *
+ * @pseudocode
+ * 1. Create a shallow copy of `target`.
+ * 2. For each key in `source`:
+ *    - If both values are plain objects, recursively merge them.
+ *    - Otherwise, assign a cloned array or the source value.
+ * 3. Return the merged copy.
+ *
+ * @param {Record<string, any>} target
+ * @param {Record<string, any>} source
+ * @returns {Record<string, any>} New merged object.
+ */
+export function deepMerge(target, source) {
+  const result = { ...target };
+  for (const [key, value] of Object.entries(source)) {
+    const targetValue = target[key];
+    if (isPlainObject(targetValue) && isPlainObject(value)) {
+      result[key] = deepMerge(targetValue, value);
+    } else if (Array.isArray(value)) {
+      result[key] = [...value];
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * @param {any} value
+ * @returns {value is Record<string, any>}
+ */
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/utils/deepMerge.test.js
+++ b/tests/utils/deepMerge.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { deepMerge } from "../../src/utils/deepMerge.js";
+
+describe("deepMerge", () => {
+  it("merges nested objects without mutating inputs", () => {
+    const a = { foo: { bar: 1, baz: 2 } };
+    const b = { foo: { bar: 3 } };
+    const result = deepMerge(a, b);
+    expect(result).toEqual({ foo: { bar: 3, baz: 2 } });
+    expect(a).toEqual({ foo: { bar: 1, baz: 2 } });
+    expect(b).toEqual({ foo: { bar: 3 } });
+  });
+
+  it("replaces arrays and clones them", () => {
+    const a = { list: [1, 2] };
+    const arr = [3];
+    const b = { list: arr };
+    const result = deepMerge(a, b);
+    expect(result.list).toEqual([3]);
+    expect(result.list).not.toBe(arr);
+    expect(a.list).toEqual([1, 2]);
+  });
+
+  it("overrides non-object values", () => {
+    const a = { count: 1, flag: true };
+    const b = { count: 2, flag: false };
+    const result = deepMerge(a, b);
+    expect(result).toEqual({ count: 2, flag: false });
+  });
+});


### PR DESCRIPTION
## Summary
- add immutable object-only deepMerge helper
- cover nested merging, array replacement, and override behavior

## Testing
- `npx prettier src/utils/deepMerge.js tests/utils/deepMerge.test.js --check`
- `npx eslint .`
- `npx vitest run --reporter=basic`
- `npx playwright test` *(fails: marked.parseInline is not a function; screenshot diff; interrupted navigation)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a36be43b588326845ccc2df86cbbe7