### PR TITLE
test: clarify battle link navigation

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -18,7 +18,7 @@ test.describe.parallel("Browse Judoka screen", () => {
     await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
   });
 
-  test("battle link navigates", async ({ page }) => {
+  test("battle link navigates from browse judoka", async ({ page }) => {
     await page.getByTestId(NAV_CLASSIC_BATTLE).click();
     await expect(page).toHaveURL(/battleJudoka\.html/);
   });
@@ -89,11 +89,11 @@ test.describe.parallel("Browse Judoka screen", () => {
 
     const before = await card.boundingBox();
     await card.hover();
-    await page.waitForFunction(selector => {
+    await page.waitForFunction((selector) => {
       const cardElement = document.querySelector(selector);
       if (!cardElement) return false; // Element not found yet
       const style = window.getComputedStyle(cardElement);
-      return style.transform !== 'none';
+      return style.transform !== "none";
     }, "#carousel-container .judoka-card");
     await page.waitForTimeout(200); // Allow animation to complete
     const after = await card.boundingBox();

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -12,7 +12,7 @@ test.describe.parallel("View Judoka screen", () => {
     await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
   });
 
-  test("battle link navigates", async ({ page }) => {
+  test("battle link navigates from random judoka", async ({ page }) => {
     const battleLink = page.getByTestId(NAV_CLASSIC_BATTLE);
     await battleLink.click();
     await expect(page).toHaveURL(/battleJudoka\.html/);


### PR DESCRIPTION
## Summary
- clarify battle link navigation from random judoka page
- clarify battle link navigation from browse judoka page

## Testing
- `npx prettier playwright/random-judoka.spec.js playwright/browse-judoka.spec.js --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test --reporter=dot` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab67c89c80832680a19707c0523fe4