### PR TITLE
test: centralize classic battle mocks

### DIFF
--- a/tests/helpers/classicBattle/autoSelect.test.js
+++ b/tests/helpers/classicBattle/autoSelect.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setupClassicBattleDom } from "./utils.js";
-import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
+import { applyMockSetup } from "./mockSetup.js";
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -22,42 +22,12 @@ vi.mock("../../../src/utils/scheduler.js", () => ({
   stop: vi.fn()
 }));
 
+let timerSpy;
+let fetchJsonMock;
 let generateRandomCardMock;
-vi.mock("../../../src/helpers/randomCard.js", () => ({
-  generateRandomCard: (...args) => generateRandomCardMock(...args)
-}));
-
 let getRandomJudokaMock;
 let renderMock;
-let JudokaCardMock;
-vi.mock("../../../src/helpers/cardUtils.js", () => ({
-  getRandomJudoka: (...args) => getRandomJudokaMock(...args)
-}));
-vi.mock("../../../src/components/JudokaCard.js", () => {
-  renderMock = vi.fn();
-  JudokaCardMock = vi.fn().mockImplementation(() => ({ render: renderMock }));
-  return { JudokaCard: JudokaCardMock };
-});
-
-let fetchJsonMock;
-vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn().mockResolvedValue(defaultSettings),
-  validateWithSchema: vi.fn().mockResolvedValue(undefined)
-}));
-
-vi.mock("../../../src/helpers/utils.js", () => ({
-  createGokyoLookup: () => ({})
-}));
-
 let currentFlags;
-vi.mock("../../../src/helpers/featureFlags.js", () => ({
-  featureFlagsEmitter: new EventTarget(),
-  initFeatureFlags: vi.fn().mockResolvedValue({ featureFlags: currentFlags }),
-  isEnabled: (flag) => currentFlags[flag]?.enabled ?? false
-}));
-
-let timerSpy;
 
 beforeEach(() => {
   ({
@@ -68,6 +38,13 @@ beforeEach(() => {
     renderMock,
     currentFlags
   } = setupClassicBattleDom());
+  applyMockSetup({
+    fetchJsonMock,
+    generateRandomCardMock,
+    getRandomJudokaMock,
+    renderMock,
+    currentFlags
+  });
 });
 
 afterEach(() => {

--- a/tests/helpers/classicBattle/matchEnd.test.js
+++ b/tests/helpers/classicBattle/matchEnd.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setupClassicBattleDom } from "./utils.js";
 import { CLASSIC_BATTLE_POINTS_TO_WIN } from "../../../src/helpers/constants.js";
-import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
+import { applyMockSetup } from "./mockSetup.js";
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -23,41 +23,6 @@ vi.mock("../../../src/utils/scheduler.js", () => ({
   stop: vi.fn()
 }));
 
-let generateRandomCardMock;
-vi.mock("../../../src/helpers/randomCard.js", () => ({
-  generateRandomCard: (...args) => generateRandomCardMock(...args)
-}));
-
-let getRandomJudokaMock;
-let renderMock;
-let JudokaCardMock;
-vi.mock("../../../src/helpers/cardUtils.js", () => ({
-  getRandomJudoka: (...args) => getRandomJudokaMock(...args)
-}));
-vi.mock("../../../src/components/JudokaCard.js", () => {
-  renderMock = vi.fn();
-  JudokaCardMock = vi.fn().mockImplementation(() => ({ render: renderMock }));
-  return { JudokaCard: JudokaCardMock };
-});
-
-let fetchJsonMock;
-vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn().mockResolvedValue(defaultSettings),
-  validateWithSchema: vi.fn().mockResolvedValue(undefined)
-}));
-
-vi.mock("../../../src/helpers/utils.js", () => ({
-  createGokyoLookup: () => ({})
-}));
-
-let currentFlags;
-vi.mock("../../../src/helpers/featureFlags.js", () => ({
-  featureFlagsEmitter: new EventTarget(),
-  initFeatureFlags: vi.fn().mockResolvedValue({ featureFlags: currentFlags }),
-  isEnabled: (flag) => currentFlags[flag]?.enabled ?? false
-}));
-
 vi.mock("../../../src/components/Modal.js", () => ({
   createModal: (content) => {
     const el = document.createElement("div");
@@ -73,6 +38,11 @@ vi.mock("../../../src/components/Modal.js", () => ({
 }));
 
 let timerSpy;
+let fetchJsonMock;
+let generateRandomCardMock;
+let getRandomJudokaMock;
+let renderMock;
+let currentFlags;
 
 beforeEach(() => {
   ({
@@ -83,6 +53,13 @@ beforeEach(() => {
     renderMock,
     currentFlags
   } = setupClassicBattleDom());
+  applyMockSetup({
+    fetchJsonMock,
+    generateRandomCardMock,
+    getRandomJudokaMock,
+    renderMock,
+    currentFlags
+  });
 });
 
 afterEach(() => {

--- a/tests/helpers/classicBattle/mockSetup.js
+++ b/tests/helpers/classicBattle/mockSetup.js
@@ -1,0 +1,58 @@
+import { vi } from "vitest";
+import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
+
+const mocks = {
+  fetchJsonMock: undefined,
+  generateRandomCardMock: undefined,
+  getRandomJudokaMock: undefined,
+  renderMock: undefined,
+  JudokaCardMock: undefined,
+  currentFlags: {}
+};
+
+vi.mock("../../../src/helpers/randomCard.js", () => ({
+  generateRandomCard: (...args) => mocks.generateRandomCardMock(...args)
+}));
+
+vi.mock("../../../src/helpers/cardUtils.js", () => ({
+  getRandomJudoka: (...args) => mocks.getRandomJudokaMock(...args)
+}));
+
+vi.mock("../../../src/components/JudokaCard.js", () => {
+  mocks.renderMock = vi.fn();
+  mocks.JudokaCardMock = vi.fn().mockImplementation(() => ({ render: mocks.renderMock }));
+  return { JudokaCard: mocks.JudokaCardMock };
+});
+
+vi.mock("../../../src/helpers/dataUtils.js", () => ({
+  fetchJson: (...args) => mocks.fetchJsonMock(...args),
+  importJsonModule: vi.fn().mockResolvedValue(defaultSettings),
+  validateWithSchema: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock("../../../src/helpers/utils.js", () => ({
+  createGokyoLookup: () => ({})
+}));
+
+vi.mock("../../../src/helpers/featureFlags.js", () => ({
+  featureFlagsEmitter: new EventTarget(),
+  initFeatureFlags: vi.fn().mockResolvedValue({ featureFlags: mocks.currentFlags }),
+  isEnabled: (flag) => mocks.currentFlags[flag]?.enabled ?? false
+}));
+
+export function applyMockSetup({
+  fetchJsonMock,
+  generateRandomCardMock,
+  getRandomJudokaMock,
+  renderMock,
+  currentFlags
+} = {}) {
+  mocks.fetchJsonMock = fetchJsonMock;
+  mocks.generateRandomCardMock = generateRandomCardMock;
+  mocks.getRandomJudokaMock = getRandomJudokaMock;
+  mocks.renderMock = renderMock;
+  mocks.currentFlags = currentFlags ?? {};
+  return mocks;
+}
+
+export { mocks };

--- a/tests/helpers/classicBattle/pauseTimer.test.js
+++ b/tests/helpers/classicBattle/pauseTimer.test.js
@@ -1,39 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
 import { createRoundMessage } from "./domUtils.js";
-import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
+import { applyMockSetup } from "./mockSetup.js";
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
 
+let fetchJsonMock;
 let generateRandomCardMock;
-vi.mock("../../../src/helpers/randomCard.js", () => ({
-  generateRandomCard: (...args) => generateRandomCardMock(...args)
-}));
-
 let getRandomJudokaMock;
 let renderMock;
-let JudokaCardMock;
-vi.mock("../../../src/helpers/cardUtils.js", () => ({
-  getRandomJudoka: (...args) => getRandomJudokaMock(...args)
-}));
-vi.mock("../../../src/components/JudokaCard.js", () => {
-  renderMock = vi.fn();
-  JudokaCardMock = vi.fn().mockImplementation(() => ({ render: renderMock }));
-  return { JudokaCard: JudokaCardMock };
-});
-
-let fetchJsonMock;
-vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn().mockResolvedValue(defaultSettings),
-  validateWithSchema: vi.fn().mockResolvedValue(undefined)
-}));
-
-vi.mock("../../../src/helpers/utils.js", () => ({
-  createGokyoLookup: () => ({})
-}));
 
 describe("classicBattle timer pause", () => {
   let timer;
@@ -71,6 +48,12 @@ describe("classicBattle timer pause", () => {
       const el = document.createElement("div");
       el.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
       return el;
+    });
+    applyMockSetup({
+      fetchJsonMock,
+      generateRandomCardMock,
+      getRandomJudokaMock,
+      renderMock
     });
 
     showMessage = vi.fn();

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setupClassicBattleDom } from "./utils.js";
 import { createTimerNodes } from "./domUtils.js";
-import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
+import { applyMockSetup } from "./mockSetup.js";
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -23,42 +23,12 @@ vi.mock("../../../src/utils/scheduler.js", () => ({
   stop: vi.fn()
 }));
 
+let timerSpy;
+let fetchJsonMock;
 let generateRandomCardMock;
-vi.mock("../../../src/helpers/randomCard.js", () => ({
-  generateRandomCard: (...args) => generateRandomCardMock(...args)
-}));
-
 let getRandomJudokaMock;
 let renderMock;
-let JudokaCardMock;
-vi.mock("../../../src/helpers/cardUtils.js", () => ({
-  getRandomJudoka: (...args) => getRandomJudokaMock(...args)
-}));
-vi.mock("../../../src/components/JudokaCard.js", () => {
-  renderMock = vi.fn();
-  JudokaCardMock = vi.fn().mockImplementation(() => ({ render: renderMock }));
-  return { JudokaCard: JudokaCardMock };
-});
-
-let fetchJsonMock;
-vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn().mockResolvedValue(defaultSettings),
-  validateWithSchema: vi.fn().mockResolvedValue(undefined)
-}));
-
-vi.mock("../../../src/helpers/utils.js", () => ({
-  createGokyoLookup: () => ({})
-}));
-
 let currentFlags;
-vi.mock("../../../src/helpers/featureFlags.js", () => ({
-  featureFlagsEmitter: new EventTarget(),
-  initFeatureFlags: vi.fn().mockResolvedValue({ featureFlags: currentFlags }),
-  isEnabled: (flag) => currentFlags[flag]?.enabled ?? false
-}));
-
-let timerSpy;
 
 beforeEach(() => {
   ({
@@ -69,6 +39,13 @@ beforeEach(() => {
     renderMock,
     currentFlags
   } = setupClassicBattleDom());
+  applyMockSetup({
+    fetchJsonMock,
+    generateRandomCardMock,
+    getRandomJudokaMock,
+    renderMock,
+    currentFlags
+  });
 });
 
 afterEach(() => {

--- a/tests/helpers/classicBattle/selectionPrompt.test.js
+++ b/tests/helpers/classicBattle/selectionPrompt.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setupClassicBattleDom } from "./utils.js";
-import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
+import { applyMockSetup } from "./mockSetup.js";
 
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
@@ -22,42 +22,12 @@ vi.mock("../../../src/utils/scheduler.js", () => ({
   stop: vi.fn()
 }));
 
+let timerSpy;
+let fetchJsonMock;
 let generateRandomCardMock;
-vi.mock("../../../src/helpers/randomCard.js", () => ({
-  generateRandomCard: (...args) => generateRandomCardMock(...args)
-}));
-
 let getRandomJudokaMock;
 let renderMock;
-let JudokaCardMock;
-vi.mock("../../../src/helpers/cardUtils.js", () => ({
-  getRandomJudoka: (...args) => getRandomJudokaMock(...args)
-}));
-vi.mock("../../../src/components/JudokaCard.js", () => {
-  renderMock = vi.fn();
-  JudokaCardMock = vi.fn().mockImplementation(() => ({ render: renderMock }));
-  return { JudokaCard: JudokaCardMock };
-});
-
-let fetchJsonMock;
-vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn().mockResolvedValue(defaultSettings),
-  validateWithSchema: vi.fn().mockResolvedValue(undefined)
-}));
-
-vi.mock("../../../src/helpers/utils.js", () => ({
-  createGokyoLookup: () => ({})
-}));
-
 let currentFlags;
-vi.mock("../../../src/helpers/featureFlags.js", () => ({
-  featureFlagsEmitter: new EventTarget(),
-  initFeatureFlags: vi.fn().mockResolvedValue({ featureFlags: currentFlags }),
-  isEnabled: (flag) => currentFlags[flag]?.enabled ?? false
-}));
-
-let timerSpy;
 
 beforeEach(() => {
   ({
@@ -68,6 +38,13 @@ beforeEach(() => {
     renderMock,
     currentFlags
   } = setupClassicBattleDom());
+  applyMockSetup({
+    fetchJsonMock,
+    generateRandomCardMock,
+    getRandomJudokaMock,
+    renderMock,
+    currentFlags
+  });
 });
 
 afterEach(() => {

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
-import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
+import { applyMockSetup } from "./mockSetup.js";
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
@@ -14,33 +14,10 @@ vi.mock("../../../src/helpers/classicBattle/timerService.js", async () => {
   };
 });
 
+let fetchJsonMock;
 let generateRandomCardMock;
-vi.mock("../../../src/helpers/randomCard.js", () => ({
-  generateRandomCard: (...args) => generateRandomCardMock(...args)
-}));
-
 let getRandomJudokaMock;
 let renderMock;
-let JudokaCardMock;
-vi.mock("../../../src/helpers/cardUtils.js", () => ({
-  getRandomJudoka: (...args) => getRandomJudokaMock(...args)
-}));
-vi.mock("../../../src/components/JudokaCard.js", () => {
-  renderMock = vi.fn();
-  JudokaCardMock = vi.fn().mockImplementation(() => ({ render: renderMock }));
-  return { JudokaCard: JudokaCardMock };
-});
-
-let fetchJsonMock;
-vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn().mockResolvedValue(defaultSettings),
-  validateWithSchema: vi.fn().mockResolvedValue(undefined)
-}));
-
-vi.mock("../../../src/helpers/utils.js", () => ({
-  createGokyoLookup: () => ({})
-}));
 
 describe("classicBattle stalled stat selection recovery", () => {
   let timerSpy;
@@ -60,6 +37,12 @@ describe("classicBattle stalled stat selection recovery", () => {
       const el = document.createElement("div");
       el.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
       return el;
+    });
+    applyMockSetup({
+      fetchJsonMock,
+      generateRandomCardMock,
+      getRandomJudokaMock,
+      renderMock
     });
     vi.spyOn(Math, "random").mockReturnValue(0);
   });

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
-import defaultSettings from "../../../src/data/settings.json" with { type: "json" };
+import { applyMockSetup } from "./mockSetup.js";
 vi.mock("../../../src/helpers/motionUtils.js", () => ({
   shouldReduceMotionSync: () => true
 }));
@@ -21,35 +21,10 @@ vi.mock("../../../src/utils/scheduler.js", () => ({
   stop: vi.fn()
 }));
 
+let fetchJsonMock;
 let generateRandomCardMock;
-
-vi.mock("../../../src/helpers/randomCard.js", () => ({
-  generateRandomCard: (...args) => generateRandomCardMock(...args)
-}));
-
 let getRandomJudokaMock;
 let renderMock;
-let JudokaCardMock;
-
-vi.mock("../../../src/helpers/cardUtils.js", () => ({
-  getRandomJudoka: (...args) => getRandomJudokaMock(...args)
-}));
-vi.mock("../../../src/components/JudokaCard.js", () => {
-  renderMock = vi.fn();
-  JudokaCardMock = vi.fn().mockImplementation(() => ({ render: renderMock }));
-  return { JudokaCard: JudokaCardMock };
-});
-
-let fetchJsonMock;
-vi.mock("../../../src/helpers/dataUtils.js", () => ({
-  fetchJson: (...args) => fetchJsonMock(...args),
-  importJsonModule: vi.fn().mockResolvedValue(defaultSettings),
-  validateWithSchema: vi.fn().mockResolvedValue(undefined)
-}));
-
-vi.mock("../../../src/helpers/utils.js", () => ({
-  createGokyoLookup: () => ({})
-}));
 
 vi.mock("../../../src/helpers/classicBattle/orchestrator.js", () => {
   let state = "roundDecision";
@@ -108,6 +83,12 @@ describe("classicBattle stat selection", () => {
       const el = document.createElement("div");
       el.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
       return el;
+    });
+    applyMockSetup({
+      fetchJsonMock,
+      generateRandomCardMock,
+      getRandomJudokaMock,
+      renderMock
     });
   });
 


### PR DESCRIPTION
## Summary
- add reusable `mockSetup` helper for classic battle card and data utilities
- reduce duplicate `vi.mock` calls in classic battle tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a9d3361e2c8326a735d76314940da4