### PR TITLE
docs: add route registration pseudocode

### DIFF
--- a/playwright/fixtures/commonRoutes.js
+++ b/playwright/fixtures/commonRoutes.js
@@ -3,6 +3,13 @@ import fs from "fs";
 /**
  * Register routes to serve fixture data for core JSON files and flag images.
  *
+ * @pseudocode
+ * 1. Register fixture JSON for key data files.
+ * 2. Proxy portraits and other static assets from local directories.
+ * 3. Serve fonts and vendor scripts from local copies.
+ * 4. Fulfill additional JSON requests with fixtures when available.
+ * 5. Provide placeholder responses for external assets such as flags.
+ *
  * @param {import('@playwright/test').Page} page - The Playwright page.
  * @returns {Promise<void>} Promise resolving when all routes have been registered in parallel.
  */


### PR DESCRIPTION
## Summary
- document high-level steps for registering Playwright fixtures and asset routes

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: marked.parseInline is not a function)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a4bf153d7c8326a249e62c808fc22e