### PR TITLE
test: cover status aria attributes

### DIFF
--- a/playwright/battle-state-progress.spec.js
+++ b/playwright/battle-state-progress.spec.js
@@ -1,0 +1,22 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+import { classicBattleStates } from "./fixtures/classicBattleStates.js";
+
+test.describe.parallel("Battle state progress", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      Math.random = () => 0.42;
+    });
+    await page.goto("/src/pages/battleJudoka.html");
+  });
+
+  test("progress ids match classicBattleStates", async ({ page }) => {
+    const expectedIds = classicBattleStates
+      .filter((s) => s.id < 90)
+      .sort((a, b) => a.id - b.id)
+      .map((s) => String(s.id));
+    const ids = await page.$$eval("#battle-state-progress li", (lis) =>
+      lis.map((li) => li.textContent.trim())
+    );
+    expect(ids).toEqual(expectedIds);
+  });
+});

--- a/playwright/battleJudoka.spec.js
+++ b/playwright/battleJudoka.spec.js
@@ -4,11 +4,6 @@ import {
   NAV_RANDOM_JUDOKA,
   NAV_CLASSIC_BATTLE
 } from "./fixtures/navigationChecks.js";
-import { readFileSync } from "node:fs";
-
-const classicBattleStates = JSON.parse(
-  readFileSync(new URL("../src/data/classicBattleStates.json", import.meta.url))
-);
 
 test.describe.parallel("Battle Judoka page", () => {
   test.beforeEach(async ({ page }) => {
@@ -28,33 +23,6 @@ test.describe.parallel("Battle Judoka page", () => {
     await page.goBack({ waitUntil: "load" });
     await page.getByTestId(NAV_CLASSIC_BATTLE).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
-  });
-
-  test("status aria attributes and progress ids", async ({ page }) => {
-    await page.setViewportSize({ width: 280, height: 800 });
-
-    const axTree = await page.accessibility.snapshot({ interestingOnly: false });
-
-    const collectStatusNodes = (node) => {
-      if (!node) return [];
-      const matches = node.role === "status" ? [node] : [];
-      return node.children ? matches.concat(node.children.flatMap(collectStatusNodes)) : matches;
-    };
-
-    const statusNodes = collectStatusNodes(axTree);
-    expect(statusNodes.length).toBeGreaterThan(0);
-
-    const ariaLiveCount = await page.locator('[role="status"][aria-live]').count();
-    expect(ariaLiveCount).toBeGreaterThan(0);
-
-    const expectedIds = classicBattleStates
-      .filter((s) => s.id < 90)
-      .sort((a, b) => a.id - b.id)
-      .map((s) => String(s.id));
-    const ids = await page.$$eval("#battle-state-progress li", (lis) =>
-      lis.map((li) => li.textContent.trim())
-    );
-    expect(ids).toEqual(expectedIds);
   });
 
   test("narrow viewport screenshot", async ({ page }) => {

--- a/playwright/fixtures/classicBattleStates.js
+++ b/playwright/fixtures/classicBattleStates.js
@@ -1,0 +1,5 @@
+import { readFileSync } from "node:fs";
+
+export const classicBattleStates = JSON.parse(
+  readFileSync(new URL("../../src/data/classicBattleStates.json", import.meta.url))
+);

--- a/playwright/status-aria-attributes.spec.js
+++ b/playwright/status-aria-attributes.spec.js
@@ -1,0 +1,43 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+
+const pages = [
+  "/",
+  "/src/pages/browseJudoka.html",
+  "/src/pages/createJudoka.html",
+  "/src/pages/randomJudoka.html",
+  "/src/pages/meditation.html",
+  "/src/pages/updateJudoka.html",
+  "/src/pages/settings.html",
+  "/src/pages/vectorSearch.html",
+  "/src/pages/prdViewer.html",
+  "/src/pages/tooltipViewer.html",
+  "/src/pages/battleJudoka.html",
+  "/src/pages/changeLog.html",
+  "/src/pages/mockupViewer.html"
+];
+
+test.describe.parallel("Status aria attributes", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      Math.random = () => 0.42;
+      localStorage.setItem(
+        "settings",
+        JSON.stringify({
+          typewriterEffect: false,
+          featureFlags: { enableTestMode: { enabled: true } }
+        })
+      );
+    });
+  });
+
+  for (const url of pages) {
+    test(`${url} has role=status and aria-live=polite`, async ({ page }) => {
+      await page.goto(url, { waitUntil: "domcontentloaded" });
+      const statuses = await page.$$('[role="status"]');
+      expect(statuses.length).toBeGreaterThan(0);
+      for (const el of statuses) {
+        expect(await el.getAttribute("aria-live")).toBe("polite");
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add helper to load classic battle states once per file
- verify battle state progress IDs in its own spec
- check role and aria-live attributes across app pages

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warn: 'evaluateRoundApi' is defined but never used)*
- `npx vitest run`
- `npx playwright test playwright/status-aria-attributes.spec.js playwright/battle-state-progress.spec.js playwright/battleJudoka.spec.js` *(fails: battleJudoka narrow viewport screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aa1e00b4888326b4ffcacbd454892a