### PR TITLE
Resolve stat button readiness via global promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ npx playwright test
 - Test helper shortcuts are available in `playwright/fixtures/waits.js`:
   - `await waitForBattleReady(page)` and `await waitForSettingsReady(page)`.
   - `await waitForBattleState(page, "waitingForPlayerAction", 10000)` for machine state assertions.
-  - `await waitForStatButtonsReady(page)` to wait until stat buttons are re-enabled for a round.
+  - `await page.evaluate(() => window.statButtonsReadyPromise)` to wait until stat buttons are re-enabled for a round.
 - Avoid waiting for brittle UI states like the header timer element (`#next-round-timer`) to be visible at page load. The initial pre‑match countdown is rendered via snackbar, not the header timer, and may be empty initially.
 - When targeting round start readiness, it’s fine to wait for the selection prompt snackbar (e.g., “Select your move”) or `#stat-buttons[data-buttons-ready="true"]`.
 

--- a/playwright/fixtures/waits.js
+++ b/playwright/fixtures/waits.js
@@ -4,7 +4,6 @@
  * @pseudocode
  * - waitForBattleReady: resolves when Classic Battle has initialized (battleReadyPromise).
  * - waitForSettingsReady: resolves when Settings page has initialized (settingsReadyPromise).
- * - waitForStatButtonsReady: waits for #stat-buttons and data flag.
  */
 
 /**
@@ -21,19 +20,6 @@ export async function waitForBattleReady(page) {
  */
 export async function waitForSettingsReady(page) {
   await page.evaluate(() => window.settingsReadyPromise);
-}
-
-/**
- * Wait for stat buttons to be attached and marked ready.
- * @param {import('@playwright/test').Page} page
- * @param {number} [timeout=10000]
- */
-export async function waitForStatButtonsReady(page, timeout = 10000) {
-  await page.waitForSelector("#stat-buttons", { timeout });
-  await page.waitForFunction(
-    () => document.querySelector("#stat-buttons")?.dataset?.buttonsReady === "true",
-    { timeout }
-  );
 }
 
 /**

--- a/playwright/statReset.spec.js
+++ b/playwright/statReset.spec.js
@@ -1,9 +1,5 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import {
-  waitForBattleReady,
-  waitForBattleState,
-  waitForStatButtonsReady
-} from "./fixtures/waits.js";
+import { waitForBattleReady, waitForBattleState } from "./fixtures/waits.js";
 
 /**
  * Verify stat buttons are cleared after the next round begins.
@@ -34,7 +30,7 @@ test.describe.parallel("Classic battle button reset", () => {
     // Also wait for the selection prompt that signifies the next round started
     await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
     // Wait for stat buttons to be fully re-enabled for the new round
-    await waitForStatButtonsReady(page);
+    await page.evaluate(() => window.statButtonsReadyPromise);
     // Re-query the button to avoid any stale handle if DOM updated
     const btn = page.locator("#stat-buttons button[data-stat='power']");
     // After round reset, ensure the element is attached before style reads

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -424,15 +424,22 @@ export function setupNextButton() {
  *
  * @pseudocode
  * 1. Gather all stat buttons inside `#stat-buttons`.
- * 2. Define `setEnabled` to toggle disabled state and tabindex.
- * 3. On click or Enter/Space, disable all buttons and handle selection.
- * 4. Return controls to enable/disable the group.
+ * 2. Define `setEnabled` to toggle disabled state, tabindex and `data-buttons-ready`.
+ * 3. Resolve `window.statButtonsReadyPromise` when buttons are enabled; reset when disabled.
+ * 4. On click or Enter/Space, disable all buttons and handle selection.
+ * 5. Return controls to enable/disable the group.
  *
  * @param {ReturnType<typeof import('./roundManager.js').createBattleStore>} store - Battle store.
  */
 export function initStatButtons(store) {
   const statButtons = document.querySelectorAll("#stat-buttons button");
   const statContainer = document.getElementById("stat-buttons");
+  let resolveReady;
+  const resetReadyPromise = () => {
+    window.statButtonsReadyPromise = new Promise((r) => {
+      resolveReady = r;
+    });
+  };
 
   function setEnabled(enable = true) {
     statButtons.forEach((btn) => {
@@ -443,9 +450,15 @@ export function initStatButtons(store) {
     if (statContainer) {
       statContainer.dataset.buttonsReady = String(enable);
     }
+    if (enable) {
+      resolveReady?.();
+    } else {
+      resetReadyPromise();
+    }
   }
 
   // Start disabled until the game enters the player action state
+  resetReadyPromise();
   setEnabled(false);
 
   statButtons.forEach((btn) => {


### PR DESCRIPTION
## Summary
- resolve `window.statButtonsReadyPromise` when stat buttons become active again
- remove unused `waitForStatButtonsReady` helper and await the global promise in reset test
- document new readiness wait

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: missing snapshots, timeouts)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab14a3e8f08326b4d03ff895e4ea0f