### PR TITLE
refactor: centralize loading spinner

### DIFF
--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -1,0 +1,48 @@
+import { SPINNER_DELAY_MS } from "../helpers/constants.js";
+
+/**
+ * Create a loading spinner and helper methods to control its visibility.
+ *
+ * @pseudocode
+ * 1. Create `<div class="loading-spinner" aria-hidden="true">` and append to `parent`.
+ * 2. Hide the spinner initially and expose `show`, `hide`, and `remove` helpers.
+ *    - `show` displays the spinner after `delay` milliseconds.
+ *    - `hide` clears any pending timer and hides the spinner.
+ *    - `remove` clears the timer and removes the spinner from the DOM.
+ * 3. Return the spinner element and helper methods.
+ *
+ * @param {HTMLElement} parent - Element to append the spinner to.
+ * @param {object} [options]
+ * @param {number} [options.delay=SPINNER_DELAY_MS] - Delay before showing the spinner.
+ * @returns {{element:HTMLDivElement, show:() => void, hide:() => void, remove:() => void}} Spinner controls.
+ */
+export function createSpinner(parent, { delay = SPINNER_DELAY_MS } = {}) {
+  const element = document.createElement("div");
+  element.className = "loading-spinner";
+  element.setAttribute("aria-hidden", "true");
+  element.style.display = "none";
+  parent.appendChild(element);
+
+  let timerId;
+
+  const show = () => {
+    clearTimeout(timerId);
+    timerId = setTimeout(() => {
+      element.style.display = "block";
+    }, delay);
+  };
+
+  const hide = () => {
+    clearTimeout(timerId);
+    timerId = undefined;
+    element.style.display = "none";
+  };
+
+  const remove = () => {
+    clearTimeout(timerId);
+    timerId = undefined;
+    element.remove();
+  };
+
+  return { element, show, hide, remove };
+}

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -4,8 +4,8 @@ import { CarouselController } from "./carousel/controller.js";
 import { applyAccessibilityImprovements } from "./carousel/accessibility.js";
 import { setupFocusHandlers } from "./carousel/focus.js";
 import { setupLazyPortraits } from "./lazyPortrait.js";
-import { SPINNER_DELAY_MS } from "./constants.js";
 import { CAROUSEL_SWIPE_THRESHOLD } from "./constants.js";
+import { createSpinner } from "../components/Spinner.js";
 
 /**
  * Adds scroll markers to indicate the user's position in the carousel.
@@ -142,18 +142,6 @@ function validateGokyoData(gokyoData) {
  * @param {HTMLElement} wrapper - The wrapper element to append the spinner to.
  * @returns {Object} An object containing the spinner element and timeout ID.
  */
-export function createLoadingSpinner(wrapper) {
-  const spinner = document.createElement("div");
-  spinner.className = "loading-spinner";
-  wrapper.appendChild(spinner);
-
-  const timeoutId = setTimeout(() => {
-    spinner.style.display = "block";
-  }, SPINNER_DELAY_MS);
-
-  return { spinner, timeoutId };
-}
-
 /**
  * Handles broken images in a card by setting a fallback image.
  *
@@ -200,13 +188,12 @@ export async function buildCardCarousel(judokaList, gokyoData) {
 
   const gokyoLookup = validateGokyoData(gokyoData);
 
-  const { spinner, timeoutId } = createLoadingSpinner(wrapper);
+  const spinner = createSpinner(wrapper);
+  spinner.show();
 
   await appendCards(container, judokaList, gokyoLookup);
   setupResponsiveSizing(container);
 
-  clearTimeout(timeoutId);
-  spinner.style.display = "none";
   spinner.remove();
 
   // Initialize unified controller (buttons, keyboard, swipe, markers, counter)

--- a/src/helpers/changeLogPage.js
+++ b/src/helpers/changeLogPage.js
@@ -3,6 +3,7 @@ import { DATA_DIR } from "./constants.js";
 import { escapeHTML, formatDate } from "./utils.js";
 import { onDomReady } from "./domReady.js";
 import { initTooltips } from "./tooltip.js";
+import { createSpinner } from "../components/Spinner.js";
 
 /**
  * Sort judoka entries by lastUpdated descending, then by full name ascending.
@@ -80,6 +81,12 @@ export async function setupChangeLogPage() {
   const table = document.getElementById("changelog-table");
   const tbody = table?.querySelector("tbody");
   const loading = document.getElementById("loading-container");
+  let spinner;
+  if (loading) {
+    loading.innerHTML = "";
+    spinner = createSpinner(loading);
+    spinner.show();
+  }
   if (!table || !tbody) return;
 
   try {
@@ -94,7 +101,8 @@ export async function setupChangeLogPage() {
     console.error("Failed to load judoka:", err);
     table.insertAdjacentHTML("afterend", "<p>No Judoka data found</p>");
   } finally {
-    if (loading) loading.remove();
+    spinner?.remove();
+    loading?.remove();
   }
 
   initTooltips();

--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -4,6 +4,7 @@ import { initTooltips } from "./tooltip.js";
 import { SidebarList } from "../components/SidebarList.js";
 import { getPrdTaskStats } from "./prdTaskStats.js";
 import { getSanitizer } from "./sanitizeHtml.js";
+import { createSpinner } from "../components/Spinner.js";
 
 /**
  * Load PRD filenames and related metadata.
@@ -198,8 +199,8 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
   const prevButtons = document.querySelectorAll('[data-nav="prev"]');
   const titleEl = document.getElementById("prd-title");
   const summaryEl = document.getElementById("task-summary");
-  const spinner = document.getElementById("prd-spinner");
   if (!container || !listPlaceholder || !files.length) return;
+  const spinner = createSpinner(container.parentElement);
 
   // Prepare arrays for lazy population and a small cache of in-flight fetches.
   const documents = Array(files.length);
@@ -349,14 +350,14 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
   url.searchParams.set("doc", baseNames[startIndex]);
   history.replaceState({ index: startIndex }, "", url.toString());
 
-  if (spinner) spinner.style.display = "block";
+  spinner.show();
   // Load the initial doc synchronously if possible for snappy first paint.
   if (!ensureDocSync(startIndex)) {
     await fetchOne(startIndex);
   }
   renderDoc(startIndex);
   container.focus();
-  if (spinner) spinner.style.display = "none";
+  spinner.remove();
 
   // Opportunistically fetch remaining docs in the background to speed up later navigation.
   // Avoid blocking UI; fire-and-forget.

--- a/src/helpers/vectorSearchPage.js
+++ b/src/helpers/vectorSearchPage.js
@@ -7,16 +7,9 @@ import { prepareSearchUi, getSelectedTags } from "./vectorSearchPage/queryUi.js"
 import { renderResults } from "./vectorSearchPage/renderResults.js";
 import { getExtractor, SIMILARITY_THRESHOLD, preloadExtractor } from "./api/vectorSearchPage.js";
 import { getSanitizer } from "./sanitizeHtml.js";
+import { createSpinner } from "../components/Spinner.js";
 
 let spinner;
-
-function setSpinnerDisplay(display) {
-  if (spinner) {
-    spinner.style.display = display;
-  } else {
-    console.warn("Search spinner element not found; skipping style update.");
-  }
-}
 
 /**
  * Load surrounding context for a search result element.
@@ -177,13 +170,13 @@ export async function handleSearch(event) {
     renderResults(tbody, toRender, terms, loadResultContext);
   } catch (err) {
     console.error("Search failed", err);
-    setSpinnerDisplay("none");
+    spinner.hide();
     if (messageEl) messageEl.textContent = "An error occurred while searching.";
   }
 }
 
 function showSearching(messageEl) {
-  setSpinnerDisplay("block");
+  spinner.show();
   if (messageEl) {
     messageEl.textContent = "Searching...";
     messageEl.classList.remove("search-result-empty");
@@ -195,7 +188,7 @@ function finalizeSearchUi(messageEl) {
     messageEl.textContent = "";
     messageEl.classList.remove("search-result-empty");
   }
-  setSpinnerDisplay("none");
+  spinner.hide();
 }
 
 function handleNoMatches(matches, messageEl) {
@@ -220,7 +213,7 @@ function handleNoMatches(matches, messageEl) {
  *
  * @pseudocode
  * 1. Begin preloading the feature extractor.
- * 2. Cache the spinner element and hide it if present.
+ * 2. Create a spinner and hide it initially.
  * 3. Locate the search form element.
  * 4. Attempt to load embeddings and metadata together.
  *    - On failure, hide the spinner, show an error message, attach form handlers, and exit early.
@@ -230,8 +223,8 @@ function handleNoMatches(matches, messageEl) {
  */
 export async function init() {
   preloadExtractor();
-  spinner = document.getElementById("search-spinner");
-  setSpinnerDisplay("none");
+  const container = document.querySelector(".vector-search-container") || document.body;
+  spinner = createSpinner(container);
   const form = document.getElementById("vector-search-form");
   const messageEl = document.getElementById("search-results-message");
 
@@ -244,7 +237,7 @@ export async function init() {
     ]);
   } catch (err) {
     console.error("Embedding load failed", err);
-    setSpinnerDisplay("none");
+    spinner.hide();
     if (messageEl) {
       messageEl.textContent = "Failed to load search data. Please try again later.";
     }

--- a/tests/helpers/browseJudokaPage.test.js
+++ b/tests/helpers/browseJudokaPage.test.js
@@ -147,20 +147,25 @@ describe("browseJudokaPage helpers", () => {
       return wrapper;
     });
 
-    const createLoadingSpinner = (wrapper) => {
-      const spinner = document.createElement("div");
-      spinner.className = "loading-spinner";
-      wrapper.appendChild(spinner);
-      return { spinner, timeoutId: 0 };
+    const createSpinner = (wrapper) => {
+      const element = document.createElement("div");
+      element.className = "loading-spinner";
+      wrapper.appendChild(element);
+      return {
+        element,
+        show: vi.fn(),
+        hide: vi.fn(),
+        remove: () => element.remove()
+      };
     };
 
     vi.doMock("../../src/helpers/domReady.js", () => ({ onDomReady: vi.fn() }));
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
     vi.doMock("../../src/helpers/carouselBuilder.js", () => ({
       buildCardCarousel,
-      initScrollMarkers: vi.fn(),
-      createLoadingSpinner
+      initScrollMarkers: vi.fn()
     }));
+    vi.doMock("../../src/components/Spinner.js", () => ({ createSpinner }));
     vi.doMock("../../src/helpers/buttonEffects.js", () => ({ setupButtonEffects: vi.fn() }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({
       initTooltips: vi.fn().mockResolvedValue(() => {})
@@ -237,8 +242,15 @@ describe("browseJudokaPage helpers", () => {
     vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson }));
     vi.doMock("../../src/helpers/carouselBuilder.js", () => ({
       buildCardCarousel,
-      initScrollMarkers: vi.fn(),
-      createLoadingSpinner: () => ({ spinner: document.createElement("div"), timeoutId: 0 })
+      initScrollMarkers: vi.fn()
+    }));
+    vi.doMock("../../src/components/Spinner.js", () => ({
+      createSpinner: () => ({
+        element: document.createElement("div"),
+        show: vi.fn(),
+        hide: vi.fn(),
+        remove: vi.fn()
+      })
     }));
     vi.doMock("../../src/helpers/buttonEffects.js", () => ({ setupButtonEffects: vi.fn() }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({

--- a/tests/helpers/changeLogPage.test.js
+++ b/tests/helpers/changeLogPage.test.js
@@ -37,7 +37,7 @@ describe("changeLogPage", () => {
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue([sample[0]])
     }));
-    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+    vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "", SPINNER_DELAY_MS: 0 }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({
       initTooltips: vi.fn().mockResolvedValue(() => {})
     }));

--- a/tests/helpers/vectorSearchPage.test.js
+++ b/tests/helpers/vectorSearchPage.test.js
@@ -4,6 +4,14 @@ import { describe, it, expect, vi } from "vitest";
 vi.doMock("../../src/helpers/domReady.js", () => ({
   onDomReady: vi.fn()
 }));
+vi.doMock("../../src/components/Spinner.js", () => ({
+  createSpinner: () => ({
+    element: document.createElement("div"),
+    show: vi.fn(),
+    hide: vi.fn(),
+    remove: vi.fn()
+  })
+}));
 
 describe("vector search page integration", () => {
   it("passes selected tag to findMatches", async () => {
@@ -33,7 +41,6 @@ describe("vector search page integration", () => {
     __setExtractor(async () => ({ data: [0, 0, 0] }));
 
     document.body.innerHTML = `
-      <div id="search-spinner"></div>
       <form id="vector-search-form">
         <input id="vector-search-input" />
         <select id="tag-filter"><option value="foo">foo</option></select>
@@ -78,7 +85,6 @@ describe("vector search page integration", () => {
 
     document.body.innerHTML = `
       <select id="tag-filter"></select>
-      <div id="search-spinner"></div>
       <form id="vector-search-form"></form>
       <p id="embedding-stats"></p>
     `;
@@ -112,7 +118,6 @@ describe("vector search page integration", () => {
     const { init } = await import("../../src/helpers/vectorSearchPage.js");
 
     document.body.innerHTML = `
-      <div id="search-spinner" style="display:block"></div>
       <form id="vector-search-form"></form>
       <p id="search-results-message"></p>
     `;
@@ -121,7 +126,6 @@ describe("vector search page integration", () => {
 
     const msg = document.getElementById("search-results-message");
     expect(msg.textContent).toContain("Failed to load search data");
-    expect(document.getElementById("search-spinner").style.display).toBe("none");
 
     consoleError.mockRestore();
   });
@@ -152,7 +156,6 @@ describe("search result message styling", () => {
     __setExtractor(async () => ({ data: [0, 0, 0] }));
 
     document.body.innerHTML = `
-      <div id="search-spinner"></div>
       <form id="vector-search-form">
         <input id="vector-search-input" />
         <select id="tag-filter"><option value="all">all</option></select>
@@ -202,7 +205,6 @@ describe("search result message styling", () => {
     __setExtractor(async () => ({ data: [0, 0, 0] }));
 
     document.body.innerHTML = `
-      <div id="search-spinner"></div>
       <form id="vector-search-form">
         <input id="vector-search-input" />
         <select id="tag-filter"><option value="all">all</option></select>
@@ -252,7 +254,6 @@ describe("search result message styling", () => {
     __setExtractor(async () => ({ data: [0, 0, 0] }));
 
     document.body.innerHTML = `
-      <div id="search-spinner"></div>
       <form id="vector-search-form">
         <input id="vector-search-input" />
         <select id="tag-filter"><option value="all">all</option></select>
@@ -317,7 +318,6 @@ describe("snippet highlighting", () => {
     __setExtractor(async () => ({ data: [0, 0, 0] }));
 
     document.body.innerHTML = `
-      <div id="search-spinner"></div>
       <form id="vector-search-form">
         <input id="vector-search-input" />
         <select id="tag-filter"><option value="all">all</option></select>
@@ -400,7 +400,6 @@ describe("synonym expansion", () => {
     });
 
     document.body.innerHTML = `
-      <div id="search-spinner"></div>
       <form id="vector-search-form">
         <input id="vector-search-input" />
         <select id="tag-filter"><option value="all">all</option></select>
@@ -447,7 +446,6 @@ describe("search results", () => {
     const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
     __setExtractor(async () => ({ data: [0, 0, 0] }));
     document.body.innerHTML = `
-      <div id="search-spinner"></div>
       <form id="vector-search-form">
         <input id="vector-search-input" />
         <select id="tag-filter"><option value="all">all</option></select>
@@ -498,7 +496,6 @@ describe("search results", () => {
     const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
     __setExtractor(async () => ({ data: [0, 0, 0] }));
     document.body.innerHTML = `
-      <div id="search-spinner"></div>
       <form id="vector-search-form">
         <input id="vector-search-input" />
         <select id="tag-filter"><option value="all">all</option></select>
@@ -543,7 +540,6 @@ describe("search results", () => {
     const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
     __setExtractor(async () => ({ data: [0, 0, 0] }));
     document.body.innerHTML = `
-      <div id="search-spinner"></div>
       <form id="vector-search-form">
         <input id="vector-search-input" />
         <select id="tag-filter"><option value="all">all</option></select>
@@ -578,7 +574,6 @@ describe("search results", () => {
     const { __setExtractor } = await import("../../src/helpers/api/vectorSearchPage.js");
     __setExtractor(async () => ({ data: [0, 0, 0] }));
     document.body.innerHTML = `
-      <div id="search-spinner"></div>
       <form id="vector-search-form">
         <input id="vector-search-input" />
         <select id="tag-filter"><option value="all">all</option></select>


### PR DESCRIPTION
## Summary
- add Spinner component exposing show/hide/remove helpers
- replace ad-hoc spinner logic across helpers with reusable component
- update tests for new spinner API

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a5bc693cb08326b2d44b8018a2d7b4