### PR TITLE
test: clarify page load tests

### DIFF
--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -12,7 +12,7 @@ test.describe.parallel("Homepage", () => {
     await page.evaluate(() => window.navReadyPromise);
   });
 
-  test("page loads", async ({ page }) => {
+  test("homepage loads", async ({ page }) => {
     await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
   });
 

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -50,7 +50,7 @@ test.describe.parallel("Settings page", () => {
     await waitForSettingsReady(page);
   });
 
-  test("page loads", async ({ page }) => {
+  test("settings page loads", async ({ page }) => {
     await verifyPageBasics(page, [NAV_CLASSIC_BATTLE, NAV_RANDOM_JUDOKA]);
   });
 


### PR DESCRIPTION
## Summary
- clarify settings page load test name
- clarify homepage load test name

## Testing
- `npx prettier . --check` *(fails: playwright/browse-judoka.spec.js needs formatting)*
- `npx eslint .` *(fails: 2 errors, 6 warnings)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab63341aac83269813dc06e900e75c