### PR TITLE
test: await broken icon insertion in homepage fallback test

### DIFF
--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -76,19 +76,22 @@ test.describe.parallel("Homepage", () => {
 
   test("fallback icon applied on load failure", async ({ page }) => {
     await page.addInitScript(() => {
-      document.addEventListener("DOMContentLoaded", () => {
-        const img = document.createElement("img");
-        img.id = "broken-icon";
-        img.src = "./missing-icon.svg";
-        img.alt = "Broken icon";
-        document.body.appendChild(img);
+      window.brokenIconInsertedPromise = new Promise((resolve) => {
+        document.addEventListener("DOMContentLoaded", () => {
+          const img = document.createElement("img");
+          img.id = "broken-icon";
+          img.src = "./missing-icon.svg";
+          img.alt = "Broken icon";
+          document.body.appendChild(img);
+          resolve();
+        });
       });
     });
 
     await page.goto("/index.html");
+    await page.evaluate(() => window.brokenIconInsertedPromise);
 
     const icon = page.locator("#broken-icon");
-    await icon.waitFor();
     await expect.poll(() => icon.getAttribute("src")).toContain("judokonLogoSmall.png");
     await expect(icon).toHaveClass(/svg-fallback/);
   });


### PR DESCRIPTION
## Summary
- Resolve `brokenIconInsertedPromise` when the broken image is appended on the homepage
- Wait for this promise before asserting fallback `src` and class

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: 11 failed, 2 interrupted, 84 skipped)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab28d4b8dc8326be4c1043e2f2ad11