### PR TITLE
docs: add settings loader pseudocode

### DIFF
--- a/src/helpers/settingsStorage.js
+++ b/src/helpers/settingsStorage.js
@@ -18,7 +18,16 @@ let settingsSchemaPromise;
 
 /**
  * Lazily load the settings JSON schema.
- * @returns {Promise<object>}
+ *
+ * @pseudocode
+ * 1. If `settingsSchemaPromise` exists, return it (cached).
+ * 2. Otherwise:
+ *    a. Create a promise that attempts to `fetch` the schema JSON.
+ *    b. If the fetch fails, dynamically import the JSON module as a fallback.
+ *    c. Store this promise in `settingsSchemaPromise`.
+ * 3. Await and return the resolved schema (no cloning; treat as read-only).
+ *
+ * @returns {Promise<object>} Parsed schema object.
  */
 export async function getSettingsSchema() {
   if (!settingsSchemaPromise) {

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -6,4 +6,4 @@ export {
 } from "./settingsStorage.js";
 export { getSetting, getFeatureFlag } from "./settingsCache.js";
 export { DEFAULT_SETTINGS } from "../config/settingsDefaults.js";
-export { loadSettings } from "../config/loadSettings.js";
+export { loadSettings, loadDefaultSettings } from "../config/loadSettings.js";


### PR DESCRIPTION
## Summary
- document lazy schema fetch and fallback logic
- add cached loader for default settings with dynamic import fallback
- re-export default settings loader through settings utilities

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: 1 warning)*
- `npx vitest run` *(fails: Cannot read properties of null (reading 'click'))*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae038a0c83268f465a1bc5946e3b