### PR TITLE
Add mouseover tooltip support

### DIFF
--- a/playwright/tooltip.spec.js
+++ b/playwright/tooltip.spec.js
@@ -25,14 +25,14 @@ test.describe.parallel("Tooltip behavior", () => {
     await page.waitForFunction(() => window.initDone === true);
   });
 
-  test("tooltip appears on hover and hides on mouse leave", async ({ page }) => {
+  test("tooltip appears on hover and hides on mouse out", async ({ page }) => {
     const button = page.locator("#tip-btn");
     await button.hover();
     const tooltip = page.locator(".tooltip");
     await expect(tooltip).toBeVisible();
     await expect(tooltip).toContainText("raw physical strength");
 
-    await page.dispatchEvent("#tip-btn", "mouseleave");
+    await page.dispatchEvent("#tip-btn", "mouseout");
     await expect(tooltip).toBeHidden();
   });
 });

--- a/src/helpers/tooltip.js
+++ b/src/helpers/tooltip.js
@@ -118,9 +118,9 @@ function ensureTooltipElement() {
  * 2. Read the current settings and exit early if tooltips are disabled.
  * 3. Load tooltip data with `loadTooltips()`.
  * 4. Select all elements matching `[data-tooltip-id]` within `root`.
- * 5. For each element, attach hover and focus listeners.
+ * 5. For each element, attach hover (mouseenter/mouseover) and focus listeners.
  *    - `show` looks up the tooltip text, sanitizes it with DOMPurify, and positions the element.
- *    - `hide` hides the tooltip element.
+ *    - `hide` hides the tooltip element (mouseleave/mouseout and blur).
  * 6. When an ID is missing, log a warning only once and show the fallback text "More info coming…".
  * 7. Return a cleanup function that removes the hover and focus listeners.
  *
@@ -188,16 +188,20 @@ export async function initTooltips(root = globalThis.document) {
 
   elements.forEach((el) => {
     el.addEventListener("mouseenter", show);
+    el.addEventListener("mouseover", show);
     el.addEventListener("focus", show);
     el.addEventListener("mouseleave", hide);
+    el.addEventListener("mouseout", hide);
     el.addEventListener("blur", hide);
   });
 
   return () => {
     elements.forEach((el) => {
       el.removeEventListener("mouseenter", show);
+      el.removeEventListener("mouseover", show);
       el.removeEventListener("focus", show);
       el.removeEventListener("mouseleave", hide);
+      el.removeEventListener("mouseout", hide);
       el.removeEventListener("blur", hide);
     });
   };

--- a/tests/helpers/tooltip.test.js
+++ b/tests/helpers/tooltip.test.js
@@ -24,13 +24,13 @@ describe("initTooltips", () => {
 
     await initTooltips();
 
-    el.dispatchEvent(new Event("mouseenter"));
+    el.dispatchEvent(new Event("mouseover"));
 
     const tip = document.querySelector(".tooltip");
     expect(tip.innerHTML.replace(/\n/g, "")).toBe("<strong>Bold</strong><br><em>italic</em>");
     expect(tip.style.display).toBe("block");
 
-    el.dispatchEvent(new Event("mouseleave"));
+    el.dispatchEvent(new Event("mouseout"));
     expect(tip.style.display).toBe("none");
   });
 
@@ -49,10 +49,10 @@ describe("initTooltips", () => {
 
     const tip = document.querySelector(".tooltip");
 
-    el.dispatchEvent(new Event("mouseenter"));
+    el.dispatchEvent(new Event("mouseover"));
     expect(tip.textContent).toBe("More info coming…");
-    el.dispatchEvent(new Event("mouseleave"));
-    el.dispatchEvent(new Event("mouseenter"));
+    el.dispatchEvent(new Event("mouseout"));
+    el.dispatchEvent(new Event("mouseover"));
 
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -73,10 +73,10 @@ describe("initTooltips", () => {
 
     const tip = document.querySelector(".tooltip");
 
-    el.dispatchEvent(new Event("mouseenter"));
+    el.dispatchEvent(new Event("mouseover"));
     expect(tip.textContent).toBe("More info coming…");
-    el.dispatchEvent(new Event("mouseleave"));
-    el.dispatchEvent(new Event("mouseenter"));
+    el.dispatchEvent(new Event("mouseout"));
+    el.dispatchEvent(new Event("mouseover"));
 
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
@@ -98,7 +98,7 @@ describe("initTooltips", () => {
     await initTooltips();
 
     const tip = document.querySelector(".tooltip");
-    el.dispatchEvent(new Event("mouseenter"));
+    el.dispatchEvent(new Event("mouseover"));
 
     expect(tip.textContent).toBe("Theme description");
   });
@@ -120,7 +120,7 @@ describe("initTooltips", () => {
     Object.defineProperty(tip, "offsetHeight", { value: 10 });
     el.getBoundingClientRect = () => ({ bottom: 0, left: 0, width: 0, height: 0 });
 
-    el.dispatchEvent(new Event("mouseenter"));
+    el.dispatchEvent(new Event("mouseover"));
 
     expect(tip.style.top).toBe(`${window.innerHeight - 10}px`);
     expect(tip.style.left).toBe("0px");
@@ -153,9 +153,9 @@ describe("initTooltips", () => {
 
     const tip = document.querySelector(".tooltip");
     els.forEach((el, i) => {
-      el.dispatchEvent(new Event("mouseenter"));
+      el.dispatchEvent(new Event("mouseover"));
       expect(tip.textContent).toBe(text[i]);
-      el.dispatchEvent(new Event("mouseleave"));
+      el.dispatchEvent(new Event("mouseout"));
     });
   });
 
@@ -209,14 +209,14 @@ describe("initTooltips", () => {
     const cleanup = await initTooltips();
 
     const tip = document.querySelector(".tooltip");
-    el.dispatchEvent(new Event("mouseenter"));
+    el.dispatchEvent(new Event("mouseover"));
     expect(tip.style.display).toBe("block");
-    el.dispatchEvent(new Event("mouseleave"));
+    el.dispatchEvent(new Event("mouseout"));
     expect(tip.style.display).toBe("none");
 
     cleanup();
 
-    el.dispatchEvent(new Event("mouseenter"));
+    el.dispatchEvent(new Event("mouseover"));
     expect(tip.style.display).toBe("none");
   });
 });


### PR DESCRIPTION
## Summary
- show tooltips on `mouseover`/hide on `mouseout`
- remove new tooltip listeners in cleanup
- update tooltip hover tests

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: evaluateRoundApi is defined but never used)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aa2602b67c8326be2c42f8b338c72f