### PR TITLE
chore: await nav ready in update tests

### DIFF
--- a/playwright/updateJudoka.spec.js
+++ b/playwright/updateJudoka.spec.js
@@ -11,6 +11,7 @@ test.describe.parallel("Update Judoka page", () => {
       route.fulfill({ path: "tests/fixtures/navigationItems.json" })
     );
     await page.goto("/src/pages/updateJudoka.html");
+    await page.evaluate(() => window.navReadyPromise);
   });
 
   test("page loads", async ({ page }) => {
@@ -18,15 +19,11 @@ test.describe.parallel("Update Judoka page", () => {
   });
 
   test("navigation links work", async ({ page }) => {
-    const randomLink = page.getByTestId(NAV_RANDOM_JUDOKA);
-    await randomLink.waitFor();
-    await randomLink.click();
+    await page.getByTestId(NAV_RANDOM_JUDOKA).click();
     await expect(page).toHaveURL(/randomJudoka\.html/);
     await page.goBack({ waitUntil: "load" });
-
-    const battleLink = page.getByTestId(NAV_CLASSIC_BATTLE);
-    await battleLink.waitFor();
-    await battleLink.click();
+    await page.evaluate(() => window.navReadyPromise);
+    await page.getByTestId(NAV_CLASSIC_BATTLE).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
 });

--- a/src/pages/updateJudoka.html
+++ b/src/pages/updateJudoka.html
@@ -55,7 +55,8 @@
         <li><a href="./settings.html" data-testid="nav-13">Settings</a></li>
       </ul>
     </nav>
-    <!-- Ensure setupBottomNavbar.js is loaded -->
+    <!-- Ensure navigation helper and bottom navbar scripts are loaded -->
+    <script type="module" src="../helpers/navigationBar.js"></script>
     <script type="module" src="../helpers/setupBottomNavbar.js"></script>
     <script type="module" src="../helpers/setupDisplaySettings.js"></script>
 


### PR DESCRIPTION
## Summary
- load navigation helper on updateJudoka page so `navReadyPromise` is available
- wait on `window.navReadyPromise` in Playwright tests instead of link-specific waits

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (errors: TypeError: globalThis.dispatchEvent is not a function)
- `npx playwright test` *(interrupted: 2 tests did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab28cf6b408326a1dc5fa845308db3