### PR TITLE
feat: allow configurable stat hint duration

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -697,10 +697,12 @@ export function setDebugPanelEnabled(enabled) {
  *
  * @pseudocode
  * 1. Skip if `localStorage.statHintShown` is set or unavailable.
- * 2. Trigger hover events on `#stat-help` for 3 seconds.
+ * 2. Trigger hover events on `#stat-help` for `durationMs` milliseconds.
  * 3. Record that the hint has been shown.
+ *
+ * @param {number} [durationMs=3000] Hover duration in milliseconds.
  */
-export function maybeShowStatHint() {
+export function maybeShowStatHint(durationMs = 3000) {
   try {
     if (typeof localStorage === "undefined") return;
     const hintShown = localStorage.getItem("statHintShown");
@@ -709,7 +711,7 @@ export function maybeShowStatHint() {
     help?.dispatchEvent(new Event("mouseenter"));
     setTimeout(() => {
       help?.dispatchEvent(new Event("mouseleave"));
-    }, 3000);
+    }, durationMs);
     localStorage.setItem("statHintShown", "true");
   } catch {}
 }

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -160,34 +160,16 @@ describe("classicBattlePage stat button interactions", () => {
 describe("classicBattlePage stat help tooltip", () => {
   it("shows tooltip only once", async () => {
     vi.useFakeTimers();
-    const startRound = vi.fn();
-    const waitForOpponentCard = vi.fn();
-    const loadSettings = vi.fn().mockResolvedValue({ featureFlags: {} });
-    const initTooltips = vi.fn().mockResolvedValue(() => {});
-    const setTestMode = vi.fn();
-
-    const store = {};
-    vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
-      createBattleStore: () => store,
-      startRound
-    }));
-    vi.doMock("../../src/helpers/classicBattle/selectionHandler.js", () => ({
-      handleStatSelection: vi.fn()
-    }));
-    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForOpponentCard }));
-    vi.doMock("../../src/config/loadSettings.js", () => ({ loadSettings }));
-    vi.doMock("../../src/helpers/tooltip.js", () => ({ initTooltips }));
-    vi.doMock("../../src/helpers/testModeUtils.js", () => ({ setTestMode }));
-    vi.doMock("../../src/helpers/stats.js", () => ({ loadStatNames: async () => [] }));
 
     const help = document.createElement("button");
     help.id = "stat-help";
     document.body.appendChild(help);
     const spy = vi.spyOn(help, "dispatchEvent");
 
-    const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
-    await setupClassicBattlePage();
-    await vi.runAllTimersAsync();
+    const { maybeShowStatHint } = await import("../../src/helpers/classicBattle/uiHelpers.js");
+
+    maybeShowStatHint(0);
+    vi.runAllTimers();
 
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy.mock.calls[0][0].type).toBe("mouseenter");
@@ -195,8 +177,8 @@ describe("classicBattlePage stat help tooltip", () => {
     expect(localStorage.getItem("statHintShown")).toBe("true");
 
     spy.mockClear();
-    await setupClassicBattlePage();
-    await vi.runAllTimersAsync();
+    maybeShowStatHint(0);
+    vi.runAllTimers();
     expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- allow stat hint tooltip to accept a configurable duration
- streamline stat-help test by directly calling `maybeShowStatHint(0)`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 10 failed, 2 interrupted, 38 did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aad98acd408326b5a04b32c2d4de9d