### PR TITLE
feat(timerService): awaitable next-round scheduling

### DIFF
--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -104,10 +104,11 @@ describe("classicBattle scheduleNextRound", () => {
     await orchestrator.dispatchBattleEvent("continue");
     expect(machine.getState()).toBe("cooldown");
 
-    battleMod.scheduleNextRound({ matchEnded: false });
+    const readyPromise = battleMod.scheduleNextRound({ matchEnded: false });
 
     timerSpy.advanceTimersByTime(3000);
     await vi.runAllTimersAsync();
+    await readyPromise;
 
     expect(dispatchSpy).toHaveBeenCalledWith("ready");
     expect(startRoundWrapper).toHaveBeenCalledTimes(1);
@@ -141,8 +142,9 @@ describe("classicBattle scheduleNextRound", () => {
     await orchestrator.dispatchBattleEvent("continue");
     expect(machine.getState()).toBe("cooldown");
 
-    battleMod.scheduleNextRound({ matchEnded: false });
+    const readyPromise = battleMod.scheduleNextRound({ matchEnded: false });
     document.getElementById("next-button").dispatchEvent(new MouseEvent("click"));
+    await readyPromise;
     await vi.runAllTimersAsync();
 
     expect(startRoundWrapper).toHaveBeenCalledTimes(1);

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -39,13 +39,12 @@ describe("timerService next round handling", () => {
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
     const { nextButton } = createTimerNodes();
     nextButton.addEventListener("click", mod.onNextButtonClick);
-    mod.scheduleNextRound({ matchEnded: false });
+    const promise = mod.scheduleNextRound({ matchEnded: false });
     nextButton.click();
-    await vi.waitFor(() => {
-      expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
-    });
+    await promise;
     // Current flow guarantees at least one dispatch; a second may occur
     // via attribute observation. Accept one or more invocations.
+    expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
     expect(dispatchBattleEvent.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -55,10 +54,8 @@ describe("timerService next round handling", () => {
     });
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
     createTimerNodes();
-    mod.scheduleNextRound({ matchEnded: false });
-    await vi.waitFor(() => {
-      expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
-    });
+    await mod.scheduleNextRound({ matchEnded: false });
+    expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
     expect(dispatchBattleEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/helpers/timerService.test.js
+++ b/tests/helpers/timerService.test.js
@@ -82,8 +82,9 @@ describe("timerService", () => {
     skip.skipCurrentPhase();
 
     const { scheduleNextRound } = await import("../../src/helpers/classicBattle/timerService.js");
-    scheduleNextRound({ matchEnded: false });
+    const promise = scheduleNextRound({ matchEnded: false });
     await vi.runAllTimersAsync();
+    await promise;
 
     expect(btn.dataset.nextReady).toBe("true");
     expect(btn.disabled).toBe(false);


### PR DESCRIPTION
## Summary
- make `scheduleNextRound` return a promise that resolves when the "ready" event dispatches
- resolve the promise on cooldown expiry or when the Next button dispatches early
- update tests to `await` `scheduleNextRound` rather than using `vi.waitFor`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aacfaadab4832692878e11ea2a488f