### PR TITLE
docs: document DEFAULT_SETTINGS as canonical defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Before submitting or completing a task, verify that your work:
 | ----------------------------- | ----------------------------------------------------------------------- |
 | Tooltip content               | src/data/tooltips.json                                                  |
 | Game stats and player data    | src/data/judoka.json, src/data/statNames.json                           |
-| Feature flags & settings      | src/pages/settings.html, src/data/settings.json                         |
+| Feature flags & settings      | src/pages/settings.html, src/config/settingsDefaults.js                 |
 | Tooltip viewer                | src/pages/tooltipViewer.html                                            |
 | Debug + Observability targets | Components with data-_, like data-tooltip-id, data-flag, data-feature-_ |
 | UI test entry points          | playwright/_.spec.js, tests/\*\*/_.test.js                              |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -59,7 +59,7 @@ Before submitting or completing a task, verify that your work:
 | ----------------------------- | ----------------------------------------------------------------------- |
 | Tooltip content               | src/data/tooltips.json                                                  |
 | Game stats and player data    | src/data/judoka.json, src/data/statNames.json                           |
-| Feature flags & settings      | src/pages/settings.html, src/data/settings.json                         |
+| Feature flags & settings      | src/pages/settings.html, src/config/settingsDefaults.js                 |
 | Tooltip viewer                | src/pages/tooltipViewer.html                                            |
 | Debug + Observability targets | Components with data-_, like data-tooltip-id, data-flag, data-feature-_ |
 | UI test entry points          | playwright/_.spec.js, tests/\*\*/_.test.js                              |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,32 @@
+# Settings Migration Guide
+
+This guide explains how to introduce new settings and how JU-DO-KON! overlays user values on top of defaults.
+
+## Adding a New Setting
+
+1. **Define the default**
+   - Update `src/data/settings.json` with the new key and its default value.
+   - Regenerate the frozen object in `src/config/settingsDefaults.js` by importing the updated JSON. The exported `DEFAULT_SETTINGS` object is the authoritative source for default values.
+2. **Expose the control**
+   - Add the corresponding UI to `src/pages/settings.html`.
+   - Provide labels and descriptions in `src/data/tooltips.json` when necessary.
+3. **Persist and access**
+   - Use helpers from `src/helpers/settingsUtils.js` or `src/helpers/featureFlags.js` to read and write the value.
+   - Update tests or schemas if the new setting requires them.
+
+## Overlay Behavior
+
+`DEFAULT_SETTINGS` is always cloned as the base. Stored values from `loadSettings()` overlay this object, and unknown keys are discarded via `mergeKnown`. This ensures that:
+
+- New settings automatically fall back to their defaults when not present in storage.
+- Removing a setting from `DEFAULT_SETTINGS` deletes it from cached and stored data on the next load.
+
+Run the full test suite and formatting checks after modifying settings:
+
+```bash
+npx prettier . --check
+npx eslint .
+npx vitest run
+npx playwright test
+npm run check:contrast
+```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ AI agents should begin by reading:
 ### 🔑 Entry Points
 
 - `/src/pages/settings.html` – UI for toggling feature flags
+- `/src/config/settingsDefaults.js` – `DEFAULT_SETTINGS` source of truth for defaults
 - `/data/tooltips.json` – Tooltip content (auditable by agents)
 - `/data/judoka.json` – Card data for stat logic
 - `/components/` – Frontend logic with `data-*` hooks for observability
@@ -81,8 +82,10 @@ Pages that display snackbars must include a persistent container near the end of
 
 ## Settings API
 
-Settings are loaded once and cached for synchronous use. Helpers in
-`src/helpers/settingsUtils.js` provide safe access:
+Settings are loaded once and cached for synchronous use. Default values come
+from `DEFAULT_SETTINGS` in `src/config/settingsDefaults.js` and are overlaid
+with any persisted values. Helpers in `src/helpers/settingsUtils.js` provide
+safe access:
 
 - `getSetting(key)` – read a setting value from the cache.
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -121,7 +121,7 @@ On load, the Settings page must pre-populate each control with values from
 ## Data & Persistence
 
 - The Settings page **must pull current states** from data sources (`settings.json`, `gameModes.json`, and `navigationItems.json`) on load, using the `navigationCache` helper for navigation persistence, and pre-populate all controls with those values.
-- Default feature flag values live in `settings.json`, while their labels and descriptions come from `tooltips.json`.
+- Default settings originate from `DEFAULT_SETTINGS` in `src/config/settingsDefaults.js`, while their labels and descriptions come from `tooltips.json`.
 - `gameModes.json` defines all available modes, while `navigationItems.json` references each by `id` to control order and visibility via CSS; if `navigationItems.json` isn't reachable, a bundled fallback provides default ordering.
 - Changes should trigger **immediate data writes** without requiring a “Save Changes” button.
 - All live updates must persist across page refreshes within the same session.


### PR DESCRIPTION
## Summary
- point README and agent docs to DEFAULT_SETTINGS as the source of truth
- describe overlay behavior and migration steps in new MIGRATION guide
- clarify PRD that defaults originate from DEFAULT_SETTINGS

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a39e597f2c8326991dbe61924fc5f7