### PR TITLE
feat: inject quitMatch for quit button

### DIFF
--- a/src/helpers/classicBattle/quitButton.js
+++ b/src/helpers/classicBattle/quitButton.js
@@ -3,17 +3,18 @@
  *
  * @pseudocode
  * 1. Locate `#quit-match-button` and exit if missing.
- * 2. Add a click handler that dynamically imports `quitMatch`.
+ * 2. Add a click handler that obtains `quitMatch` from deps or via dynamic import.
  * 3. Invoke `quitMatch` with the provided store and button.
  *
  * @param {ReturnType<import('./roundManager.js').createBattleStore>} store - Battle state store.
+ * @param {{quitMatch?: typeof import('./quitModal.js').quitMatch}} [deps]
  * @returns {void}
  */
-export function initQuitButton(store) {
+export function initQuitButton(store, { quitMatch: injectedQuitMatch } = {}) {
   const quitBtn = document.getElementById("quit-match-button");
   if (!quitBtn) return;
   quitBtn.addEventListener("click", async () => {
-    const { quitMatch } = await import("./quitModal.js");
+    const quitMatch = injectedQuitMatch ?? (await import("./quitModal.js")).quitMatch;
     quitMatch(store, quitBtn);
   });
 }

--- a/tests/helpers/classicBattle/matchControls.test.js
+++ b/tests/helpers/classicBattle/matchControls.test.js
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createRoundMessage, createTimerNodes } from "./domUtils.js";
 
+const mockQuitMatch = () => {
+  const msg = document.getElementById("round-message");
+  if (msg) msg.textContent = "quit";
+  window.location.href = "http://localhost/index.html";
+};
+
 vi.mock("../../../src/helpers/classicBattle/quitModal.js", () => ({
-  quitMatch: () => {
-    const msg = document.getElementById("round-message");
-    if (msg) msg.textContent = "quit";
-    window.location.href = "http://localhost/index.html";
-  }
+  quitMatch: mockQuitMatch
 }));
 
 describe("classicBattle match controls", () => {
@@ -61,9 +63,8 @@ describe("classicBattle match controls", () => {
     );
     const { initQuitButton } = await import("../../../src/helpers/classicBattle/quitButton.js");
     window.battleStore = createBattleStore();
-    initQuitButton(window.battleStore);
+    initQuitButton(window.battleStore, { quitMatch: mockQuitMatch });
     document.getElementById("quit-match-button").click();
-    await new Promise((r) => setTimeout(r, 0));
     expect(document.getElementById("round-message").textContent).toBe("quit");
     expect(window.location.href).toBe("http://localhost/index.html");
   });


### PR DESCRIPTION
## Summary
- allow classic battle quit button to inject a quitMatch dependency for tests
- adjust match controls test to use synchronous quitMatch mock

## Testing
- `npx prettier src/helpers/classicBattle/quitButton.js tests/helpers/classicBattle/matchControls.test.js --check`
- `npx eslint .` *(fails: warnings for unused directives and variables)*
- `npx vitest run`
- `npx playwright test` *(fails: network errors and timeouts)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b4460f08326af5a1be2afcb5757