### PR TITLE
feat: add onStateTransition hook for battle machine

### DIFF
--- a/playwright/fixtures/waits.js
+++ b/playwright/fixtures/waits.js
@@ -44,9 +44,9 @@ export async function waitForStatButtonsReady(page, timeout = 10000) {
  * @param {number} [timeout=10000]
  */
 export async function waitForBattleState(page, stateName, timeout = 10000) {
-  const hasHelper = await page.evaluate(() => typeof window.waitForBattleState === "function");
+  const hasHelper = await page.evaluate(() => typeof window.onStateTransition === "function");
   if (hasHelper) {
-    await page.evaluate((s, t) => window.waitForBattleState(s, t), stateName, timeout);
+    await page.evaluate((s, t) => window.onStateTransition(s, t), stateName, timeout);
     return;
   }
   await page.waitForFunction((s) => window.__classicBattleState === s, stateName, { timeout });

--- a/tests/helpers/classicBattle/battleStateBadge.test.js
+++ b/tests/helpers/classicBattle/battleStateBadge.test.js
@@ -92,11 +92,11 @@ describe("battleStateBadge displays state transitions", () => {
     });
     badgeObserver.observe(badge, { childList: true });
 
-    const { dispatchBattleEvent } = await import(
+    const { dispatchBattleEvent, onStateTransition } = await import(
       "../../../src/helpers/classicBattle/orchestrator.js"
     );
     await dispatchBattleEvent("startClicked");
-    await window.waitForBattleState("waitingForPlayerAction");
+    await onStateTransition("waitingForPlayerAction");
 
     badgeObserver.disconnect();
 


### PR DESCRIPTION
## Summary
- provide `onStateTransition` promise helper for Classic Battle state changes
- update test utilities and battle state badge test to use the new hook

## Testing
- `npx prettier src/helpers/classicBattle/orchestrator.js tests/helpers/classicBattle/battleStateBadge.test.js playwright/fixtures/waits.js --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatches and network-related errors)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aaed004ed48326a4536b611bb24caf