### PR TITLE
refactor: inject spinners via helpers

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -178,7 +178,8 @@ test.describe.parallel("Browse Judoka screen", () => {
     await page.reload();
 
     const spinner = page.locator(".loading-spinner");
-    await spinner.waitFor({ state: "visible" });
+    await spinner.waitFor({ state: "attached" });
+    await expect(spinner).toBeVisible();
     await page.waitForSelector(".card-carousel .judoka-card");
     await expect(spinner).toBeHidden();
   });

--- a/src/pages/changeLog.html
+++ b/src/pages/changeLog.html
@@ -41,9 +41,7 @@
 
       <main class="container" role="main">
         <h1>Recent Judoka Updates</h1>
-        <div id="loading-container">
-          <div class="loading-spinner"></div>
-        </div>
+        <div id="loading-container"></div>
         <table id="changelog-table" aria-label="Judoka update log">
           <thead>
             <tr>

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -32,7 +32,6 @@
         </aside>
         <section class="preview">
           <div id="prd-content" tabindex="0"></div>
-          <div class="loading-spinner" id="prd-spinner" aria-hidden="true"></div>
         </section>
       </main>
 

--- a/src/pages/vectorSearch.html
+++ b/src/pages/vectorSearch.html
@@ -44,7 +44,6 @@
         <p class="small-text" id="context-note">
           Click a result to load more context when available.
         </p>
-        <div id="search-spinner" class="loading-spinner" aria-hidden="true"></div>
         <table id="vector-results-table" aria-label="Search results">
           <thead>
             <tr>

--- a/tests/helpers/browseJudokaPage.test.js
+++ b/tests/helpers/browseJudokaPage.test.js
@@ -147,15 +147,19 @@ describe("browseJudokaPage helpers", () => {
       return wrapper;
     });
 
+    let show;
+    let remove;
     const createSpinner = (wrapper) => {
       const element = document.createElement("div");
       element.className = "loading-spinner";
       wrapper.appendChild(element);
+      show = vi.fn();
+      remove = vi.fn(() => element.remove());
       return {
         element,
-        show: vi.fn(),
+        show,
         hide: vi.fn(),
-        remove: () => element.remove()
+        remove
       };
     };
 
@@ -198,12 +202,14 @@ describe("browseJudokaPage helpers", () => {
     await Promise.resolve();
 
     expect(carousel.querySelector(".loading-spinner")).not.toBeNull();
+    expect(show).toHaveBeenCalled();
 
     fetchResolvers[0]([{ id: 1, country: "JP" }]);
     fetchResolvers[1]([]);
     await pagePromise;
 
     expect(carousel.querySelector(".loading-spinner")).toBeNull();
+    expect(remove).toHaveBeenCalled();
     expect(toggleCountryPanelMode).toHaveBeenCalledWith(panel, false);
   });
 


### PR DESCRIPTION
## Summary
- remove hard-coded spinner elements from vector search, PRD viewer, and changelog pages
- verify spinner injection via helpers and tests
- adjust spinner tests for browse judoka flow

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a5ed22edac8326a847f760eba74adb