### PR TITLE
test: wait for battle state progress to render

### DIFF
--- a/playwright/battle-state-progress.spec.js
+++ b/playwright/battle-state-progress.spec.js
@@ -14,6 +14,7 @@ test.describe.parallel("Battle state progress", () => {
       .filter((s) => s.id < 90)
       .sort((a, b) => a.id - b.id)
       .map((s) => String(s.id));
+    await page.waitForSelector("#battle-state-progress li");
     const ids = await page.$$eval("#battle-state-progress li", (lis) =>
       lis.map((li) => li.textContent.trim())
     );


### PR DESCRIPTION
## Summary
- wait for battle state progress list items to render before collecting IDs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/battle-state-progress.spec.js`
- `npx playwright test`
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68aa2c045b7083269087edb2334c68ad