### PR TITLE
docs: document battle engine facade

### DIFF
--- a/src/helpers/battleEngineFacade.js
+++ b/src/helpers/battleEngineFacade.js
@@ -1,8 +1,33 @@
 import { BattleEngine } from "./BattleEngine.js";
 
+/**
+ * Facade for a singleton BattleEngine instance.
+ *
+ * @pseudocode
+ * Import and re-export `BattleEngine` and `STATS`.
+ * Instantiate `battleEngine`.
+ * Export wrappers:
+ *  - `setPointsToWin(value)` -> `battleEngine.setPointsToWin(value)`
+ *  - `getPointsToWin()` -> `battleEngine.getPointsToWin()`
+ *  - `stopTimer()` -> `battleEngine.stopTimer()`
+ *  - `startRound(...args)` -> `battleEngine.startRound(...args)`
+ *  - `startCoolDown(...args)` -> `battleEngine.startCoolDown(...args)`
+ *  - `pauseTimer()` -> `battleEngine.pauseTimer()`
+ *  - `resumeTimer()` -> `battleEngine.resumeTimer()`
+ *  - `handleStatSelection(...args)` -> `battleEngine.handleStatSelection(...args)`
+ *  - `quitMatch()` -> `battleEngine.quitMatch()`
+ *  - `getScores()` -> `battleEngine.getScores()`
+ *  - `getRoundsPlayed()` -> `battleEngine.getRoundsPlayed()`
+ *  - `isMatchEnded()` -> `battleEngine.isMatchEnded()`
+ *  - `getTimerState()` -> `battleEngine.getTimerState()`
+ *  - `watchForDrift(...args)` -> `battleEngine.watchForDrift(...args)`
+ *  - `_resetForTest()` -> `battleEngine._resetForTest()`
+ */
 export { BattleEngine, STATS } from "./BattleEngine.js";
 
 export const battleEngine = new BattleEngine();
+
+// Thin wrappers delegate directly to the underlying `battleEngine` instance.
 
 export const setPointsToWin = (value) => battleEngine.setPointsToWin(value);
 export const getPointsToWin = () => battleEngine.getPointsToWin();


### PR DESCRIPTION
## Summary
- add module-level pseudocode describing the battle engine facade and its wrapper exports
- note that exported helpers delegate directly to a shared `battleEngine` instance

## Testing
- `npx prettier . --check`
- `npx eslint .` *(1 warning)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a42c157c7c832684264f9188922a80