### PR TITLE
State-gate stat buttons in Classic Battle

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -64,6 +64,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Each match begins with both sides receiving **25 random cards**.
 - At the start of each round, both players draw their top card.
 - The player selects one stat (Power, Speed, Technique, etc.).
+- Stat buttons stay disabled until the selection phase and turn off after a choice is made.
 - The higher value wins the round and scores **1 point**; used cards are discarded.
 - The match ends when a player reaches a **user-selected win target of 5, 10, or 15 points** (default 10) or after **25 rounds** (draw).
 

--- a/design/productRequirementsDocuments/prdClassicBattleEngine.md
+++ b/design/productRequirementsDocuments/prdClassicBattleEngine.md
@@ -194,12 +194,12 @@ A new round begins — both the user and opponent are assigned random judoka via
 ### 5. `waitingForPlayerAction`
 The game waits for a stat selection.
 
-- **Triggers:**  
-  - `statSelected` → **`roundDecision`**  
-  - `timeout` (if `FF_AUTO_SELECT` enabled) → **`roundDecision`**  
-  - `timeout` (if `FF_AUTO_SELECT` disabled) → **`interruptRound`**  
-  - `interrupt` → **`interruptRound`**  
-- **Notes:** The user always chooses first; AI only selects if it is the AI’s turn in other modes.
+- **Triggers:**
+  - `statSelected` → **`roundDecision`**
+  - `timeout` (if `FF_AUTO_SELECT` enabled) → **`roundDecision`**
+  - `timeout` (if `FF_AUTO_SELECT` disabled) → **`interruptRound`**
+  - `interrupt` → **`interruptRound`**
+- **Notes:** The user always chooses first; AI only selects if it is the AI’s turn in other modes. Stat buttons remain disabled until this state is entered and are disabled again when leaving it.
 
 ---
 

--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -58,8 +58,12 @@ export async function roundStartEnter(machine) {
 }
 export async function roundStartExit() {}
 
-export async function waitingForPlayerActionEnter() {}
-export async function waitingForPlayerActionExit() {}
+export async function waitingForPlayerActionEnter() {
+  emitBattleEvent("statButtons:enable");
+}
+export async function waitingForPlayerActionExit() {
+  emitBattleEvent("statButtons:disable");
+}
 
 export async function roundDecisionEnter(machine) {
   const { store } = machine.context;

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -366,6 +366,9 @@ export function initStatButtons(store) {
     }
   }
 
+  // Start disabled until the game enters the player action state
+  setEnabled(false);
+
   statButtons.forEach((btn) => {
     const statName = btn.dataset.stat;
     const clickHandler = async () => {

--- a/src/helpers/classicBattle/view.js
+++ b/src/helpers/classicBattle/view.js
@@ -14,6 +14,7 @@ import {
   initDebugPanel,
   maybeShowStatHint
 } from "./uiHelpers.js";
+import { onBattleEvent } from "./battleEvents.js";
 import { initBattleStateProgress } from "../battleStateProgress.js";
 import { initTooltips } from "../tooltip.js";
 import { start as startScheduler, stop as stopScheduler } from "../../utils/scheduler.js";
@@ -73,6 +74,8 @@ export class ClassicBattleView {
 
     setupNextButton();
     this.statButtonControls = initStatButtons(store);
+    onBattleEvent("statButtons:enable", () => this.statButtonControls?.enable());
+    onBattleEvent("statButtons:disable", () => this.statButtonControls?.disable());
 
     initDebugPanel();
     registerRoundStartErrorHandler(() => this.startRound());

--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -21,6 +21,7 @@ This directory contains unit tests for Classic Battle helpers.
 - `scheduleNextRound.test.js`: schedules and auto-dispatches the next round.
 - `selectionPrompt.test.js`: displays the selection prompt until a stat is chosen.
 - `stallRecovery.test.js`: recovers when stat selection stalls.
+- `statButtons.state.test.js`: toggles stat buttons based on battle state.
 - `statSelection.test.js`: resolves round outcomes after stat selection.
 - `stateTransitions.test.js`: validates `classicBattleStates.json` transitions.
 - `timerService.drift.test.js`: falls back to messaging when timers drift.

--- a/tests/helpers/classicBattle/statButtons.state.test.js
+++ b/tests/helpers/classicBattle/statButtons.state.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BattleStateMachine } from "../../../src/helpers/classicBattle/stateMachine.js";
+import {
+  waitingForPlayerActionEnter,
+  waitingForPlayerActionExit
+} from "../../../src/helpers/classicBattle/orchestratorHandlers.js";
+import { ClassicBattleView } from "../../../src/helpers/classicBattle/view.js";
+
+vi.mock("../../../src/helpers/battleJudokaPage.js", () => ({ waitForOpponentCard: vi.fn() }));
+vi.mock("../../../src/helpers/setupScoreboard.js", () => ({ setupScoreboard: vi.fn() }));
+vi.mock("../../../src/helpers/classicBattle/quitButton.js", () => ({ initQuitButton: vi.fn() }));
+vi.mock("../../../src/helpers/classicBattle/skipHandler.js", () => ({ skipCurrentPhase: vi.fn() }));
+vi.mock("../../../src/helpers/classicBattle/interruptHandlers.js", () => ({
+  initInterruptHandlers: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", async () => {
+  const actual = await vi.importActual("../../../src/helpers/classicBattle/uiHelpers.js");
+  return {
+    ...actual,
+    watchBattleOrientation: vi.fn(),
+    registerRoundStartErrorHandler: vi.fn(),
+    setupNextButton: vi.fn(),
+    applyStatLabels: vi.fn().mockResolvedValue(),
+    setBattleStateBadgeEnabled: vi.fn(),
+    applyBattleFeatureFlags: vi.fn(),
+    initDebugPanel: vi.fn(),
+    maybeShowStatHint: vi.fn()
+  };
+});
+vi.mock("../../../src/helpers/battleStateProgress.js", () => ({
+  initBattleStateProgress: vi.fn().mockResolvedValue(null)
+}));
+vi.mock("../../../src/helpers/tooltip.js", () => ({ initTooltips: vi.fn().mockResolvedValue() }));
+vi.mock("../../../src/utils/scheduler.js", () => ({
+  onFrame: vi.fn(),
+  onSecondTick: vi.fn(),
+  cancel: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn()
+}));
+vi.mock("../../../src/helpers/setupBottomNavbar.js", () => ({}));
+vi.mock("../../../src/helpers/setupDisplaySettings.js", () => ({}));
+vi.mock("../../../src/helpers/setupSvgFallback.js", () => ({}));
+vi.mock("../../../src/helpers/setupClassicBattleHomeLink.js", () => ({}));
+
+describe("classicBattle stat button state", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="stat-buttons"><button data-stat="power"></button></div>';
+  });
+
+  it("enables stat buttons only while waiting for player action", async () => {
+    const view = new ClassicBattleView();
+    view.controller = {
+      battleStore: {},
+      timerControls: {},
+      isEnabled: () => false,
+      addEventListener: vi.fn(),
+      startRound: vi.fn()
+    };
+    await view.init();
+
+    const btn = document.querySelector("#stat-buttons button");
+    expect(btn.disabled).toBe(true);
+
+    const states = new Map([
+      ["cooldown", { name: "cooldown", triggers: [{ on: "ready", target: "roundStart" }] }],
+      [
+        "roundStart",
+        {
+          name: "roundStart",
+          triggers: [{ on: "cardsRevealed", target: "waitingForPlayerAction" }]
+        }
+      ],
+      [
+        "waitingForPlayerAction",
+        {
+          name: "waitingForPlayerAction",
+          triggers: [{ on: "statSelected", target: "roundDecision" }]
+        }
+      ],
+      ["roundDecision", { name: "roundDecision", triggers: [] }]
+    ]);
+
+    const machine = new BattleStateMachine(
+      states,
+      "cooldown",
+      {
+        waitingForPlayerAction: waitingForPlayerActionEnter,
+        roundDecision: waitingForPlayerActionExit
+      },
+      {}
+    );
+
+    await machine.dispatch("ready");
+    await machine.dispatch("cardsRevealed");
+    expect(btn.disabled).toBe(false);
+
+    await machine.dispatch("statSelected");
+    expect(btn.disabled).toBe(true);
+  });
+});

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -53,6 +53,11 @@ describe("classicBattlePage stat button interactions", () => {
 
     const [first, second, third] = container.querySelectorAll("button");
 
+    container.querySelectorAll("button").forEach((b) => {
+      b.disabled = false;
+      b.tabIndex = 0;
+    });
+
     first.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     await Promise.resolve();
     expect(handleStatSelection).toHaveBeenCalledWith(store, "power");


### PR DESCRIPTION
## Summary
- Disable stat buttons by default so they only activate during the player's turn
- Emit battle events to enable/disable stat buttons when entering or exiting `waitingForPlayerAction`
- Cover stat button enable/disable flow with unit tests and document the behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a8d913adec8326a17f01f1fa2fcff3