### PR TITLE
Expose drift timer cancellation

### DIFF
--- a/src/helpers/classicBattle/runTimerWithDrift.js
+++ b/src/helpers/classicBattle/runTimerWithDrift.js
@@ -11,46 +11,53 @@ import { onSecondTick as scheduleSecond, cancel as cancelSchedule } from "../../
  *    restart the timer, giving up after several retries.
  * 3. On expiration or when giving up, stop monitoring and invoke the
  *    corresponding callback.
+ * 4. Expose a `cancel` function to stop drift monitoring manually.
  *
  * @param {function(function, function, number): Promise<void>} startFn
  * - Function that starts the underlying timer.
- * @returns {function(number, function, function, function): Promise<void>}
- * - Function to run the timer with drift handling.
+ * @returns {{run: function(number, function, function, function): Promise<void>, cancel: function(): void}}
+ * - Object with `run` and `cancel` helpers for timer management.
  */
 export function runTimerWithDrift(
   startFn,
   { onSecondTick = scheduleSecond, cancel = cancelSchedule } = {}
 ) {
-  return async function (duration, onTick, onExpired, onDriftGiveUp) {
+  let stopWatch;
+  const cancelWatch = () => {
+    if (stopWatch) stopWatch();
+  };
+
+  async function run(duration, onTick, onExpired, onDriftGiveUp) {
     const MAX_DRIFT_RETRIES = 3;
     let retries = 0;
-    let stopWatch;
 
     const expired = async () => {
-      if (stopWatch) stopWatch();
+      cancelWatch();
       await onExpired();
     };
 
-    const run = async (dur) => {
-      const maybePromise = startFn(onTick, expired, dur);
-      if (stopWatch) stopWatch();
-      stopWatch = watchForDrift(dur, handleDrift, { onSecondTick, cancel });
-      if (maybePromise && typeof maybePromise.then === "function") {
-        await maybePromise;
-      }
-    };
-
-    const handleDrift = async (remaining) => {
+    async function handleDrift(remaining) {
+      cancelWatch();
       retries += 1;
       if (retries > MAX_DRIFT_RETRIES) {
-        if (stopWatch) stopWatch();
         await onDriftGiveUp();
         return;
       }
       scoreboard.showMessage("Waiting…");
-      await run(remaining);
-    };
+      await start(remaining);
+    }
 
-    await run(duration);
-  };
+    async function start(dur) {
+      const maybePromise = startFn(onTick, expired, dur);
+      cancelWatch();
+      stopWatch = watchForDrift(dur, handleDrift, { onSecondTick, cancel });
+      if (maybePromise && typeof maybePromise.then === "function") {
+        await maybePromise;
+      }
+    }
+
+    await start(duration);
+  }
+
+  return { run, cancel: cancelWatch };
 }

--- a/tests/helpers/classicBattle/timerService.cleanup.test.js
+++ b/tests/helpers/classicBattle/timerService.cleanup.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTimerNodes } from "./domUtils.js";
+
+describe("timerService cleanup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("removes drift watcher on skip", async () => {
+    const secondCallbacks = new Map();
+    vi.doMock("../../../src/utils/scheduler.js", () => ({
+      onSecondTick: (cb) => {
+        const id = secondCallbacks.size + 1;
+        secondCallbacks.set(id, cb);
+        return id;
+      },
+      cancel: (id) => {
+        secondCallbacks.delete(id);
+      }
+    }));
+    vi.doMock("../../../src/helpers/setupScoreboard.js", () => ({
+      showMessage: vi.fn(),
+      showTemporaryMessage: () => () => {},
+      showAutoSelect: vi.fn(),
+      clearTimer: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
+      updateDebugPanel: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/classicBattle/autoSelectStat.js", () => ({
+      autoSelectStat: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/classicBattle/orchestrator.js", () => ({
+      dispatchBattleEvent: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/classicBattle/featureFlags.js", () => ({
+      isEnabled: () => false
+    }));
+    vi.doMock("../../../src/helpers/timerUtils.js", () => ({
+      getDefaultTimer: () => 5
+    }));
+    vi.doMock("../../../src/helpers/battleEngineFacade.js", () => ({
+      startRound: () => Promise.resolve(),
+      watchForDrift: (_d, _cb, { onSecondTick, cancel }) => {
+        const id = onSecondTick(() => {});
+        return () => cancel(id);
+      },
+      stopTimer: vi.fn()
+    }));
+
+    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const skip = await import("../../../src/helpers/classicBattle/skipHandler.js");
+    createTimerNodes();
+    await mod.startTimer(async () => {});
+    expect(secondCallbacks.size).toBe(1);
+    skip.skipCurrentPhase();
+    expect(secondCallbacks.size).toBe(0);
+  });
+});

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -24,7 +24,7 @@ describe("timerService next round handling", () => {
       STATS: []
     }));
     vi.doMock("../../../src/helpers/classicBattle/runTimerWithDrift.js", () => ({
-      runTimerWithDrift: () => async () => {}
+      runTimerWithDrift: () => ({ run: async () => {}, cancel: () => {} })
     }));
     const dispatchBattleEvent = vi.fn();
     vi.doMock("../../../src/helpers/classicBattle/orchestrator.js", () => ({
@@ -62,9 +62,12 @@ describe("timerService next round handling", () => {
       STATS: []
     }));
     vi.doMock("../../../src/helpers/classicBattle/runTimerWithDrift.js", () => ({
-      runTimerWithDrift: () => async (_d, _t, onExpired) => {
-        await onExpired();
-      }
+      runTimerWithDrift: () => ({
+        run: async (_d, _t, onExpired) => {
+          await onExpired();
+        },
+        cancel: () => {}
+      })
     }));
     const dispatchBattleEvent = vi.fn();
     vi.doMock("../../../src/helpers/classicBattle/orchestrator.js", () => ({


### PR DESCRIPTION
## Summary
- return `{ run, cancel }` from `runTimerWithDrift`
- invoke `cancel` in classic battle skip handlers
- verify skip removes drift watcher

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a4b6b7c57883268c8d4016423ba0ef