### PR TITLE
test: cover loadSettings merge behavior

### DIFF
--- a/tests/config/loadSettings.test.js
+++ b/tests/config/loadSettings.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+/**
+ * @fileoverview
+ * Tests for loadSettings verifying precedence and merge behavior.
+ */
+
+describe("loadSettings", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    localStorage.clear();
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("applies precedence defaults < repo JSON < localStorage", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sound: false, typewriterEffect: true })
+      })
+    );
+    localStorage.setItem("settings", JSON.stringify({ sound: true }));
+    const { loadSettings } = await import("../../src/config/loadSettings.js");
+    const settings = await loadSettings();
+    expect(settings.sound).toBe(true);
+    expect(settings.typewriterEffect).toBe(true);
+    expect(settings.motionEffects).toBe(true);
+  });
+
+  it("ignores localStorage with invalid JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ sound: false })
+      })
+    );
+    localStorage.setItem("settings", "{ not valid");
+    const { loadSettings } = await import("../../src/config/loadSettings.js");
+    const settings = await loadSettings();
+    expect(settings.sound).toBe(false);
+  });
+
+  it("strips unknown keys and warns", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+    );
+    localStorage.setItem("settings", JSON.stringify({ bogus: true }));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { loadSettings } = await import("../../src/config/loadSettings.js");
+    const settings = await loadSettings();
+    expect(settings.bogus).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith('Unknown setting "bogus" ignored');
+    warnSpy.mockRestore();
+  });
+
+  it("deeply merges nested objects and replaces arrays", async () => {
+    vi.doMock("../../src/config/settingsDefaults.js", () => ({
+      DEFAULT_SETTINGS: { items: [1], nested: { a: 1, arr: [1] } }
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ items: [2, 3], nested: { b: 2, arr: [2] } })
+      })
+    );
+    localStorage.setItem("settings", JSON.stringify({ nested: { arr: [3] } }));
+    const { loadSettings } = await import("../../src/config/loadSettings.js");
+    const settings = await loadSettings();
+    expect(settings).toEqual({ items: [2, 3], nested: { a: 1, b: 2, arr: [3] } });
+  });
+});


### PR DESCRIPTION
## Summary
- add config tests for settings precedence
- verify unknown key warnings and deep merge behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: No "validateWithSchema" export defined)*
- `npx playwright test` *(fails: 3 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a39e54661883268f8e59f3a1dcfbb4