### PR TITLE
refactor: rename classic battle win events

### DIFF
--- a/src/data/classicBattleStates.json
+++ b/src/data/classicBattleStates.json
@@ -78,8 +78,8 @@
     "description": "Compares the selected stat and determines the round outcome.",
     "onEnter": ["compare:selectedStat", "compute:roundOutcome", "announce:roundOutcome"],
     "triggers": [
-      { "on": "outcome=winP1", "target": "roundOver" },
-      { "on": "outcome=winP2", "target": "roundOver" },
+      { "on": "outcome=winPlayer", "target": "roundOver" },
+      { "on": "outcome=winOpponent", "target": "roundOver" },
       { "on": "outcome=draw", "target": "roundOver" },
       { "on": "interrupt", "target": "interruptRound" }
     ]
@@ -93,7 +93,7 @@
       {
         "on": "matchPointReached",
         "target": "matchDecision",
-        "guard": "scoreP1 >= winTarget || scoreP2 >= winTarget",
+        "guard": "playerScore >= winTarget || opponentScore >= winTarget",
         "note": "Checks the user-selected win target (5/10/15)."
       },
       { "on": "continue", "target": "cooldown" },

--- a/src/helpers/classicBattle/orchestrator.js
+++ b/src/helpers/classicBattle/orchestrator.js
@@ -223,15 +223,7 @@ export async function initClassicBattleOrchestrator(store, startRoundWrapper, op
   return machine;
 }
 
-function normalizeEventName(eventName) {
-  if (typeof eventName !== "string") return eventName;
-  if (eventName === "outcome=winPlayer") return "outcome=winP1";
-  if (eventName === "outcome=winOpponent") return "outcome=winP2";
-  return eventName;
-}
-
 export async function dispatchBattleEvent(eventName, payload) {
   if (!machine) return;
-  const mapped = normalizeEventName(eventName);
-  await machine.dispatch(mapped, payload);
+  await machine.dispatch(eventName, payload);
 }

--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -95,7 +95,7 @@ export async function resolveRound(store) {
   const opponentSnackbarId = setTimeout(() => showSnackbar("Opponent is choosing…"), 500);
 
   const delay = 300 + Math.floor(Math.random() * 401);
-  await new Promise(resolve => setTimeout(resolve, delay));
+  await new Promise((resolve) => setTimeout(resolve, delay));
 
   clearTimeout(opponentSnackbarId);
   await revealComputerCard();

--- a/src/helpers/timerUtils.js
+++ b/src/helpers/timerUtils.js
@@ -127,14 +127,17 @@ export function createCountdownTimer(
     // Hard fallback to ensure expiration even if the scheduler never ticks
     // in certain test environments.
     try {
-      hardTimeoutId = setTimeout(async () => {
-        if (subId !== null) {
-          // Timer still running; stop and expire once.
-          stop();
-          if (typeof onTick === "function") onTick(0);
-          if (typeof onExpired === "function") await onExpired();
-        }
-      }, Math.max(0, Math.floor(remaining) * 1000 + 5));
+      hardTimeoutId = setTimeout(
+        async () => {
+          if (subId !== null) {
+            // Timer still running; stop and expire once.
+            stop();
+            if (typeof onTick === "function") onTick(0);
+            if (typeof onExpired === "function") await onExpired();
+          }
+        },
+        Math.max(0, Math.floor(remaining) * 1000 + 5)
+      );
     } catch {}
     if (pauseOnHidden && typeof document !== "undefined") {
       document.addEventListener("visibilitychange", handleVisibility);


### PR DESCRIPTION
## Summary
- rename win triggers to `winPlayer` and `winOpponent`
- remove deprecated event name normalization and dispatch events directly
- format classic battle helpers for new event names

## Testing
- `npm run validate:data`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/statSelection.test.js`
- `npx playwright test` *(fails: screenshot mismatch and interrupted tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a63ddd1eb083268e467c6798bcfeec