### PR TITLE
Move debug panel before battle area

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -528,15 +528,15 @@ export function applyBattleFeatureFlags(battleArea, banner) {
  *
  * @pseudocode
  * 1. Locate `#debug-panel`; exit if missing.
- * 2. If enabled and opponent slot exists, ensure panel is a `<details>` element.
- * 3. Restore open state from localStorage and prepend to opponent slot.
+ * 2. If enabled and the battle area exists, ensure the panel is a `<details>` element.
+ * 3. Restore open state from localStorage and insert before the battle area.
  * 4. Otherwise remove the panel.
  */
 export function initDebugPanel() {
   const debugPanel = document.getElementById("debug-panel");
   if (!debugPanel) return;
-  const opponentSlot = document.getElementById("opponent-card");
-  if (isEnabled("battleDebugPanel") && opponentSlot) {
+  const battleArea = document.getElementById("battle-area");
+  if (isEnabled("battleDebugPanel") && battleArea) {
     if (debugPanel.tagName !== "DETAILS") {
       const details = document.createElement("details");
       details.id = "debug-panel";
@@ -560,7 +560,7 @@ export function initDebugPanel() {
         } catch {}
       });
     } catch {}
-    opponentSlot.prepend(panel);
+    battleArea.before(panel);
     panel.classList.remove("hidden");
   } else {
     debugPanel.remove();
@@ -571,12 +571,12 @@ export function initDebugPanel() {
  * Enable or disable the debug panel dynamically.
  *
  * @pseudocode
- * 1. If enabling, ensure a `<details>` panel exists and prepend to opponent slot.
+ * 1. If enabling, ensure a `<details>` panel exists and insert before the battle area.
  * 2. Persist open state to localStorage on toggle.
  * 3. If disabling, hide and remove the panel.
  */
 export function setDebugPanelEnabled(enabled) {
-  const opponentSlot = document.getElementById("opponent-card");
+  const battleArea = document.getElementById("battle-area");
   let panel = document.getElementById("debug-panel");
   if (enabled) {
     if (!panel) {
@@ -614,8 +614,8 @@ export function setDebugPanelEnabled(enabled) {
       });
     } catch {}
     panel.classList.remove("hidden");
-    if (opponentSlot && panel.parentElement !== opponentSlot) {
-      opponentSlot.prepend(panel);
+    if (battleArea && panel.nextElementSibling !== battleArea) {
+      battleArea.before(panel);
     }
   } else if (panel) {
     panel.classList.add("hidden");

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -54,6 +54,10 @@
       </div>
 
       <main class="container" role="main">
+        <details id="debug-panel" class="debug-panel hidden" aria-label="Battle Debug Panel">
+          <summary>Battle Debug</summary>
+          <pre id="debug-output" role="status" aria-live="polite"></pre>
+        </details>
         <section id="battle-area">
           <div id="player-card" class="card-slot player-slot"></div>
           <div id="controls">
@@ -123,10 +127,6 @@
                 Quit Match
               </button>
             </div>
-            <details id="debug-panel" class="debug-panel hidden" aria-label="Battle Debug Panel">
-              <summary>Battle Debug</summary>
-              <pre id="debug-output" role="status" aria-live="polite"></pre>
-            </details>
           </div>
           <div
             id="opponent-card"

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -15,20 +15,16 @@
   color: #000;
   border-radius: 10%;
   padding: 0.8rem;
-  margin-top: 1rem;
   font-family: monospace;
   font-size: 1rem;
   overflow-x: auto;
+  overflow-y: auto;
   text-align: left;
-  max-width: 300px;
-  margin: 5vh auto;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
-}
-
-#opponent-card .debug-panel {
-  margin: 0;
-  max-width: none;
   width: 100%;
+  max-height: 30vh;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
 }
 
 /* Header for collapsible Battle Debug panel */

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -225,18 +225,11 @@ body {
   align-items: center;
 }
 
-/* Stack the opponent slot content vertically so the Battle Debug panel
-   sits above the opponent card without being covered. */
+/* Stack opponent slot content vertically */
 #battle-area #opponent-card {
   flex-direction: column;
   align-items: stretch;
   gap: var(--space-sm);
-}
-
-#battle-area #opponent-card .debug-panel {
-  order: -1; /* ensure it appears before the card content */
-  position: relative;
-  z-index: 5;
 }
 
 #battle-area #controls {

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -77,7 +77,8 @@ describe("classicBattlePage feature flag updates", () => {
     const panel = document.getElementById("debug-panel");
     expect(panel).toBeTruthy();
     expect(panel.classList.contains("hidden")).toBe(false);
-    expect(panel.parentElement).toBe(opponent);
+    expect(panel.parentElement).toBe(document.body);
+    expect(panel.nextElementSibling).toBe(battleArea);
 
     // Disable battleDebugPanel
     currentFlags.battleDebugPanel.enabled = false;


### PR DESCRIPTION
## Summary
- position battle debug panel above the battle area
- insert debug panel before `#battle-area` in UI helpers
- restyle debug panel for full-width top placement

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot and flow tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a9d6e646a483269f571d15167d7772