### PR TITLE
refactor: decouple round logic from UI

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -9,3 +9,4 @@ export {
 } from "./classicBattle/uiHelpers.js";
 export { getOpponentJudoka } from "./classicBattle/cardSelection.js";
 export { scheduleNextRound } from "./classicBattle/timerService.js";
+export { applyRoundUI } from "./classicBattle/roundUI.js";

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -1,0 +1,35 @@
+import { disableNextRoundButton, showSelectionPrompt, updateDebugPanel } from "./uiHelpers.js";
+import { resetStatButtons } from "../battle/index.js";
+import { syncScoreDisplay } from "./uiService.js";
+import { startTimer, handleStatSelectionTimeout } from "./timerService.js";
+import * as scoreboard from "../setupScoreboard.js";
+import { handleStatSelection } from "./selectionHandler.js";
+
+/**
+ * Apply UI updates for a newly started round.
+ *
+ * @pseudocode
+ * 1. Reset stat buttons and disable the Next Round button.
+ * 2. Clear the round result display and sync the score.
+ * 3. Update the round counter and show the selection prompt.
+ * 4. Start the round timer and stall timeout.
+ * 5. Update the debug panel.
+ *
+ * @param {ReturnType<typeof import('./roundManager.js').createBattleStore>} store - Battle state store.
+ * @param {number} roundNumber - Current round number to display.
+ */
+export function applyRoundUI(store, roundNumber) {
+  resetStatButtons();
+  disableNextRoundButton();
+  const roundResultEl = document.getElementById("round-result");
+  if (roundResultEl) roundResultEl.textContent = "";
+  syncScoreDisplay();
+  scoreboard.updateRoundCounter(roundNumber);
+  showSelectionPrompt();
+  startTimer((stat, opts) => handleStatSelection(store, stat, opts));
+  store.statTimeoutId = setTimeout(
+    () => handleStatSelectionTimeout(store, (s, opts) => handleStatSelection(store, s, opts)),
+    35000
+  );
+  updateDebugPanel();
+}

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -3,6 +3,7 @@
  */
 import { createBattleStore, startRound } from "./classicBattle/roundManager.js";
 import { handleStatSelection } from "./classicBattle/selectionHandler.js";
+import { applyRoundUI } from "./classicBattle/roundUI.js";
 import { onDomReady } from "./domReady.js";
 import { setupScoreboard, showMessage } from "./setupScoreboard.js";
 import { waitForOpponentCard } from "./battleJudokaPage.js";
@@ -38,7 +39,8 @@ let statButtonControls;
 async function startRoundWrapper() {
   statButtonControls?.disable();
   try {
-    await startRound(battleStore);
+    const { roundNumber } = await startRound(battleStore);
+    applyRoundUI(battleStore, roundNumber);
     await waitForOpponentCard(5000);
   } catch (error) {
     console.error("Error starting round:", error);

--- a/tests/helpers/classicBattle/autoSelect.test.js
+++ b/tests/helpers/classicBattle/autoSelect.test.js
@@ -87,7 +87,8 @@ describe("classicBattle auto select", () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
-    await battleMod.startRound(store);
+    const { roundNumber } = await battleMod.startRound(store);
+    battleMod.applyRoundUI(store, roundNumber);
     timerSpy.advanceTimersByTime(31000);
     await vi.runOnlyPendingTimersAsync();
     const events = dispatchSpy.mock.calls.map((c) => c[0]);
@@ -118,7 +119,8 @@ describe("classicBattle auto select", () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
-    await battleMod.startRound(store);
+    const { roundNumber: roundNumber2 } = await battleMod.startRound(store);
+    battleMod.applyRoundUI(store, roundNumber2);
     timerSpy.advanceTimersByTime(31000);
     await vi.runOnlyPendingTimersAsync();
     const events = dispatchSpy.mock.calls.map((c) => c[0]);

--- a/tests/helpers/classicBattle/interrupt.test.js
+++ b/tests/helpers/classicBattle/interrupt.test.js
@@ -93,7 +93,8 @@ describe("classicBattle interrupts", () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
-    await battleMod.startRound(store);
+    const { roundNumber } = await battleMod.startRound(store);
+    battleMod.applyRoundUI(store, roundNumber);
     timerSpy.advanceTimersByTime(31000);
     await vi.runOnlyPendingTimersAsync();
     const events = dispatchSpy.mock.calls.map((c) => c[0]);

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -112,12 +112,14 @@ describe("classicBattle scheduleNextRound", () => {
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
     const startRoundWrapper = vi.fn(async () => {
-      await battleMod.startRound(store);
+      const { roundNumber } = await battleMod.startRound(store);
+      battleMod.applyRoundUI(store, roundNumber);
     });
     await orchestrator.initClassicBattleOrchestrator(store, startRoundWrapper);
     const machine = orchestrator.getBattleStateMachine();
 
-    await battleMod.startRound(store);
+    const { roundNumber } = await battleMod.startRound(store);
+    battleMod.applyRoundUI(store, roundNumber);
 
     machine.current = "roundOver";
     await orchestrator.dispatchBattleEvent("continue");

--- a/tests/helpers/classicBattle/selectionPrompt.test.js
+++ b/tests/helpers/classicBattle/selectionPrompt.test.js
@@ -80,7 +80,8 @@ describe("classicBattle selection prompt", () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
-    await battleMod.startRound(store);
+    const { roundNumber } = await battleMod.startRound(store);
+    battleMod.applyRoundUI(store, roundNumber);
     expect(document.querySelector(".snackbar").textContent).toBe("Select your move");
     timerSpy.advanceTimersByTime(5000);
     expect(document.querySelector(".snackbar")).toBeNull();

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -73,7 +73,8 @@ describe("classicBattle stalled stat selection recovery", () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
-    await battleMod.startRound(store);
+    const { roundNumber } = await battleMod.startRound(store);
+    battleMod.applyRoundUI(store, roundNumber);
     timerSpy.advanceTimersByTime(35000);
     expect(document.querySelector("header #round-message").textContent).toMatch(/stalled/i);
     timerSpy.advanceTimersByTime(5000);

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -183,12 +183,14 @@ describe("scheduleNextRound early click", () => {
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
     const startRoundWrapper = vi.fn(async () => {
-      await battleMod.startRound(store);
+      const { roundNumber } = await battleMod.startRound(store);
+      battleMod.applyRoundUI(store, roundNumber);
     });
     await orchestrator.initClassicBattleOrchestrator(store, startRoundWrapper);
     const machine = orchestrator.getBattleStateMachine();
 
-    await battleMod.startRound(store);
+    const { roundNumber } = await battleMod.startRound(store);
+    battleMod.applyRoundUI(store, roundNumber);
     expect(generateRandomCardMock).toHaveBeenCalledTimes(1);
 
     machine.current = "roundOver";


### PR DESCRIPTION
## Summary
- extract round-start UI logic into new `applyRoundUI` helper
- have `startRound` return round state without DOM work
- wire classicBattlePage to use `applyRoundUI`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a8406caf54832693b59d7b96d519b4