### PR TITLE
refactor: remove redundant logo alt text tests

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -24,11 +24,6 @@ test.describe.parallel("Browse Judoka screen", () => {
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 
-  test("logo has alt text", async ({ page }) => {
-    const logo = page.getByRole("img", { name: "JU-DO-KON! Logo" });
-    await expect(logo).toBeVisible();
-  });
-
   test("scroll buttons have labels", async ({ page }) => {
     const left = page.getByRole("button", { name: /prev\./i });
     const right = page.getByRole("button", { name: /next/i });

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -14,11 +14,6 @@ test.describe.parallel("Homepage", () => {
     await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 
-  test("logo has alt text", async ({ page }) => {
-    const logo = page.getByAltText("JU-DO-KON! Logo");
-    await expect(logo).toHaveAttribute("alt", "JU-DO-KON! Logo");
-  });
-
   test("navigation links visible", async ({ page }) => {
     await page.waitForSelector("footer .bottom-navbar a");
     await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -18,10 +18,6 @@ test.describe.parallel("View Judoka screen", () => {
     await battleLink.click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
-  test("logo has alt text", async ({ page }) => {
-    const logo = page.getByRole("img", { name: "JU-DO-KON! Logo" });
-    await expect(logo).toHaveAttribute("alt", "JU-DO-KON! Logo");
-  });
 
   test("draw button accessible name constant", async ({ page }) => {
     const btn = page.getByTestId("draw-button");


### PR DESCRIPTION
## Summary
- Rely on shared `verifyPageBasics` helper for logo checks
- Drop duplicate "logo has alt text" tests from page specs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a98767c63c8326aeb7a10bc5645b44