### PR TITLE
feat(card): allow custom synchronous sanitizer

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -6,7 +6,7 @@
  * 2. Apply `id`, `href`, `className` and `onClick` options if present.
  * 3. Always include the `card` class plus any additional `className`.
  * 4. Insert string content with `textContent` by default, or with sanitized
- *    HTML when `html` is true.
+ *    HTML when `html` is true using a provided or default sanitizer.
  *
  * @class
  */
@@ -15,11 +15,13 @@ import { getSanitizer } from "../helpers/sanitizeHtml.js";
 export class Card {
   /**
    * @param {string|Node} content - Text or HTML to place inside the card.
-   * @param {{id?: string, className?: string, href?: string, onClick?: Function, html?: boolean}} [options] - Optional settings.
+   * @param {{id?: string, className?: string, href?: string, onClick?: Function, html?: boolean, sanitize?: Function}} [options] - Optional settings.
    *    When `html` is true, the `content` string is sanitized before insertion.
+   *    The `sanitize` option may return a sanitizer synchronously or as a Promise
+   *    and defaults to `getSanitizer`.
    */
   constructor(content, options = {}) {
-    const { id, className, href, onClick, html = false } = options;
+    const { id, className, href, onClick, html = false, sanitize = getSanitizer } = options;
     this.element = href ? document.createElement("a") : document.createElement("div");
     if (id) this.element.id = id;
     if (href) this.element.href = href;
@@ -34,10 +36,16 @@ export class Card {
     }
     if (typeof content === "string") {
       if (html) {
-        // Sanitize HTML content before inserting into the DOM
-        getSanitizer().then(({ sanitize }) => {
-          this.element.innerHTML = sanitize(content);
-        });
+        const maybe = sanitize();
+        if (typeof maybe?.then === "function") {
+          // Sanitize HTML content when sanitizer is loaded asynchronously
+          maybe.then(({ sanitize: fn }) => {
+            this.element.innerHTML = fn(content);
+          });
+        } else {
+          // Sanitize immediately when provided synchronously
+          this.element.innerHTML = maybe.sanitize(content);
+        }
       } else {
         this.element.textContent = content;
       }

--- a/tests/helpers/cardComponent.test.js
+++ b/tests/helpers/cardComponent.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { Card, createCard } from "../../src/components/Card.js";
-import { getSanitizer } from "../../src/helpers/sanitizeHtml.js";
 
 describe("createCard", () => {
   it("creates a div card with text content", () => {
@@ -10,11 +9,11 @@ describe("createCard", () => {
     expect(card.textContent).toBe("Hello");
   });
 
-  it("inserts sanitized HTML when the html flag is true", async () => {
-    const { sanitize } = await getSanitizer();
-    const card = createCard(sanitize("<em>hi</em>"), { html: true });
-    await Promise.resolve();
+  it("inserts sanitized HTML when the html flag is true", () => {
+    const sanitize = vi.fn(() => ({ sanitize: (h) => h }));
+    const card = createCard("<em>hi</em>", { html: true, sanitize });
     expect(card.innerHTML).toBe("<em>hi</em>");
+    expect(sanitize).toHaveBeenCalled();
   });
 
   it("creates an anchor card when href provided", () => {


### PR DESCRIPTION
## Summary
- allow `Card` to use a custom `sanitize` option that may resolve synchronously or asynchronously
- streamline card component tests with a sync sanitize stub

## Testing
- `npx prettier src/components/Card.js tests/helpers/cardComponent.test.js --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab81bfb9508326a082b69ce3d05c67