### PR TITLE
feat: allow autostart query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ JU-DO-KON! is a strategic digital card game inspired by Top Trumps, featuring ju
 
 When you open `src/pages/battleJudoka.html`, a modal prompts you to choose the match length (win target) before the first round. Options are sourced from `src/data/battleRounds.json` (fallbacks provided if loading fails). Selecting an option sets the engine’s points-to-win and starts the pre-round countdown.
 
+For debugging or automated tests, append `?autostart=1` to `battleJudoka.html` to skip the modal and begin a default-length match immediately.
+
 ---
 
 ## 🚧 Development Status

--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -10,16 +10,19 @@ import { isTestModeEnabled } from "../testModeUtils.js";
  * Initialize round selection modal for Classic Battle.
  *
  * @pseudocode
- * 1. If test mode is enabled:
+ * 1. If the page URL includes `autostart=1`:
  *    a. Set `pointsToWin` to the default value.
  *    b. Invoke `onStart` and return early.
- * 2. Attempt to fetch `battleRounds.json` using `fetchJson`.
+ * 2. If test mode is enabled:
+ *    a. Set `pointsToWin` to the default value.
+ *    b. Invoke `onStart` and return early.
+ * 3. Attempt to fetch `battleRounds.json` using `fetchJson`.
  *    a. On failure, log the error, fall back to default rounds, and note the load error.
- * 3. Create buttons for each option with `createButton` and assign tooltip ids.
- * 4. Assemble a modal via `createModal`, append an error note if needed, and attach to the document.
- * 5. Attempt to initialize tooltips for the modal; log errors but continue.
- * 6. Open the modal.
- * 7. When a button is clicked:
+ * 4. Create buttons for each option with `createButton` and assign tooltip ids.
+ * 5. Assemble a modal via `createModal`, append an error note if needed, and attach to the document.
+ * 6. Attempt to initialize tooltips for the modal; log errors but continue.
+ * 7. Open the modal.
+ * 8. When a button is clicked:
  *    a. Call `setPointsToWin` with the round value.
  *    b. Close and destroy the modal, then invoke the provided start callback.
  *
@@ -31,8 +34,8 @@ export async function initRoundSelectModal(onStart) {
   // supplying `?autostart=1` in the page URL. This is a deliberate, low-risk
   // convenience that mirrors existing `isTestModeEnabled()` behaviour.
   try {
-    if (typeof window !== "undefined") {
-      const params = new URL(window.location.href).searchParams;
+    if (typeof location !== "undefined") {
+      const params = new URLSearchParams(location.search);
       if (params.get("autostart") === "1") {
         setPointsToWin(CLASSIC_BATTLE_POINTS_TO_WIN);
         if (typeof onStart === "function") await onStart();

--- a/tests/helpers/classicBattle/roundSelectModal.test.js
+++ b/tests/helpers/classicBattle/roundSelectModal.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
+import { CLASSIC_BATTLE_POINTS_TO_WIN } from "../../../src/helpers/constants.js";
+
 const rounds = JSON.parse(readFileSync(resolve("src/data/battleRounds.json"), "utf8"));
 
 const mocks = vi.hoisted(() => ({
@@ -44,6 +46,7 @@ describe("initRoundSelectModal", () => {
     mocks.fetchJson.mockResolvedValue(rounds);
     mocks.cleanup = vi.fn();
     mocks.initTooltips.mockResolvedValue(mocks.cleanup);
+    window.history.replaceState({}, "", "/");
   });
 
   it("renders three options from battleRounds.json", async () => {
@@ -93,5 +96,15 @@ describe("initRoundSelectModal", () => {
     expect(mocks.setPointsToWin).toHaveBeenCalledWith(5);
     expect(onStart).toHaveBeenCalled();
     consoleErr.mockRestore();
+  });
+
+  it("auto-starts a default match when ?autostart=1 is present", async () => {
+    const onStart = vi.fn();
+    window.history.replaceState({}, "", "?autostart=1");
+    await initRoundSelectModal(onStart);
+    expect(mocks.setPointsToWin).toHaveBeenCalledWith(CLASSIC_BATTLE_POINTS_TO_WIN);
+    expect(onStart).toHaveBeenCalled();
+    expect(mocks.fetchJson).not.toHaveBeenCalled();
+    expect(document.querySelector(".round-select-buttons")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- allow bypassing Classic Battle round select modal via `?autostart=1`
- document `?autostart=1` query parameter
- add coverage for autostart query parameter

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a8ef43aed48326b9eee69e6db8affe