### PR TITLE
Handle invalid hash decoding in tooltip viewer

### DIFF
--- a/src/helpers/tooltipViewerPage.js
+++ b/src/helpers/tooltipViewerPage.js
@@ -125,7 +125,7 @@ export function bindCopyButtons(keyCopyBtn, bodyCopyBtn) {
  * Select and scroll to the list item referenced by `location.hash`.
  *
  * @pseudocode
- * 1. Read and decode the URL hash.
+ * 1. Read and decode the URL hash; exit if decoding fails.
  * 2. Find the matching list item and invoke `select`.
  * 3. Scroll the element into view when found.
  *
@@ -134,7 +134,12 @@ export function bindCopyButtons(keyCopyBtn, bodyCopyBtn) {
  */
 export function applyHashSelection(listPlaceholder, select) {
   if (location.hash) {
-    const key = decodeURIComponent(location.hash.slice(1));
+    let key;
+    try {
+      key = decodeURIComponent(location.hash.slice(1));
+    } catch {
+      return;
+    }
     const el = listPlaceholder.querySelector(`[data-key="${key}"]`);
     if (el) {
       select(key);


### PR DESCRIPTION
## Summary
- prevent `decodeURIComponent` from throwing in tooltip viewer when URL hash is invalid
- document early exit behavior in `applyHashSelection`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a5ff5fa82483269ed5060ebdbd30a3