### PR TITLE
refactor: streamline homepage tests

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -2,7 +2,7 @@
 
 | Spec file | Responsibilities |
 |-----------|------------------|
-| `homepage.spec.js` | Verifies footer navigation link visibility, ordering, and mobile hamburger menu behavior, along with other interactive elements. |
+| `homepage.spec.js` | Verifies footer navigation link visibility, ordering, and other interactive elements. |
 | `homepage-layout.spec.js` | Focuses on responsive layout of the homepage grid and footer without testing navigation behavior. |
 
 # Playwright Tests

--- a/playwright/homepage-layout.spec.js
+++ b/playwright/homepage-layout.spec.js
@@ -55,8 +55,13 @@ test.describe.parallel("Homepage layout", () => {
   test.describe.parallel("mobile", () => {
     test.use({ viewport: { width: 500, height: 800 } });
 
-    test("grid has one column", async ({ page }) => {
+    test.beforeEach(async ({ page }) => {
       await page.goto("/index.html");
+      await page.waitForSelector(".game-mode-grid");
+      await page.waitForSelector("footer .bottom-navbar a");
+    });
+
+    test("grid has one column", async ({ page }) => {
       const columnCount = await page.evaluate(() => {
         const style = getComputedStyle(document.querySelector(".game-mode-grid"));
         return style.gridTemplateColumns.split(/\s+/).filter(Boolean).length;
@@ -65,9 +70,6 @@ test.describe.parallel("Homepage layout", () => {
     });
 
     test("grid does not overlap footer", async ({ page }, testInfo) => {
-      await page.goto("/index.html");
-      await page.waitForSelector("footer .bottom-navbar a");
-
       const grid = page.locator(".game-mode-grid");
       const gridBox = await grid.boundingBox();
       const navBox = await page.locator(".bottom-navbar").boundingBox();

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -6,7 +6,7 @@ import {
 } from "./fixtures/navigationChecks.js";
 
 test.describe.parallel("Homepage", () => {
-  // Navigation coverage: footer link visibility, ordering, and hamburger toggle.
+  // Navigation coverage: footer link visibility and ordering.
   test.beforeEach(async ({ page }) => {
     await page.goto("/index.html");
   });
@@ -45,20 +45,6 @@ test.describe.parallel("Homepage", () => {
     expect(classicOrder).toBeLessThan(updateOrder);
     expect(updateOrder).toBeLessThan(randomOrder);
   });
-  // Navigation: hamburger menu toggles on narrow screens
-  test("hamburger menu toggles navigation on narrow screens", async ({ page }) => {
-    await page.setViewportSize({ width: 320, height: 800 });
-    await page.reload();
-    await page.waitForSelector(".bottom-navbar .nav-toggle");
-    const toggle = page.locator(".bottom-navbar .nav-toggle");
-    const list = page.locator(".bottom-navbar ul");
-    await expect(toggle).toHaveAttribute("aria-expanded", "false");
-    await expect(list).not.toHaveClass(/expanded/);
-    await toggle.click();
-    await expect(toggle).toHaveAttribute("aria-expanded", "true");
-    await expect(list).toHaveClass(/expanded/);
-  });
-
   // Navigation: Random Judoka tile routes to dedicated page
   test("view judoka link navigates", async ({ page }) => {
     await page.getByTestId(NAV_RANDOM_JUDOKA).click();


### PR DESCRIPTION
## Summary
- remove deprecated hamburger menu test from homepage spec
- reuse shared setup for mobile homepage layout tests
- update Playwright README to reflect current coverage

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: 'evaluateRoundApi' unused)*
- `NODE_OPTIONS=--experimental-vm-modules npx vitest run`
- `npx playwright test` *(fails: network errors, screenshot mismatches, timeouts)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aa0c53b8dc83268ec8792baf0c5972