### PR TITLE
Ensure battle state list syncs with state data

### DIFF
--- a/src/helpers/battleStateProgress.js
+++ b/src/helpers/battleStateProgress.js
@@ -5,7 +5,7 @@
  * 1. Fetch `classicBattleStates.json` using `fetchJson`.
  * 2. Filter for core states (IDs below 90).
  * 3. Sort core states by `id` in ascending order.
- * 4. If `#battle-state-progress` already has the same number of items, skip rendering.
+ * 4. If `#battle-state-progress` already matches state IDs and names, skip rendering.
  * 5. Otherwise, clear the list and render each state as an `<li>` with `data-state` and its numeric ID.
  * 6. Define `updateActive(state)` to query list items and toggle the `active` class on the match.
  * 7. Observe `#machine-state` for text changes; on each change call `updateActive`.
@@ -42,7 +42,14 @@ export async function initBattleStateProgress() {
     return;
   }
 
-  if (list.children.length !== core.length) {
+  const items = Array.from(list.querySelectorAll("li"));
+  const needsRender =
+    items.length !== core.length ||
+    items.some(
+      (li, i) => li.dataset.state !== core[i].name || Number(li.textContent.trim()) !== core[i].id
+    );
+
+  if (needsRender) {
     list.textContent = "";
     const frag = document.createDocumentFragment();
     core.forEach((s) => {


### PR DESCRIPTION
## Summary
- verify battle state progress list against state names and IDs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a8bfbe72fc83268bbd2e8892be2aa7