### PR TITLE
Clarify judoka visibility tests

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -9,7 +9,7 @@ test.describe.parallel("Browse Judoka screen", () => {
   }); // Close beforeEach
   // Ensure proper nesting of braces and remove any extra closing brace
 
-  test("essential elements visible", async ({ page }) => {
+  test("browse judoka elements visible", async ({ page }) => {
     await expect(page.getByTestId(COUNTRY_TOGGLE_LOCATOR)).toBeVisible();
     await expect(page.getByTestId("country-toggle")).toHaveAttribute(
       "aria-label",
@@ -89,11 +89,11 @@ test.describe.parallel("Browse Judoka screen", () => {
 
     const before = await card.boundingBox();
     await card.hover();
-    await page.waitForFunction(selector => {
+    await page.waitForFunction((selector) => {
       const cardElement = document.querySelector(selector);
       if (!cardElement) return false; // Element not found yet
       const style = window.getComputedStyle(cardElement);
-      return style.transform !== 'none';
+      return style.transform !== "none";
     }, "#carousel-container .judoka-card");
     await page.waitForTimeout(200); // Allow animation to complete
     const after = await card.boundingBox();

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -7,7 +7,7 @@ test.describe.parallel("View Judoka screen", () => {
     await page.evaluate(() => window.randomJudokaReadyPromise);
   });
 
-  test("essential elements visible", async ({ page }) => {
+  test("random judoka elements visible", async ({ page }) => {
     await expect(page.getByTestId("draw-button")).toBeVisible();
     await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
   });

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -59,7 +59,7 @@ test.describe.parallel("Settings page", () => {
     await expect(toggle).toBeVisible();
   });
 
-  test("essential elements visible", async ({ page }) => {
+  test("settings elements visible", async ({ page }) => {
     await verifyPageBasics(page, [NAV_CLASSIC_BATTLE, NAV_RANDOM_JUDOKA]);
     await expect(page.getByText(/sound/i)).toBeVisible();
     await expect(page.getByText(/motion effects/i)).toBeVisible();


### PR DESCRIPTION
## Summary
- Clarify visibility expectations in settings page test
- Add explicit random judoka element visibility test label
- Clarify browse judoka screen elements visibility test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: globalThis.dispatchEvent is not a function)*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab67bccbe08326a49937dd50031b6f