### PR TITLE
Decouple scoreboard from engine timer

### DIFF
--- a/src/components/Scoreboard.js
+++ b/src/components/Scoreboard.js
@@ -9,12 +9,14 @@
  *    - `#score-display` with `aria-live="polite"` and `aria-atomic="true"` for the match score.
  * 2. Append them to the provided container (typically the page header).
  * 3. Store references to these elements for later updates.
- * 4. Return the container element.
+ * 4. Save injected timer controls for countdown management.
+ * 5. Return the container element.
  *
+ * @param {HTMLDivElement} [container=document.createElement("div")] - Wrapper to populate.
+ * @param {object} [controls] - Timer control callbacks.
  * @returns {HTMLDivElement} The scoreboard element.
  */
 import { shouldReduceMotionSync } from "../helpers/motionUtils.js";
-import { startCoolDown } from "../helpers/battleEngineFacade.js";
 import { showSnackbar, updateSnackbar } from "../helpers/showSnackbar.js";
 
 let messageEl;
@@ -24,8 +26,9 @@ let roundCounterEl;
 let scoreRafId = 0;
 let currentPlayer = 0;
 let currentOpponent = 0;
+let timerControls = {};
 
-export function createScoreboard(container = document.createElement("div")) {
+export function createScoreboard(container = document.createElement("div"), controls = {}) {
   messageEl = document.createElement("p");
   messageEl.id = "round-message";
   messageEl.setAttribute("aria-live", "polite");
@@ -50,6 +53,7 @@ export function createScoreboard(container = document.createElement("div")) {
   scoreEl.setAttribute("aria-atomic", "true");
 
   container.append(messageEl, timerEl, roundCounterEl, scoreEl);
+  timerControls = controls;
   return container;
 }
 
@@ -58,13 +62,18 @@ export function createScoreboard(container = document.createElement("div")) {
  * header.
  *
  * @pseudocode
- * 1. Locate child elements within `container` by their IDs.
- * 2. Store these nodes in module-scoped variables for later updates.
+ * 1. Capture provided timer-control callbacks.
+ * 2. Locate child elements within `container` by their IDs.
+ * 3. Store these nodes in module-scoped variables for later updates.
  *
  * @param {HTMLElement} container - Header element containing the scoreboard nodes.
+ * @param {object} [controls] - Timer control callbacks.
  * @returns {void}
  */
-export function initScoreboard(container) {
+export function initScoreboard(container, controls = {}) {
+  if (controls && typeof controls === "object") {
+    timerControls = controls;
+  }
   if (!container) return;
   messageEl = container.querySelector("#round-message");
   timerEl = container.querySelector("#next-round-timer");
@@ -287,7 +296,9 @@ export function updateScore(playerScore, opponentScore) {
 }
 
 function runCountdown(duration, onTick, onExpired, handleDrift) {
-  startCoolDown(onTick, onExpired, duration, handleDrift);
+  if (timerControls && typeof timerControls.startCoolDown === "function") {
+    timerControls.startCoolDown(onTick, onExpired, duration, handleDrift);
+  }
 }
 
 function createDriftHandler(restartFn, onGiveUp) {

--- a/src/helpers/classicBattle/orchestrator.js
+++ b/src/helpers/classicBattle/orchestrator.js
@@ -4,15 +4,10 @@ import { resetGame as resetGameLocal, startRound as startRoundLocal } from "./ro
 import * as scoreboard from "../setupScoreboard.js";
 import { getDefaultTimer } from "../timerUtils.js";
 import { updateDebugPanel } from "./uiHelpers.js";
-import { setupScoreboard } from "../setupScoreboard.js";
 import { resolveRound } from "./selectionHandler.js";
 import { getOpponentJudoka } from "./cardSelection.js";
 import { getStatValue } from "../battle/index.js";
 import { scheduleNextRound } from "./timerService.js";
-
-if (typeof process === "undefined" || !process.env.VITEST) {
-  setupScoreboard();
-}
 
 let machine = null;
 

--- a/src/helpers/classicBattle/view.js
+++ b/src/helpers/classicBattle/view.js
@@ -17,7 +17,6 @@ import {
 import { initBattleStateProgress } from "../battleStateProgress.js";
 import { initTooltips } from "../tooltip.js";
 import { start as startScheduler, stop as stopScheduler } from "../../utils/scheduler.js";
-import { pauseTimer, resumeTimer } from "../battleEngineFacade.js";
 import "../setupBottomNavbar.js";
 import "../setupDisplaySettings.js";
 import "../setupSvgFallback.js";
@@ -67,7 +66,7 @@ export class ClassicBattleView {
       window.addEventListener("pagehide", stopScheduler, { once: true });
     }
 
-    setupScoreboard();
+    setupScoreboard(this.controller.timerControls);
     initQuitButton(store);
     initInterruptHandlers(store);
     watchBattleOrientation(() => this.applyBattleOrientation());
@@ -93,14 +92,14 @@ export class ClassicBattleView {
       window.startRoundOverride = () => this.startRound();
       window.freezeBattleHeader = () => {
         try {
-          pauseTimer();
+          this.controller.timerControls.pauseTimer();
           stopScheduler();
         } catch {}
       };
       window.resumeBattleHeader = () => {
         try {
           startScheduler();
-          resumeTimer();
+          this.controller.timerControls.resumeTimer();
         } catch {}
       };
     } catch {}

--- a/src/helpers/setupScoreboard.js
+++ b/src/helpers/setupScoreboard.js
@@ -16,12 +16,17 @@ import {
  *
  * @pseudocode
  * 1. Locate the `<header>` element.
- * 2. Pass the header to `initScoreboard()` so the module can query its children.
+ * 2. Pass the header and timer controls to `initScoreboard()` so the module can query its children.
+ *
+ * @param {object} controls - Timer control callbacks.
  */
-function setupScoreboard() {
+function setupScoreboard(controls) {
   const header = document.querySelector("header");
-  if (!header) return;
-  initScoreboard(header);
+  if (!header) {
+    initScoreboard(null, controls);
+    return;
+  }
+  initScoreboard(header, controls);
 }
 export {
   setupScoreboard,

--- a/tests/components/Scoreboard.test.js
+++ b/tests/components/Scoreboard.test.js
@@ -42,7 +42,11 @@ describe("Scoreboard component", () => {
     showSnackbar.mockClear();
     updateSnackbar.mockClear();
     header = document.createElement("header");
-    createScoreboard(header);
+    createScoreboard(header, {
+      startCoolDown: battleEngine.startCoolDown,
+      pauseTimer: battleEngine.pauseTimer,
+      resumeTimer: battleEngine.resumeTimer
+    });
     document.body.appendChild(header);
   });
 
@@ -97,6 +101,11 @@ describe("Scoreboard component", () => {
   it("startCountdown displays fallback on drift", () => {
     const timer = vi.useFakeTimers();
     const coolSpy = vi.spyOn(battleEngine, "startCoolDown");
+    initScoreboard(undefined, {
+      startCoolDown: coolSpy,
+      pauseTimer: battleEngine.pauseTimer,
+      resumeTimer: battleEngine.resumeTimer
+    });
     startCountdown(2);
     const onDrift = coolSpy.mock.calls[0][3];
     onDrift(1);
@@ -108,6 +117,11 @@ describe("Scoreboard component", () => {
   it("drift handler restarts only up to the retry limit", () => {
     const timer = vi.useFakeTimers();
     const coolSpy = vi.spyOn(battleEngine, "startCoolDown");
+    initScoreboard(undefined, {
+      startCoolDown: coolSpy,
+      pauseTimer: battleEngine.pauseTimer,
+      resumeTimer: battleEngine.resumeTimer
+    });
     const onFinish = vi.fn();
     startCountdown(5, onFinish);
     const onDrift = coolSpy.mock.calls[0][3];
@@ -127,7 +141,11 @@ describe("Scoreboard component", () => {
     document.body.innerHTML = "";
     const existing = createScoreboardHeader();
     document.body.appendChild(existing);
-    initScoreboard(existing);
+    initScoreboard(existing, {
+      startCoolDown: battleEngine.startCoolDown,
+      pauseTimer: battleEngine.pauseTimer,
+      resumeTimer: battleEngine.resumeTimer
+    });
     showMessage("Hi");
     expect(document.getElementById("round-message").textContent).toBe("Hi");
     updateScore(2, 3);

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -384,6 +384,7 @@ describe("startRoundWrapper failures", () => {
     vi.doMock("../../src/helpers/cardUtils.js", () => ({ toggleInspectorPanels: vi.fn() }));
     vi.doMock("../../src/helpers/viewportDebug.js", () => ({ toggleViewportSimulation: vi.fn() }));
     vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+      startCoolDown: vi.fn(),
       pauseTimer: vi.fn(),
       resumeTimer: vi.fn(),
       STATS: []
@@ -445,7 +446,12 @@ describe("syncScoreDisplay", () => {
       .fn()
       .mockReturnValueOnce({ playerScore: 1, opponentScore: 2 })
       .mockReturnValueOnce({ playerScore: 3, opponentScore: 4 });
-    vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({ getScores }));
+    vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+      getScores,
+      startCoolDown: vi.fn(),
+      pauseTimer: vi.fn(),
+      resumeTimer: vi.fn()
+    }));
     vi.doMock("../../src/components/Button.js", () => ({
       createButton: (label, { id } = {}) => {
         const btn = document.createElement("button");

--- a/tests/helpers/scoreboard.integration.test.js
+++ b/tests/helpers/scoreboard.integration.test.js
@@ -4,11 +4,11 @@ vi.mock("../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
 
-// We intentionally DO NOT call setupScoreboard's onDomReady init here.
-// The goal is to verify Scoreboard functions work without explicit initialization.
+// We intentionally avoid calling setupScoreboard's DOM initializer here.
+// Timer controls are injected directly so functions work without explicit setup.
 
 describe("Scoreboard integration without explicit init", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers();
     vi.resetModules();
     document.body.innerHTML = "";
@@ -69,6 +69,8 @@ describe("Scoreboard integration without explicit init", () => {
         }, 1000);
       },
       stopTimer: vi.fn(),
+      pauseTimer: vi.fn(),
+      resumeTimer: vi.fn(),
       STATS: ["power"]
       // the rest are not needed in this test
     }));
@@ -78,6 +80,14 @@ describe("Scoreboard integration without explicit init", () => {
       showSnackbar: vi.fn(),
       updateSnackbar: vi.fn()
     }));
+
+    const engine = await import("../../src/helpers/battleEngineFacade.js");
+    const { initScoreboard } = await import("../../src/components/Scoreboard.js");
+    initScoreboard(undefined, {
+      startCoolDown: engine.startCoolDown,
+      pauseTimer: engine.pauseTimer,
+      resumeTimer: engine.resumeTimer
+    });
   });
 
   it("renders messages, score, round counter, and round timer without init", async () => {


### PR DESCRIPTION
## Summary
- inject timer-control callbacks into Scoreboard instead of importing the battle engine directly
- pass timer controls through setupScoreboard and ClassicBattleController so the view can pause or resume timers
- adjust classic battle orchestrator and related tests for the new initialization flow

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a8a4b3af688326a730e75ddb7d30e1