### PR TITLE
Split battle Judoka status checks from screenshot capture

### DIFF
--- a/playwright/battleJudoka.spec.js
+++ b/playwright/battleJudoka.spec.js
@@ -30,7 +30,7 @@ test.describe.parallel("Battle Judoka page", () => {
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 
-  test("narrow viewport screenshot and status aria attributes", async ({ page }) => {
+  test("status aria attributes and progress ids", async ({ page }) => {
     await page.setViewportSize({ width: 280, height: 800 });
 
     const axTree = await page.accessibility.snapshot({ interestingOnly: false });
@@ -55,7 +55,10 @@ test.describe.parallel("Battle Judoka page", () => {
       lis.map((li) => li.textContent.trim())
     );
     expect(ids).toEqual(expectedIds);
+  });
 
+  test("narrow viewport screenshot", async ({ page }) => {
+    await page.setViewportSize({ width: 280, height: 800 });
     await expect(page).toHaveScreenshot("battleJudoka-narrow.png", {
       mask: [page.locator("#battle-state-progress")]
     });


### PR DESCRIPTION
## Summary
- split combined battle Judoka test into atomic checks for `role="status"` nodes with progress IDs
- add separate screenshot-only test for narrow viewport capture

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a98e90c6dc8326be40dba1efeffc8e