### PR TITLE
Enable paused timer test and remove console logs

### DIFF
--- a/src/helpers/api/countryService.js
+++ b/src/helpers/api/countryService.js
@@ -1,6 +1,7 @@
 import { fetchJson, importJsonModule } from "../dataUtils.js";
 import { DATA_DIR } from "../constants.js";
 import { getItem, setItem } from "../storage.js";
+import { debugLog } from "../debug.js";
 
 const STORAGE_KEY = "countryCodeMapping";
 const DEFAULT_COUNTRY = "Vanuatu";
@@ -38,10 +39,7 @@ export async function loadCountryMapping() {
       } catch (err) {
         // Reduce noise in tests/CI: prefer debug logging over warnings
         // and fall back to local module import.
-
-        if (typeof window !== "undefined" && window.DEBUG_LOGGING) {
-          console.log("Failed to fetch countryCodeMapping.json", err);
-        }
+        debugLog("Failed to fetch countryCodeMapping.json", err);
         const data = await importJsonModule("../../data/countryCodeMapping.json");
         setItem(STORAGE_KEY, data);
         return data;


### PR DESCRIPTION
## Summary
- enable classic battle paused timer scenario and silence console output with spies
- replace direct console logging in country service with debugLog

## Testing
- `npx prettier tests/helpers/classicBattle/pauseTimer.test.js src/helpers/api/countryService.js --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: network errors, screenshot mismatches, timeouts)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a9d32a203c832697853c2d14fdccfa