### PR TITLE
refactor: centralize spinner styles

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -8,6 +8,7 @@
 @import "./battle.css";
 @import "./tooltip.css";
 @import "./snackbar.css";
+@import "./spinner.css";
 
 .debug-panel {
   background-color: #f9f9f9;

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -81,26 +81,6 @@
   font-size: var(--font-small);
 }
 
-.loading-spinner {
-  display: none;
-  border: 4px solid var(--color-surface);
-  border: solid 1px var(--color-secondary);
-  border-radius: 50%;
-  width: 40px;
-  height: 40px;
-  animation: spin 1s linear infinite;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
-@keyframes spin {
-  to {
-    transform: translate(-50%, -50%) rotate(360deg);
-  }
-}
-
 .draw-card-btn {
   display: flex;
   align-items: center;

--- a/src/styles/prdViewer.css
+++ b/src/styles/prdViewer.css
@@ -73,23 +73,3 @@
   font-weight: 600;
   margin-bottom: var(--space-sm);
 }
-
-.loading-spinner {
-  display: none;
-  border: 4px solid var(--color-surface);
-  border: solid 1px var(--color-secondary);
-  border-radius: 50%;
-  width: 40px;
-  height: 40px;
-  animation: spin 1s linear infinite;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
-@keyframes spin {
-  to {
-    transform: translate(-50%, -50%) rotate(360deg);
-  }
-}

--- a/src/styles/spinner.css
+++ b/src/styles/spinner.css
@@ -1,0 +1,19 @@
+.loading-spinner {
+  display: none;
+  border: 4px solid var(--color-surface);
+  border: solid 1px var(--color-secondary);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+@keyframes spin {
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- extract shared loading spinner styles into a new `spinner.css`
- import spinner styles via `components.css`
- drop duplicated spinner rules from `navbar.css` and `prdViewer.css`

## Testing
- `npx prettier . --check`
- `npx eslint . && echo 'eslint ok'`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a5cc61f1ec8326a0e85f7b584a9950