### PR TITLE
feat: add immediate spinner hook for tests

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -185,17 +185,23 @@ test.describe.parallel("Browse Judoka screen", () => {
     await expect(left).toBeDisabled();
   });
 
-  test.skip("shows loading spinner on slow network", async ({ page }) => {
+  test("shows loading spinner", async ({ page }) => {
     const context = await page.context();
-    await context.route("**/src/data/judoka.json", async (route) => {
-      await new Promise((r) => setTimeout(r, 2500));
-      await route.fulfill({ path: "tests/fixtures/judoka.json" });
-    });
-    await context.route("**/src/data/gokyo.json", async (route) => {
-      await new Promise((r) => setTimeout(r, 2500));
-      await route.fulfill({ path: "tests/fixtures/gokyo.json" });
-    });
+    await context.route("**/src/data/judoka.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/judoka.json" })
+    );
+    await context.route("**/src/data/gokyo.json", (route) =>
+      route.fulfill({ path: "tests/fixtures/gokyo.json" })
+    );
 
+    await page.addInitScript(() => {
+      window.__testHooks = window.__testHooks || {
+        showSpinnerImmediately: () => {
+          window.__showSpinnerImmediately__ = true;
+        }
+      };
+      window.__testHooks.showSpinnerImmediately();
+    });
     await page.reload();
 
     const spinner = page.locator(".loading-spinner");


### PR DESCRIPTION
## Summary
- expose `showSpinnerImmediately` test hook to display carousel spinner without delay
- simplify spinner test by intercepting fixture data and using new hook

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aacb0f0a088326a59a2c880cc26f5a