### PR TITLE
Refactor vector search controller and add error-path test

### DIFF
--- a/tests/helpers/vectorSearchPage/errorHandling.test.js
+++ b/tests/helpers/vectorSearchPage/errorHandling.test.js
@@ -23,4 +23,19 @@ describe("error handling", () => {
     expect(msg.textContent).toContain("Failed to load search data");
     consoleError.mockRestore();
   });
+
+  it("shows a fallback message when query vector construction fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const findMatches = vi.fn();
+    mockVectorSearch({ findMatches });
+    mockDataUtils();
+    mockConstants();
+    const { handleSearch } = await setupPage(undefined, async () => ({ data: 123 }));
+    document.getElementById("vector-search-input").value = "test";
+    await handleSearch(new Event("submit"));
+    expect(findMatches).not.toHaveBeenCalled();
+    const msg = document.getElementById("search-results-message");
+    expect(msg.textContent).toContain("An error occurred while searching.");
+    consoleError.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- Delegate query vector generation to `buildQueryVector`
- Extract result rendering into `renderSearchResults`
- Add a test covering search failures when vector building fails

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a96e2d42c08326b91f2d1a9ee3588e