### PR TITLE
Expose battle readiness promise and allow cooldown override

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -10,6 +10,7 @@ const rounds = JSON.parse(readFileSync(resolve("src/data/battleRounds.json"), "u
 test.describe.parallel("Classic battle flow", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
+      window.__NEXT_ROUND_COOLDOWN_MS = 0;
       localStorage.setItem(
         "settings",
         JSON.stringify({ featureFlags: { enableTestMode: { enabled: false } } })
@@ -39,9 +40,9 @@ test.describe.parallel("Classic battle flow", () => {
     await page.evaluate(() => window.skipBattlePhase?.());
     await page.evaluate(() => window.freezeBattleHeader?.());
     const result = page.locator("header #round-message");
-    await expect(result).not.toHaveText("", { timeout: 15000 });
+    await expect(result).not.toHaveText("");
     const snackbar = page.locator(".snackbar");
-    await expect(snackbar).toHaveText(/Next round in: \d+s/, { timeout: 15000 });
+    await expect(snackbar).toHaveText(/Next round in: \d+s/);
   });
 
   test("tie message appears on equal stats", async ({ page }) => {
@@ -57,7 +58,7 @@ test.describe.parallel("Classic battle flow", () => {
     await expect(snackbar).toHaveText("You Picked: Power");
     const msg = page.locator("header #round-message");
     await expect(msg).toHaveText(/Tie/);
-    await expect(snackbar).toHaveText(/Next round in: \d+s/, { timeout: 15000 });
+    await expect(snackbar).toHaveText(/Next round in: \d+s/);
   });
 
   test("quit match confirmation", async ({ page }) => {
@@ -66,7 +67,7 @@ test.describe.parallel("Classic battle flow", () => {
     await roundOptions.first().waitFor();
     await roundOptions.first().click();
     await expect(page.locator(".modal-backdrop:not([hidden])")).toHaveCount(0);
-    await page.waitForSelector('[data-ready="true"]');
+    await page.evaluate(() => window.battleReadyPromise);
     await page.locator("[data-testid='home-link']").click();
     const confirmButton = page.locator("#confirm-quit-button");
     await confirmButton.waitFor({ state: "attached" });

--- a/src/helpers/battleInit.js
+++ b/src/helpers/battleInit.js
@@ -12,6 +12,32 @@
  * @returns {void}
  */
 const readyParts = new Set();
+
+/**
+ * Promise that resolves once the battle screen has fully initialized.
+ *
+ * @pseudocode
+ * 1. Create a promise and capture its resolve callback.
+ * 2. Add a one-time listener for `battle:init` that resolves the promise.
+ * 3. Expose the promise globally via `window.battleReadyPromise`.
+ */
+let resolveReady;
+export const battleReadyPromise = new Promise((resolve) => {
+  resolveReady = resolve;
+});
+
+document.addEventListener(
+  "battle:init",
+  () => {
+    resolveReady();
+  },
+  { once: true }
+);
+
+if (typeof window !== "undefined") {
+  window.battleReadyPromise = battleReadyPromise;
+}
+
 export function markBattlePartReady(part) {
   readyParts.add(part);
   if (readyParts.has("home") && readyParts.has("state")) {


### PR DESCRIPTION
## Summary
- export and globally expose `battleReadyPromise` resolved on `battle:init`
- allow overriding next round cooldown via `window.__NEXT_ROUND_COOLDOWN_MS`
- streamline classic battle Playwright tests by awaiting `battleReadyPromise`

## Testing
- `npx prettier src/helpers/battleInit.js src/helpers/classicBattle/timerService.js playwright/classicBattleFlow.spec.js --check`
- `npx eslint .`
- `npx vitest run --reporter=dot --silent` *(fails: excessive output)*
- `npx playwright test` *(fails: network errors and screenshot differences)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aad63100888326ae6cee86dd63c829