### PR TITLE
Guard navigation viewport checks for SSR

### DIFF
--- a/src/helpers/api/navigation.js
+++ b/src/helpers/api/navigation.js
@@ -91,7 +91,7 @@ function preserveLogoAndWire(navBar, logo, menu, animations) {
  * Build a navigation menu for a given orientation.
  *
  * @pseudocode
- * 1. Determine if the current viewport matches the provided orientation.
+ * 1. Determine if the current viewport matches the provided orientation when `window` is available; otherwise assume landscape.
  * 2. Select the navbar and logo; exit if either is missing.
  * 3. Validate game modes and build a menu container with orientation class.
  * 4. Populate the container using the appropriate template per mode.
@@ -104,11 +104,13 @@ function preserveLogoAndWire(navBar, logo, menu, animations) {
  */
 export function buildMenu(gameModes, { orientation }) {
   const matches =
-    typeof window.matchMedia === "function"
-      ? window.matchMedia(`(orientation: ${orientation})`).matches
-      : orientation === "landscape"
-        ? window.innerWidth > window.innerHeight
-        : window.innerHeight >= window.innerWidth;
+    typeof window !== "undefined"
+      ? typeof window.matchMedia === "function"
+        ? window.matchMedia(`(orientation: ${orientation})`).matches
+        : orientation === "landscape"
+          ? window.innerWidth > window.innerHeight
+          : window.innerHeight >= window.innerWidth
+      : orientation === "landscape";
   if (!matches) return null;
 
   const navBar = document.querySelector(".bottom-navbar");

--- a/tests/helpers/buildMenu.ssr.test.js
+++ b/tests/helpers/buildMenu.ssr.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { buildMenu } from "../../src/helpers/api/navigation.js";
+
+const modes = [
+  {
+    id: "test",
+    name: "Test",
+    url: "test.html",
+    order: 0,
+    image: "test.png"
+  }
+];
+
+describe("buildMenu SSR fallback", () => {
+  it("builds menu using default orientation when window is undefined", () => {
+    const originalWindow = globalThis.window;
+    document.body.innerHTML = '<nav class="bottom-navbar"><div class="logo"></div></nav>';
+    try {
+      globalThis.window = undefined;
+      const menu = buildMenu(modes, { orientation: "landscape" });
+      expect(menu).toBeTruthy();
+      const link = document.querySelector(".bottom-navbar a");
+      expect(link).toBeTruthy();
+    } finally {
+      globalThis.window = originalWindow;
+      document.body.innerHTML = "";
+    }
+  });
+
+  it("returns null for portrait orientation when window is undefined", () => {
+    const originalWindow = globalThis.window;
+    document.body.innerHTML = '<nav class="bottom-navbar"><div class="logo"></div></nav>';
+    try {
+      globalThis.window = undefined;
+      const menu = buildMenu(modes, { orientation: "portrait" });
+      expect(menu).toBeNull();
+      const link = document.querySelector(".bottom-navbar a");
+      expect(link).toBeNull();
+    } finally {
+      globalThis.window = originalWindow;
+      document.body.innerHTML = "";
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- avoid `window` reference errors in navigation by guarding orientation checks and assuming landscape when `window` is missing
- add SSR test for `buildMenu`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a58522bc8083269dc78885eec4074b