### PR TITLE
feat: add battle outcome helpers

### DIFF
--- a/tests/helpers/battleEngine/outcome.test.js
+++ b/tests/helpers/battleEngine/outcome.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { BattleEngine, determineOutcome, applyOutcome } from "../../../src/helpers/BattleEngine.js";
+
+describe("determineOutcome", () => {
+  it("returns player win when player value higher", () => {
+    expect(determineOutcome(5, 3)).toEqual({ delta: 2, outcome: "winPlayer" });
+  });
+
+  it("returns opponent win when opponent value higher", () => {
+    expect(determineOutcome(3, 5)).toEqual({ delta: -2, outcome: "winOpponent" });
+  });
+
+  it("returns draw when values equal", () => {
+    expect(determineOutcome(4, 4)).toEqual({ delta: 0, outcome: "draw" });
+  });
+});
+
+describe("applyOutcome", () => {
+  let engine;
+  beforeEach(() => {
+    engine = new BattleEngine();
+    engine._resetForTest();
+  });
+
+  it("increments player score on player win", () => {
+    applyOutcome(engine, { outcome: "winPlayer" });
+    expect(engine.playerScore).toBe(1);
+    expect(engine.opponentScore).toBe(0);
+  });
+
+  it("increments opponent score on opponent win", () => {
+    applyOutcome(engine, { outcome: "winOpponent" });
+    expect(engine.playerScore).toBe(0);
+    expect(engine.opponentScore).toBe(1);
+  });
+
+  it("leaves scores unchanged on draw", () => {
+    applyOutcome(engine, { outcome: "draw" });
+    expect(engine.playerScore).toBe(0);
+    expect(engine.opponentScore).toBe(0);
+  });
+});
+
+describe("BattleEngine handleStatSelection", () => {
+  let engine;
+  beforeEach(() => {
+    engine = new BattleEngine();
+    engine._resetForTest();
+  });
+
+  it("handles player win", () => {
+    const res = engine.handleStatSelection(5, 3);
+    expect(res).toMatchObject({
+      outcome: "winPlayer",
+      delta: 2,
+      matchEnded: false,
+      playerScore: 1,
+      opponentScore: 0
+    });
+  });
+
+  it("handles opponent win", () => {
+    const res = engine.handleStatSelection(3, 5);
+    expect(res).toMatchObject({
+      outcome: "winOpponent",
+      delta: -2,
+      playerScore: 0,
+      opponentScore: 1
+    });
+  });
+
+  it("handles tie", () => {
+    const res = engine.handleStatSelection(4, 4);
+    expect(res).toMatchObject({
+      outcome: "draw",
+      delta: 0,
+      playerScore: 0,
+      opponentScore: 0
+    });
+  });
+
+  it("ends match when points threshold reached", () => {
+    engine.setPointsToWin(1);
+    const res = engine.handleStatSelection(5, 3);
+    expect(res.matchEnded).toBe(true);
+    expect(res.message).toMatch(/win the match/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add determineOutcome and applyOutcome utilities for battle scoring
- return round result from stat selection handler
- test engine win/lose/tie and match-end cases

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: missing assets, 5 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a8cf755aa0832685fe04ff75d99c23