### PR TITLE
docs: add pseudocode for waitFor helper

### DIFF
--- a/tests/waitFor.js
+++ b/tests/waitFor.js
@@ -7,6 +7,12 @@ import { expect } from "vitest";
  * delays. The returned promise rejects if the predicate never returns `true`
  * within the timeout.
  *
+ * @pseudocode
+ * initialize polling via `expect.poll`
+ * repeatedly evaluate predicate
+ * resolve on success
+ * reject after timeout
+ *
  * @param {() => boolean} predicate - Condition to repeatedly evaluate.
  * @param {object} [options] - Configuration options.
  * @param {number} [options.timeout=500] - Maximum time to wait in milliseconds.


### PR DESCRIPTION
## Summary
- document polling steps for `waitFor` test helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a4d1079f6c8326aa1be07cf757e7e8