### PR TITLE
fix: refresh battle state progress items

### DIFF
--- a/src/helpers/battleStateProgress.js
+++ b/src/helpers/battleStateProgress.js
@@ -5,11 +5,12 @@
  * 1. Fetch `classicBattleStates.json` using `fetchJson`.
  * 2. Filter for core states (IDs below 90).
  * 3. Sort core states by `id` in ascending order.
- * 4. Render each state as an `<li>` with `data-state` and its numeric ID inside `#battle-state-progress`.
- * 5. Define `updateActive(state)` to toggle the `active` class on matching items.
- * 6. Observe `#machine-state` for text changes; on each change call `updateActive`.
- * 7. If `#machine-state` is missing, poll `window.__classicBattleState` via `requestAnimationFrame` and store the ID.
- * 8. Return a cleanup function that disconnects the observer or cancels the animation frame loop.
+ * 4. If `#battle-state-progress` already has the same number of items, skip rendering.
+ * 5. Otherwise, clear the list and render each state as an `<li>` with `data-state` and its numeric ID.
+ * 6. Define `updateActive(state)` to query list items and toggle the `active` class on the match.
+ * 7. Observe `#machine-state` for text changes; on each change call `updateActive`.
+ * 8. If `#machine-state` is missing, poll `window.__classicBattleState` via `requestAnimationFrame` and store the ID.
+ * 9. Return a cleanup function that disconnects the observer or cancels the animation frame loop.
  *
  * @returns {Promise<(() => void) | undefined>} Resolves with a cleanup function.
  */
@@ -37,18 +38,21 @@ export async function initBattleStateProgress() {
   const core = Array.isArray(states)
     ? states.filter((s) => s.id < 90).sort((a, b) => a.id - b.id)
     : [];
-  const frag = document.createDocumentFragment();
-  core.forEach((s) => {
-    const li = document.createElement("li");
-    li.dataset.state = s.name;
-    li.textContent = String(s.id);
-    frag.appendChild(li);
-  });
-  list.appendChild(frag);
 
-  const items = Array.from(list.querySelectorAll("li"));
+  if (list.children.length !== core.length) {
+    list.textContent = "";
+    const frag = document.createDocumentFragment();
+    core.forEach((s) => {
+      const li = document.createElement("li");
+      li.dataset.state = s.name;
+      li.textContent = String(s.id);
+      frag.appendChild(li);
+    });
+    list.appendChild(frag);
+  }
+
   const updateActive = (state) => {
-    items.forEach((li) => {
+    list.querySelectorAll("li").forEach((li) => {
       li.classList.toggle("active", li.dataset.state === state);
     });
   };


### PR DESCRIPTION
## Summary
- skip re-rendering battle state progress when list length matches expected states
- clear list before adding new state items
- requery battle state items in `updateActive` to include new additions

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: 2 warnings, no errors)*
- `npx vitest run`
- `npx playwright test` *(fails: network issues and timeouts)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a81d6649f883268bde3fd8e2d37e0a