### PR TITLE
docs: add pseudocode for epic badge

### DIFF
--- a/src/components/EpicCard.js
+++ b/src/components/EpicCard.js
@@ -9,6 +9,16 @@ export class EpicCard extends JudokaCard {
   /**
    * Render the card with an added epic badge.
    *
+   * @pseudocode
+   * 1. container ← await super.render()
+   * 2. badge ← create <span> with class "epic-badge"
+   * 3. set badge text to "EPIC"
+   * 4. append badge to this.element
+   * 5. return container
+   *
+   * Assumes `super.render` sets `this.element` to the card container and returns it.
+   * Side effect: mutates `this.element` by adding the badge.
+   *
    * @returns {Promise<HTMLElement>} Resolves with the card container element.
    */
   async render() {


### PR DESCRIPTION
## Summary
- document EpicCard's badge rendering flow and assumptions

## Testing
- `npx prettier . --check`
- `npx eslint .` (warning)
- `npx vitest run`
- `npx playwright test` (fails: Error Context: test results show multiple failures)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a3adff69ac8326bc4851053f2b0cd2