### PR TITLE
refactor resolveUrl and env detection

### DIFF
--- a/src/helpers/env.js
+++ b/src/helpers/env.js
@@ -1,0 +1,48 @@
+/**
+ * Determine if the code is running in a Node environment.
+ *
+ * @pseudocode
+ * 1. Check that `process.versions.node` exists and `typeof window === "undefined"`.
+ * 2. Return `true` when both conditions hold; otherwise, return `false`.
+ *
+ * @returns {boolean} `true` if running under Node.
+ */
+export function isNodeEnvironment() {
+  return Boolean(
+    typeof process !== "undefined" && process?.versions?.node && typeof window === "undefined"
+  );
+}
+
+/**
+ * Check whether a browser `window` object is available.
+ *
+ * @pseudocode
+ * 1. Return `true` when `typeof window !== "undefined"`.
+ * 2. Otherwise return `false`.
+ *
+ * @returns {boolean} `true` when a browser `window` exists.
+ */
+export function isBrowserEnvironment() {
+  return typeof window !== "undefined";
+}
+
+/**
+ * Derive a base URL for resolving relative paths in the browser.
+ *
+ * @pseudocode
+ * 1. When `document.baseURI` is available, return it.
+ * 2. Otherwise use `window.location.href` when defined.
+ * 3. Fallback to `window.location.origin`.
+ * 4. If none are available, return `"http://localhost"`.
+ *
+ * @returns {string} Base URL string.
+ */
+export function getBaseUrl() {
+  if (typeof document !== "undefined" && document.baseURI) {
+    return document.baseURI;
+  }
+  if (typeof window !== "undefined") {
+    return window.location?.href || window.location?.origin || "http://localhost";
+  }
+  return "http://localhost";
+}

--- a/tests/helpers/dataUtils.test.js
+++ b/tests/helpers/dataUtils.test.js
@@ -32,16 +32,17 @@ describe("resolveUrl and readData", () => {
     expect(fetchMock).toHaveBeenCalled();
   });
 
-  it("falls back to window.location.href when origin is unavailable", async () => {
+  it("uses provided base when resolving relative URLs", async () => {
     const originalWindow = global.window;
     const originalProcess = global.process;
     vi.resetModules();
-    global.window = { location: { href: "https://example.com/subdir/page.html" } };
+    const href = "https://example.com/subdir/page.html";
+    global.window = { location: { href } };
     // Simulate non-Node environment
     // @ts-ignore
     delete global.process;
     const { resolveUrl } = await import("../../src/helpers/dataUtils.js");
-    const parsed = await resolveUrl("data/file.json");
+    const parsed = await resolveUrl("data/file.json", window.location.href);
     expect(parsed.href).toBe("https://example.com/subdir/data/file.json");
     global.window = originalWindow;
     global.process = originalProcess;


### PR DESCRIPTION
## Summary
- extract environment helpers to `src/helpers/env.js`
- add optional base param to `resolveUrl` and use env helpers for browser base
- avoid direct `window`/`document` access in `dataUtils` default export
- update tests for new `resolveUrl` signature

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a855508a3c832691dfa000870bfe69