### PR TITLE
feat: add debug copy button

### DIFF
--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -22,7 +22,8 @@
     "roundMedium": "**Medium**\\nFirst to 10 points wins.",
     "roundLong": "**Long**\\nFirst to 15 points wins.",
     "next": "**Next**\nStart the next round or skip the current phase.",
-    "toggleLayout": "**Toggle layout**\nSwitch between grid and carousel."
+    "toggleLayout": "**Toggle layout**\nSwitch between grid and carousel.",
+    "copyDebug": "**Copy debug info**\nCopy current diagnostics to clipboard."
   },
   "mode": {
     "classicBattle": "**Classic Battle Mode** pits you against an opponent.\nFirst to 10 round‑wins becomes the champion.",

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -39,6 +39,12 @@
   padding: 0.25rem 0;
 }
 
+.debug-panel summary #debug-copy {
+  margin-left: auto;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.25rem;
+}
+
 /* Hide native marker and add a rotating chevron */
 .debug-panel summary::-webkit-details-marker {
   display: none;

--- a/tests/helpers/classicBattle/debugCopy.test.js
+++ b/tests/helpers/classicBattle/debugCopy.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setDebugPanelEnabled } from "../../../src/helpers/classicBattle/uiHelpers.js";
+
+describe("debug copy button", () => {
+  let writeText;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="battle-area"></div>';
+    writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true
+    });
+  });
+
+  it("copies debug output text to clipboard", () => {
+    setDebugPanelEnabled(true);
+    const pre = document.getElementById("debug-output");
+    pre.textContent = "debug info";
+    const btn = document.getElementById("debug-copy");
+    btn.dispatchEvent(new Event("click", { bubbles: true }));
+    expect(writeText).toHaveBeenCalledWith("debug info");
+  });
+});


### PR DESCRIPTION
## Summary
- add Copy button to debug panel summary and wire to navigator.clipboard
- document copy control in tooltips and style to align with header
- test that copying invokes clipboard write

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`
- `npm run validate:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9dba825388326bd4f96d318d6e55b