### PR TITLE
feat: allow forcing spinner via flag

### DIFF
--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -31,7 +31,7 @@ export function setupLayoutToggle(layoutBtn, panel) {
  *
  * @pseudocode
  * 1. Grab DOM elements for the carousel, layout toggle, and country filters.
- * 2. Show a loading spinner and load judoka and gokyo data from JSON files.
+ * 2. Show a loading spinner (immediately when `forceSpinner` flag is set) and load judoka and gokyo data from JSON files.
  * 3. Render the card carousel, display a message if there are no judoka, and hide the spinner.
  * 4. Attach event listeners for filtering, layout toggle, and panel controls.
  * 5. Handle errors by rendering a fallback card and showing a retry button when loading fails.
@@ -97,8 +97,16 @@ export async function setupBrowseJudokaPage() {
   }
 
   async function init() {
-    const spinner = createSpinner(carouselContainer);
+    const forceSpinner =
+      new URLSearchParams(globalThis.location?.search || "").has("forceSpinner") ||
+      globalThis.__forceSpinner__ === true;
+    const spinner = createSpinner(carouselContainer, {
+      delay: forceSpinner ? 0 : undefined
+    });
     spinner.show();
+    if (forceSpinner) {
+      spinner.element.style.display = "block";
+    }
     try {
       const { allJudoka, gokyoData } = await loadData();
       const render = (list) => renderCarousel(list, gokyoData);

--- a/tests/helpers/browseJudokaPage.test.js
+++ b/tests/helpers/browseJudokaPage.test.js
@@ -198,10 +198,12 @@ describe("browseJudokaPage helpers", () => {
     clear.id = "clear-filter";
     document.body.append(carousel, list, toggleBtn, layoutBtn, panel, clear);
 
+    globalThis.__forceSpinner__ = true;
     const pagePromise = setupBrowseJudokaPage();
-    await Promise.resolve();
 
-    expect(carousel.querySelector(".loading-spinner")).not.toBeNull();
+    const spinnerEl = carousel.querySelector(".loading-spinner");
+    expect(spinnerEl).not.toBeNull();
+    expect(spinnerEl.style.display).toBe("block");
     expect(show).toHaveBeenCalled();
 
     fetchResolvers[0]([{ id: 1, country: "JP" }]);
@@ -211,6 +213,7 @@ describe("browseJudokaPage helpers", () => {
     expect(carousel.querySelector(".loading-spinner")).toBeNull();
     expect(remove).toHaveBeenCalled();
     expect(toggleCountryPanelMode).toHaveBeenCalledWith(panel, false);
+    delete globalThis.__forceSpinner__;
   });
 
   it("renders a fallback card when judoka data fails to load", async () => {


### PR DESCRIPTION
## Summary
- allow forcing spinner display via `forceSpinner` query or global flag
- enable force flag in browseJudokaPage tests and remove timer waits

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aabac19d1483269303aa416758bce9