### PR TITLE
feat: signal homepage readiness

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,7 @@
           </ul>
         </nav>
       </footer>
+      <script type="module" src="./src/helpers/homePage.js"></script>
       <script type="module" src="./src/helpers/setupBottomNavbar.js"></script>
       <script type="module" src="./src/helpers/setupHoverZoom.js"></script>
       <script type="module" src="./src/helpers/setupDisplaySettings.js"></script>

--- a/playwright/homepage-layout.spec.js
+++ b/playwright/homepage-layout.spec.js
@@ -8,7 +8,7 @@ test.describe.parallel("Homepage layout", () => {
 
     test.beforeEach(async ({ page }) => {
       await page.goto("/index.html");
-      await page.waitForSelector(".game-mode-grid");
+      await page.evaluate(() => window.homepageReadyPromise);
       await page.evaluate(() => window.navReadyPromise);
     });
 
@@ -57,7 +57,7 @@ test.describe.parallel("Homepage layout", () => {
 
     test.beforeEach(async ({ page }) => {
       await page.goto("/index.html");
-      await page.waitForSelector(".game-mode-grid");
+      await page.evaluate(() => window.homepageReadyPromise);
       await page.evaluate(() => window.navReadyPromise);
     });
 

--- a/src/helpers/homePage.js
+++ b/src/helpers/homePage.js
@@ -1,0 +1,34 @@
+let resolveHomepageReady;
+
+/**
+ * Resolve when the homepage grid is available.
+ *
+ * @type {Promise<void>}
+ */
+export const homepageReadyPromise =
+  typeof window !== "undefined"
+    ? new Promise((resolve) => {
+        resolveHomepageReady = resolve;
+      })
+    : Promise.resolve();
+
+if (typeof window !== "undefined") {
+  window.homepageReadyPromise = homepageReadyPromise;
+}
+
+if (typeof document !== "undefined") {
+  if (document.querySelector(".game-mode-grid")) {
+    resolveHomepageReady?.();
+  } else {
+    const observer = new MutationObserver(() => {
+      if (document.querySelector(".game-mode-grid")) {
+        observer.disconnect();
+        resolveHomepageReady?.();
+      }
+    });
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add `homepageReadyPromise` that resolves when `.game-mode-grid` is present
- load homepage helper on index.html
- await readiness promise in Playwright homepage layout tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab14a7cd0483268f779c7bb55343b7