### PR TITLE
test: refine settings page specs

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -1,0 +1,7 @@
+# Playwright Tests
+
+## Settings tests
+- Routes for navigation and game mode data are registered through `fixtures/commonSetup.js`, keeping specs concise.
+- Each test navigates to `/src/pages/settings.html` and asserts a single concern.
+- `controls expose correct labels` verifies accessible labels for toggles and feature flags.
+- `tab order follows expected sequence` ensures keyboard navigation visits controls in order.


### PR DESCRIPTION
## Summary
- split settings page spec into separate label and tab-order tests
- centralize route setup with shared fixture and document settings tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 6 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a9c1768e888326aed079a88e792f9f