### PR TITLE
refactor tests with battle utils

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -1,6 +1,8 @@
 import { test, expect } from "./fixtures/commonSetup.js";
 import { readFileSync } from "fs";
 import { resolve } from "path";
+// battleTestUtils resets engine state and manipulates timer for scenarios
+import { _resetForTest, setTieRound } from "../tests/helpers/battleTestUtils.js";
 // selectors use header as the container for battle info
 
 const rounds = JSON.parse(readFileSync(resolve("src/data/battleRounds.json"), "utf8"));
@@ -48,17 +50,8 @@ test.describe.parallel("Classic battle flow", () => {
     await page.evaluate(() => window.freezeBattleHeader?.());
     const timer = page.locator("header #next-round-timer");
     await timer.waitFor();
-    await page.evaluate(async () => {
-      const { _resetForTest } = await import(
-        new URL("/src/helpers/classicBattle.js", window.location.href)
-      );
-      _resetForTest(window.battleStore);
-      document.querySelector("#next-round-timer").textContent = "Time Left: 3s";
-      document.querySelector("#player-card").innerHTML =
-        `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;
-      document.querySelector("#opponent-card").innerHTML =
-        `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;
-    });
+    await page.evaluate(_resetForTest);
+    await page.evaluate(setTieRound);
     await page.locator("button[data-stat='power']").click();
     const snackbar = page.locator(".snackbar");
     await expect(snackbar).toHaveText("You Picked: Power");

--- a/tests/helpers/battleTestUtils.js
+++ b/tests/helpers/battleTestUtils.js
@@ -1,0 +1,30 @@
+/**
+ * Utilities for battle-related browser tests.
+ *
+ * @pseudocode
+ * _resetForTest
+ *   1. Dynamically import classicBattle.js relative to the current page.
+ *   2. Invoke its `_resetForTest` with the page's battle store.
+ * setTieRound
+ *   1. Set the next round timer to a short value.
+ *   2. Populate player and opponent cards with equal Power stats to force a tie.
+ */
+export async function _resetForTest() {
+  const mod = await import(new URL("/src/helpers/classicBattle.js", window.location.href));
+  mod._resetForTest(window.battleStore);
+}
+
+/**
+ * Prepare a tie scenario with a 3 second timer.
+ *
+ * @pseudocode
+ * 1. Update timer text to "Time Left: 3s".
+ * 2. Give both players Power 3 to ensure a tie.
+ */
+export function setTieRound() {
+  document.getElementById("next-round-timer").textContent = "Time Left: 3s";
+  document.getElementById("player-card").innerHTML =
+    `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;
+  document.getElementById("opponent-card").innerHTML =
+    `<ul><li class='stat'><strong>Power</strong> <span>3</span></li></ul>`;
+}


### PR DESCRIPTION
## Summary
- add battle test utilities for reset and timer setup
- use battleTestUtils in Playwright classic battle flow spec and document usage

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aa0c7406ac8326be7266d6aebc0ad3