### PR TITLE
feat(battle): add lifecycle promises

### DIFF
--- a/playwright/battle-state-progress.spec.js
+++ b/playwright/battle-state-progress.spec.js
@@ -16,7 +16,7 @@ test.describe.parallel("Battle state progress", () => {
       .filter((s) => s.id < 90)
       .sort((a, b) => a.id - b.id)
       .map((s) => String(s.id));
-    await page.waitForSelector("#battle-state-progress li");
+    await page.evaluate(() => window.roundOptionsReadyPromise);
     const ids = await page.$$eval("#battle-state-progress li", (lis) =>
       lis.map((li) => li.textContent.trim())
     );

--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -21,11 +21,12 @@ test.describe.parallel("Classic battle flow", () => {
 
   test("shows countdown before first round", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
+    await page.evaluate(() => window.roundOptionsReadyPromise);
     const roundOptions = page.locator(".round-select-buttons button");
-    await roundOptions.first().waitFor();
     await expect(roundOptions).toHaveText(rounds.map((r) => r.label));
     await roundOptions.first().click();
     await expect(page.locator(".modal-backdrop:not([hidden])")).toHaveCount(0);
+    await page.evaluate(() => window.nextRoundTimerReadyPromise);
     const snackbar = page.locator(".snackbar");
     await expect(snackbar).toHaveText(/Next round in: \d+s/);
     await page.evaluate(() => window.freezeBattleHeader?.());
@@ -35,13 +36,14 @@ test.describe.parallel("Classic battle flow", () => {
 
   test("timer auto-selects when expired", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
+    await page.evaluate(() => window.roundPromptPromise);
     const countdown = page.locator("header #next-round-timer");
-    await countdown.waitFor();
     await expect(countdown).toHaveText(/\d+/);
     await page.evaluate(() => window.skipBattlePhase?.());
     await page.evaluate(() => window.freezeBattleHeader?.());
     const result = page.locator("header #round-message");
     await expect(result).not.toHaveText("");
+    await page.evaluate(() => window.nextRoundTimerReadyPromise);
     const snackbar = page.locator(".snackbar");
     await expect(snackbar).toHaveText(/Next round in: \d+s/);
   });
@@ -50,8 +52,8 @@ test.describe.parallel("Classic battle flow", () => {
     await page.goto("/src/pages/battleJudoka.html");
     await page.evaluate(() => window.skipBattlePhase?.());
     await page.evaluate(() => window.freezeBattleHeader?.());
+    await page.evaluate(() => window.roundPromptPromise);
     const timer = page.locator("header #next-round-timer");
-    await timer.waitFor();
     await page.evaluate(_resetForTest);
     await page.evaluate(setTieRound);
     await page.locator("button[data-stat='power']").click();
@@ -59,13 +61,14 @@ test.describe.parallel("Classic battle flow", () => {
     await expect(snackbar).toHaveText("You Picked: Power");
     const msg = page.locator("header #round-message");
     await expect(msg).toHaveText(/Tie/);
+    await page.evaluate(() => window.nextRoundTimerReadyPromise);
     await expect(snackbar).toHaveText(/Next round in: \d+s/);
   });
 
   test("quit match confirmation", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
+    await page.evaluate(() => window.roundOptionsReadyPromise);
     const roundOptions = page.locator(".round-select-buttons button");
-    await roundOptions.first().waitFor();
     await roundOptions.first().click();
     await expect(page.locator(".modal-backdrop:not([hidden])")).toHaveCount(0);
     await waitForBattleReady(page);
@@ -86,7 +89,7 @@ test.describe.parallel("Classic battle flow", () => {
     await waitForSettingsReady(page);
     await page.goBack();
     await expect(page).toHaveURL(/battleJudoka.html/);
-    await page.waitForFunction(() => window.__classicBattleState === "matchOver");
+    await page.evaluate(() => window.matchOverPromise);
     await expect(page.locator("header #next-round-timer")).toHaveText("");
   });
 });

--- a/playwright/statReset.spec.js
+++ b/playwright/statReset.spec.js
@@ -12,18 +12,18 @@ test.describe.parallel("Classic battle button reset", () => {
   test("no button stays selected after next round", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
     await waitForBattleReady(page);
-    await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
+    await page.evaluate(() => window.roundPromptPromise);
     await page.locator("#stat-buttons button[data-stat='power']").click();
     await page.locator("#next-button").click();
     await page.evaluate(() => window.skipBattlePhase?.());
-    await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
+    await page.evaluate(() => window.roundPromptPromise);
     await expect(page.locator("#stat-buttons .selected")).toHaveCount(0);
   });
 
   test("tap highlight color cleared after reset", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
     await waitForBattleReady(page);
-    await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
+    await page.evaluate(() => window.roundPromptPromise);
     // Select a stat, then advance to the next round
     const initialBtn = page.locator("#stat-buttons button[data-stat='power']");
     await initialBtn.click();
@@ -32,7 +32,7 @@ test.describe.parallel("Classic battle button reset", () => {
     // Wait until the state machine reports the new round is awaiting input
     await waitForBattleState(page, "waitingForPlayerAction", 15000);
     // Also wait for the selection prompt that signifies the next round started
-    await page.locator(".snackbar").filter({ hasText: "Select your move" }).waitFor();
+    await page.evaluate(() => window.roundPromptPromise);
     // Wait for stat buttons to be fully re-enabled for the new round
     await waitForStatButtonsReady(page);
     // Re-query the button to avoid any stale handle if DOM updated

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -12,3 +12,9 @@ export { getOpponentJudoka } from "./classicBattle/cardSelection.js";
 export { scheduleNextRound } from "./classicBattle/timerService.js";
 export { applyRoundUI } from "./classicBattle/roundUI.js";
 export { getOpponentCardData } from "./classicBattle/opponentController.js";
+export {
+  roundOptionsReadyPromise,
+  roundPromptPromise,
+  nextRoundTimerReadyPromise,
+  matchOverPromise
+} from "./classicBattle/promises.js";

--- a/src/helpers/classicBattle/bootstrap.js
+++ b/src/helpers/classicBattle/bootstrap.js
@@ -1,6 +1,7 @@
 import { onDomReady } from "../domReady.js";
 import ClassicBattleController from "./controller.js";
 import ClassicBattleView from "./view.js";
+import "./promises.js";
 
 /**
  * Bootstrap Classic Battle page by wiring controller and view.

--- a/src/helpers/classicBattle/promises.js
+++ b/src/helpers/classicBattle/promises.js
@@ -1,0 +1,44 @@
+import { onBattleEvent } from "./battleEvents.js";
+
+/**
+ * Create a self-resetting promise tied to a battle event.
+ *
+ * @pseudocode
+ * 1. Define a `reset` function that assigns a new Promise and exposes it on `window`.
+ * 2. Resolve the current promise when the specified event fires.
+ * 3. After resolving, call `reset()` to prepare for the next event.
+ *
+ * @param {string} key - Global name for the promise.
+ * @param {string} eventName - Battle event to listen for.
+ * @returns {() => Promise<void>} Function returning the current promise.
+ */
+function setupPromise(key, eventName) {
+  let resolve;
+  function reset() {
+    const p = new Promise((r) => {
+      resolve = r;
+    });
+    if (typeof window !== "undefined") {
+      window[key] = p;
+    }
+    return p;
+  }
+  let promise = reset();
+  onBattleEvent(eventName, () => {
+    resolve();
+    promise = reset();
+  });
+  return () => promise;
+}
+
+export let roundOptionsReadyPromise;
+export let roundPromptPromise;
+export let nextRoundTimerReadyPromise;
+export let matchOverPromise;
+
+(() => {
+  roundOptionsReadyPromise = setupPromise("roundOptionsReadyPromise", "roundOptionsReady")();
+  roundPromptPromise = setupPromise("roundPromptPromise", "roundPrompt")();
+  nextRoundTimerReadyPromise = setupPromise("nextRoundTimerReadyPromise", "nextRoundTimerReady")();
+  matchOverPromise = setupPromise("matchOverPromise", "matchOver")();
+})();

--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -5,6 +5,7 @@ import { createModal } from "../../components/Modal.js";
 import { setPointsToWin } from "../battleEngineFacade.js";
 import { initTooltips } from "../tooltip.js";
 import { isTestModeEnabled } from "../testModeUtils.js";
+import { emitBattleEvent } from "./battleEvents.js";
 
 /**
  * Initialize round selection modal for Classic Battle.
@@ -102,4 +103,5 @@ export async function initRoundSelectModal(onStart) {
     console.error("Failed to initialize tooltips:", err);
   }
   modal.open();
+  emitBattleEvent("roundOptionsReady");
 }

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -6,7 +6,7 @@ import * as scoreboard from "../setupScoreboard.js";
 import { handleStatSelection } from "./selectionHandler.js";
 import { showMatchSummaryModal } from "./uiService.js";
 import { handleReplay } from "./roundManager.js";
-import { onBattleEvent } from "./battleEvents.js";
+import { onBattleEvent, emitBattleEvent } from "./battleEvents.js";
 
 /**
  * Apply UI updates for a newly started round.
@@ -58,6 +58,7 @@ onBattleEvent("roundResolved", (e) => {
     showMatchSummaryModal(result, async () => {
       await handleReplay(store);
     });
+    emitBattleEvent("matchOver");
   }
   resetStatButtons();
   updateDebugPanel();

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -5,6 +5,7 @@ import { updateDebugPanel } from "./uiHelpers.js";
 import * as snackbar from "../showSnackbar.js";
 import { setSkipHandler } from "./skipHandler.js";
 import { autoSelectStat } from "./autoSelectStat.js";
+import { emitBattleEvent } from "./battleEvents.js";
 
 let nextRoundTimer = null;
 let nextRoundReadyResolve = null;
@@ -231,6 +232,7 @@ export function scheduleNextRound(result) {
   return new Promise((resolve) => {
     if (result.matchEnded) {
       setSkipHandler(null);
+      emitBattleEvent("nextRoundTimerReady");
       resolve();
       return;
     }
@@ -248,6 +250,7 @@ export function scheduleNextRound(result) {
     const cooldownSeconds = Math.max(0, Math.round(overrideMs / 1000));
 
     nextRoundReadyResolve = () => {
+      emitBattleEvent("nextRoundTimerReady");
       resolve();
       nextRoundReadyResolve = null;
     };

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -17,7 +17,7 @@ import { toggleInspectorPanels } from "../cardUtils.js";
 import { createModal } from "../../components/Modal.js";
 import { createButton } from "../../components/Button.js";
 import { syncScoreDisplay } from "./uiService.js";
-import { onBattleEvent } from "./battleEvents.js";
+import { onBattleEvent, emitBattleEvent } from "./battleEvents.js";
 
 function getDebugOutputEl() {
   return document.getElementById("debug-output");
@@ -68,6 +68,7 @@ export function showSelectionPrompt() {
     el.textContent = "";
   }
   snackbar.showSnackbar("Select your move");
+  emitBattleEvent("roundPrompt");
 }
 
 /**


### PR DESCRIPTION
## Summary
- expose round lifecycle promises for options, prompt, timer and match end
- wait on lifecycle promises in Playwright battle specs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab149b4fc48326958ec12e2ad0c1dd