### PR TITLE
refactor: centralize settings loaders

### DIFF
--- a/src/helpers/featureFlags.js
+++ b/src/helpers/featureFlags.js
@@ -1,4 +1,5 @@
-import { loadSettings, updateSetting } from "./settingsStorage.js";
+import { loadSettings } from "../config/loadSettings.js";
+import { updateSetting } from "./settingsStorage.js";
 import { setCachedSettings } from "./settingsCache.js";
 import { DEFAULT_SETTINGS } from "../config/settingsDefaults.js";
 
@@ -27,6 +28,7 @@ export async function initFeatureFlags() {
   try {
     settings = await loadSettings();
     cachedFlags = settings.featureFlags || { ...DEFAULT_SETTINGS.featureFlags };
+    setCachedSettings(settings);
   } catch {
     settings = { ...DEFAULT_SETTINGS };
     cachedFlags = { ...DEFAULT_SETTINGS.featureFlags };

--- a/src/helpers/settings/applyInitialValues.js
+++ b/src/helpers/settings/applyInitialValues.js
@@ -1,3 +1,6 @@
+import { DEFAULT_SETTINGS } from "../../config/settingsDefaults.js";
+import { loadSettings } from "../../config/loadSettings.js";
+
 /**
  * Apply a value to an input or checkbox element.
  *
@@ -28,7 +31,7 @@ export function applyInputState(element, value) {
  * @param {import("../../config/settingsDefaults.js").Settings} settings - Current settings.
  * @param {Record<string, string>} [tooltipMap] - Flattened tooltip lookup.
  */
-export function applyInitialControlValues(controls, settings, tooltipMap = {}) {
+export function applyInitialControlValues(controls, settings = DEFAULT_SETTINGS, tooltipMap = {}) {
   applyInputState(controls.soundToggle, settings.sound);
   if (controls.soundToggle && settings.tooltipIds?.sound) {
     controls.soundToggle.dataset.tooltipId = settings.tooltipIds.sound;
@@ -96,4 +99,17 @@ export function applyInitialControlValues(controls, settings, tooltipMap = {}) {
   const mapDescEl = document.getElementById("full-navigation-map-desc");
   if (mapLabel && mapLabelEl) mapLabelEl.textContent = mapLabel;
   if (mapDesc && mapDescEl) mapDescEl.textContent = mapDesc;
+}
+
+/**
+ * Load settings and apply them to controls.
+ *
+ * @param {Object} controls - Collection of form elements.
+ * @param {Record<string, string>} [tooltipMap] - Flattened tooltip lookup.
+ * @returns {Promise<import("../../config/settingsDefaults.js").Settings>} Resolved settings.
+ */
+export async function applyInitialValues(controls, tooltipMap = {}) {
+  const settings = await loadSettings().catch(() => DEFAULT_SETTINGS);
+  applyInitialControlValues(controls, settings, tooltipMap);
+  return settings;
 }

--- a/src/helpers/settingsCache.js
+++ b/src/helpers/settingsCache.js
@@ -1,4 +1,5 @@
 import { DEFAULT_SETTINGS } from "../config/settingsDefaults.js";
+import { loadSettings } from "../config/loadSettings.js";
 
 /**
  * Clone a settings object, duplicating nested structures to avoid mutations.
@@ -25,6 +26,21 @@ function cloneSettings(settings) {
 }
 
 let cachedSettings = cloneSettings(DEFAULT_SETTINGS);
+
+/**
+ * Initialize the settings cache from persisted data.
+ *
+ * @returns {Promise<import("../config/settingsDefaults.js").Settings>} Loaded settings.
+ */
+export async function initSettingsCache() {
+  try {
+    const settings = await loadSettings();
+    setCachedSettings(settings);
+    return settings;
+  } catch {
+    return cachedSettings;
+  }
+}
 
 /**
  * Replace the cached settings object.

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -1,5 +1,4 @@
 export {
-  loadSettings,
   saveSettings,
   updateSetting,
   resetSettings,
@@ -7,3 +6,4 @@ export {
 } from "./settingsStorage.js";
 export { getSetting, getFeatureFlag } from "./settingsCache.js";
 export { DEFAULT_SETTINGS } from "../config/settingsDefaults.js";
+export { loadSettings } from "../config/loadSettings.js";

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -31,7 +31,7 @@ describe("classicBattlePage stat button interactions", () => {
       handleStatSelection
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
-    vi.doMock("../../src/helpers/settingsStorage.js", () => ({ loadSettings }));
+    vi.doMock("../../src/config/loadSettings.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
     vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar }));
@@ -100,7 +100,7 @@ describe("classicBattlePage stat button interactions", () => {
       handleStatSelection
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
-    vi.doMock("../../src/helpers/settingsStorage.js", () => ({ loadSettings }));
+    vi.doMock("../../src/config/loadSettings.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
     vi.doMock("../../src/helpers/stats.js", () => ({
@@ -170,7 +170,7 @@ describe("classicBattlePage stat help tooltip", () => {
       handleStatSelection: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
-    vi.doMock("../../src/helpers/settingsStorage.js", () => ({ loadSettings }));
+    vi.doMock("../../src/config/loadSettings.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
     vi.doMock("../../src/helpers/stats.js", () => ({ loadStatNames: async () => [] }));
@@ -221,7 +221,7 @@ describe("classicBattlePage test mode flag", () => {
       handleStatSelection: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
-    vi.doMock("../../src/helpers/settingsStorage.js", () => ({ loadSettings }));
+    vi.doMock("../../src/config/loadSettings.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
     vi.doMock("../../src/helpers/stats.js", () => ({ loadStatNames: async () => [] }));
@@ -264,7 +264,8 @@ describe("classicBattlePage test mode flag", () => {
       handleStatSelection: vi.fn()
     }));
     vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
-    vi.doMock("../../src/helpers/settingsStorage.js", () => ({ loadSettings, updateSetting }));
+    vi.doMock("../../src/config/loadSettings.js", () => ({ loadSettings }));
+    vi.doMock("../../src/helpers/settingsStorage.js", () => ({ updateSetting }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
     vi.doMock("../../src/helpers/stats.js", () => ({ loadStatNames: async () => [] }));
@@ -408,9 +409,11 @@ describe("syncScoreDisplay", () => {
       }
     }));
 
-    vi.doMock("../../src/helpers/settingsStorage.js", () => ({
-      getSetting: () => true,
+    vi.doMock("../../src/config/loadSettings.js", () => ({
       loadSettings: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/settingsStorage.js", () => ({
+      getSetting: () => true
     }));
     const { syncScoreDisplay, showMatchSummaryModal } = await import(
       "../../src/helpers/classicBattle/uiService.js"

--- a/tests/helpers/featureFlags.test.js
+++ b/tests/helpers/featureFlags.test.js
@@ -10,8 +10,10 @@ import { DEFAULT_SETTINGS } from "../../src/config/settingsDefaults.js";
 describe("initFeatureFlags", () => {
   it("falls back to defaults and emits change on load failure", async () => {
     vi.resetModules();
+    vi.doMock("../../src/config/loadSettings.js", () => ({
+      loadSettings: vi.fn().mockRejectedValue(new Error("fail"))
+    }));
     vi.doMock("../../src/helpers/settingsStorage.js", () => ({
-      loadSettings: vi.fn().mockRejectedValue(new Error("fail")),
       updateSetting: vi.fn()
     }));
     const { initFeatureFlags, featureFlagsEmitter, isEnabled } = await import(


### PR DESCRIPTION
## Summary
- Refactor settings storage to rely on shared `loadSettings` and eliminate `importJsonModule`
- Add cache initialization helper and wire feature flags to new loader
- Export async control initialization for settings UI

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a375359104832692396f32651b0b27