### PR TITLE
docs: clarify settings schema and default loader pseudocode

### DIFF
--- a/src/helpers/settingsCache.js
+++ b/src/helpers/settingsCache.js
@@ -28,11 +28,18 @@ function cloneSettings(settings) {
 let cachedSettings = cloneSettings(DEFAULT_SETTINGS);
 
 /**
- * Initialize the settings cache from persisted data.
+ * Load settings into the in-memory cache, falling back to defaults on error.
  *
- * @returns {Promise<import("../config/settingsDefaults.js").Settings>} Loaded settings.
+ * @pseudocode
+ * 1. Attempt to load settings via `loadSettings()`.
+ *    - `loadSettings` may fetch JSON and fall back to `importJsonModule` internally.
+ * 2. On success, cache a cloned copy with `setCachedSettings`.
+ * 3. Return the cached settings.
+ * 4. If any step fails, return the existing `cachedSettings` defaults.
+ *
+ * @returns {Promise<import("../config/settingsDefaults.js").Settings>} Cached settings.
  */
-export async function initSettingsCache() {
+export async function loadDefaultSettings() {
   try {
     const settings = await loadSettings();
     setCachedSettings(settings);

--- a/src/helpers/settingsStorage.js
+++ b/src/helpers/settingsStorage.js
@@ -18,7 +18,14 @@ let settingsSchemaPromise;
 
 /**
  * Lazily load the settings JSON schema.
- * @returns {Promise<object>}
+ *
+ * @pseudocode
+ * 1. When no cached promise exists:
+ *    a. Create `settingsSchemaPromise` that attempts to `fetch` the schema URL.
+ *    b. On fetch failure, fall back to a dynamic `import()` (akin to `importJsonModule`).
+ * 2. Return `settingsSchemaPromise` so subsequent calls reuse the cached schema.
+ *
+ * @returns {Promise<object>} Parsed schema object.
  */
 export async function getSettingsSchema() {
   if (!settingsSchemaPromise) {

--- a/src/helpers/settingsUtils.js
+++ b/src/helpers/settingsUtils.js
@@ -4,6 +4,6 @@ export {
   resetSettings,
   getSettingsSchema
 } from "./settingsStorage.js";
-export { getSetting, getFeatureFlag } from "./settingsCache.js";
+export { getSetting, getFeatureFlag, loadDefaultSettings } from "./settingsCache.js";
 export { DEFAULT_SETTINGS } from "../config/settingsDefaults.js";
 export { loadSettings } from "../config/loadSettings.js";


### PR DESCRIPTION
## Summary
- document lazy loading and fallback for `getSettingsSchema`
- rename and document `loadDefaultSettings` caching of defaults
- expose `loadDefaultSettings` via settings utilities

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a4828467248326988dd8a99e2ad0bc