### PR TITLE
Resolve signature move readiness with global promise

### DIFF
--- a/playwright/signatureMove.spec.js
+++ b/playwright/signatureMove.spec.js
@@ -10,15 +10,15 @@ test.describe.parallel(
     test("random judoka page", async ({ page }) => {
       await page.goto("/src/pages/randomJudoka.html");
       await page.getByTestId("draw-button").click();
+      await page.evaluate(() => window.signatureMoveReadyPromise);
       const sigMove = page.locator(".signature-move-container");
-      await sigMove.waitFor();
       await expect(sigMove).toHaveScreenshot("randomJudoka-signature.png");
     });
 
     test("browse judoka page", async ({ page }) => {
       await page.goto("/src/pages/browseJudoka.html");
+      await page.evaluate(() => window.signatureMoveReadyPromise);
       const sigMove = page.locator(".signature-move-container").first();
-      await sigMove.waitFor();
       await expect(sigMove).toHaveScreenshot("browseJudoka-signature.png");
     });
   }

--- a/src/helpers/cardBuilder.js
+++ b/src/helpers/cardBuilder.js
@@ -4,6 +4,7 @@ import { getMissingJudokaFields, hasRequiredJudokaFields } from "./judokaValidat
 import { enableCardFlip } from "./cardFlip.js";
 import { cardSectionRegistry } from "./cardSections.js";
 import { createInspectorPanel } from "./inspector/createInspectorPanel.js";
+import { markSignatureMoveReady } from "./signatureMove.js";
 
 /**
  * Generates the "last updated" HTML for a judoka card.
@@ -132,6 +133,9 @@ export async function generateJudokaCard(judoka, gokyoLookup, container, options
   );
   if (card) {
     container.appendChild(card);
+    if (card.querySelector(".signature-move-container")) {
+      markSignatureMoveReady();
+    }
   }
   return card;
 }

--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -6,6 +6,7 @@ import { DATA_DIR } from "./constants.js";
 import { getFallbackJudoka } from "./judokaUtils.js";
 import { JudokaCard } from "../components/JudokaCard.js";
 import { setupLazyPortraits } from "./lazyPortrait.js";
+import { markSignatureMoveReady } from "./signatureMove.js";
 
 /**
  * Replaces the contents of an element with the given card and animates it.
@@ -23,6 +24,9 @@ export function displayCard(element, card, skipAnimation = false) {
   if (!element || !card) return;
   element.innerHTML = "";
   element.appendChild(card);
+  if (card.querySelector(".signature-move-container")) {
+    markSignatureMoveReady();
+  }
   setupLazyPortraits(card);
   if (!skipAnimation) {
     requestAnimationFrame(() => {

--- a/src/helpers/signatureMove.js
+++ b/src/helpers/signatureMove.js
@@ -1,0 +1,25 @@
+/**
+ * Promise and helpers to signal when signature moves finish rendering.
+ *
+ * @pseudocode
+ * 1. Create a promise and store its resolver in `resolveReady`.
+ * 2. Expose the promise on `window.signatureMoveReadyPromise`.
+ * 3. Export `markSignatureMoveReady` to invoke the resolver.
+ */
+let resolveReady;
+export const signatureMoveReadyPromise = new Promise((resolve) => {
+  resolveReady = resolve;
+});
+if (typeof window !== "undefined") {
+  window.signatureMoveReadyPromise = signatureMoveReadyPromise;
+}
+
+/**
+ * Resolve the ready promise when signature moves render.
+ *
+ * @pseudocode
+ * 1. If a resolver exists, invoke it.
+ */
+export function markSignatureMoveReady() {
+  resolveReady?.();
+}


### PR DESCRIPTION
## Summary
- Expose `signatureMoveReadyPromise` globally and resolve it when signature moves render
- Trigger promise resolution from card rendering helpers
- Await readiness promise in Playwright signature move tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68ab28c3b9bc83269cde2afee1123602