### PR TITLE
refactor: decouple quit button binding

### DIFF
--- a/src/helpers/classicBattle/quitButton.js
+++ b/src/helpers/classicBattle/quitButton.js
@@ -1,0 +1,20 @@
+/**
+ * Attach the Classic Battle Quit button listener.
+ *
+ * @pseudocode
+ * 1. Locate `#quit-match-button` and exit if missing.
+ * 2. Add a click handler that dynamically imports `quitMatch`.
+ * 3. Invoke `quitMatch` with the provided store and button and mark the home link ready.
+ *
+ * @param {ReturnType<import('./roundManager.js').createBattleStore>} store - Battle state store.
+ * @returns {void}
+ */
+export function initQuitButton(store) {
+  const quitBtn = document.getElementById("quit-match-button");
+  if (!quitBtn) return;
+  quitBtn.addEventListener("click", async () => {
+    const { quitMatch } = await import("./quitModal.js");
+    quitMatch(store, quitBtn);
+    window.homeLinkReady = true;
+  });
+}

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -5,30 +5,26 @@ import { _resetForTest as resetEngineForTest } from "../battleEngineFacade.js";
 import * as battleEngine from "../battleEngineFacade.js";
 import * as scoreboard from "../setupScoreboard.js";
 import { syncScoreDisplay } from "./uiService.js";
-import { quitMatch } from "./quitModal.js";
 import { cancel as cancelFrame, stop as stopScheduler } from "../../utils/scheduler.js";
 import { resetSkipState } from "./skipHandler.js";
 
 /**
- * Create a new battle state store and attach button handlers.
+ * Create a new battle state store.
  *
- * @returns {{quitModal: ReturnType<typeof createModal>|null, statTimeoutId: ReturnType<typeof setTimeout>|null, autoSelectId: ReturnType<typeof setTimeout>|null, compareRaf: number}}
+ * @pseudocode
+ * 1. Initialize battle state values.
+ * 2. Return the store.
+ *
+ * @returns {{quitModal: ReturnType<import("../../components/Modal.js").createModal>|null, statTimeoutId: ReturnType<typeof setTimeout>|null, autoSelectId: ReturnType<typeof setTimeout>|null, compareRaf: number, selectionMade: boolean}}
  */
 export function createBattleStore() {
-  const store = {
+  return {
     quitModal: null,
     statTimeoutId: null,
     autoSelectId: null,
     compareRaf: 0,
     selectionMade: false
   };
-  const quitButton = document.getElementById("quit-match-button");
-  if (quitButton) {
-    quitButton.addEventListener("click", () => {
-      quitMatch(store);
-    });
-  }
-  return store;
 }
 
 function getStartRound(store) {

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -16,6 +16,7 @@ import { STATS } from "./battleEngineFacade.js";
 import { toggleInspectorPanels } from "./cardUtils.js";
 import { showSnackbar } from "./showSnackbar.js";
 import { initClassicBattleOrchestrator } from "./classicBattle/orchestrator.js";
+import { initQuitButton } from "./classicBattle/quitButton.js";
 import { onNextButtonClick } from "./classicBattle/timerService.js";
 import { skipCurrentPhase } from "./classicBattle/skipHandler.js";
 import { initFeatureFlags, isEnabled, featureFlagsEmitter } from "./featureFlags.js";
@@ -195,6 +196,7 @@ export async function setupClassicBattlePage() {
     window.addEventListener("pagehide", stopScheduler, { once: true });
   }
   setupScoreboard();
+  initQuitButton(battleStore);
   initInterruptHandlers(battleStore);
   watchBattleOrientation();
   await initFeatureFlags();
@@ -245,17 +247,6 @@ export async function setupClassicBattlePage() {
       } catch {}
     };
   } catch {}
-
-  const quitBtn = document.getElementById("quit-match-button");
-  if (quitBtn) {
-    quitBtn.addEventListener("click", async () => {
-      if (window.battleStore) {
-        const { quitMatch } = await import("./classicBattle/quitModal.js");
-        quitMatch(window.battleStore, quitBtn);
-        window.homeLinkReady = true;
-      }
-    });
-  }
 }
 
 function initStatButtons(store) {

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -59,8 +59,11 @@ describe("classicBattle match controls", () => {
     const { createBattleStore } = await import(
       "../../../src/helpers/classicBattle/roundManager.js"
     );
+    const { initQuitButton } = await import("../../../src/helpers/classicBattle/quitButton.js");
     window.battleStore = createBattleStore();
+    initQuitButton(window.battleStore);
     document.getElementById("quit-match-button").click();
+    await new Promise((r) => setTimeout(r, 0));
     expect(document.getElementById("round-message").textContent).toBe("quit");
     expect(window.location.href).toBe("http://localhost/index.html");
   });


### PR DESCRIPTION
## Summary
- keep roundManager's `createBattleStore` free of DOM work
- add `initQuitButton` helper to attach quit handler on demand
- invoke new helper from Classic Battle page and update tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a845cfea24832686bc60b1e92d34fe