### PR TITLE
refactor classic battle state handlers

### DIFF
--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -3,6 +3,7 @@ import { chooseOpponentStat, evaluateRound as evaluateRoundApi } from "../api/ba
 import { getStatValue } from "../battle/index.js";
 import { getOpponentJudoka } from "./cardSelection.js";
 import { emitBattleEvent } from "./battleEvents.js";
+import { isStateTransition } from "./orchestratorHandlers.js";
 
 // Local dispatcher to avoid circular import with orchestrator.
 // Uses a window-exposed getter set by the orchestrator at runtime.
@@ -156,11 +157,7 @@ export async function handleStatSelection(store, stat) {
         setTimeout(() => {
           // Only run if still awaiting resolution and selection remains.
           try {
-            if (
-              typeof window !== "undefined" &&
-              window.__classicBattleState === "roundDecision" &&
-              store.playerChoice
-            ) {
+            if (isStateTransition(null, "roundDecision") && store.playerChoice) {
               resolveRound(store, stat, playerVal, opponentVal).catch(() => {});
             }
           } catch {}

--- a/tests/helpers/classicBattle/stateTransitions.test.js
+++ b/tests/helpers/classicBattle/stateTransitions.test.js
@@ -1,11 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import classicBattleStates from "../../../src/data/classicBattleStates.json" with { type: "json" };
 import { BattleStateMachine } from "../../../src/helpers/classicBattle/stateMachine.js";
+import {
+  emitBattleEvent,
+  onBattleEvent,
+  offBattleEvent
+} from "../../../src/helpers/classicBattle/battleEvents.js";
+import { isStateTransition } from "../../../src/helpers/classicBattle/orchestratorHandlers.js";
 
 const statesByName = new Map(classicBattleStates.map((s) => [s.name, s]));
 
 // Generates a BattleStateMachine scoped to a single transition
-function createMachineForTransition(state, trigger) {
+function createMachineForTransition(state, trigger, onTransition) {
   const source = { ...state, triggers: [trigger] };
   const machineStates = new Map([[state.name, source]]);
   if (trigger.target !== state.name) {
@@ -14,7 +20,7 @@ function createMachineForTransition(state, trigger) {
       statesByName.get(trigger.target) || { name: trigger.target, triggers: [] }
     );
   }
-  return new BattleStateMachine(machineStates, state.name, {});
+  return new BattleStateMachine(machineStates, state.name, {}, {}, onTransition);
 }
 
 describe("classicBattleStates.json transitions", () => {
@@ -22,9 +28,21 @@ describe("classicBattleStates.json transitions", () => {
     if (!Array.isArray(state.triggers)) continue;
     for (const trigger of state.triggers) {
       it(`${state.name} --${trigger.on}--> ${trigger.target}`, async () => {
-        const machine = createMachineForTransition(state, trigger);
+        delete window.__classicBattleState;
+        delete window.__classicBattlePrevState;
+        const spy = vi.fn();
+        const onTransition = ({ from, to }) => {
+          window.__classicBattlePrevState = from;
+          window.__classicBattleState = to;
+          emitBattleEvent("debugPanelUpdate");
+        };
+        onBattleEvent("debugPanelUpdate", spy);
+        const machine = createMachineForTransition(state, trigger, onTransition);
         await machine.dispatch(trigger.on);
         expect(machine.getState()).toBe(trigger.target);
+        expect(spy).toHaveBeenCalled();
+        expect(isStateTransition(state.name, trigger.target)).toBe(true);
+        offBattleEvent("debugPanelUpdate", spy);
       });
     }
   }


### PR DESCRIPTION
## Summary
- move classic battle onEnter/onExit handlers into dedicated module
- add isStateTransition helper to centralize state checks
- test state transitions dispatch debug events

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/stateTransitions.test.js`
- `npx vitest run` *(failed: process interrupted; see notes)*
- `npx playwright test` *(failed: screenshot mismatch; see notes)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a8c62219a083269f92cdee0504310d