### PR TITLE
feat: make battle orientation helper async

### DIFF
--- a/playwright/battle-orientation.spec.js
+++ b/playwright/battle-orientation.spec.js
@@ -5,16 +5,12 @@ test.describe.parallel("Battle orientation behavior", () => {
     await page.goto("/src/pages/battleJudoka.html");
 
     await page.setViewportSize({ width: 320, height: 480 });
-    await page.evaluate(() => window.applyBattleOrientation?.());
-    await page.waitForFunction(
-      () => document.querySelector(".battle-header")?.dataset.orientation === "portrait"
-    );
+    await page.evaluate(() => window.applyBattleOrientation());
+    await expect(page.locator(".battle-header")).toHaveAttribute("data-orientation", "portrait");
 
     await page.setViewportSize({ width: 480, height: 320 });
-    await page.evaluate(() => window.applyBattleOrientation?.());
-    await page.waitForFunction(
-      () => document.querySelector(".battle-header")?.dataset.orientation === "landscape"
-    );
+    await page.evaluate(() => window.applyBattleOrientation());
+    await expect(page.locator(".battle-header")).toHaveAttribute("data-orientation", "landscape");
   });
 
   test("truncates round message below 320px", async ({ page }) => {

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -304,32 +304,45 @@ export function watchBattleOrientation(callback) {
     return;
   }
 
+  const invoke = () => Promise.resolve(callback());
+  try {
+    window.applyBattleOrientation = invoke;
+  } catch {}
+
   let pollId;
   const pollIfMissing = () => {
     if (pollId) return;
     pollId = scheduleFrame(() => {
-      if (callback()) {
-        cancelFrame(pollId);
-        pollId = 0;
-      }
+      invoke().then((ok) => {
+        if (ok) {
+          cancelFrame(pollId);
+          pollId = 0;
+        }
+      });
     });
   };
 
-  if (!callback()) {
-    pollIfMissing();
-  }
+  invoke().then((ok) => {
+    if (!ok) {
+      pollIfMissing();
+    }
+  });
 
   let rafId;
   const onChange = () => {
-    if (!callback()) {
-      pollIfMissing();
-    }
+    invoke().then((ok) => {
+      if (!ok) {
+        pollIfMissing();
+      }
+    });
     if (rafId) return;
     rafId = requestAnimationFrame(() => {
       rafId = 0;
-      if (!callback()) {
-        pollIfMissing();
-      }
+      invoke().then((ok) => {
+        if (!ok) {
+          pollIfMissing();
+        }
+      });
     });
   };
 

--- a/src/helpers/classicBattle/view.js
+++ b/src/helpers/classicBattle/view.js
@@ -127,9 +127,16 @@ export class ClassicBattleView {
 
   /**
    * Applies current orientation to header.
-   * @returns {boolean}
+   *
+   * @pseudocode
+   * 1. Query `.battle-header`; resolve `false` if missing.
+   * 2. Determine orientation via `getOrientation`.
+   * 3. Update `data-orientation` when changed.
+   * 4. Resolve `true` once attributes are set.
+   *
+   * @returns {Promise<boolean>} Resolves `true` when applied, `false` if header missing.
    */
-  applyBattleOrientation() {
+  async applyBattleOrientation() {
     const header = document.querySelector(".battle-header");
     if (header) {
       const next = this.getOrientation();


### PR DESCRIPTION
## Summary
- return a Promise from `applyBattleOrientation` and expose async wrapper
- await orientation update in Playwright tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test --reporter=list`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aabe879b008326ad29f3bdb782a6b5