### PR TITLE
refactor: separate render utilities from vector search API

### DIFF
--- a/src/helpers/api/vectorSearchPage.js
+++ b/src/helpers/api/vectorSearchPage.js
@@ -81,48 +81,6 @@ export function preloadExtractor() {
 }
 
 /**
- * Format a file path string for display in the Source column.
- * Each path segment appears on a new line.
- *
- * @pseudocode
- * 1. Create an empty `DocumentFragment`.
- * 2. Split `source` by `/`.
- * 3. For each segment:
- *    a. Append a `<span>` with the segment text.
- *    b. Append a `<br>` if it is not the last segment.
- * 4. Return the fragment.
- *
- * @param {string} source - File path like "design/foo/bar.md".
- * @returns {DocumentFragment} Fragment with line breaks between segments.
- */
-export function formatSourcePath(source) {
-  const fragment = document.createDocumentFragment();
-  source.split("/").forEach((part, idx, arr) => {
-    const span = document.createElement("span");
-    span.textContent = part;
-    fragment.appendChild(span);
-    if (idx < arr.length - 1) {
-      fragment.appendChild(document.createElement("br"));
-    }
-  });
-  return fragment;
-}
-
-/**
- * Format tag arrays for display.
- *
- * @pseudocode
- * 1. If `tags` is an array, join with `", "`.
- * 2. Otherwise, return an empty string.
- *
- * @param {string[]} tags - Tag names.
- * @returns {string} Comma separated tag string.
- */
-export function formatTags(tags) {
-  return Array.isArray(tags) ? tags.join(", ") : "";
-}
-
-/**
  * Inject a custom extractor for testing.
  * @param {any} model - Mock extractor to use.
  */

--- a/src/helpers/vectorSearchPage/renderResults.js
+++ b/src/helpers/vectorSearchPage/renderResults.js
@@ -1,5 +1,5 @@
 import { createSnippetElement } from "../snippetFormatter.js";
-import { formatSourcePath, formatTags } from "../api/vectorSearchPage.js";
+import { formatSourcePath, formatTags } from "./renderUtils.js";
 
 export const RESULT_TABLE_CONFIG = {
   scoreClasses: [

--- a/src/helpers/vectorSearchPage/renderUtils.js
+++ b/src/helpers/vectorSearchPage/renderUtils.js
@@ -1,0 +1,41 @@
+/**
+ * Format a file path string for display in the Source column.
+ * Each path segment appears on a new line.
+ *
+ * @pseudocode
+ * 1. Create an empty `DocumentFragment`.
+ * 2. Split `source` by `/`.
+ * 3. For each segment:
+ *    a. Append a `<span>` with the segment text.
+ *    b. Append a `<br>` if it is not the last segment.
+ * 4. Return the fragment.
+ *
+ * @param {string} source - File path like "design/foo/bar.md".
+ * @returns {DocumentFragment} Fragment with line breaks between segments.
+ */
+export function formatSourcePath(source) {
+  const fragment = document.createDocumentFragment();
+  source.split("/").forEach((part, idx, arr) => {
+    const span = document.createElement("span");
+    span.textContent = part;
+    fragment.appendChild(span);
+    if (idx < arr.length - 1) {
+      fragment.appendChild(document.createElement("br"));
+    }
+  });
+  return fragment;
+}
+
+/**
+ * Format tag arrays for display.
+ *
+ * @pseudocode
+ * 1. If `tags` is an array, join with `", "`.
+ * 2. Otherwise, return an empty string.
+ *
+ * @param {string[]} tags - Tag names.
+ * @returns {string} Comma separated tag string.
+ */
+export function formatTags(tags) {
+  return Array.isArray(tags) ? tags.join(", ") : "";
+}

--- a/tests/vectorSearch/vectorSearchHelpers.test.js
+++ b/tests/vectorSearch/vectorSearchHelpers.test.js
@@ -1,9 +1,6 @@
 import { describe, it, expect } from "vitest";
-import {
-  selectMatches,
-  formatSourcePath,
-  formatTags
-} from "../../src/helpers/api/vectorSearchPage.js";
+import { selectMatches } from "../../src/helpers/api/vectorSearchPage.js";
+import { formatSourcePath, formatTags } from "../../src/helpers/vectorSearchPage/renderUtils.js";
 
 /**
  * Unit tests for vector search helper utilities.


### PR DESCRIPTION
## Summary
- move `formatSourcePath` and `formatTags` to `vectorSearchPage/renderUtils.js`
- update result rendering and tests to import from the new helper
- keep selection and extractor logic in `api/vectorSearchPage.js`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68a75b6cee9c8326b1534dfbd5967970