### PR TITLE
refactor: rename computer to opponent

### DIFF
--- a/design/productRequirementsDocuments/prdBattleDebugPanel.md
+++ b/design/productRequirementsDocuments/prdBattleDebugPanel.md
@@ -31,7 +31,7 @@ Developers and testers need a way to observe internal game state (e.g., scores, 
 | Priority | Feature                       | Description                                                                                 |
 | -------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
 | P1       | Debug Panel Toggle            | Add a toggle in Settings to enable/disable the debug panel overlay in battle mode           |
-| P1       | Real-Time State Display       | Show current player/computer scores, timer state, match end status, and (if test mode) seed |
+| P1       | Real-Time State Display       | Show current player/opponent scores, timer state, match end status, and (if test mode) seed |
 | P1       | Persistent Panel Placement    | Panel appears in the battle UI, does not overlap controls, and remains visible when enabled |
 | P2       | Accessibility Compliance      | Panel uses semantic markup (e.g., <pre>, aria-live) for screen reader compatibility         |
 | P3       | Hide in Production by Default | Panel is hidden unless explicitly enabled (or DEBUG_LOGGING=true)                           |
@@ -40,7 +40,7 @@ Developers and testers need a way to observe internal game state (e.g., scores, 
 
 - Debug panel is hidden by default for all users
 - Enabling the toggle in Settings immediately shows the debug panel in Classic Battle
-- Panel displays a JSON-formatted object with: playerScore, computerScore, timer, matchEnded, and seed (if test mode)
+- Panel displays a JSON-formatted object with: playerScore, opponentScore, timer, matchEnded, and seed (if test mode)
 - Panel updates in real time after each round, stat selection, and timer event
 - Panel uses <pre> and aria-live attributes for accessibility
 - Disabling the toggle hides the panel immediately

--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -56,7 +56,7 @@ test.describe.parallel("Classic battle flow", () => {
       document.querySelector("#next-round-timer").textContent = "Time Left: 3s";
       document.querySelector("#player-card").innerHTML =
         `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;
-      document.querySelector("#computer-card").innerHTML =
+      document.querySelector("#opponent-card").innerHTML =
         `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;
     });
     await page.locator("button[data-stat='power']").click();

--- a/src/components/Scoreboard.js
+++ b/src/components/Scoreboard.js
@@ -23,7 +23,7 @@ let scoreEl;
 let roundCounterEl;
 let scoreRafId = 0;
 let currentPlayer = 0;
-let currentComputer = 0;
+let currentOpponent = 0;
 
 export function createScoreboard(container = document.createElement("div")) {
   messageEl = document.createElement("p");
@@ -88,7 +88,7 @@ function ensureRefs() {
   }
 }
 
-function setScoreText(player, computer) {
+function setScoreText(player, opponent) {
   if (!scoreEl) return;
   let playerSpan = scoreEl.firstElementChild;
   let opponentSpan = scoreEl.lastElementChild;
@@ -98,10 +98,10 @@ function setScoreText(player, computer) {
     scoreEl.append(playerSpan, opponentSpan);
   }
   playerSpan.textContent = `You: ${player}`;
-  opponentSpan.textContent = `\nOpponent: ${computer}`;
+  opponentSpan.textContent = `\nOpponent: ${opponent}`;
 }
 
-function animateScore(startPlayer, startComputer, playerTarget, computerTarget) {
+function animateScore(startPlayer, startOpponent, playerTarget, opponentTarget) {
   cancelAnimationFrame(scoreRafId);
   if (shouldReduceMotionSync()) return;
   const startTime = performance.now();
@@ -109,8 +109,8 @@ function animateScore(startPlayer, startComputer, playerTarget, computerTarget) 
   const step = (now) => {
     const progress = Math.min((now - startTime) / duration, 1);
     const playerVal = Math.round(startPlayer + (playerTarget - startPlayer) * progress);
-    const computerVal = Math.round(startComputer + (computerTarget - startComputer) * progress);
-    setScoreText(playerVal, computerVal);
+    const opponentVal = Math.round(startOpponent + (opponentTarget - startOpponent) * progress);
+    setScoreText(playerVal, opponentVal);
     if (progress < 1) {
       scoreRafId = requestAnimationFrame(step);
     }
@@ -272,18 +272,18 @@ export function startCountdown(seconds, onFinish) {
  *    targets using `requestAnimationFrame`.
  *
  * @param {number} playerScore - Player's score.
- * @param {number} computerScore - Opponent's score.
+ * @param {number} opponentScore - Opponent's score.
  * @returns {void}
  */
-export function updateScore(playerScore, computerScore) {
+export function updateScore(playerScore, opponentScore) {
   ensureRefs();
   if (!scoreEl) return;
-  setScoreText(playerScore, computerScore);
+  setScoreText(playerScore, opponentScore);
   const startPlayer = currentPlayer;
-  const startComputer = currentComputer;
+  const startOpponent = currentOpponent;
   currentPlayer = playerScore;
-  currentComputer = computerScore;
-  animateScore(startPlayer, startComputer, playerScore, computerScore);
+  currentOpponent = opponentScore;
+  animateScore(startPlayer, startOpponent, playerScore, opponentScore);
 }
 
 function runCountdown(duration, onTick, onExpired, handleDrift) {

--- a/src/helpers/api/battleUI.js
+++ b/src/helpers/api/battleUI.js
@@ -42,7 +42,7 @@ export function chooseOpponentStat(values, difficulty = "easy") {
  *
  * @param {number} playerVal - Player's stat value.
  * @param {number} opponentVal - Opponent's stat value.
- * @returns {{message: string, matchEnded: boolean, playerScore: number, computerScore: number}}
+ * @returns {{message: string, matchEnded: boolean, playerScore: number, opponentScore: number}}
  */
 export function evaluateRound(playerVal, opponentVal) {
   return handleStatSelection(playerVal, opponentVal);

--- a/src/helpers/battleJudokaPage.js
+++ b/src/helpers/battleJudokaPage.js
@@ -1,19 +1,19 @@
 /**
- * Wait until the computer's card loads. Resolves when a `.judoka-card` appears
+ * Wait until the opponent's card loads. Resolves when a `.judoka-card` appears
  * or after a timeout.
  *
  * @param {number} [timeoutMs=5000] - Maximum wait time in milliseconds.
  * @returns {Promise<void>}
  *
  * @pseudocode
- * 1. Fetch the `#computer-card` container.
+ * 1. Fetch the `#opponent-card` container.
  * 2. Resolve immediately if missing or a `.judoka-card` is already present.
  * 3. Resolve immediately if `MutationObserver` is unavailable.
  * 4. Otherwise observe mutations and resolve once a `.judoka-card` appears.
  * 5. Set a timeout that disconnects the observer and resolves after `timeoutMs`.
  */
-export function waitForComputerCard(timeoutMs = 5000) {
-  const container = document.getElementById("computer-card");
+export function waitForOpponentCard(timeoutMs = 5000) {
+  const container = document.getElementById("opponent-card");
   if (!container) return Promise.resolve();
   if (container.querySelector(".judoka-card")) {
     return Promise.resolve();

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -2,10 +2,10 @@ export * from "./classicBattle/roundManager.js";
 export * from "./classicBattle/selectionHandler.js";
 export * from "./classicBattle/quitModal.js";
 export {
-  revealComputerCard,
+  revealOpponentCard,
   enableNextRoundButton,
   disableNextRoundButton,
   updateDebugPanel
 } from "./classicBattle/uiHelpers.js";
-export { getComputerJudoka } from "./classicBattle/cardSelection.js";
+export { getOpponentJudoka } from "./classicBattle/cardSelection.js";
 export { scheduleNextRound } from "./classicBattle/timerService.js";

--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -14,7 +14,7 @@ import { setupLazyPortraits } from "../lazyPortrait.js";
 
 let judokaData = null;
 let gokyoLookup = null;
-let computerJudoka = null;
+let opponentJudoka = null;
 let loadErrorModal = null;
 
 function qaInfo(text) {
@@ -70,17 +70,17 @@ function showLoadError(error) {
 }
 
 /**
- * Draw battle cards for the player and computer.
+ * Draw battle cards for the player and opponent.
  *
  * @pseudocode
  * 1. Load judoka and gokyo data when not cached.
  * 2. Filter out judoka marked `isHidden`.
  * 3. Render a random player card using `generateRandomCard` and store the result.
  * 4. Choose a random opponent judoka avoiding duplicates.
- * 5. If `JudokaCard.render` returns an HTMLElement, render a placeholder card for the computer with obscured stats; otherwise log an error.
+ * 5. If `JudokaCard.render` returns an HTMLElement, render a placeholder card for the opponent with obscured stats; otherwise log an error.
  * 6. Return the selected judoka objects.
  *
- * @returns {Promise<{playerJudoka: object|null, computerJudoka: object|null}>}
+ * @returns {Promise<{playerJudoka: object|null, opponentJudoka: object|null}>}
  */
 async function ensureJudokaData() {
   if (judokaData) return Array.isArray(judokaData) ? judokaData : [];
@@ -117,7 +117,7 @@ function pickOpponent(available, playerJudoka) {
   return compJudoka;
 }
 
-async function renderComputerPlaceholder(container, placeholder, enableInspector) {
+async function renderOpponentPlaceholder(container, placeholder, enableInspector) {
   if (!container) return;
 
   // Preserve the debug panel across placeholder re-renders
@@ -131,7 +131,7 @@ async function renderComputerPlaceholder(container, placeholder, enableInspector
   if (!target) {
     try {
       target = await getFallbackJudoka();
-      qaInfo("Using fallback judoka for computer placeholder");
+      qaInfo("Using fallback judoka for opponent placeholder");
     } catch {
       // If even the fallback cannot be retrieved, bail silently.
       return;
@@ -173,10 +173,10 @@ export async function drawCards() {
 
   const lookup = await ensureGokyoLookup();
   // If lookup failed completely, bail out; judoka may be empty but we can still proceed.
-  if (!lookup) return { playerJudoka: null, computerJudoka: null };
+  if (!lookup) return { playerJudoka: null, opponentJudoka: null };
 
   const playerContainer = document.getElementById("player-card");
-  const computerContainer = document.getElementById("computer-card");
+  const opponentContainer = document.getElementById("opponent-card");
 
   try {
     await loadSettings();
@@ -217,7 +217,7 @@ export async function drawCards() {
       compJudoka = null;
     }
   }
-  computerJudoka = compJudoka;
+  opponentJudoka = compJudoka;
 
   // Choose a placeholder based on a stable ID (1) or the opponent.
   // Do not validate here to allow minimal objects during tests.
@@ -225,22 +225,22 @@ export async function drawCards() {
   if (!placeholder) {
     try {
       placeholder = await getFallbackJudoka();
-      qaInfo("Using fallback judoka for computer placeholder");
+      qaInfo("Using fallback judoka for opponent placeholder");
     } catch {
       placeholder = null;
     }
   }
-  await renderComputerPlaceholder(computerContainer, placeholder, enableInspector);
+  await renderOpponentPlaceholder(opponentContainer, placeholder, enableInspector);
 
-  return { playerJudoka, computerJudoka };
+  return { playerJudoka, opponentJudoka };
 }
 
-export function getComputerJudoka() {
-  return computerJudoka;
+export function getOpponentJudoka() {
+  return opponentJudoka;
 }
 
-export function clearComputerJudoka() {
-  computerJudoka = null;
+export function clearOpponentJudoka() {
+  opponentJudoka = null;
 }
 
 export function getGokyoLookup() {
@@ -249,7 +249,7 @@ export function getGokyoLookup() {
 
 /**
  * Ensure the gokyo lookup is available, loading it if missing.
- * Primarily used by tests or code paths that call `revealComputerCard` directly.
+ * Primarily used by tests or code paths that call `revealOpponentCard` directly.
  * @returns {Promise<ReturnType<typeof createGokyoLookup>>} Lookup (empty on failure).
  */
 export async function getOrLoadGokyoLookup() {
@@ -259,6 +259,6 @@ export async function getOrLoadGokyoLookup() {
 export function _resetForTest() {
   judokaData = null;
   gokyoLookup = null;
-  computerJudoka = null;
+  opponentJudoka = null;
   loadErrorModal = null;
 }

--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -3,7 +3,7 @@ import { chooseOpponentStat, evaluateRound as evaluateRoundApi } from "../api/ba
 import * as scoreboard from "../setupScoreboard.js";
 import { showSnackbar } from "../showSnackbar.js";
 import { getStatValue, resetStatButtons, showResult } from "../battle/index.js";
-import { revealComputerCard } from "./uiHelpers.js";
+import { revealOpponentCard } from "./uiHelpers.js";
 import { scheduleNextRound } from "./timerService.js";
 import { showMatchSummaryModal } from "./uiService.js";
 import { handleReplay } from "./roundManager.js";
@@ -20,7 +20,7 @@ import { dispatchBattleEvent } from "./orchestrator.js";
  * @returns {string} One of the values from `STATS`.
  */
 export function simulateOpponentStat(difficulty = "easy") {
-  const card = document.getElementById("computer-card");
+  const card = document.getElementById("opponent-card");
   const values = card ? STATS.map((stat) => ({ stat, value: getStatValue(card, stat) })) : [];
   return chooseOpponentStat(values, difficulty);
 }
@@ -34,19 +34,19 @@ export function simulateOpponentStat(difficulty = "easy") {
  */
 export function evaluateRound(store, stat) {
   const playerCard = document.getElementById("player-card");
-  const computerCard = document.getElementById("computer-card");
+  const opponentCard = document.getElementById("opponent-card");
   const playerVal = getStatValue(playerCard, stat);
-  const computerVal = getStatValue(computerCard, stat);
-  const result = evaluateRoundApi(playerVal, computerVal);
+  const opponentVal = getStatValue(opponentCard, stat);
+  const result = evaluateRoundApi(playerVal, opponentVal);
   syncScoreDisplay();
   const msg = result.message || "";
   showResult(msg);
   scoreboard.showMessage(msg);
-  showStatComparison(store, stat, playerVal, computerVal);
+  showStatComparison(store, stat, playerVal, opponentVal);
   updateDebugPanel();
   const outcome =
-    playerVal > computerVal ? "winPlayer" : playerVal < computerVal ? "winOpponent" : "draw";
-  return { ...result, outcome, playerVal, computerVal };
+    playerVal > opponentVal ? "winPlayer" : playerVal < opponentVal ? "winOpponent" : "draw";
+  return { ...result, outcome, playerVal, opponentVal };
 }
 
 /**
@@ -98,7 +98,7 @@ export async function resolveRound(store) {
   await new Promise((resolve) => setTimeout(resolve, delay));
 
   clearTimeout(opponentSnackbarId);
-  await revealComputerCard();
+  await revealOpponentCard();
   const result = evaluateRound(store, stat);
 
   const outcomeEvent =

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -1,7 +1,7 @@
 import {
-  getComputerJudoka,
+  getOpponentJudoka,
   getGokyoLookup,
-  clearComputerJudoka,
+  clearOpponentJudoka,
   getOrLoadGokyoLookup
 } from "./cardSelection.js";
 import { loadSettings } from "../settingsStorage.js";
@@ -32,17 +32,17 @@ export function showSelectionPrompt() {
 }
 
 /**
- * Reveal the computer's hidden card.
+ * Reveal the opponent's hidden card.
  *
  * @pseudocode
  * 1. Exit early if no stored judoka exists.
- * 2. Render `computerJudoka` into the computer card container.
+ * 2. Render `opponentJudoka` into the opponent card container.
  * 3. Clear the stored judoka after rendering.
  */
-export async function revealComputerCard() {
-  const judoka = getComputerJudoka();
+export async function revealOpponentCard() {
+  const judoka = getOpponentJudoka();
   if (!judoka) return;
-  const container = document.getElementById("computer-card");
+  const container = document.getElementById("opponent-card");
   // Preserve the debug panel across card re-renders
   const debugPanel = container ? container.querySelector("#debug-panel") : null;
   try {
@@ -78,7 +78,7 @@ export async function revealComputerCard() {
       } catch {}
     }
   }
-  clearComputerJudoka();
+  clearOpponentJudoka();
 }
 
 export function enableNextRoundButton() {

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -12,9 +12,9 @@ import { navigateToHome } from "../navUtils.js";
  * 2. Forward the values to `scoreboard.updateScore`.
  */
 export function syncScoreDisplay() {
-  const { playerScore, computerScore } = getScores();
+  const { playerScore, opponentScore } = getScores();
   if (typeof scoreboard.updateScore === "function") {
-    scoreboard.updateScore(playerScore, computerScore);
+    scoreboard.updateScore(playerScore, opponentScore);
     return;
   }
   // Fallback for tests that partially mock setupScoreboard without updateScore
@@ -28,7 +28,7 @@ export function syncScoreDisplay() {
       el.append(playerSpan, opponentSpan);
     }
     playerSpan.textContent = `You: ${playerScore}`;
-    opponentSpan.textContent = `\nOpponent: ${computerScore}`;
+    opponentSpan.textContent = `\nOpponent: ${opponentScore}`;
   }
 }
 
@@ -43,7 +43,7 @@ export function syncScoreDisplay() {
  *    - Quit navigates to `index.html`.
  *    - Next runs `onNext`.
  *
- * @param {{message: string, playerScore: number, computerScore: number}} result
+ * @param {{message: string, playerScore: number, opponentScore: number}} result
  * @param {Function} onNext Callback invoked when starting the next match.
  * @returns {ReturnType<typeof createModal>} Created modal instance.
  */
@@ -54,7 +54,7 @@ export function showMatchSummaryModal(result, onNext) {
 
   const scoreEl = document.createElement("p");
   scoreEl.id = "match-summary-score";
-  scoreEl.textContent = `Final Score – You: ${result.playerScore} Opponent: ${result.computerScore}`;
+  scoreEl.textContent = `Final Score – You: ${result.playerScore} Opponent: ${result.opponentScore}`;
 
   const actions = document.createElement("div");
   actions.className = "modal-actions";

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -5,7 +5,7 @@ import { createBattleStore, startRound } from "./classicBattle/roundManager.js";
 import { handleStatSelection } from "./classicBattle/selectionHandler.js";
 import { onDomReady } from "./domReady.js";
 import { setupScoreboard, showMessage } from "./setupScoreboard.js";
-import { waitForComputerCard } from "./battleJudokaPage.js";
+import { waitForOpponentCard } from "./battleJudokaPage.js";
 import { initTooltips } from "./tooltip.js";
 import { setTestMode } from "./testModeUtils.js";
 import { toggleViewportSimulation } from "./viewportDebug.js";
@@ -39,7 +39,7 @@ async function startRoundWrapper() {
   statButtonControls?.disable();
   try {
     await startRound(battleStore);
-    await waitForComputerCard(5000);
+    await waitForOpponentCard(5000);
   } catch (error) {
     console.error("Error starting round:", error);
     try {
@@ -314,8 +314,8 @@ function applyBattleFeatureFlags(battleArea, banner) {
 function initDebugPanel() {
   const debugPanel = document.getElementById("debug-panel");
   if (!debugPanel) return;
-  const computerSlot = document.getElementById("computer-card");
-  if (isEnabled("battleDebugPanel") && computerSlot) {
+  const opponentSlot = document.getElementById("opponent-card");
+  if (isEnabled("battleDebugPanel") && opponentSlot) {
     if (debugPanel.tagName !== "DETAILS") {
       const details = document.createElement("details");
       details.id = "debug-panel";
@@ -339,7 +339,7 @@ function initDebugPanel() {
         } catch {}
       });
     } catch {}
-    computerSlot.prepend(panel);
+    opponentSlot.prepend(panel);
     panel.classList.remove("hidden");
   } else {
     debugPanel.remove();
@@ -347,7 +347,7 @@ function initDebugPanel() {
 }
 
 function setDebugPanelEnabled(enabled) {
-  const computerSlot = document.getElementById("computer-card");
+  const opponentSlot = document.getElementById("opponent-card");
   let panel = document.getElementById("debug-panel");
   if (enabled) {
     if (!panel) {
@@ -385,8 +385,8 @@ function setDebugPanelEnabled(enabled) {
       });
     } catch {}
     panel.classList.remove("hidden");
-    if (computerSlot && panel.parentElement !== computerSlot) {
-      computerSlot.prepend(panel);
+    if (opponentSlot && panel.parentElement !== opponentSlot) {
+      opponentSlot.prepend(panel);
     }
   } else if (panel) {
     panel.classList.add("hidden");

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -128,7 +128,7 @@
             </details>
           </div>
           <div
-            id="computer-card"
+            id="opponent-card"
             class="card-slot opponent-slot"
             aria-label="Mystery Judoka: hidden card"
           >

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -25,7 +25,7 @@
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
 }
 
-#computer-card .debug-panel {
+#opponent-card .debug-panel {
   margin: 0;
   max-width: none;
   width: 100%;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -227,13 +227,13 @@ body {
 
 /* Stack the opponent slot content vertically so the Battle Debug panel
    sits above the opponent card without being covered. */
-#battle-area #computer-card {
+#battle-area #opponent-card {
   flex-direction: column;
   align-items: stretch;
   gap: var(--space-sm);
 }
 
-#battle-area #computer-card .debug-panel {
+#battle-area #opponent-card .debug-panel {
   order: -1; /* ensure it appears before the card content */
   position: relative;
   z-index: 5;

--- a/tests/helpers/BattleEngine.test.js
+++ b/tests/helpers/BattleEngine.test.js
@@ -7,8 +7,8 @@ describe("compareStats", () => {
     expect(compareStats(5, 3)).toEqual({ delta: 2, winner: "player" });
   });
 
-  it("detects computer win", () => {
-    expect(compareStats(3, 5)).toEqual({ delta: -2, winner: "computer" });
+  it("detects opponent win", () => {
+    expect(compareStats(3, 5)).toEqual({ delta: -2, winner: "opponent" });
   });
 
   it("detects tie", () => {

--- a/tests/helpers/battleEngine/interrupts.test.js
+++ b/tests/helpers/battleEngine/interrupts.test.js
@@ -39,7 +39,7 @@ describe("BattleEngine interrupts", () => {
       5
     );
     engine.playerScore = 1;
-    engine.computerScore = 2;
+    engine.opponentScore = 2;
 
     const result = engine.interruptRound("referee");
 
@@ -50,7 +50,7 @@ describe("BattleEngine interrupts", () => {
     expect(result).toEqual({
       message: "Round interrupted: referee",
       playerScore: 1,
-      computerScore: 2
+      opponentScore: 2
     });
   });
 
@@ -64,7 +64,7 @@ describe("BattleEngine interrupts", () => {
       5
     );
     engine.playerScore = 3;
-    engine.computerScore = 4;
+    engine.opponentScore = 4;
 
     const result = engine.interruptMatch("injury");
 
@@ -75,7 +75,7 @@ describe("BattleEngine interrupts", () => {
     expect(result).toEqual({
       message: "Match interrupted: injury",
       playerScore: 3,
-      computerScore: 4
+      opponentScore: 4
     });
   });
 
@@ -92,7 +92,7 @@ describe("BattleEngine interrupts", () => {
 
     const modification = {
       playerScore: 5,
-      computerScore: 1,
+      opponentScore: 1,
       roundsPlayed: 2,
       resetRound: true
     };
@@ -101,13 +101,13 @@ describe("BattleEngine interrupts", () => {
 
     expect(timerApi.stop).toHaveBeenCalled();
     expect(engine.playerScore).toBe(5);
-    expect(engine.computerScore).toBe(1);
+    expect(engine.opponentScore).toBe(1);
     expect(engine.roundsPlayed).toBe(2);
     expect(engine.roundInterrupted).toBe(false);
     expect(result).toEqual({
       message: `Round modified: ${JSON.stringify(modification)}`,
       playerScore: 5,
-      computerScore: 1
+      opponentScore: 1
     });
   });
 

--- a/tests/helpers/battleJudokaPage.test.js
+++ b/tests/helpers/battleJudokaPage.test.js
@@ -4,15 +4,15 @@ vi.doMock("../../src/helpers/domReady.js", () => ({
   onDomReady: vi.fn()
 }));
 
-describe("waitForComputerCard", () => {
+describe("waitForOpponentCard", () => {
   it("resolves when the judoka card is inserted", async () => {
-    const { waitForComputerCard } = await import("../../src/helpers/battleJudokaPage.js");
+    const { waitForOpponentCard } = await import("../../src/helpers/battleJudokaPage.js");
 
     const container = document.createElement("div");
-    container.id = "computer-card";
+    container.id = "opponent-card";
     document.body.append(container);
 
-    const promise = waitForComputerCard();
+    const promise = waitForOpponentCard();
 
     await Promise.resolve();
     const card = document.createElement("div");
@@ -23,15 +23,15 @@ describe("waitForComputerCard", () => {
   });
 
   it("resolves immediately if card already present", async () => {
-    const { waitForComputerCard } = await import("../../src/helpers/battleJudokaPage.js");
+    const { waitForOpponentCard } = await import("../../src/helpers/battleJudokaPage.js");
 
     const container = document.createElement("div");
-    container.id = "computer-card";
+    container.id = "opponent-card";
     const card = document.createElement("div");
     card.className = "judoka-card";
     container.appendChild(card);
     document.body.append(container);
 
-    await expect(waitForComputerCard()).resolves.toBeUndefined();
+    await expect(waitForOpponentCard()).resolves.toBeUndefined();
   });
 });

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -39,9 +39,9 @@ describe.sequential("classicBattle card selection", () => {
   let timerSpy;
   beforeEach(() => {
     document.body.innerHTML = "";
-    const { playerCard, computerCard } = createBattleCardContainers();
+    const { playerCard, opponentCard } = createBattleCardContainers();
     const header = createBattleHeader();
-    document.body.append(playerCard, computerCard, header);
+    document.body.append(playerCard, opponentCard, header);
     timerSpy = vi.useFakeTimers();
     fetchJsonMock = vi.fn(async () => []);
     generateRandomCardMock = vi.fn(async (_d, _g, container, _pm, cb) => {
@@ -58,7 +58,7 @@ describe.sequential("classicBattle card selection", () => {
     resetDom();
   });
 
-  it("draws a different card for the computer", async () => {
+  it("draws a different card for the opponent", async () => {
     fetchJsonMock.mockImplementation(async (p) => {
       if (p.includes("judoka")) {
         return [{ id: 1 }];
@@ -80,13 +80,13 @@ describe.sequential("classicBattle card selection", () => {
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
     await battleMod.startRound(store);
-    const { getComputerJudoka } = battleMod;
+    const { getOpponentJudoka } = battleMod;
     expect(JudokaCardMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 1 }),
       expect.anything(),
       { useObscuredStats: true, enableInspector: false }
     );
-    expect(getComputerJudoka()).toEqual(expect.objectContaining({ id: 2 }));
+    expect(getOpponentJudoka()).toEqual(expect.objectContaining({ id: 2 }));
   });
 
   it("excludes hidden judoka from selection", async () => {
@@ -199,7 +199,7 @@ describe.sequential("classicBattle card selection", () => {
     _resetForTest();
     await drawCards();
     expect(consoleSpy).toHaveBeenCalledWith("JudokaCard did not render an HTMLElement");
-    const container = document.getElementById("computer-card");
+    const container = document.getElementById("opponent-card");
     expect(container.innerHTML).toBe("");
     consoleSpy.mockRestore();
   });

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -24,7 +24,7 @@ vi.mock("../../../src/helpers/motionUtils.js", () => ({
 }));
 
 vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
-  revealComputerCard: vi.fn(),
+  revealOpponentCard: vi.fn(),
   disableNextRoundButton: vi.fn(),
   enableNextRoundButton: vi.fn(),
   updateDebugPanel: vi.fn()
@@ -35,10 +35,10 @@ describe("countdown resets after stat selection", () => {
   let store;
   beforeEach(async () => {
     document.body.innerHTML = "";
-    const { playerCard, computerCard } = createBattleCardContainers();
+    const { playerCard, opponentCard } = createBattleCardContainers();
     const header = createBattleHeader();
     header.querySelector("#next-round-timer")?.remove();
-    document.body.append(playerCard, computerCard, header);
+    document.body.append(playerCard, opponentCard, header);
     createRoundMessage("round-result");
     createTimerNodes();
     document.body.innerHTML += '<div id="stat-buttons"><button data-stat="power"></button></div>';
@@ -52,7 +52,7 @@ describe("countdown resets after stat selection", () => {
     document.getElementById("next-round-timer").textContent = "Time Left: 10s";
     document.getElementById("player-card").innerHTML =
       '<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>';
-    document.getElementById("computer-card").innerHTML =
+    document.getElementById("opponent-card").innerHTML =
       '<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>';
 
     const timer = vi.useFakeTimers();

--- a/tests/helpers/classicBattle/difficulty.test.js
+++ b/tests/helpers/classicBattle/difficulty.test.js
@@ -10,9 +10,9 @@ describe("simulateOpponentStat difficulty", () => {
 
   beforeEach(async () => {
     document.body.innerHTML = "";
-    const { computerCard } = createBattleCardContainers();
-    document.body.appendChild(computerCard);
-    computerCard.innerHTML = `
+    const { opponentCard } = createBattleCardContainers();
+    document.body.appendChild(opponentCard);
+    opponentCard.innerHTML = `
       <ul>
         <li class="stat"><strong>power</strong> <span>1</span></li>
         <li class="stat"><strong>speed</strong> <span>2</span></li>

--- a/tests/helpers/classicBattle/matchEnd.test.js
+++ b/tests/helpers/classicBattle/matchEnd.test.js
@@ -127,7 +127,7 @@ describe("classicBattle match end", () => {
     for (let i = 0; i < CLASSIC_BATTLE_POINTS_TO_WIN; i++) {
       document.getElementById("player-card").innerHTML =
         `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
-      document.getElementById("computer-card").innerHTML =
+      document.getElementById("opponent-card").innerHTML =
         `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
       await selectStat();
     }
@@ -138,7 +138,7 @@ describe("classicBattle match end", () => {
 
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
-    document.getElementById("computer-card").innerHTML =
+    document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     {
       const p = battleMod.handleStatSelection(store, "power");
@@ -164,7 +164,7 @@ describe("classicBattle match end", () => {
     for (let i = 0; i < CLASSIC_BATTLE_POINTS_TO_WIN; i++) {
       document.getElementById("player-card").innerHTML =
         `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-      document.getElementById("computer-card").innerHTML =
+      document.getElementById("opponent-card").innerHTML =
         `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
       await selectStat();
     }
@@ -177,7 +177,7 @@ describe("classicBattle match end", () => {
 
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    document.getElementById("computer-card").innerHTML =
+    document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
     {
       const p = battleMod.handleStatSelection(store, "power");

--- a/tests/helpers/classicBattle/mocks.js
+++ b/tests/helpers/classicBattle/mocks.js
@@ -62,7 +62,7 @@ export function mockSelectionHandler() {
 
 export function mockBattleJudokaPage() {
   vi.doMock("../../../src/helpers/battleJudokaPage.js", () => ({
-    waitForComputerCard: vi.fn()
+    waitForOpponentCard: vi.fn()
   }));
 }
 

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -9,7 +9,7 @@ let clearMessage;
 let clearTimer;
 let showSnackbar;
 let scheduleNextRound;
-let revealComputerCard;
+let revealOpponentCard;
 let resetStatButtons;
 let updateDebugPanel;
 
@@ -20,7 +20,7 @@ beforeEach(() => {
   clearMessage = vi.fn();
   clearTimer = vi.fn();
   scheduleNextRound = vi.fn();
-  revealComputerCard = vi.fn();
+  revealOpponentCard = vi.fn();
   resetStatButtons = vi.fn();
   updateDebugPanel = vi.fn();
 
@@ -39,7 +39,7 @@ beforeEach(() => {
   }));
 
   vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
-    revealComputerCard,
+    revealOpponentCard,
     updateDebugPanel,
     showSelectionPrompt: vi.fn(),
     disableNextRoundButton: vi.fn()
@@ -61,7 +61,7 @@ beforeEach(() => {
     quitMatch: vi.fn(),
     pauseTimer: vi.fn(),
     stopTimer: vi.fn(),
-    getScores: vi.fn().mockReturnValue({ playerScore: 0, computerScore: 0 }),
+    getScores: vi.fn().mockReturnValue({ playerScore: 0, opponentScore: 0 }),
     _resetForTest: vi.fn(),
     STATS: ["power"]
   }));

--- a/tests/helpers/classicBattle/pauseTimer.test.js
+++ b/tests/helpers/classicBattle/pauseTimer.test.js
@@ -44,14 +44,14 @@ describe("classicBattle timer pause", () => {
   beforeEach(async () => {
     vi.resetModules();
     document.body.innerHTML = "";
-    const { playerCard, computerCard } = createBattleCardContainers();
+    const { playerCard, opponentCard } = createBattleCardContainers();
     const header = createBattleHeader();
     const roundResult = createRoundMessage("round-result");
     const statButtons = document.createElement("div");
     statButtons.id = "stat-buttons";
     statButtons.dataset.tooltipId = "ui.selectStat";
     statButtons.innerHTML = '<button data-stat="power"></button>';
-    document.body.append(playerCard, computerCard, header, roundResult, statButtons);
+    document.body.append(playerCard, opponentCard, header, roundResult, statButtons);
 
     timer = vi.useFakeTimers();
 
@@ -102,7 +102,7 @@ describe("classicBattle timer pause", () => {
     // timer ticks in this unit test.
     document.getElementById("player-card").innerHTML =
       '<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>';
-    document.getElementById("computer-card").innerHTML =
+    document.getElementById("opponent-card").innerHTML =
       '<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>';
     // eslint-disable-next-line no-console
     console.log("pauseTimer: BEFORE handleStatSelection");

--- a/tests/helpers/classicBattle/selectionPrompt.test.js
+++ b/tests/helpers/classicBattle/selectionPrompt.test.js
@@ -87,7 +87,7 @@ describe("classicBattle selection prompt", () => {
     expect(document.querySelector("header #round-message").textContent).toBe("");
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
-    document.getElementById("computer-card").innerHTML =
+    document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     {
       const p = battleMod.handleStatSelection(store, "power");

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -46,9 +46,9 @@ describe("classicBattle stalled stat selection recovery", () => {
   let timerSpy;
   beforeEach(() => {
     document.body.innerHTML = "";
-    const { playerCard, computerCard } = createBattleCardContainers();
+    const { playerCard, opponentCard } = createBattleCardContainers();
     const header = createBattleHeader();
-    document.body.append(playerCard, computerCard, header);
+    document.body.append(playerCard, opponentCard, header);
     timerSpy = vi.useFakeTimers();
     fetchJsonMock = vi.fn(async () => []);
     generateRandomCardMock = vi.fn(async (_d, _g, container, _pm, cb) => {

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -90,13 +90,13 @@ describe("classicBattle stat selection", () => {
 
   beforeEach(() => {
     document.body.innerHTML = "";
-    const { playerCard, computerCard } = createBattleCardContainers();
+    const { playerCard, opponentCard } = createBattleCardContainers();
     const header = createBattleHeader();
     const roundResult = document.createElement("p");
     roundResult.id = "round-result";
     roundResult.setAttribute("aria-live", "polite");
     roundResult.setAttribute("aria-atomic", "true");
-    document.body.append(playerCard, computerCard, header, roundResult);
+    document.body.append(playerCard, opponentCard, header, roundResult);
     timerSpy = vi.useFakeTimers();
     fetchJsonMock = vi.fn(async () => []);
     generateRandomCardMock = vi.fn(async (_data, _g, container, _pm, cb) => {
@@ -159,7 +159,7 @@ describe("classicBattle stat selection", () => {
   it("shows tie message when values are equal", async () => {
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    document.getElementById("computer-card").innerHTML =
+    document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     await selectStat("power");
     expect(document.querySelector("header #round-message").textContent).toMatch(/Tie/);
@@ -174,18 +174,18 @@ describe("classicBattle stat selection", () => {
     _resetForTest(store);
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
-    document.getElementById("computer-card").innerHTML =
+    document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     const result = evaluateRound(store, "power");
     expect(result.message).toMatch(/win/);
     expect(result.playerScore).toBe(1);
-    expect(result.computerScore).toBe(0);
+    expect(result.opponentScore).toBe(0);
   });
 
   it("shows stat comparison after selection", async () => {
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
-    document.getElementById("computer-card").innerHTML =
+    document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     await selectStat("power");
     expect(document.getElementById("round-result").textContent).toBe("Power – You: 5 Opponent: 3");
@@ -195,7 +195,7 @@ describe("classicBattle stat selection", () => {
     const orchestrator = await import("../../../src/helpers/classicBattle/orchestrator.js");
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
-    document.getElementById("computer-card").innerHTML =
+    document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     await selectStat("power");
     expect(orchestrator.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "evaluate");
@@ -211,7 +211,7 @@ describe("classicBattle stat selection", () => {
     orchestrator.__reset();
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
-    document.getElementById("computer-card").innerHTML =
+    document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     await selectStat("power");
     await selectStat("power");

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -127,10 +127,10 @@ describe("scheduleNextRound early click", () => {
       return await importOriginal();
     });
     document.body.innerHTML = "";
-    const { playerCard, computerCard } = createBattleCardContainers();
+    const { playerCard, opponentCard } = createBattleCardContainers();
     const header = createBattleHeader();
     header.querySelector("#next-round-timer")?.remove();
-    document.body.append(playerCard, computerCard, header);
+    document.body.append(playerCard, opponentCard, header);
     const { nextButton } = createTimerNodes();
     nextButton.disabled = true;
     timerSpy = vi.useFakeTimers();

--- a/tests/helpers/classicBattle/utils.js
+++ b/tests/helpers/classicBattle/utils.js
@@ -7,7 +7,7 @@ import { createBattleHeader, createBattleCardContainers } from "../../utils/test
  *   - reset Vitest modules
  *   - clear document body
  * build DOM nodes
- *   - create player/computer cards and battle header
+ *   - create player/opponent cards and battle header
  *   - append nodes and snackbar container to body
  * mock APIs
  *   - use fake timers
@@ -18,9 +18,9 @@ import { createBattleHeader, createBattleCardContainers } from "../../utils/test
 export function setupClassicBattleDom() {
   vi.resetModules();
   document.body.innerHTML = "";
-  const { playerCard, computerCard } = createBattleCardContainers();
+  const { playerCard, opponentCard } = createBattleCardContainers();
   const header = createBattleHeader();
-  document.body.append(playerCard, computerCard, header);
+  document.body.append(playerCard, opponentCard, header);
   const container = document.createElement("div");
   container.id = "snackbar-container";
   container.setAttribute("role", "status");

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -18,14 +18,14 @@ describe("classicBattlePage feature flag updates", () => {
     // Minimal DOM
     const battleArea = document.createElement("div");
     battleArea.id = "battle-area";
-    const computer = document.createElement("div");
-    computer.id = "computer-card";
+    const opponent = document.createElement("div");
+    opponent.id = "opponent-card";
     const stats = document.createElement("div");
     stats.id = "stat-buttons";
     const btn = document.createElement("button");
     btn.dataset.stat = "power";
     stats.appendChild(btn);
-    document.body.append(battleArea, stats, computer);
+    document.body.append(battleArea, stats, opponent);
 
     const currentFlags = {
       viewportSimulation: { enabled: false },
@@ -54,7 +54,7 @@ describe("classicBattlePage feature flag updates", () => {
       startRound: vi.fn(),
       resetGame: vi.fn()
     }));
-    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard: vi.fn() }));
+    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForOpponentCard: vi.fn() }));
     vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar: vi.fn() }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({
       initTooltips: vi.fn().mockResolvedValue(() => {})
@@ -76,7 +76,7 @@ describe("classicBattlePage feature flag updates", () => {
     const panel = document.getElementById("debug-panel");
     expect(panel).toBeTruthy();
     expect(panel.classList.contains("hidden")).toBe(false);
-    expect(panel.parentElement).toBe(computer);
+    expect(panel.parentElement).toBe(opponent);
 
     // Disable battleDebugPanel
     currentFlags.battleDebugPanel.enabled = false;

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -15,7 +15,7 @@ beforeEach(() => {
 describe("classicBattlePage stat button interactions", () => {
   it("activates stat buttons via click and keyboard", async () => {
     const startRound = vi.fn();
-    const waitForComputerCard = vi.fn();
+    const waitForOpponentCard = vi.fn();
     const handleStatSelection = vi.fn();
     const store = {};
     const loadSettings = vi.fn().mockResolvedValue({ featureFlags: {} });
@@ -30,7 +30,7 @@ describe("classicBattlePage stat button interactions", () => {
     vi.doMock("../../src/helpers/classicBattle/selectionHandler.js", () => ({
       handleStatSelection
     }));
-    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
+    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForOpponentCard }));
     vi.doMock("../../src/config/loadSettings.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
@@ -85,7 +85,7 @@ describe("classicBattlePage stat button interactions", () => {
 
   it("navigates to Next Round and Quit buttons", async () => {
     const startRound = vi.fn();
-    const waitForComputerCard = vi.fn();
+    const waitForOpponentCard = vi.fn();
     const handleStatSelection = vi.fn();
     const store = {};
     const loadSettings = vi.fn().mockResolvedValue({ featureFlags: {} });
@@ -99,7 +99,7 @@ describe("classicBattlePage stat button interactions", () => {
     vi.doMock("../../src/helpers/classicBattle/selectionHandler.js", () => ({
       handleStatSelection
     }));
-    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
+    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForOpponentCard }));
     vi.doMock("../../src/config/loadSettings.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
@@ -156,7 +156,7 @@ describe("classicBattlePage stat help tooltip", () => {
   it("shows tooltip only once", async () => {
     vi.useFakeTimers();
     const startRound = vi.fn();
-    const waitForComputerCard = vi.fn();
+    const waitForOpponentCard = vi.fn();
     const loadSettings = vi.fn().mockResolvedValue({ featureFlags: {} });
     const initTooltips = vi.fn().mockResolvedValue(() => {});
     const setTestMode = vi.fn();
@@ -169,7 +169,7 @@ describe("classicBattlePage stat help tooltip", () => {
     vi.doMock("../../src/helpers/classicBattle/selectionHandler.js", () => ({
       handleStatSelection: vi.fn()
     }));
-    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
+    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForOpponentCard }));
     vi.doMock("../../src/config/loadSettings.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
@@ -199,7 +199,7 @@ describe("classicBattlePage stat help tooltip", () => {
 describe("classicBattlePage test mode flag", () => {
   it("applies data attribute and banner visibility when enabled", async () => {
     const startRound = vi.fn();
-    const waitForComputerCard = vi.fn();
+    const waitForOpponentCard = vi.fn();
     const loadSettings = vi.fn().mockResolvedValue({
       featureFlags: {
         enableTestMode: {
@@ -220,7 +220,7 @@ describe("classicBattlePage test mode flag", () => {
     vi.doMock("../../src/helpers/classicBattle/selectionHandler.js", () => ({
       handleStatSelection: vi.fn()
     }));
-    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
+    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForOpponentCard }));
     vi.doMock("../../src/config/loadSettings.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
@@ -243,7 +243,7 @@ describe("classicBattlePage test mode flag", () => {
 
   it("feature flag changes update banner and data attribute", async () => {
     const startRound = vi.fn();
-    const waitForComputerCard = vi.fn();
+    const waitForOpponentCard = vi.fn();
     const loadSettings = vi.fn().mockResolvedValue({
       featureFlags: {
         enableTestMode: { enabled: false }
@@ -263,7 +263,7 @@ describe("classicBattlePage test mode flag", () => {
     vi.doMock("../../src/helpers/classicBattle/selectionHandler.js", () => ({
       handleStatSelection: vi.fn()
     }));
-    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
+    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForOpponentCard }));
     vi.doMock("../../src/config/loadSettings.js", () => ({ loadSettings }));
     vi.doMock("../../src/helpers/settingsStorage.js", () => ({ updateSetting }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
@@ -295,14 +295,14 @@ describe("startRoundWrapper failures", () => {
   it("shows error message, opens retry modal, and re-enables stat buttons", async () => {
     const showMessage = vi.fn();
     const startRound = vi.fn().mockRejectedValue(new Error("fail"));
-    const waitForComputerCard = vi.fn().mockResolvedValue();
+    const waitForOpponentCard = vi.fn().mockResolvedValue();
 
     vi.doMock("../../src/helpers/domReady.js", () => ({ onDomReady: () => {} }));
     vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
       createBattleStore: () => ({}),
       startRound
     }));
-    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForComputerCard }));
+    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForOpponentCard }));
     vi.doMock("../../src/helpers/classicBattle/selectionHandler.js", () => ({
       handleStatSelection: vi.fn()
     }));
@@ -389,8 +389,8 @@ describe("syncScoreDisplay", () => {
 
     const getScores = vi
       .fn()
-      .mockReturnValueOnce({ playerScore: 1, computerScore: 2 })
-      .mockReturnValueOnce({ playerScore: 3, computerScore: 4 });
+      .mockReturnValueOnce({ playerScore: 1, opponentScore: 2 })
+      .mockReturnValueOnce({ playerScore: 3, opponentScore: 4 });
     vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({ getScores }));
     vi.doMock("../../src/components/Button.js", () => ({
       createButton: (label, { id } = {}) => {
@@ -421,7 +421,7 @@ describe("syncScoreDisplay", () => {
 
     syncScoreDisplay();
     const handleReplay = vi.fn();
-    showMatchSummaryModal({ message: "", playerScore: 1, computerScore: 2 }, handleReplay);
+    showMatchSummaryModal({ message: "", playerScore: 1, opponentScore: 2 }, handleReplay);
     let board = document.getElementById("score-display").textContent;
     let summary = document.querySelector(".modal-backdrop #match-summary-score").textContent;
     let match = board.match(/You: (\d+)\nOpponent: (\d+)/);
@@ -432,7 +432,7 @@ describe("syncScoreDisplay", () => {
     document.querySelectorAll(".modal-backdrop").forEach((el) => el.remove());
 
     syncScoreDisplay();
-    showMatchSummaryModal({ message: "", playerScore: 3, computerScore: 4 }, vi.fn());
+    showMatchSummaryModal({ message: "", playerScore: 3, opponentScore: 4 }, vi.fn());
     board = document.getElementById("score-display").textContent;
     summary = document.querySelector(".modal-backdrop #match-summary-score").textContent;
     match = board.match(/You: (\d+)\nOpponent: (\d+)/);

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -64,19 +64,19 @@ export function createRandomCardDom() {
 }
 
 /**
- * Creates card containers for player and computer cards.
+ * Creates card containers for player and opponent cards.
  *
  * @pseudocode
  * 1. Create a div for the player card and assign id "player-card".
- * 2. Create a div for the computer card and assign id "computer-card".
- * 3. Return an object with playerCard and computerCard.
+ * 2. Create a div for the opponent card and assign id "opponent-card".
+ * 3. Return an object with playerCard and opponentCard.
  */
 export function createBattleCardContainers() {
   const playerCard = document.createElement("div");
   playerCard.id = "player-card";
-  const computerCard = document.createElement("div");
-  computerCard.id = "computer-card";
-  return { playerCard, computerCard };
+  const opponentCard = document.createElement("div");
+  opponentCard.id = "opponent-card";
+  return { playerCard, opponentCard };
 }
 
 /**


### PR DESCRIPTION
## Summary
- rename computer-related variables and winner labels to opponent
- switch computer-card DOM id and styles to opponent-card
- update tests and docs for opponent terminology

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a646faa0f483268e2c17c6636356f1