### PR TITLE
refactor: split pseudo-Japanese helpers

### DIFF
--- a/src/helpers/meditationPage.js
+++ b/src/helpers/meditationPage.js
@@ -2,7 +2,7 @@
  * Initialize the Meditation page.
  *
  * @pseudocode
- * 1. Import `setupLanguageToggle` from `pseudoJapanese.js` and `loadQuote` from `quoteBuilder.js`.
+ * 1. Import `setupLanguageToggle` from `pseudoJapanese/ui.js` and `loadQuote` from `quoteBuilder.js`.
  * 2. Define `setupMeditationPage` which:
  *    a. Retrieves the quote element from the DOM.
  *    b. Calls `loadQuote` to display a random quote.
@@ -12,7 +12,7 @@
  *
  * @returns {void}
  */
-import { setupLanguageToggle } from "./pseudoJapanese.js";
+import { setupLanguageToggle } from "./pseudoJapanese/ui.js";
 import { onDomReady } from "./domReady.js";
 import { initTooltips } from "./tooltip.js";
 import { loadQuote } from "./quoteBuilder.js";

--- a/src/helpers/pseudoJapanese/converter.js
+++ b/src/helpers/pseudoJapanese/converter.js
@@ -1,0 +1,78 @@
+import { DATA_DIR } from "../constants.js";
+import { seededRandom } from "../testModeUtils.js";
+
+export const STATIC_FALLBACK = "\u65e5\u672c\u8a9e\u98a8\u30c6\u30ad\u30b9\u30c8"; // 日本語風テキスト
+let cachedConverter;
+let lastFetch;
+
+export async function loadConverter() {
+  if (cachedConverter && lastFetch === fetch) {
+    return cachedConverter;
+  }
+  lastFetch = fetch;
+  try {
+    const response = await fetch(`${DATA_DIR}japaneseConverter.json`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch converter mapping: ${response.status}`);
+    }
+    cachedConverter = await response.json();
+  } catch {
+    cachedConverter = null;
+  }
+  return cachedConverter;
+}
+
+/**
+ * Convert English text to pseudo-Japanese using a JSON lookup table.
+ *
+ * @pseudocode
+ * 1. If input is null, undefined, or empty string, return empty string.
+ * 2. Load the converter JSON using `loadConverter`.
+ *    - If loading fails, return `STATIC_FALLBACK`.
+ * 3. Clean the `text` by removing characters other than letters, numbers, and whitespace.
+ * 4. Build a list of fallback characters from the mapping values.
+ * 5. If the cleaned text contains only digits and whitespace, return an empty
+ *    string.
+ * 6. For each character in the cleaned text:
+ *    - Preserve whitespace characters as-is.
+ *    - Map letters (case-insensitive) using the converter table when possible.
+ *    - Replace digits and unmapped letters with a random fallback character.
+ *      - Use `seededRandom()` for deterministic output in Test Mode.
+ * 7. Join and return the converted string.
+ *
+ * @param {string} input - The text to convert.
+ * @returns {Promise<string>} The pseudo-Japanese representation.
+ */
+export async function convertToPseudoJapanese(input) {
+  if (input === undefined || input === null || input === "") return "";
+
+  const converter = await loadConverter();
+  if (!converter || !converter.letters) {
+    return STATIC_FALLBACK;
+  }
+
+  const mapping = converter.letters;
+  const cleaned = String(input).replace(/[^A-Za-z0-9\s]/g, "");
+  const fallbackChars = Object.values(mapping).flat();
+
+  if (/^[0-9\s]*$/.test(cleaned)) {
+    return "";
+  }
+
+  return cleaned
+    .split("")
+    .map((char) => {
+      if (/\s/.test(char)) {
+        return char;
+      }
+
+      const letters = mapping[char.toLowerCase()];
+      if (letters) {
+        return letters[Math.floor(seededRandom() * letters.length)];
+      }
+
+      // digits or unmapped letters
+      return fallbackChars[Math.floor(seededRandom() * fallbackChars.length)];
+    })
+    .join("");
+}

--- a/src/helpers/pseudoJapanese/ui.js
+++ b/src/helpers/pseudoJapanese/ui.js
@@ -1,81 +1,4 @@
-import { DATA_DIR } from "./constants.js";
-import { seededRandom } from "./testModeUtils.js";
-
-const STATIC_FALLBACK = "\u65e5\u672c\u8a9e\u98a8\u30c6\u30ad\u30b9\u30c8"; // 日本語風テキスト
-let cachedConverter;
-let lastFetch;
-
-async function loadConverter() {
-  if (cachedConverter && lastFetch === fetch) {
-    return cachedConverter;
-  }
-  lastFetch = fetch;
-  try {
-    const response = await fetch(`${DATA_DIR}japaneseConverter.json`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch converter mapping: ${response.status}`);
-    }
-    cachedConverter = await response.json();
-  } catch {
-    cachedConverter = null;
-  }
-  return cachedConverter;
-}
-
-/**
- * Convert English text to pseudo-Japanese using a JSON lookup table.
- *
- * @pseudocode
- * 1. If input is null, undefined, or empty string, return empty string.
- * 2. Load the converter JSON using `loadConverter`.
- *    - If loading fails, return `STATIC_FALLBACK`.
- * 3. Clean the `text` by removing characters other than letters, numbers, and whitespace.
- * 4. Build a list of fallback characters from the mapping values.
- * 5. If the cleaned text contains only digits and whitespace, return an empty
- *    string.
- * 6. For each character in the cleaned text:
- *    - Preserve whitespace characters as-is.
- *    - Map letters (case-insensitive) using the converter table when possible.
- *    - Replace digits and unmapped letters with a random fallback character.
- *      - Use `seededRandom()` for deterministic output in Test Mode.
- * 7. Join and return the converted string.
- *
- * @param {string} input - The text to convert.
- * @returns {Promise<string>} The pseudo-Japanese representation.
- */
-export async function convertToPseudoJapanese(input) {
-  if (input === undefined || input === null || input === "") return "";
-
-  const converter = await loadConverter();
-  if (!converter || !converter.letters) {
-    return STATIC_FALLBACK;
-  }
-
-  const mapping = converter.letters;
-  const cleaned = String(input).replace(/[^A-Za-z0-9\s]/g, "");
-  const fallbackChars = Object.values(mapping).flat();
-
-  if (/^[0-9\s]*$/.test(cleaned)) {
-    return "";
-  }
-
-  return cleaned
-    .split("")
-    .map((char) => {
-      if (/\s/.test(char)) {
-        return char;
-      }
-
-      const letters = mapping[char.toLowerCase()];
-      if (letters) {
-        return letters[Math.floor(seededRandom() * letters.length)];
-      }
-
-      // digits or unmapped letters
-      return fallbackChars[Math.floor(seededRandom() * fallbackChars.length)];
-    })
-    .join("");
-}
+import { convertToPseudoJapanese, STATIC_FALLBACK } from "./converter.js";
 
 /**
  * Convert all text nodes within an element to pseudo-Japanese while
@@ -132,7 +55,6 @@ export async function convertElementToPseudoJapanese(element) {
  * @param {HTMLElement} element - The element whose text will be toggled.
  * @returns {HTMLButtonElement|null} The toggle button if found, otherwise `null`.
  */
-
 export function setupLanguageToggle(element) {
   const button = document.getElementById("language-toggle");
   if (!button) {

--- a/tests/helpers/pseudoJapanese.test.js
+++ b/tests/helpers/pseudoJapanese.test.js
@@ -17,7 +17,9 @@ describe("convertToPseudoJapanese", () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => mapping });
     vi.spyOn(Math, "random").mockReturnValue(0);
 
-    const { convertToPseudoJapanese } = await import("../../src/helpers/pseudoJapanese.js");
+    const { convertToPseudoJapanese } = await import(
+      "../../src/helpers/pseudoJapanese/converter.js"
+    );
 
     const cases = [
       ["short", "abc", "アバカ"],
@@ -35,7 +37,9 @@ describe("convertToPseudoJapanese", () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => mapping });
     vi.spyOn(Math, "random").mockReturnValue(0);
 
-    const { convertToPseudoJapanese } = await import("../../src/helpers/pseudoJapanese.js");
+    const { convertToPseudoJapanese } = await import(
+      "../../src/helpers/pseudoJapanese/converter.js"
+    );
 
     const result = await convertToPseudoJapanese("a1!b2?c3.");
     expect(result).toBe("アアバアカア");
@@ -45,7 +49,9 @@ describe("convertToPseudoJapanese", () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => mapping });
     vi.spyOn(Math, "random").mockReturnValue(0);
 
-    const { convertToPseudoJapanese } = await import("../../src/helpers/pseudoJapanese.js");
+    const { convertToPseudoJapanese } = await import(
+      "../../src/helpers/pseudoJapanese/converter.js"
+    );
 
     const result = await convertToPseudoJapanese("one\ntwo");
     expect(result).toBe("アアエ\nアアア");
@@ -56,7 +62,9 @@ describe("convertToPseudoJapanese", () => {
     vi.spyOn(Math, "random").mockReturnValue(0);
     vi.useFakeTimers();
 
-    const { convertToPseudoJapanese } = await import("../../src/helpers/pseudoJapanese.js");
+    const { convertToPseudoJapanese } = await import(
+      "../../src/helpers/pseudoJapanese/converter.js"
+    );
 
     const input = "a".repeat(999);
 
@@ -70,7 +78,9 @@ describe("convertToPseudoJapanese", () => {
   it("returns static fallback when the mapping fails to load", async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error("fail"));
 
-    const { convertToPseudoJapanese } = await import("../../src/helpers/pseudoJapanese.js");
+    const { convertToPseudoJapanese } = await import(
+      "../../src/helpers/pseudoJapanese/converter.js"
+    );
     const result = await convertToPseudoJapanese("anything");
     expect(result).toBe("\u65e5\u672c\u8a9e\u98a8\u30c6\u30ad\u30b9\u30c8");
   });
@@ -78,7 +88,9 @@ describe("convertToPseudoJapanese", () => {
   it("handles empty string and null/undefined input", async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => mapping });
     vi.spyOn(Math, "random").mockReturnValue(0);
-    const { convertToPseudoJapanese } = await import("../../src/helpers/pseudoJapanese.js");
+    const { convertToPseudoJapanese } = await import(
+      "../../src/helpers/pseudoJapanese/converter.js"
+    );
     expect(await convertToPseudoJapanese("")).toBe("");
     expect(await convertToPseudoJapanese(null)).toBe("");
     expect(await convertToPseudoJapanese(undefined)).toBe("");
@@ -87,13 +99,17 @@ describe("convertToPseudoJapanese", () => {
   it("handles input with only unsupported characters", async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => mapping });
     vi.spyOn(Math, "random").mockReturnValue(0);
-    const { convertToPseudoJapanese } = await import("../../src/helpers/pseudoJapanese.js");
+    const { convertToPseudoJapanese } = await import(
+      "../../src/helpers/pseudoJapanese/converter.js"
+    );
     expect(await convertToPseudoJapanese("123!@#")).toBe("");
   });
 
   it("returns fallback if mapping is missing 'letters' property", async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => ({}) });
-    const { convertToPseudoJapanese } = await import("../../src/helpers/pseudoJapanese.js");
+    const { convertToPseudoJapanese } = await import(
+      "../../src/helpers/pseudoJapanese/converter.js"
+    );
     const result = await convertToPseudoJapanese("abc");
     expect(result).toBe("\u65e5\u672c\u8a9e\u98a8\u30c6\u30ad\u30b9\u30c8");
   });
@@ -107,7 +123,9 @@ describe("convertToPseudoJapanese", () => {
     });
     // Use Math.random to always pick the second option
     vi.spyOn(Math, "random").mockReturnValue(0.99);
-    const { convertToPseudoJapanese } = await import("../../src/helpers/pseudoJapanese.js");
+    const { convertToPseudoJapanese } = await import(
+      "../../src/helpers/pseudoJapanese/converter.js"
+    );
     expect(await convertToPseudoJapanese("ab")).toBe("ァビ");
   });
 });


### PR DESCRIPTION
## Summary
- move conversion logic into `src/helpers/pseudoJapanese/converter.js`
- move DOM helpers into `src/helpers/pseudoJapanese/ui.js`
- update meditation page and tests to import new modules

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a75fde6874832681d7e8bcbf41fee5