### PR TITLE
feat(settings): signal ready state

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -80,6 +80,7 @@ test.describe.parallel("Classic battle flow", () => {
     await timer.waitFor();
     await page.locator("[data-testid='nav-13']").click();
     await expect(page).toHaveURL(/settings.html/);
+    await page.waitForSelector("[data-settings-ready]");
     await page.goBack();
     await expect(page).toHaveURL(/battleJudoka.html/);
     await page.waitForFunction(() => window.__classicBattleState === "matchOver");

--- a/playwright/responsive-contrast.spec.js
+++ b/playwright/responsive-contrast.spec.js
@@ -10,7 +10,7 @@ test.describe.parallel("Responsive scenarios", () => {
 
   test("toggles high-contrast display mode", async ({ page }) => {
     await page.goto("/src/pages/settings.html");
-    await page.locator("#display-mode-high-contrast").waitFor();
+    await page.waitForSelector("[data-settings-ready]");
     await page.check("#display-mode-high-contrast");
     await expect(page.locator("body")).toHaveAttribute("data-theme", "high-contrast");
   });

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -36,6 +36,9 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
   for (const { url, name, tag } of pages) {
     test(`${tag} screenshot ${url}`, async ({ page }) => {
       await page.goto(url, { waitUntil: "domcontentloaded" });
+      if (url.endsWith("/src/pages/settings.html")) {
+        await page.waitForSelector("[data-settings-ready]");
+      }
       await expect(page).toHaveScreenshot(name, { fullPage: true });
     });
   }

--- a/playwright/settings-screenshot.spec.js
+++ b/playwright/settings-screenshot.spec.js
@@ -23,6 +23,7 @@ test.describe.parallel(
           );
         }, mode);
         await page.goto("/src/pages/settings.html", { waitUntil: "domcontentloaded" });
+        await page.waitForSelector("[data-settings-ready]");
         await expect(page.locator("body")).toHaveAttribute("data-theme", mode);
         await expect(page).toHaveScreenshot(`settings-${mode}.png`, { fullPage: true });
       });

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -46,7 +46,7 @@ function getLabelData() {
 test.describe.parallel("Settings page", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/settings.html", { waitUntil: "domcontentloaded" });
-    await page.getByRole("checkbox", { name: "Sound" }).waitFor({ state: "visible" });
+    await page.waitForSelector("[data-settings-ready]");
   });
 
   test("page loads", async ({ page }) => {
@@ -55,7 +55,6 @@ test.describe.parallel("Settings page", () => {
 
   test("mode toggle visible", async ({ page }) => {
     const toggle = page.getByRole("checkbox", { name: "Classic Battle" });
-    await toggle.waitFor({ state: "attached" });
     await expect(toggle).toBeVisible();
   });
 
@@ -68,7 +67,6 @@ test.describe.parallel("Settings page", () => {
   });
 
   test("controls expose correct labels", async ({ page }) => {
-    await page.getByRole("checkbox", { name: "Classic Battle" }).waitFor({ state: "attached" });
     const { sortedNames, flagLabels } = getLabelData();
 
     await expect(page.locator("#sound-toggle")).toHaveAttribute("aria-label", "Sound");
@@ -98,7 +96,6 @@ test.describe.parallel("Settings page", () => {
   });
 
   test("tab order follows expected sequence", async ({ page }) => {
-    await page.getByRole("checkbox", { name: "Classic Battle" }).waitFor({ state: "attached" });
     const { flagLabels, expectedLabels } = getLabelData();
 
     const renderedFlagCount = await page

--- a/playwright/status-aria-attributes.spec.js
+++ b/playwright/status-aria-attributes.spec.js
@@ -33,6 +33,9 @@ test.describe.parallel("Status aria attributes", () => {
   for (const url of pages) {
     test(`${url} has role=status and aria-live=polite`, async ({ page }) => {
       await page.goto(url, { waitUntil: "domcontentloaded" });
+      if (url.endsWith("/src/pages/settings.html")) {
+        await page.waitForSelector("[data-settings-ready]");
+      }
       const statuses = await page.$$('[role="status"]');
       expect(statuses.length).toBeGreaterThan(0);
       for (const el of statuses) {

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -278,7 +278,8 @@ export async function fetchSettingsData() {
  * 1. Sections render expanded by default.
  * 2. Apply initial display, motion, and feature settings.
  * 3. Initialize controls and render switches using provided data.
- * 4. Return the updated `document.body` for inspection.
+ * 4. Mark the page as ready and emit a `settings:ready` event.
+ * 5. Return the updated `document.body` for inspection.
  *
  * @param {Settings} settings - Current settings.
  * @param {Array} gameModes - List of available game modes.
@@ -290,6 +291,8 @@ export function renderSettingsControls(settings, gameModes, tooltipMap) {
   applyInitialSettings(settings);
   const controlsApi = initializeControls(settings);
   controlsApi.renderSwitches(gameModes, tooltipMap);
+  document.body.setAttribute("data-settings-ready", "");
+  document.dispatchEvent(new Event("settings:ready"));
   return document.body;
 }
 


### PR DESCRIPTION
## Summary
- mark settings page ready and dispatch `settings:ready`
- rely on `[data-settings-ready]` in Playwright specs instead of custom waits

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aabe92d19883269f1656238eea23d6