### PR TITLE
fix: close modal before quitting test

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -62,6 +62,10 @@ test.describe.parallel("Classic battle flow", () => {
 
   test("quit match confirmation", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
+    const roundOptions = page.locator(".round-select-buttons button");
+    await roundOptions.first().waitFor();
+    await roundOptions.first().click();
+    await expect(page.locator(".modal-backdrop:not([hidden])")).toHaveCount(0);
     await page.waitForFunction(() => window.homeLinkReady);
     await page.locator("[data-testid='home-link']").click();
     const confirmButton = page.locator("#confirm-quit-button");


### PR DESCRIPTION
## Summary
- ensure classic battle quit test starts a match before quitting to avoid overlay

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aa2575d6348326ae5beb815f8f5337