### PR TITLE
Return replacement promises from appendCards

### DIFF
--- a/src/helpers/carousel/cards.js
+++ b/src/helpers/carousel/cards.js
@@ -11,13 +11,15 @@ import { getMissingJudokaFields, hasRequiredJudokaFields } from "../judokaValida
  *    b. Generate a card or fall back to a default judoka.
  *    c. Apply accessibility attributes and append to the container.
  *    d. On portrait load error, rebuild the card using fallback judoka and replace the broken card.
+ *    e. Collect a promise that resolves when the portrait either loads or is replaced.
  *
  * @param {HTMLElement} container - Carousel container element.
  * @param {Judoka[]} judokaList - Array of judoka objects.
  * @param {Object} gokyoLookup - Lookup object for gokyo data.
- * @returns {Promise<void>} Resolves when all cards are appended.
+ * @returns {Promise<void[]>} Resolves when all portraits load or are replaced.
  */
 export async function appendCards(container, judokaList, gokyoLookup) {
+  const replacements = [];
   for (const judoka of judokaList) {
     let entry = judoka;
     if (!hasRequiredJudokaFields(judoka)) {
@@ -35,29 +37,37 @@ export async function appendCards(container, judokaList, gokyoLookup) {
     if (card) {
       const img = card.querySelector("img");
       if (img) {
-        // If a portrait fails to load, rebuild the card with fallback judoka
-        // and replace the broken element to maintain consistent content.
-        img.addEventListener(
-          "error",
-          async () => {
-            try {
-              const fallback = await getFallbackJudoka();
-              // Build a replacement card without auto-appending to container.
-              const fallbackCard = await generateJudokaCard(fallback, gokyoLookup);
-              if (fallbackCard) {
-                const parent = container || card.parentElement;
-                if (parent && parent.contains(card)) {
-                  parent.replaceChild(fallbackCard, card);
-                } else if (parent) {
-                  parent.appendChild(fallbackCard);
+        // Create a promise that resolves when the image either loads or is replaced
+        const replacement = new Promise((resolve) => {
+          const cleanup = () => resolve();
+          img.addEventListener("load", cleanup, { once: true });
+          // If a portrait fails to load, rebuild the card with fallback judoka
+          // and replace the broken element to maintain consistent content.
+          img.addEventListener(
+            "error",
+            async () => {
+              try {
+                const fallback = await getFallbackJudoka();
+                // Build a replacement card without auto-appending to container.
+                const fallbackCard = await generateJudokaCard(fallback, gokyoLookup);
+                if (fallbackCard) {
+                  const parent = container || card.parentElement;
+                  if (parent && parent.contains(card)) {
+                    parent.replaceChild(fallbackCard, card);
+                  } else if (parent) {
+                    parent.appendChild(fallbackCard);
+                  }
                 }
+              } catch (err) {
+                console.error("Failed to swap to fallback card", err);
+              } finally {
+                cleanup();
               }
-            } catch (err) {
-              console.error("Failed to swap to fallback card", err);
-            }
-          },
-          { once: true }
-        );
+            },
+            { once: true }
+          );
+        });
+        replacements.push(replacement);
       }
       card.tabIndex = 0;
       card.setAttribute("role", "listitem");
@@ -65,4 +75,5 @@ export async function appendCards(container, judokaList, gokyoLookup) {
       container.appendChild(card);
     }
   }
+  return Promise.all(replacements);
 }

--- a/tests/helpers/appendCards.test.js
+++ b/tests/helpers/appendCards.test.js
@@ -23,12 +23,13 @@ describe("appendCards", () => {
 
     const container = document.createElement("div");
     const judokaList = [{ id: 1, firstname: "Real", surname: "Judoka" }];
-    await appendCards(container, judokaList, {});
+    const replacementPromise = appendCards(container, judokaList, {});
+    await Promise.resolve();
 
     const initialCard = container.firstElementChild;
     const img = initialCard.querySelector("img");
     img.dispatchEvent(new Event("error"));
-    await new Promise((r) => setTimeout(r, 0));
+    await replacementPromise;
 
     expect(getFallbackJudoka).toHaveBeenCalled();
     expect(container.children.length).toBe(1);


### PR DESCRIPTION
## Summary
- collect promises for image load/error replacements in `appendCards`
- wait on returned replacement promise in `appendCards` test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: browse judoka spec and others)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aaed0e56148326a7512ea186fd94d9