### PR TITLE
feat: expose browse judoka readiness

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -8,6 +8,7 @@ test.describe.parallel("Browse Judoka screen", () => {
     await page.goto("/src/pages/browseJudoka.html");
     // Wait for the bottom navbar links to be ready
     await page.evaluate(() => window.navReadyPromise);
+    await page.evaluate(() => window.browseJudokaReadyPromise);
   });
 
   test("essential elements visible", async ({ page }) => {
@@ -59,7 +60,7 @@ test.describe.parallel("Browse Judoka screen", () => {
   test("resetting filter shows all judoka", async ({ page }) => {
     const toggle = page.getByTestId(COUNTRY_TOGGLE_LOCATOR);
 
-    await page.waitForSelector("[data-testid=carousel-container] .judoka-card");
+    await page.evaluate(() => window.browseJudokaReadyPromise);
     const allCards = page.locator("[data-testid=carousel-container] .judoka-card");
     const initialCount = await allCards.count();
 
@@ -78,7 +79,7 @@ test.describe.parallel("Browse Judoka screen", () => {
   test("displays country flags", async ({ page }) => {
     const toggle = page.getByTestId(COUNTRY_TOGGLE_LOCATOR);
     await toggle.click();
-    await page.waitForSelector("#country-list .slide");
+    await page.evaluate(() => window.browseJudokaReadyPromise);
     const slides = page.locator("#country-list .slide");
     await expect(slides).toHaveCount(4);
     await expect(slides.first().locator("img")).toHaveAttribute("alt", /all countries/i);
@@ -86,7 +87,7 @@ test.describe.parallel("Browse Judoka screen", () => {
 
   test("judoka card enlarges on hover", async ({ page }) => {
     const card = page.locator("#carousel-container .judoka-card").first();
-    await card.waitFor();
+    await page.evaluate(() => window.browseJudokaReadyPromise);
 
     const before = await card.boundingBox();
     await card.hover();
@@ -103,8 +104,8 @@ test.describe.parallel("Browse Judoka screen", () => {
     );
     await page.setViewportSize({ width: 320, height: 800 });
     await page.reload();
+    await page.evaluate(() => window.browseJudokaReadyPromise);
     const container = page.locator('[data-testid="carousel"]');
-    await page.waitForSelector('[data-testid="carousel"] .judoka-card');
 
     await container.focus();
     const markers = page.locator(".scroll-marker");
@@ -134,9 +135,8 @@ test.describe.parallel("Browse Judoka screen", () => {
     );
     await page.setViewportSize({ width: 320, height: 800 });
     await page.reload();
+    await page.evaluate(() => window.browseJudokaReadyPromise);
     const container = page.locator(".card-carousel");
-    await container.waitFor();
-    await page.waitForSelector('[data-testid="carousel"] .judoka-card');
 
     const markers = page.locator(".scroll-marker");
     const counter = page.locator(".page-counter");
@@ -205,9 +205,8 @@ test.describe.parallel("Browse Judoka screen", () => {
     await page.reload();
 
     const spinner = page.locator(".loading-spinner");
-    await spinner.waitFor({ state: "attached" });
     await expect(spinner).toBeVisible();
-    await page.waitForSelector(".card-carousel .judoka-card");
+    await page.evaluate(() => window.browseJudokaReadyPromise);
     await expect(spinner).toBeHidden();
   });
 });

--- a/playwright/card-inspector-accessibility.spec.js
+++ b/playwright/card-inspector-accessibility.spec.js
@@ -19,14 +19,22 @@ const JUDOKA = {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const createInspectorPanelPath = path.resolve(__dirname, "../src/helpers/inspector/createInspectorPanel.js");
+const createInspectorPanelPath = path.resolve(
+  __dirname,
+  "../src/helpers/inspector/createInspectorPanel.js"
+);
 const mountInspectorPanelPath = path.resolve(__dirname, "../tests/helpers/mountInspectorPanel.js");
 
-const createInspectorPanelScript = fs.readFileSync(createInspectorPanelPath, "utf8")
+const createInspectorPanelScript = fs
+  .readFileSync(createInspectorPanelPath, "utf8")
   .replace("export function createInspectorPanel", "function createInspectorPanel");
 
-const mountInspectorPanelScript = fs.readFileSync(mountInspectorPanelPath, "utf8")
-  .replace('import { createInspectorPanel } from "../../src/helpers/inspector/createInspectorPanel.js";', '')
+const mountInspectorPanelScript = fs
+  .readFileSync(mountInspectorPanelPath, "utf8")
+  .replace(
+    'import { createInspectorPanel } from "../../src/helpers/inspector/createInspectorPanel.js";',
+    ""
+  )
   .replace("export function mountInspectorPanel", "function mountInspectorPanel");
 
 const initScript = createInspectorPanelScript + "\n" + mountInspectorPanelScript;

--- a/scripts/lib/debugUtils.js
+++ b/scripts/lib/debugUtils.js
@@ -116,9 +116,15 @@ export async function tryClickStat(page, stat, { force = false, timeout = 1000 }
         try {
           const el = document.querySelector(sel);
           if (!el) return { ok: false, reason: "no-element" };
-          try { el.disabled = false; } catch {}
-          try { el.classList.remove && el.classList.remove("disabled"); } catch {}
-          try { if (el.tabIndex === -1) el.tabIndex = 0; } catch {}
+          try {
+            el.disabled = false;
+          } catch {}
+          try {
+            el.classList.remove && el.classList.remove("disabled");
+          } catch {}
+          try {
+            if (el.tabIndex === -1) el.tabIndex = 0;
+          } catch {}
           el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
           return { ok: true, reason: "dispatched" };
         } catch (e) {
@@ -138,20 +144,24 @@ export async function getBattleSnapshot(page) {
       const byId = (id) => document.getElementById(id);
       const text = (id) => (byId(id) ? byId(id).textContent || "" : "");
       const machineTimerEl = byId("machine-timer");
-      const progressItems = Array.from(document.querySelectorAll("#battle-state-progress > li")).map(
-        (li) => li.textContent || ""
+      const progressItems = Array.from(
+        document.querySelectorAll("#battle-state-progress > li")
+      ).map((li) => li.textContent || "");
+      const statButtons = Array.from(document.querySelectorAll("#stat-buttons button")).map(
+        (b) => ({
+          text: b.textContent || "",
+          stat: b.dataset.stat || "",
+          disabled: !!b.disabled,
+          classes: b.className || ""
+        })
       );
-      const statButtons = Array.from(document.querySelectorAll("#stat-buttons button")).map((b) => ({
-        text: b.textContent || "",
-        stat: b.dataset.stat || "",
-        disabled: !!b.disabled,
-        classes: b.className || ""
-      }));
       const logArr = Array.isArray(window.__classicBattleStateLog)
         ? window.__classicBattleStateLog.slice(-20)
         : [];
       const active = document.activeElement;
-      const activeDesc = active ? `${active.tagName.toLowerCase()}#${active.id || ''}.${active.className || ''}` : "";
+      const activeDesc = active
+        ? `${active.tagName.toLowerCase()}#${active.id || ""}.${active.className || ""}`
+        : "";
       return {
         state: window.__classicBattleState || null,
         prev: window.__classicBattlePrevState || null,
@@ -173,7 +183,10 @@ export async function getBattleSnapshot(page) {
         progressItems,
         statButtons,
         store: window.battleStore
-          ? { selectionMade: !!window.battleStore.selectionMade, playerChoice: window.battleStore.playerChoice || null }
+          ? {
+              selectionMade: !!window.battleStore.selectionMade,
+              playerChoice: window.battleStore.playerChoice || null
+            }
           : null,
         machineLog: logArr,
         activeElement: activeDesc
@@ -194,4 +207,3 @@ export async function takeScreenshot(page, path) {
     console.warn("screenshot failed:", String(e));
   }
 }
-

--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -11,6 +11,18 @@ import { setupButtonEffects } from "./buttonEffects.js";
 import { setupCountryToggle } from "./browse/setupCountryToggle.js";
 import { setupCountryFilter } from "./browse/setupCountryFilter.js";
 
+let resolveBrowseReady;
+export const browseJudokaReadyPromise =
+  typeof window !== "undefined"
+    ? new Promise((resolve) => {
+        resolveBrowseReady = resolve;
+      })
+    : Promise.resolve();
+
+if (typeof window !== "undefined") {
+  window.browseJudokaReadyPromise = browseJudokaReadyPromise;
+}
+
 /**
  * Attach listener to switch layout mode of country panel.
  *
@@ -135,6 +147,7 @@ export async function setupBrowseJudokaPage() {
         carouselContainer,
         ariaLive
       );
+      resolveBrowseReady?.();
     } catch (error) {
       spinner.remove();
       console.error("Error building the carousel:", error);
@@ -168,6 +181,7 @@ export async function setupBrowseJudokaPage() {
         }
       });
       carouselContainer.appendChild(retryButton);
+      resolveBrowseReady?.();
       return;
     }
   }


### PR DESCRIPTION
## Summary
- expose `browseJudokaReadyPromise` to signal when browse judoka page UI is ready
- update tests to await `browseJudokaReadyPromise` instead of selector waits
- format scripts and tests with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aae807441483269fac5a3ff2174399