### PR TITLE
refactor: centralize scoreboard setup

### DIFF
--- a/src/helpers/classicBattle/controller.js
+++ b/src/helpers/classicBattle/controller.js
@@ -1,7 +1,6 @@
 import { createBattleStore, startRound } from "./roundManager.js";
 import { initClassicBattleOrchestrator } from "./orchestrator.js";
 import { initFeatureFlags, isEnabled, featureFlagsEmitter } from "../featureFlags.js";
-import { setupScoreboard } from "../setupScoreboard.js";
 import { startCoolDown, pauseTimer, resumeTimer } from "../battleEngineFacade.js";
 
 /**
@@ -10,9 +9,8 @@ import { startCoolDown, pauseTimer, resumeTimer } from "../battleEngineFacade.js
  * @pseudocode
  * 1. Create a battle store via `createBattleStore`.
  * 2. Initialize feature flags and re‑emit changes.
- * 3. Inject battle engine timer controls into the Scoreboard.
- * 4. Start the battle orchestrator.
- * 5. Expose `startRound` which waits for the opponent card via an injected callback.
+ * 3. Start the battle orchestrator.
+ * 4. Expose `startRound` which waits for the opponent card via an injected callback.
  */
 export class ClassicBattleController extends EventTarget {
   /**
@@ -38,7 +36,6 @@ export class ClassicBattleController extends EventTarget {
     await initFeatureFlags();
     this.#emitFeatureFlags();
     featureFlagsEmitter.addEventListener("change", () => this.#emitFeatureFlags());
-    setupScoreboard(this.timerControls);
     await initClassicBattleOrchestrator(this.store, () => this.startRound());
   }
 

--- a/tests/helpers/classicBattle/statButtons.state.test.js
+++ b/tests/helpers/classicBattle/statButtons.state.test.js
@@ -58,6 +58,8 @@ describe("classicBattle stat button state", () => {
       startRound: vi.fn()
     };
     await view.init();
+    const { setupScoreboard } = await import("../../../src/helpers/setupScoreboard.js");
+    expect(setupScoreboard).toHaveBeenCalledWith(view.controller.timerControls);
 
     const btn = document.querySelector("#stat-buttons button");
     expect(btn.disabled).toBe(true);


### PR DESCRIPTION
## Summary
- initialize scoreboard from ClassicBattleView only
- update ClassicBattleController docs
- assert view-based scoreboard init in tests

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warn: 'evaluateRoundApi' unused)*
- `npx vitest run`
- `npx playwright test` *(fails: network errors, screenshot diffs)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aa1dc5506c83269690394a7042923a