### PR TITLE
refactor orchestrator to emit UI events

### DIFF
--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -106,7 +106,9 @@ onBattleEvent("scoreboardClearMessage", () => {
 onBattleEvent("scoreboardShowMessage", (e) => {
   try {
     scoreboard.showMessage(e.detail);
-  } catch {}
+  } catch (err) {
+    console.error("Error in scoreboard.showMessage:", err);
+  }
 });
 
 onBattleEvent("debugPanelUpdate", () => {

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -114,7 +114,9 @@ onBattleEvent("scoreboardShowMessage", (e) => {
 onBattleEvent("debugPanelUpdate", () => {
   try {
     updateDebugPanel();
-  } catch {}
+  } catch (err) {
+    console.error("Error updating debug panel:", err);
+  }
 });
 
 onBattleEvent("countdownStart", (e) => {

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -126,5 +126,7 @@ onBattleEvent("countdownStart", (e) => {
     scoreboard.startCountdown(duration, () => {
       emitBattleEvent("countdownFinished");
     });
-  } catch {}
+  } catch (err) {
+    console.error("Error in countdownStart event handler:", err);
+  }
 });

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -3,6 +3,8 @@ import * as scoreboard from "../setupScoreboard.js";
 import { createModal } from "../../components/Modal.js";
 import { createButton } from "../../components/Button.js";
 import { navigateToHome } from "../navUtils.js";
+import { updateDebugPanel } from "./uiHelpers.js";
+import { onBattleEvent, emitBattleEvent } from "./battleEvents.js";
 
 /**
  * Update the scoreboard with current scores.
@@ -90,3 +92,33 @@ export function showMatchSummaryModal(result, onNext) {
   modal.open();
   return modal;
 }
+
+// --- Event bindings ---
+
+onBattleEvent("scoreboardClearMessage", () => {
+  try {
+    scoreboard.clearMessage();
+  } catch {}
+});
+
+onBattleEvent("scoreboardShowMessage", (e) => {
+  try {
+    scoreboard.showMessage(e.detail);
+  } catch {}
+});
+
+onBattleEvent("debugPanelUpdate", () => {
+  try {
+    updateDebugPanel();
+  } catch {}
+});
+
+onBattleEvent("countdownStart", (e) => {
+  const { duration } = e.detail || {};
+  if (typeof duration !== "number") return;
+  try {
+    scoreboard.startCountdown(duration, () => {
+      emitBattleEvent("countdownFinished");
+    });
+  } catch {}
+});

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -98,7 +98,9 @@ export function showMatchSummaryModal(result, onNext) {
 onBattleEvent("scoreboardClearMessage", () => {
   try {
     scoreboard.clearMessage();
-  } catch {}
+  } catch (err) {
+    console.error("Error clearing scoreboard message:", err);
+  }
 });
 
 onBattleEvent("scoreboardShowMessage", (e) => {

--- a/tests/helpers/classicBattle/orchestrator.events.test.js
+++ b/tests/helpers/classicBattle/orchestrator.events.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mocks for UI modules invoked via uiService listeners
+const clearMessage = vi.fn();
+const showMessage = vi.fn();
+const startCountdown = vi.fn((_, cb) => cb());
+const updateDebugPanel = vi.fn();
+
+describe("classic battle orchestrator UI events", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    clearMessage.mockClear();
+    showMessage.mockClear();
+    startCountdown.mockClear();
+    updateDebugPanel.mockClear();
+    vi.doMock("../../../src/helpers/setupScoreboard.js", () => ({
+      clearMessage,
+      showMessage,
+      startCountdown
+    }));
+    vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
+      updateDebugPanel
+    }));
+  });
+
+  it("emits events and triggers UI listeners on init", async () => {
+    const { onBattleEvent } = await import("../../../src/helpers/classicBattle/battleEvents.js");
+    const clearSpy = vi.fn();
+    const debugSpy = vi.fn();
+    onBattleEvent("scoreboardClearMessage", clearSpy);
+    onBattleEvent("debugPanelUpdate", debugSpy);
+
+    await import("../../../src/helpers/classicBattle/uiService.js");
+    const orchestrator = await import("../../../src/helpers/classicBattle/orchestrator.js");
+    await orchestrator.initClassicBattleOrchestrator({});
+
+    expect(clearSpy).toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalled();
+    expect(clearMessage).toHaveBeenCalled();
+    expect(updateDebugPanel).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- emit UI update events from orchestrator instead of directly touching the DOM
- add UI service listeners that map events to scoreboard and debug panel updates
- test that orchestrator emits events and UI listeners respond

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a8b5dddca88326848b3d7fe73c7412