### PR TITLE
refactor: expose loadNextCountryBatch

### DIFF
--- a/tests/helpers/populateCountryList.test.js
+++ b/tests/helpers/populateCountryList.test.js
@@ -121,7 +121,9 @@ describe("populateCountryList", () => {
     }
     loadCountryMapping.mockResolvedValue(mapping);
 
-    const { populateCountryList } = await import("../../src/helpers/country/list.js");
+    const { populateCountryList, loadNextCountryBatch } = await import(
+      "../../src/helpers/country/list.js"
+    );
 
     const track = document.createElement("div");
     const scrollContainer = document.createElement("div");
@@ -135,9 +137,7 @@ describe("populateCountryList", () => {
 
     expect(track.querySelectorAll(".slide").length).toBe(51);
 
-    scrollContainer.scrollTop = 200;
-    scrollContainer.dispatchEvent(new Event("scroll"));
-    await new Promise((r) => setTimeout(r, 0));
+    await loadNextCountryBatch(track);
 
     expect(track.querySelectorAll(".slide").length).toBe(61);
   });


### PR DESCRIPTION
## Summary
- export loadNextCountryBatch to share batching logic
- call loadNextCountryBatch in populateCountryList scroll handler
- test country list batching without scroll events

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b4a6488832691d6661d7b475117