### PR TITLE
refactor classic battle timing

### DIFF
--- a/src/helpers/classicBattle/autoSelectStat.js
+++ b/src/helpers/classicBattle/autoSelectStat.js
@@ -16,15 +16,16 @@ const AUTO_SELECT_FEEDBACK_MS = 500;
  * @pseudocode
  * pick random stat from STATS
  * mark corresponding button as selected
- * wait AUTO_SELECT_FEEDBACK_MS
+ * wait `feedbackDelayMs`
  * dispatch "statSelected" battle event
  * invoke onSelect with random stat and delayOpponentMessage true
  *
  * @param {(stat: string, opts?: { delayOpponentMessage?: boolean }) => Promise<void>|void} onSelect
  * - Callback to handle the chosen stat.
+ * @param {number} [feedbackDelayMs=AUTO_SELECT_FEEDBACK_MS] - Visual delay before dispatch.
  * @returns {Promise<void>} Resolves after feedback completes.
  */
-export async function autoSelectStat(onSelect) {
+export async function autoSelectStat(onSelect, feedbackDelayMs = AUTO_SELECT_FEEDBACK_MS) {
   const randomStat = STATS[Math.floor(seededRandom() * STATS.length)];
   // Defensive: ensure randomStat is a string before using it in a selector
   let btn = null;
@@ -48,7 +49,7 @@ export async function autoSelectStat(onSelect) {
     } catch {}
   }
   if (btn) btn.classList.add("selected");
-  await new Promise((resolve) => setTimeout(resolve, AUTO_SELECT_FEEDBACK_MS));
+  await new Promise((resolve) => setTimeout(resolve, feedbackDelayMs));
   // Ensure timeout event is observed even in environments where the
   // timer's own dispatch might be skipped by mocks.
   try {

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -12,7 +12,7 @@ import { emitBattleEvent } from "./battleEvents.js";
  * 1. Initialize battle state values.
  * 2. Return the store.
  *
- * @returns {{quitModal: ReturnType<import("../../components/Modal.js").createModal>|null, statTimeoutId: ReturnType<typeof setTimeout>|null, autoSelectId: ReturnType<typeof setTimeout>|null, compareRaf: number, selectionMade: boolean}}
+ * @returns {{quitModal: ReturnType<import("../../components/Modal.js").createModal>|null, statTimeoutId: ReturnType<typeof setTimeout>|null, autoSelectId: ReturnType<typeof setTimeout>|null, compareRaf: number, selectionMade: boolean, stallTimeoutMs: number}}
  */
 export function createBattleStore() {
   return {
@@ -20,7 +20,8 @@ export function createBattleStore() {
     statTimeoutId: null,
     autoSelectId: null,
     compareRaf: 0,
-    selectionMade: false
+    selectionMade: false,
+    stallTimeoutMs: 35000
   };
 }
 

--- a/src/helpers/classicBattle/roundResolver.js
+++ b/src/helpers/classicBattle/roundResolver.js
@@ -40,13 +40,23 @@ export function evaluateRound(store, stat, playerVal, opponentVal) {
  * @param {string} stat - Chosen stat key.
  * @param {number} playerVal - Player's stat value.
  * @param {number} opponentVal - Opponent's stat value.
+ * @param {{delayMs?: number, sleep?: (ms: number) => Promise<void>}} [opts]
+ * - Optional overrides for testing.
  * @returns {Promise<ReturnType<typeof evaluateRound>>}
  */
-export async function resolveRound(store, stat, playerVal, opponentVal) {
+export async function resolveRound(
+  store,
+  stat,
+  playerVal,
+  opponentVal,
+  {
+    delayMs = 300 + Math.floor(Math.random() * 401),
+    sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+  } = {}
+) {
   if (!stat) return;
   await dispatchBattleEvent("evaluate");
-  const delay = 300 + Math.floor(Math.random() * 401);
-  await new Promise((resolve) => setTimeout(resolve, delay));
+  await sleep(delayMs);
   emitBattleEvent("opponentReveal");
   const result = evaluateRound(store, stat, playerVal, opponentVal);
   const outcomeEvent =

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -20,8 +20,9 @@ import { onBattleEvent } from "./battleEvents.js";
  *
  * @param {ReturnType<typeof import('./roundManager.js').createBattleStore>} store - Battle state store.
  * @param {number} roundNumber - Current round number to display.
+ * @param {number} [stallTimeoutMs=35000] - Delay before auto-select kicks in.
  */
-export function applyRoundUI(store, roundNumber) {
+export function applyRoundUI(store, roundNumber, stallTimeoutMs = 35000) {
   resetStatButtons();
   disableNextRoundButton();
   const roundResultEl = document.getElementById("round-result");
@@ -30,9 +31,10 @@ export function applyRoundUI(store, roundNumber) {
   scoreboard.updateRoundCounter(roundNumber);
   showSelectionPrompt();
   startTimer((stat, opts) => handleStatSelection(store, stat, opts));
+  store.stallTimeoutMs = stallTimeoutMs;
   store.statTimeoutId = setTimeout(
     () => handleStatSelectionTimeout(store, (s, opts) => handleStatSelection(store, s, opts)),
-    35000
+    store.stallTimeoutMs
   );
   updateDebugPanel();
 }

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -160,18 +160,19 @@ export async function startTimer(onExpiredSelect) {
  *
  * @pseudocode
  * 1. Display "Stat selection stalled" via `scoreboard.showMessage`.
- * 2. After 5 seconds call `autoSelectStat(onSelect)`.
+ * 2. After `timeoutMs` milliseconds call `autoSelectStat(onSelect)`.
  *
  * @param {{autoSelectId: ReturnType<typeof setTimeout> | null}} store
  * - Battle state store.
  * @param {(stat: string, opts?: { delayOpponentMessage?: boolean }) => void} onSelect
  * - Callback to handle stat selection.
+ * @param {number} [timeoutMs=5000] - Delay before auto-selecting.
  */
-export function handleStatSelectionTimeout(store, onSelect) {
+export function handleStatSelectionTimeout(store, onSelect, timeoutMs = 5000) {
   scoreboard.showMessage("Stat selection stalled. Pick a stat or wait for auto-pick.");
   store.autoSelectId = setTimeout(() => {
     autoSelectStat(onSelect);
-  }, 5000);
+  }, timeoutMs);
 }
 
 export function createRoundTimer(onTick, onExpired) {


### PR DESCRIPTION
## Summary
- make classic battle round UI stall timeout configurable
- allow custom stall and auto-select timings
- support optional sleep and feedback delays in battle resolution helpers

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aad98f3b90832690a2cc55f6805b13