### PR TITLE
docs: add pseudocode to exported helpers

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -128,6 +128,10 @@ export class Modal {
 /**
  * Compatibility helper returning a `Modal` instance.
  *
+ * @pseudocode
+ * 1. Instantiate a `Modal` with the supplied `content` and `options`.
+ * 2. Return the newly created instance.
+ *
  * @param {HTMLElement|DocumentFragment} content
  * @param {object} [options]
  * @returns {Modal}

--- a/src/helpers/classicBattle/eventBus.js
+++ b/src/helpers/classicBattle/eventBus.js
@@ -10,6 +10,10 @@ let stateGetter = () => null;
 /**
  * Register the event dispatcher used for battle state transitions.
  * @param {(eventName: string, payload?: any) => Promise<void>|void} fn
+ *
+ * @pseudocode
+ * 1. Verify that `fn` is a function.
+ * 2. When valid, assign it to `dispatcher`.
  */
 export function setBattleDispatcher(fn) {
   if (typeof fn === "function") dispatcher = fn;
@@ -18,6 +22,10 @@ export function setBattleDispatcher(fn) {
 /**
  * Register a getter that returns the current battle state name.
  * @param {() => string|null} fn
+ *
+ * @pseudocode
+ * 1. Check that `fn` is a function.
+ * 2. When valid, assign it to `stateGetter`.
  */
 export function setBattleStateGetter(fn) {
   if (typeof fn === "function") stateGetter = fn;
@@ -27,6 +35,10 @@ export function setBattleStateGetter(fn) {
  * Dispatch a battle event through the registered dispatcher.
  * @param {string} eventName
  * @param {any} [payload]
+ *
+ * @pseudocode
+ * 1. Call the stored `dispatcher` with `eventName` and `payload`.
+ * 2. Swallow any errors from the dispatcher.
  */
 export async function dispatchBattleEvent(eventName, payload) {
   try {
@@ -37,6 +49,10 @@ export async function dispatchBattleEvent(eventName, payload) {
 /**
  * Get the current battle state (string) if available.
  * @returns {string|null}
+ *
+ * @pseudocode
+ * 1. Invoke the stored `stateGetter` and return its value.
+ * 2. On error, return `null`.
  */
 export function getBattleState() {
   try {

--- a/src/helpers/classicBattle/orchestrator.js
+++ b/src/helpers/classicBattle/orchestrator.js
@@ -11,11 +11,36 @@ if (typeof process === "undefined" || !process.env.VITEST) {
 }
 
 let machine = null;
-
+/**
+ * Retrieve the current battle state machine instance.
+ *
+ * @pseudocode
+ * 1. Return the `machine` reference.
+ *
+ * @returns {import('./stateMachine.js').BattleStateMachine|null} Current instance.
+ */
 export function getBattleStateMachine() {
   return machine;
 }
 
+/**
+ * Initialize the classic battle orchestrator.
+ *
+ * @pseudocode
+ * 1. Derive `resetGame` and `startRound` handlers from `opts` or defaults.
+ * 2. Define `onEnter` callbacks for each battle state to manage UI and flow.
+ * 3. Define `onTransition` to mirror state changes to globals and update debug info.
+ * 4. Create the state machine via `BattleStateMachine.create` with the handlers.
+ * 5. Attach a visibility listener to pause or resume timers on tab changes.
+ * 6. Wire timer drift and error-injection hooks when an engine is present.
+ *
+ * @param {object} store - Shared battle store.
+ * @param {Function} startRoundWrapper - Optional wrapper for starting a round.
+ * @param {object} [opts] - Optional overrides.
+ * @param {Function} [opts.resetGame] - Custom reset handler.
+ * @param {Function} [opts.startRound] - Custom round start handler.
+ * @returns {Promise<void>} Resolves when setup completes.
+ */
 export async function initClassicBattleOrchestrator(store, startRoundWrapper, opts = {}) {
   const { resetGame: resetGameOpt, startRound: startRoundOpt } = opts;
   const doResetGame = typeof resetGameOpt === "function" ? resetGameOpt : resetGameLocal;

--- a/src/helpers/navUtils.js
+++ b/src/helpers/navUtils.js
@@ -1,12 +1,14 @@
 /**
- * Navigation utilities.
+ * Build an absolute URL to the app's home page.
  *
  * @pseudocode
- * - resolveHomeHref: Build an absolute URL to the app's home (index.html)
- *   that preserves the repository base path (e.g., /judokon) across
- *   environments like local dev (/src/pages/...) or GH Pages (/pages/...).
- * - navigateToHome: Set window.location to the resolved home URL; fall back
- *   to history.replaceState when direct assignment is not available.
+ * 1. Read `window.location` to obtain the current origin and pathname.
+ * 2. Extract any base path preceding `/src/pages/` or `/pages/`.
+ * 3. Ensure the base path ends with a trailing `/`.
+ * 4. Return the origin combined with the normalized base and `index.html`.
+ * 5. On error, return a relative `../../index.html` fallback.
+ *
+ * @returns {string} Absolute URL of the home page.
  */
 export function resolveHomeHref() {
   try {
@@ -22,6 +24,15 @@ export function resolveHomeHref() {
   }
 }
 
+/**
+ * Navigate to the resolved home URL.
+ *
+ * @pseudocode
+ * 1. Attempt to assign `window.location.href` to the home URL.
+ * 2. If that fails, build an absolute URL relative to the current location.
+ * 3. When `history.replaceState` is available, use it to change the address.
+ * 4. Swallow any remaining errors silently.
+ */
 export function navigateToHome() {
   try {
     window.location.href = resolveHomeHref();


### PR DESCRIPTION
## Summary
- document Modal factory with high-level steps
- add navigation utilities pseudocode
- describe classic battle event bus operations
- outline initialization flow for classic battle orchestrator

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: 10 failed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a3adfcb824832681dc4bdc98f3e294