### PR TITLE
docs: add pseudocode for autoSelectStat

### DIFF
--- a/src/helpers/classicBattle/autoSelectStat.js
+++ b/src/helpers/classicBattle/autoSelectStat.js
@@ -11,6 +11,14 @@ const AUTO_SELECT_FEEDBACK_MS = 500;
 
 /**
  * Automatically select a random stat and provide UI feedback.
+ * Avoids snackbar to prevent race conditions with the cooldown countdown.
+ *
+ * @pseudocode
+ * pick random stat from STATS
+ * mark corresponding button as selected
+ * wait AUTO_SELECT_FEEDBACK_MS
+ * dispatch "statSelected" battle event
+ * invoke onSelect with random stat and delayOpponentMessage true
  *
  * @param {(stat: string, opts?: { delayOpponentMessage?: boolean }) => Promise<void>|void} onSelect
  * - Callback to handle the chosen stat.


### PR DESCRIPTION
## Summary
- document autoSelectStat flow with pseudocode
- clarify snackbar avoidance to prevent race conditions

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a4a52a3a34832688975d09e049ffb4