### PR TITLE
docs: document battle debug panel copy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ Run all Playwright tests with:
 npx playwright test
 ```
 
+### Battle Debug Panel
+
+Enable the `battleDebugPanel` feature flag to display a panel above the player and opponent cards with live match data. The panel includes a **Copy** button that copies all text for easy sharing.
+
+
 Screenshot suites store their baseline images in `playwright/*-snapshots/`. To skip running these comparison tests locally, set the `SKIP_SCREENSHOTS` environment variable:
 
 ```bash

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -93,7 +93,7 @@ Design principles include:
 
 - 🏷️ **State exposure**: Internal game state is mirrored using `data-*` attributes  
   e.g., `data-stat="power"` or `data-feature="debugMode"`
-- 🧪 **Toggleable debug panels**: Visual overlays for layout validation or test coverage
+- 🧪 **Toggleable debug panels**: Visual overlays for layout validation or test coverage; the battle debug panel sits above the cards and includes a copy button for easy state sharing
 - 🔗 **Stable ID/class naming**: Predictable DOM structure for reliable querying
 - 🧩 **Modular JS & HTML**: Encourages safe extension and reuse of logic
 - 🧭 **Observable hashes & query params**: Modes like `#mobile` or `?debug=true` can activate UI states

--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -210,6 +210,8 @@ To enable AI agents to test, monitor, and debug the impact of feature flags:
 
 - **Optional Debug Panels (For Agent Use Only)**
   - Add a visually hidden or collapsible debug panel using the `.debug-panel` class for verbose state outputs
+  - Panel should appear above the player and opponent cards without obscuring controls
+  - Panel should include a copy button that copies its text content
   - Panel should be toggleable with a keyboard-accessible button
   - Output should be readable by screen readers (e.g. wrapped in `<pre role="status" aria-live="polite">`)
 

--- a/design/productRequirementsDocuments/prdBattleDebugPanel.md
+++ b/design/productRequirementsDocuments/prdBattleDebugPanel.md
@@ -2,7 +2,7 @@
 
 ## Overview (TL;DR)
 
-The Battle Debug Panel is a developer/tester-facing overlay in JU-DO-KON!'s Classic Battle mode. It displays real-time game state (scores, timer, match status, and test mode seed) to aid debugging, test automation, and QA. The panel is toggled via a switch in the Settings page and is hidden from regular players by default.
+The Battle Debug Panel is a developer/tester-facing overlay in JU-DO-KON!'s Classic Battle mode. It displays real-time game state (scores, timer, match status, and test mode seed) to aid debugging, test automation, and QA. The panel appears above the player and opponent cards, includes a copy button for exporting its text, is toggled via a switch in the Settings page, and is hidden from regular players by default.
 
 ## Problem Statement / Why It Matters
 
@@ -19,6 +19,7 @@ Developers and testers need a way to observe internal game state (e.g., scores, 
 - As a developer, I want to see the current scores, timer, and match state during a battle so I can verify logic and debug issues.
 - As a tester, I want to enable a debug overlay from Settings so I can observe state changes while running manual or automated tests.
 - As a player, I never see the debug panel unless I opt in via Settings (or a debug flag is set).
+- As a developer or tester, I want to copy the panel's contents so I can quickly share match state.
 
 ## Terminology / Definitions
 
@@ -27,22 +28,22 @@ Developers and testers need a way to observe internal game state (e.g., scores, 
 - **Test Mode Seed**: A value used to initialize the game state for reproducible test scenarios.
 
 ## Prioritized Functional Requirements
-
-| Priority | Feature                       | Description                                                                                 |
-| -------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
-| P1       | Debug Panel Toggle            | Add a toggle in Settings to enable/disable the debug panel overlay in battle mode           |
-| P1       | Real-Time State Display       | Show current player/opponent scores, timer state, match end status, and (if test mode) seed |
-| P1       | Persistent Panel Placement    | Panel appears in the battle UI, does not overlap controls, and remains visible when enabled |
-| P2       | Accessibility Compliance      | Panel uses semantic markup (e.g., <pre>, aria-live) for screen reader compatibility         |
-| P3       | Hide in Production by Default | Panel is hidden unless explicitly enabled (or DEBUG_LOGGING=true)                           |
-
+| Priority | Feature                    | Description |
+| -------- | -------------------------- | ----------- |
+| P1       | Debug Panel Toggle         | Toggle in Settings to enable/disable the battle debug panel |
+| P1       | Real-Time State Display    | Show scores, timer, match end status, and seed (if test mode) |
+| P1       | Persistent Panel Placement | Panel sits above the cards and stays visible when enabled |
+| P1       | Copy Button                | Button copies panel text to clipboard |
+| P2       | Accessibility Compliance   | Use <pre> and aria-live for screen readers |
+| P3       | Hide in Production by Default | Hidden unless explicitly enabled (or DEBUG_LOGGING=true) |
 ## Acceptance Criteria
 
 - Debug panel is hidden by default for all users
-- Enabling the toggle in Settings immediately shows the debug panel in Classic Battle
+- Enabling the toggle in Settings immediately shows the debug panel above the player and opponent cards in Classic Battle
 - Panel displays a JSON-formatted object with: playerScore, opponentScore, timer, matchEnded, and seed (if test mode)
 - Panel updates in real time after each round, stat selection, and timer event
 - Panel uses <pre> and aria-live attributes for accessibility
+- Panel includes a Copy button that copies its text to the clipboard
 - Disabling the toggle hides the panel immediately
 - Panel does not interfere with normal gameplay controls or layout
 

--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -81,7 +81,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Opponent stat selection runs entirely on the client. After the player picks a stat (or the timer auto-chooses), the opponent's choice is revealed after a short artificial delay to mimic turn-taking.
 - During this delay, the Scoreboard displays "Opponent is choosing..." to reinforce turn flow.
 - The cooldown timer between rounds begins only after round results are shown in the Scoreboard and is displayed using one persistent snackbar that updates its text each second.
-- The debug panel is available when the `battleDebugPanel` feature flag is enabled and appears beside the opponent's card.
+- The debug panel is available when the `battleDebugPanel` feature flag is enabled, appears above the player and opponent cards, and includes a copy button for exporting its text.
 
 ### Round Data Fallback
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -88,7 +88,7 @@ On load, the Settings page must pre-populate each control with values from
 - **Sound (binary):** ON/OFF (default: ON) – Enable or mute game audio.
 - **Full navigation map (binary):** ON/OFF (default: ON) – Display an overlay map linking to every page.
 - **Test mode feature flag (binary):** ON/OFF (default: OFF) – Run deterministic matches for testing.
-- **Battle debug panel feature flag (binary):** ON/OFF (default: OFF) – Show a panel with live match data for debugging.
+- **Battle debug panel feature flag (binary):** ON/OFF (default: OFF) – Show a panel above the cards with live match data and a copy button for debugging.
 - **Card inspector feature flag (binary):** ON/OFF (default: OFF) – Reveal raw card JSON in a collapsible panel.
 - **Viewport simulation feature flag (binary):** ON/OFF (default: OFF) – Choose preset sizes to simulate different devices.
 - **Tooltip overlay debug feature flag (binary):** ON/OFF (default: OFF) – Outline tooltip targets to debug placement.
@@ -160,10 +160,10 @@ On load, the Settings page must pre-populate each control with values from
 
 ### Battle Debug Panel Feature Flag
 
-- Enabling the flag shows a collapsible debug panel on battle pages.
+- Enabling the flag shows a collapsible debug panel above the player and opponent cards with a copy button on battle pages.
 - The panel displays real-time match state inside a `<pre>` element.
 - The panel is keyboard accessible and hidden by default.
-- The panel appears beside the opponent's card rather than at the page bottom.
+  - The panel appears above the player and opponent cards rather than at the page bottom.
 - The panel stays visible for the whole match once enabled.
 - Setting persists across page refreshes and sessions.
 


### PR DESCRIPTION
## Summary
- clarify that the Classic Battle debug panel sits above the cards
- document new copy-to-clipboard button for the battle debug panel
- note panel placement and copy ability in README and design guidelines

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `SKIP_SCREENSHOTS=true npx playwright test` *(fails: 12 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a9df9b62a08326a468c767ff4dec7a