### PR TITLE
feat: expose nav ready promise

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -7,7 +7,7 @@ test.describe.parallel("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/browseJudoka.html");
     // Wait for the bottom navbar links to be ready
-    await page.waitForSelector("body[data-nav-ready]");
+    await page.evaluate(() => window.navReadyPromise);
   });
 
   test("essential elements visible", async ({ page }) => {

--- a/playwright/homepage-layout.spec.js
+++ b/playwright/homepage-layout.spec.js
@@ -9,7 +9,7 @@ test.describe.parallel("Homepage layout", () => {
     test.beforeEach(async ({ page }) => {
       await page.goto("/index.html");
       await page.waitForSelector(".game-mode-grid");
-      await page.waitForSelector("body[data-nav-ready]");
+      await page.evaluate(() => window.navReadyPromise);
     });
 
     test("grid has two columns", async ({ page }) => {
@@ -58,7 +58,7 @@ test.describe.parallel("Homepage layout", () => {
     test.beforeEach(async ({ page }) => {
       await page.goto("/index.html");
       await page.waitForSelector(".game-mode-grid");
-      await page.waitForSelector("body[data-nav-ready]");
+      await page.evaluate(() => window.navReadyPromise);
     });
 
     test("grid has one column", async ({ page }) => {

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -9,7 +9,7 @@ test.describe.parallel("Homepage", () => {
   // Navigation coverage: footer link visibility and ordering.
   test.beforeEach(async ({ page }) => {
     await page.goto("/index.html");
-    await page.waitForSelector("body[data-nav-ready]");
+    await page.evaluate(() => window.navReadyPromise);
   });
 
   test("page loads", async ({ page }) => {

--- a/src/helpers/navigationBar.js
+++ b/src/helpers/navigationBar.js
@@ -1,5 +1,17 @@
 import { loadNavigationItems } from "./gameModeUtils.js";
 
+let navReadyResolve;
+export const navReadyPromise =
+  typeof window !== "undefined"
+    ? new Promise((resolve) => {
+        navReadyResolve = resolve;
+      })
+    : Promise.resolve();
+
+if (typeof window !== "undefined") {
+  window.navReadyPromise = navReadyPromise;
+}
+
 /**
  * Highlight the navigation link matching the current location.
  *
@@ -72,6 +84,7 @@ export async function populateNavbar() {
       ? new document.defaultView.Event("nav:ready")
       : new Event("nav:ready");
     document.dispatchEvent(evt);
+    navReadyResolve?.();
   };
   try {
     const links = document.querySelectorAll('a[data-testid^="nav-"]');


### PR DESCRIPTION
## Summary
- export navReadyPromise and expose globally for async nav readiness
- wait on window.navReadyPromise in navigation-related playwright specs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aacb171ee883268110f25c0db2cacd