### PR TITLE
docs: clarify classicBattle helper guidelines

### DIFF
--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -27,10 +27,13 @@ This directory contains unit tests for Classic Battle helpers.
 - `timerService.drift.test.js`: falls back to messaging when timers drift.
 - `timerService.nextRound.test.js`: manages cooldown and Next button interaction.
 - `timerStateExposure.test.js`: exposes timer state to window and DOM.
-- `utils.js` / `mocks.js`: shared DOM setup and mocks for these suites.
+- `mockSetup.js`: shared mock helper to reduce duplication.
+- `utils.js` / `mocks.js`: shared DOM setup and legacy mocks for these suites.
 
 ## Guidelines
 
 - One behavior per test.
-- Prefer shared helpers in `domUtils.js` and `utils/testUtils.js`.
+- Prefer shared helpers in `domUtils.js`, `utils/testUtils.js`, and `mockSetup.js`.
+- Do not commit `it.skip`; use `test.todo` or remove obsolete tests instead.
+- Timer drift, state exposure, and Next button behavior belong in `timerService` tests; `scheduleNextRound` tests cover cooldown scheduling and ready dispatch.
 - Avoid duplicating coverage across suites. Interrupt behavior triggered by browser events (such as `pagehide`, global `error`, or `unhandledrejection`) is covered exclusively in `interruptHandlers.test.js`.


### PR DESCRIPTION
## Summary
- document new shared `mockSetup.js` helper for classicBattle tests
- note timer responsibilities split between `timerService` and `scheduleNextRound`
- discourage committing `it.skip` tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68a9f6d59cbc8326a9d26c17dd591d73