### PR TITLE
refactor: replace fetchJson console log with debug logger

### DIFF
--- a/src/helpers/dataUtils.js
+++ b/src/helpers/dataUtils.js
@@ -215,7 +215,7 @@ export async function validateAndCache(url, data, schema) {
  * @throws {Error} If the fetch request fails, validation fails, or JSON parsing fails.
  */
 export async function fetchJson(url, schema) {
-  console.log(`DEBUG: fetchJson called with URL: ${url}`); // Added console.log
+  debugLog(`fetchJson called with URL: ${url}`);
   const key = String(url);
   try {
     if (dataCache.has(key)) {


### PR DESCRIPTION
## Summary
- replace noisy console.log in fetchJson with debugLog

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `DEBUG_LOGGING=false npx vitest run`
- `npx playwright test` (fails: filter panel toggles & other cases)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab4b2acd348326af04066ceb15f4cb