### PR TITLE
chore: clean up unused orientation screenshot block

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -1,7 +1,5 @@
 import { test, expect } from "./fixtures/commonSetup.js";
 
-const runScreenshots = process.env.SKIP_SCREENSHOTS !== "true";
-
 test.describe.parallel("Battle orientation behavior", () => {
   test("updates orientation data attribute on rotation", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
@@ -30,23 +28,3 @@ test.describe.parallel("Battle orientation behavior", () => {
     expect(overflow).toBe("ellipsis");
   });
 });
-
-test.describe.parallel(
-  runScreenshots ? "Battle orientation screenshots" : "Battle orientation screenshots (skipped)",
-  () => {
-    test.skip(!runScreenshots);
-
-    test.beforeEach(async ({ page }) => {
-      await page.addInitScript(() => {
-        Math.random = () => 0.42;
-        localStorage.setItem(
-          "settings",
-          JSON.stringify({
-            featureFlags: { enableTestMode: { enabled: true } }
-          })
-        );
-      });
-      await page.emulateMedia({ reducedMotion: "reduce" });
-    });
-  }
-);


### PR DESCRIPTION
## Summary
- remove empty screenshot `describe` block from battle-orientation Playwright tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a981e9a3b4832683fbe2cc616e9ef7