### PR TITLE
feat: expose settings readiness promise

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -80,7 +80,7 @@ test.describe.parallel("Classic battle flow", () => {
     await timer.waitFor();
     await page.locator("[data-testid='nav-13']").click();
     await expect(page).toHaveURL(/settings.html/);
-    await page.waitForSelector("[data-settings-ready]");
+    await page.evaluate(() => window.settingsReadyPromise);
     await page.goBack();
     await expect(page).toHaveURL(/battleJudoka.html/);
     await page.waitForFunction(() => window.__classicBattleState === "matchOver");

--- a/playwright/responsive-contrast.spec.js
+++ b/playwright/responsive-contrast.spec.js
@@ -10,7 +10,7 @@ test.describe.parallel("Responsive scenarios", () => {
 
   test("toggles high-contrast display mode", async ({ page }) => {
     await page.goto("/src/pages/settings.html");
-    await page.waitForSelector("[data-settings-ready]");
+    await page.evaluate(() => window.settingsReadyPromise);
     await page.check("#display-mode-high-contrast");
     await expect(page.locator("body")).toHaveAttribute("data-theme", "high-contrast");
   });

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -37,7 +37,7 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
     test(`${tag} screenshot ${url}`, async ({ page }) => {
       await page.goto(url, { waitUntil: "domcontentloaded" });
       if (url.endsWith("/src/pages/settings.html")) {
-        await page.waitForSelector("[data-settings-ready]");
+        await page.evaluate(() => window.settingsReadyPromise);
       }
       await expect(page).toHaveScreenshot(name, { fullPage: true });
     });

--- a/playwright/settings-screenshot.spec.js
+++ b/playwright/settings-screenshot.spec.js
@@ -23,7 +23,7 @@ test.describe.parallel(
           );
         }, mode);
         await page.goto("/src/pages/settings.html", { waitUntil: "domcontentloaded" });
-        await page.waitForSelector("[data-settings-ready]");
+        await page.evaluate(() => window.settingsReadyPromise);
         await expect(page.locator("body")).toHaveAttribute("data-theme", mode);
         await expect(page).toHaveScreenshot(`settings-${mode}.png`, { fullPage: true });
       });

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -46,7 +46,7 @@ function getLabelData() {
 test.describe.parallel("Settings page", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/settings.html", { waitUntil: "domcontentloaded" });
-    await page.waitForSelector("[data-settings-ready]");
+    await page.evaluate(() => window.settingsReadyPromise);
   });
 
   test("page loads", async ({ page }) => {

--- a/playwright/status-aria-attributes.spec.js
+++ b/playwright/status-aria-attributes.spec.js
@@ -34,7 +34,7 @@ test.describe.parallel("Status aria attributes", () => {
     test(`${url} has role=status and aria-live=polite`, async ({ page }) => {
       await page.goto(url, { waitUntil: "domcontentloaded" });
       if (url.endsWith("/src/pages/settings.html")) {
-        await page.waitForSelector("[data-settings-ready]");
+        await page.evaluate(() => window.settingsReadyPromise);
       }
       const statuses = await page.$$('[role="status"]');
       expect(statuses.length).toBeGreaterThan(0);

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -29,6 +29,13 @@ import { renderFeatureFlagSwitches } from "./settings/featureFlagSwitches.js";
 import { makeHandleUpdate } from "./settings/makeHandleUpdate.js";
 import { addNavResetButton } from "./settings/addNavResetButton.js";
 
+export const settingsReadyPromise = new Promise((resolve) => {
+  document.addEventListener("settings:ready", resolve, { once: true });
+});
+
+// Expose readiness for tests to await.
+window.settingsReadyPromise = settingsReadyPromise;
+
 let errorPopupTimeoutId;
 
 /**
@@ -278,7 +285,7 @@ export async function fetchSettingsData() {
  * 1. Sections render expanded by default.
  * 2. Apply initial display, motion, and feature settings.
  * 3. Initialize controls and render switches using provided data.
- * 4. Mark the page as ready and emit a `settings:ready` event.
+ * 4. Emit a `settings:ready` event.
  * 5. Return the updated `document.body` for inspection.
  *
  * @param {Settings} settings - Current settings.
@@ -291,7 +298,6 @@ export function renderSettingsControls(settings, gameModes, tooltipMap) {
   applyInitialSettings(settings);
   const controlsApi = initializeControls(settings);
   controlsApi.renderSwitches(gameModes, tooltipMap);
-  document.body.setAttribute("data-settings-ready", "");
   document.dispatchEvent(new Event("settings:ready"));
   return document.body;
 }


### PR DESCRIPTION
## Summary
- expose `settingsReadyPromise` and attach to `window`
- rely on `settingsReadyPromise` in Playwright tests
- remove obsolete `[data-settings-ready]` attribute

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aacb20844c8326a0f863ef281307e0