### PR TITLE
feat: guard pseudoJapanese element

### DIFF
--- a/src/helpers/pseudoJapanese.js
+++ b/src/helpers/pseudoJapanese.js
@@ -82,16 +82,19 @@ export async function convertToPseudoJapanese(input) {
  * preserving the original HTML structure.
  *
  * @pseudocode
- * 1. Traverse the element with a `TreeWalker` to collect all text nodes.
- * 2. For each text node, asynchronously convert its value using
+ * 1. If `element` is `null` or `undefined`, return immediately.
+ * 2. Traverse the element with a `TreeWalker` to collect all text nodes.
+ * 3. For each text node, asynchronously convert its value using
  *    `convertToPseudoJapanese`.
- * 3. Wait for all conversions to finish.
- * 4. Replace each text node's value with the corresponding converted text.
+ * 4. Wait for all conversions to finish.
+ * 5. Replace each text node's value with the corresponding converted text.
  *
  * @param {HTMLElement} element - The element containing text to convert.
  * @returns {Promise<void>} Resolves when conversion is complete.
  */
 export async function convertElementToPseudoJapanese(element) {
+  if (!element) return;
+
   const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
   const nodes = [];
   while (walker.nextNode()) {


### PR DESCRIPTION
## Summary
- prevent convertElementToPseudoJapanese from constructing a TreeWalker when no element is supplied
- document the early return in @pseudocode

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a5ff5335848326b10bf4c3cfea763a