### PR TITLE
feat: add scheduler interface for countdown timers

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -6,6 +6,7 @@ import * as snackbar from "../showSnackbar.js";
 import { setSkipHandler } from "./skipHandler.js";
 import { autoSelectStat } from "./autoSelectStat.js";
 import { emitBattleEvent } from "./battleEvents.js";
+import { realScheduler } from "../scheduler.js";
 
 let nextRoundTimer = null;
 let nextRoundReadyResolve = null;
@@ -169,9 +170,14 @@ export async function startTimer(onExpiredSelect) {
  * - Callback to handle stat selection.
  * @param {number} [timeoutMs=5000] - Delay before auto-selecting.
  */
-export function handleStatSelectionTimeout(store, onSelect, timeoutMs = 5000) {
+export function handleStatSelectionTimeout(
+  store,
+  onSelect,
+  timeoutMs = 5000,
+  scheduler = realScheduler
+) {
   scoreboard.showMessage("Stat selection stalled. Pick a stat or wait for auto-pick.");
-  store.autoSelectId = setTimeout(() => {
+  store.autoSelectId = scheduler.setTimeout(() => {
     autoSelectStat(onSelect);
   }, timeoutMs);
 }
@@ -228,7 +234,7 @@ export function createRoundTimer(onTick, onExpired) {
  * @param {{matchEnded: boolean}} result - Result from a completed round.
  * @returns {Promise<void>} Resolves after dispatching "ready".
  */
-export function scheduleNextRound(result) {
+export function scheduleNextRound(result, scheduler = realScheduler) {
   return new Promise((resolve) => {
     if (result.matchEnded) {
       setSkipHandler(null);
@@ -309,6 +315,6 @@ export function scheduleNextRound(result) {
     }
 
     onTick(cooldownSeconds);
-    setTimeout(() => nextRoundTimer.start(cooldownSeconds), 0);
+    scheduler.setTimeout(() => nextRoundTimer.start(cooldownSeconds), 0);
   });
 }

--- a/src/helpers/scheduler.js
+++ b/src/helpers/scheduler.js
@@ -1,0 +1,4 @@
+export const realScheduler = {
+  setTimeout: (cb, ms) => setTimeout(cb, ms),
+  clearTimeout: (id) => clearTimeout(id)
+};

--- a/src/helpers/setupScoreboard.js
+++ b/src/helpers/setupScoreboard.js
@@ -10,6 +10,7 @@ import {
   updateRoundCounter,
   clearRoundCounter
 } from "../components/Scoreboard.js";
+import { realScheduler } from "./scheduler.js";
 
 /**
  * Locate the page header and initialize scoreboard element references.
@@ -19,14 +20,16 @@ import {
  * 2. Pass the header and timer controls to `initScoreboard()` so the module can query its children.
  *
  * @param {object} controls - Timer control callbacks.
+ * @param {object} [scheduler=realScheduler] - Timer scheduler.
  */
-function setupScoreboard(controls) {
+function setupScoreboard(controls, scheduler = realScheduler) {
   const header = document.querySelector("header");
+  const withScheduler = { ...controls, scheduler };
   if (!header) {
-    initScoreboard(null, controls);
+    initScoreboard(null, withScheduler);
     return;
   }
-  initScoreboard(header, controls);
+  initScoreboard(header, withScheduler);
 }
 export {
   setupScoreboard,

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { createTimerNodes } from "./domUtils.js";
+import { createMockScheduler } from "../mockScheduler.js";
 
 describe("timerService drift handling", () => {
   it("startTimer shows fallback on drift", async () => {
@@ -51,10 +52,10 @@ describe("timerService drift handling", () => {
       return { ...actual, startCoolDown };
     });
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
-    const timer = vi.useFakeTimers();
+    const scheduler = createMockScheduler();
     createTimerNodes();
-    mod.scheduleNextRound({ matchEnded: false });
-    timer.advanceTimersByTime(2000);
+    mod.scheduleNextRound({ matchEnded: false }, scheduler);
+    scheduler.tick(0);
     onDrift(1);
     // Cooldown drift displays a non-intrusive fallback; may use snackbar
     // when a round result message is present. Accept scoreboard fallback too.
@@ -66,6 +67,5 @@ describe("timerService drift handling", () => {
     onDrift(1);
     const usedSnackbar = showSnack.mock.calls.some((c) => c[0] === "Waiting…");
     expect(usedScoreboard || usedSnackbar).toBe(true);
-    timer.clearAllTimers();
   });
 });

--- a/tests/helpers/mockScheduler.js
+++ b/tests/helpers/mockScheduler.js
@@ -1,0 +1,29 @@
+export function createMockScheduler() {
+  let now = 0;
+  const tasks = [];
+  function setTimeoutFn(cb, ms) {
+    const id = Symbol();
+    tasks.push({ id, time: now + ms, cb });
+    tasks.sort((a, b) => a.time - b.time);
+    return id;
+  }
+  function clearTimeoutFn(id) {
+    const idx = tasks.findIndex((t) => t.id === id);
+    if (idx !== -1) tasks.splice(idx, 1);
+  }
+  function tick(ms) {
+    now += ms;
+    tasks.sort((a, b) => a.time - b.time);
+    while (tasks.length && tasks[0].time <= now) {
+      const task = tasks.shift();
+      try {
+        task.cb();
+      } catch {}
+    }
+  }
+  return {
+    setTimeout: setTimeoutFn,
+    clearTimeout: clearTimeoutFn,
+    tick
+  };
+}


### PR DESCRIPTION
## Summary
- introduce real scheduler wrapper for production timers
- support injected scheduler in scoreboard setup and classic battle timers
- use mock scheduler in tests to drive countdowns deterministically

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab46dcc38083268f0d26541c014691