### PR TITLE
Remove duplicate orientation test from responsive contrast

### DIFF
--- a/playwright/responsive-contrast.spec.js
+++ b/playwright/responsive-contrast.spec.js
@@ -8,18 +8,6 @@ test.describe.parallel("Responsive scenarios", () => {
     expect(scrollWidth).toBeLessThanOrEqual(260);
   });
 
-  test("updates orientation on viewport rotation", async ({ page }) => {
-    await page.goto("/src/pages/battleJudoka.html", { waitUntil: "networkidle" });
-    await page.setViewportSize({ width: 320, height: 480 });
-    await page.waitForFunction(
-      () => document.querySelector(".battle-header")?.dataset.orientation === "portrait"
-    );
-    await page.setViewportSize({ width: 480, height: 320 });
-    await page.waitForFunction(
-      () => document.querySelector(".battle-header")?.dataset.orientation === "landscape"
-    );
-  });
-
   test("toggles high-contrast display mode", async ({ page }) => {
     await page.goto("/src/pages/settings.html");
     await page.locator("#display-mode-high-contrast").waitFor();


### PR DESCRIPTION
## Summary
- Drop redundant viewport orientation test from `responsive-contrast.spec.js`
- Keep orientation validation centralized in `battle-orientation.spec.js`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/utils/debounce.test.js`
- `npx playwright test playwright/responsive-contrast.spec.js playwright/battle-orientation.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a987413524832683b0f4607e2b715e