### PR TITLE
chore: initialize default settings

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -199,6 +199,7 @@ test.describe.parallel("Settings page", () => {
   });
 
   test("restore defaults resets settings", async ({ page }) => {
+    await expect(page.getByRole("checkbox", { name: "Sound" })).toBeChecked();
     const sound = page.getByRole("checkbox", { name: "Sound" });
     await sound.click();
     await expect(sound).not.toBeChecked();

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -118,6 +118,7 @@
                   aria-label="Sound"
                   aria-describedby="sound-desc"
                   data-tooltip-id="settings.sound"
+                  checked
                 />
                 <div class="slider round"></div>
                 <span>Sound</span>
@@ -133,6 +134,7 @@
                   aria-label="Motion Effects"
                   aria-describedby="motion-desc"
                   data-tooltip-id="settings.motionEffects"
+                  checked
                 />
                 <div class="slider round"></div>
                 <span>Motion Effects</span>
@@ -167,6 +169,7 @@
                   aria-label="Tooltips"
                   aria-describedby="tooltips-desc"
                   data-tooltip-id="settings.tooltips"
+                  checked
                 />
                 <div class="slider round"></div>
                 <span>Tooltips</span>


### PR DESCRIPTION
## Summary
- mark sound, motion, and tooltip settings checked by default
- assert settings page sound checkbox starts checked

## Testing
- `npx prettier playwright/settings.spec.js src/pages/settings.html --write`
- `npx prettier . --check --ignore-unknown`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED, page errors)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aa26442d588326a05dfbcd23de4231