### PR TITLE
Clarify viewport hints in homepage layout tests

### DIFF
--- a/playwright/homepage-layout.spec.js
+++ b/playwright/homepage-layout.spec.js
@@ -20,7 +20,7 @@ test.describe.parallel("Homepage layout", () => {
       expect(columnCount).toBe(2);
     });
 
-    test("grid does not overlap footer", async ({ page }, testInfo) => {
+    test("grid does not overlap footer (desktop)", async ({ page }, testInfo) => {
       const grid = page.locator(".game-mode-grid");
       const gridBox = await grid.boundingBox();
       const navBox = await page.locator(".bottom-navbar").boundingBox();
@@ -64,7 +64,7 @@ test.describe.parallel("Homepage layout", () => {
       expect(columnCount).toBe(1);
     });
 
-    test("grid does not overlap footer", async ({ page }, testInfo) => {
+    test("grid does not overlap footer (mobile)", async ({ page }, testInfo) => {
       const grid = page.locator(".game-mode-grid");
       const gridBox = await grid.boundingBox();
       const navBox = await page.locator(".bottom-navbar").boundingBox();


### PR DESCRIPTION
## Summary
- clarify homepage layout tests by adding viewport context to desktop and mobile footer-overlap checks

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab808938c08326ac4fc28299cb58d6