### PR TITLE
Merge meditation page basics into language toggle test

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -12,3 +12,7 @@
 - Each test navigates to `/src/pages/settings.html` and asserts a single concern.
 - `controls expose correct labels` verifies accessible labels for toggles and feature flags.
 - `tab order follows expected sequence` ensures keyboard navigation visits controls in order.
+
+## Meditation screen
+
+The meditation screen intentionally omits navigation links to keep the user focused on the quote, so tests pass an empty array to `verifyPageBasics` when verifying page structure.

--- a/playwright/pseudo-japanese-toggle.spec.js
+++ b/playwright/pseudo-japanese-toggle.spec.js
@@ -31,23 +31,24 @@ test.describe.parallel("Pseudo-Japanese toggle", () => {
     await page.waitForSelector("#quote .quote-content");
   });
 
-  test("page basics", async ({ page }) => {
-    await verifyPageBasics(page, []); // Meditation screen has no nav links
-  });
-
   test("toggle updates quote text", async ({ page }) => {
+    await verifyPageBasics(page, []); // Meditation screen has no nav links
+
     const quote = page.locator("#quote");
     const toggle = page.getByTestId("language-toggle");
 
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
     const originalHTML = await quote.innerHTML();
 
     await toggle.click();
     await expect(quote).toHaveClass(/jp-font/);
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
     const toggledHTML = await quote.innerHTML();
     expect(toggledHTML).not.toBe(originalHTML);
 
     await toggle.click();
     await expect(quote).not.toHaveClass(/jp-font/);
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
     const revertedHTML = await quote.innerHTML();
     expect(revertedHTML).toBe(originalHTML);
   });

--- a/src/helpers/pseudoJapanese/ui.js
+++ b/src/helpers/pseudoJapanese/ui.js
@@ -40,13 +40,15 @@ export async function convertElementToPseudoJapanese(element) {
  * Create a button that toggles an element's text between English and pseudo-Japanese.
  *
  * @pseudocode
- * 1. Find the existing button with id `language-toggle`.
+ * 1. Find the existing button with id `language-toggle` and initialize
+ *    its `aria-pressed` attribute to `false`.
  * 2. Attach a click handler that adds a `fading` class to the element
  *    to fade it out, then:
  *    - On the first click, cache the element's HTML and convert all
  *      text nodes using `convertElementToPseudoJapanese`.
  *    - Swap between the cached original HTML and the generated
  *      pseudo-Japanese HTML while toggling a Japanese font class.
+ *    - Update `aria-pressed` to reflect the current language state.
  *    - Remove the `fading` class so the element fades back in.
  *    - If an error occurs, log it and remove the `fading` class to
  *      reset the UI.
@@ -62,6 +64,8 @@ export function setupLanguageToggle(element) {
   }
 
   element.classList.add("fade-transition");
+
+  button.setAttribute("aria-pressed", "false");
 
   let originalHTML = "";
   let pseudoHTML = "";
@@ -87,6 +91,7 @@ export function setupLanguageToggle(element) {
         element.classList.toggle("jp-font", !showingPseudo);
         element.classList.remove("fading");
         showingPseudo = !showingPseudo;
+        button.setAttribute("aria-pressed", String(showingPseudo));
       } catch (error) {
         console.error(error);
         element.classList.remove("fading");


### PR DESCRIPTION
## Summary
- integrate page basics check into pseudo-Japanese toggle test and verify aria-pressed state
- expose aria-pressed state in language toggle helper
- document why the meditation screen has no nav links

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aa2215eee08326a8b453d9aa234687