### PR TITLE
Return carousel toggle handler

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -24,6 +24,7 @@ let inspectorEnabled = false;
  *    e. Validate `gokyo` data and build the carousel with the valid judoka.
  *    f. Append the carousel to `container`, initialize scroll markers, and reveal it.
  *    g. Log any errors that occur.
+ * 4. Return the click handler for optional manual invocation.
  *
  * @param {HTMLElement} button - Button to show the carousel.
  * @param {HTMLElement} container - Container for the carousel.
@@ -32,10 +33,10 @@ export function setupCarouselToggle(button, container) {
   let isBuilt = false;
   if (!button) {
     console.warn("Show carousel button not found. Skipping carousel initialization.");
-    return;
+    return undefined;
   }
 
-  button.addEventListener("click", async () => {
+  const handleClick = async () => {
     if (isBuilt) {
       container?.classList.remove("hidden");
       return;
@@ -80,7 +81,10 @@ export function setupCarouselToggle(button, container) {
     } catch (error) {
       console.error("Failed to build carousel:", error);
     }
-  });
+  };
+
+  button.addEventListener("click", handleClick);
+  return handleClick;
 }
 
 /**

--- a/tests/helpers/setupCarouselToggle.test.js
+++ b/tests/helpers/setupCarouselToggle.test.js
@@ -8,10 +8,6 @@ function createCarousel() {
   return wrapper;
 }
 
-async function flush() {
-  return await new Promise((resolve) => setTimeout(resolve, 0));
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
@@ -41,15 +37,13 @@ describe("setupCarouselToggle", () => {
 
     const { setupCarouselToggle } = await import("../../src/game.js");
 
-    setupCarouselToggle(button, container);
+    const handleClick = setupCarouselToggle(button, container);
 
-    button.dispatchEvent(new Event("click"));
-    await flush();
+    await handleClick();
 
     expect(buildCardCarousel).toHaveBeenCalledTimes(1);
 
-    button.dispatchEvent(new Event("click"));
-    await flush();
+    await handleClick();
 
     expect(buildCardCarousel).toHaveBeenCalledTimes(1);
   });
@@ -86,10 +80,9 @@ describe("setupCarouselToggle", () => {
 
     const { setupCarouselToggle } = await import("../../src/game.js");
 
-    setupCarouselToggle(button, container);
+    const handleClick = setupCarouselToggle(button, container);
 
-    button.dispatchEvent(new Event("click"));
-    await flush();
+    await handleClick();
 
     expect(buildCardCarousel).toHaveBeenCalledWith([valid], []);
     expect(container.classList.contains("hidden")).toBe(false);
@@ -118,16 +111,14 @@ describe("setupCarouselToggle", () => {
 
     const { setupCarouselToggle } = await import("../../src/game.js");
 
-    setupCarouselToggle(button, null);
+    const handleClick = setupCarouselToggle(button, null);
 
-    button.dispatchEvent(new Event("click"));
-    await flush();
+    await handleClick();
 
     expect(consoleError).toHaveBeenCalledTimes(1);
     expect(buildCardCarousel).not.toHaveBeenCalled();
 
-    button.dispatchEvent(new Event("click"));
-    await flush();
+    await handleClick();
 
     expect(consoleError).toHaveBeenCalledTimes(2);
     expect(buildCardCarousel).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Have `setupCarouselToggle` return its async click handler so build progress can be awaited directly
- Simplify carousel toggle tests by invoking the returned handler instead of dispatching events

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aaed05f0208326951bd09269285606