### PR TITLE
Handle round start errors

### DIFF
--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -52,9 +52,18 @@ export async function cooldownExit() {}
 
 export async function roundStartEnter(machine) {
   const { startRoundWrapper, doStartRound, store } = machine.context;
-  if (typeof startRoundWrapper === "function") await startRoundWrapper();
-  else if (typeof doStartRound === "function") await doStartRound(store);
-  await machine.dispatch("cardsRevealed");
+  try {
+    if (typeof startRoundWrapper === "function") await startRoundWrapper();
+    else if (typeof doStartRound === "function") await doStartRound(store);
+  } catch {
+    try {
+      emitBattleEvent("scoreboardShowMessage", "Round start error. Recovering…");
+      emitBattleEvent("debugPanelUpdate");
+      await machine.dispatch("interrupt", { reason: "roundStartError" });
+    } catch {}
+  } finally {
+    await machine.dispatch("cardsRevealed");
+  }
 }
 export async function roundStartExit() {}
 

--- a/tests/helpers/classicBattle/roundStartError.test.js
+++ b/tests/helpers/classicBattle/roundStartError.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { BattleStateMachine } from "../../../src/helpers/classicBattle/stateMachine.js";
+import { roundStartEnter } from "../../../src/helpers/classicBattle/orchestratorHandlers.js";
+
+describe("round start error recovery", () => {
+  it("dispatches interrupt when drawCards rejects", async () => {
+    vi.resetModules();
+    vi.doMock("../../../src/helpers/classicBattle/cardSelection.js", () => ({
+      drawCards: vi.fn().mockRejectedValue(new Error("no cards")),
+      _resetForTest: vi.fn()
+    }));
+    const { startRound } = await import("../../../src/helpers/classicBattle/roundManager.js");
+    const states = new Map([
+      [
+        "roundStart",
+        {
+          name: "roundStart",
+          triggers: [
+            { on: "cardsRevealed", target: "waitingForPlayerAction" },
+            { on: "interrupt", target: "interruptRound" }
+          ]
+        }
+      ],
+      ["waitingForPlayerAction", { name: "waitingForPlayerAction", triggers: [] }],
+      ["interruptRound", { name: "interruptRound", triggers: [] }]
+    ]);
+    const machine = new BattleStateMachine(
+      states,
+      "roundStart",
+      { roundStart: roundStartEnter },
+      { doStartRound: startRound, store: {} }
+    );
+
+    await roundStartEnter(machine);
+
+    expect(machine.getState()).toBe("interruptRound");
+  });
+});


### PR DESCRIPTION
## Summary
- guard round start calls and emit scoreboard + interrupt when they fail
- ensure cards are revealed after round start even on failure
- cover round start failures with a new unit test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a8ec6b74c083268bac700dbdddb1e8