### PR TITLE
test: split load error dialog tests

### DIFF
--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -143,12 +143,9 @@ describe.sequential("classicBattle card selection", () => {
     expect(document.getElementById("round-message").textContent).toBe("boom");
     const retry = document.getElementById("retry-draw-button");
     expect(retry).toBeTruthy();
-    await retry.click();
-    await Promise.resolve();
-    expect(fetchJsonMock).toHaveBeenCalledTimes(3);
   });
 
-  it("retries both judoka and gokyo loads after failure", async () => {
+  it("clicking Retry re-fetches data in order", async () => {
     const calls = [];
     fetchJsonMock.mockImplementation(async (p) => {
       calls.push(p);


### PR DESCRIPTION
## Summary
- split cardSelection load error test into separate dialog display and retry flow tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a9a9dbdee08326b356dbe479d80a7a