### PR TITLE
Expose randomJudoka readiness and update test

### DIFF
--- a/playwright/card-inspector-accessibility.spec.js
+++ b/playwright/card-inspector-accessibility.spec.js
@@ -19,14 +19,22 @@ const JUDOKA = {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const createInspectorPanelPath = path.resolve(__dirname, "../src/helpers/inspector/createInspectorPanel.js");
+const createInspectorPanelPath = path.resolve(
+  __dirname,
+  "../src/helpers/inspector/createInspectorPanel.js"
+);
 const mountInspectorPanelPath = path.resolve(__dirname, "../tests/helpers/mountInspectorPanel.js");
 
-const createInspectorPanelScript = fs.readFileSync(createInspectorPanelPath, "utf8")
+const createInspectorPanelScript = fs
+  .readFileSync(createInspectorPanelPath, "utf8")
   .replace("export function createInspectorPanel", "function createInspectorPanel");
 
-const mountInspectorPanelScript = fs.readFileSync(mountInspectorPanelPath, "utf8")
-  .replace('import { createInspectorPanel } from "../../src/helpers/inspector/createInspectorPanel.js";', '')
+const mountInspectorPanelScript = fs
+  .readFileSync(mountInspectorPanelPath, "utf8")
+  .replace(
+    'import { createInspectorPanel } from "../../src/helpers/inspector/createInspectorPanel.js";',
+    ""
+  )
   .replace("export function mountInspectorPanel", "function mountInspectorPanel");
 
 const initScript = createInspectorPanelScript + "\n" + mountInspectorPanelScript;

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -4,24 +4,22 @@ import { verifyPageBasics, NAV_CLASSIC_BATTLE } from "./fixtures/navigationCheck
 test.describe.parallel("View Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/randomJudoka.html");
+    await page.evaluate(() => window.randomJudokaReadyPromise);
   });
 
   test("essential elements visible", async ({ page }) => {
-    await page.getByTestId("draw-button").waitFor();
     await expect(page.getByTestId("draw-button")).toBeVisible();
     await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
   });
 
   test("battle link navigates", async ({ page }) => {
     const battleLink = page.getByTestId(NAV_CLASSIC_BATTLE);
-    await battleLink.waitFor();
     await battleLink.click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 
   test("draw button accessible name constant", async ({ page }) => {
     const btn = page.getByTestId("draw-button");
-    await btn.waitFor();
     await expect(btn).toHaveText(/draw card/i);
 
     await page.evaluate(() => {
@@ -71,7 +69,6 @@ test.describe.parallel("View Judoka screen", () => {
 
   test("draw button uses design tokens", async ({ page }) => {
     const btn = page.getByTestId("draw-button");
-    await btn.waitFor();
     const styles = await btn.evaluate((el) => {
       const cs = getComputedStyle(el);
       return { bg: cs.backgroundColor, color: cs.color };
@@ -96,7 +93,6 @@ test.describe.parallel("View Judoka screen", () => {
 
   test("draw button remains within viewport", async ({ page }) => {
     const btn = page.getByTestId("draw-button");
-    await btn.waitFor();
     const { bottom, innerHeight } = await btn.evaluate((el) => {
       const rect = el.getBoundingClientRect();
       return { bottom: rect.bottom, innerHeight: window.innerHeight };

--- a/scripts/lib/debugUtils.js
+++ b/scripts/lib/debugUtils.js
@@ -116,9 +116,15 @@ export async function tryClickStat(page, stat, { force = false, timeout = 1000 }
         try {
           const el = document.querySelector(sel);
           if (!el) return { ok: false, reason: "no-element" };
-          try { el.disabled = false; } catch {}
-          try { el.classList.remove && el.classList.remove("disabled"); } catch {}
-          try { if (el.tabIndex === -1) el.tabIndex = 0; } catch {}
+          try {
+            el.disabled = false;
+          } catch {}
+          try {
+            el.classList.remove && el.classList.remove("disabled");
+          } catch {}
+          try {
+            if (el.tabIndex === -1) el.tabIndex = 0;
+          } catch {}
           el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
           return { ok: true, reason: "dispatched" };
         } catch (e) {
@@ -138,20 +144,24 @@ export async function getBattleSnapshot(page) {
       const byId = (id) => document.getElementById(id);
       const text = (id) => (byId(id) ? byId(id).textContent || "" : "");
       const machineTimerEl = byId("machine-timer");
-      const progressItems = Array.from(document.querySelectorAll("#battle-state-progress > li")).map(
-        (li) => li.textContent || ""
+      const progressItems = Array.from(
+        document.querySelectorAll("#battle-state-progress > li")
+      ).map((li) => li.textContent || "");
+      const statButtons = Array.from(document.querySelectorAll("#stat-buttons button")).map(
+        (b) => ({
+          text: b.textContent || "",
+          stat: b.dataset.stat || "",
+          disabled: !!b.disabled,
+          classes: b.className || ""
+        })
       );
-      const statButtons = Array.from(document.querySelectorAll("#stat-buttons button")).map((b) => ({
-        text: b.textContent || "",
-        stat: b.dataset.stat || "",
-        disabled: !!b.disabled,
-        classes: b.className || ""
-      }));
       const logArr = Array.isArray(window.__classicBattleStateLog)
         ? window.__classicBattleStateLog.slice(-20)
         : [];
       const active = document.activeElement;
-      const activeDesc = active ? `${active.tagName.toLowerCase()}#${active.id || ''}.${active.className || ''}` : "";
+      const activeDesc = active
+        ? `${active.tagName.toLowerCase()}#${active.id || ""}.${active.className || ""}`
+        : "";
       return {
         state: window.__classicBattleState || null,
         prev: window.__classicBattlePrevState || null,
@@ -173,7 +183,10 @@ export async function getBattleSnapshot(page) {
         progressItems,
         statButtons,
         store: window.battleStore
-          ? { selectionMade: !!window.battleStore.selectionMade, playerChoice: window.battleStore.playerChoice || null }
+          ? {
+              selectionMade: !!window.battleStore.selectionMade,
+              playerChoice: window.battleStore.playerChoice || null
+            }
           : null,
         machineLog: logArr,
         activeElement: activeDesc
@@ -194,4 +207,3 @@ export async function takeScreenshot(page, path) {
     console.warn("screenshot failed:", String(e));
   }
 }
-

--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -307,4 +307,13 @@ export async function setupRandomJudokaPage() {
   initTooltips();
 }
 
-onDomReady(setupRandomJudokaPage);
+export const randomJudokaReadyPromise = new Promise((resolve) => {
+  onDomReady(async () => {
+    await Promise.all([setupRandomJudokaPage(), window.navReadyPromise]);
+    resolve();
+  });
+});
+
+if (typeof window !== "undefined") {
+  window.randomJudokaReadyPromise = randomJudokaReadyPromise;
+}


### PR DESCRIPTION
## Summary
- expose `randomJudokaReadyPromise` so tests can await Random Judoka page initialization and nav readiness
- replace explicit element waits in the Random Judoka Playwright spec with `page.evaluate(() => window.randomJudokaReadyPromise)`
- format stray test and debug util files via Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aae82250e48326ad2dfc2e23695155