### PR TITLE
refactor: expose initGame and bootstrap on DOMContentLoaded

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -10,7 +10,8 @@ Throughout the project, keep modules simple. Favor small, single-purpose functio
 
 ### `game.js`
 
-The main entry point for the browser. It waits for `DOMContentLoaded` and wires up all game interactions.
+Exports setup helpers and the `initGame` function. `gameBootstrap.js` listens
+for `DOMContentLoaded` and calls `initGame` in production.
 
 - Imports helper functions to:
   - Build the card carousel
@@ -20,6 +21,11 @@ The main entry point for the browser. It waits for `DOMContentLoaded` and wires 
   - Initial card setup
   - Navigation hooks
   - Feature flag checks
+
+### `gameBootstrap.js`
+
+Lightweight bootstrap that waits for `DOMContentLoaded` and invokes
+`initGame`.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
         </p>
       </noscript>
 
-      <script type="module" src="./src/game.js" defer></script>
+      <script type="module" src="./src/gameBootstrap.js" defer></script>
       <script nomodule>
         alert(
           "Your browser does not support modern JavaScript. Please update your browser to play JU-DO-KON!"

--- a/src/game.js
+++ b/src/game.js
@@ -159,29 +159,26 @@ export function setupRandomCardButton(button, container) {
 }
 
 /**
- * Initializes game interactions after the DOM is ready.
+ * Initializes game interactions.
  *
  * Queries required DOM elements, wires up control buttons, and loads data for
  * the judoka carousel when requested.
  *
  * @pseudocode
- * 1. Wait for the `DOMContentLoaded` event to ensure the full HTML document has been loaded and parsed.
- * 2. Query essential DOM elements by their IDs: `showRandom`, `gameArea`, `carousel-container`, `showCarousel`, and `hideCard`.
- * 3. If `showRandom` or `gameArea` elements are not found, it indicates the current page does not expose the necessary game UI controls, so exit silently.
- * 4. Asynchronously initialize feature flags using `initFeatureFlags`.
- * 5. After feature flags are initialized, determine if the "enableCardInspector" feature is enabled using `isEnabled` and store the result in `inspectorEnabled`.
- * 6. If `initFeatureFlags` fails, set `inspectorEnabled` to `false`.
- * 7. Call `toggleInspectorPanels` with the current `inspectorEnabled` state to update the visibility of inspector panels.
- * 8. Add an event listener to `featureFlagsEmitter` for "change" events:
- *    a. When a change occurs, re-evaluate `inspectorEnabled` using `isEnabled("enableCardInspector")`.
- *    b. Call `toggleInspectorPanels` again with the new `inspectorEnabled` state to reflect the change in UI.
- * 9. Call `setupCarouselToggle` to wire up the carousel display button, passing `showCarouselButton` and `carouselContainer`.
- * 10. Call `setupHideCardButton` to wire up the button for toggling card backs, passing `hideCard`.
- * 11. Call `setupRandomCardButton` to wire up the button for displaying a random card, passing `showRandom` and `gameArea`.
- * 12. Initialize all tooltips on the page by calling `initTooltips`.
+ * 1. Query essential DOM elements by their IDs: `showRandom`, `gameArea`, `carousel-container`, `showCarousel`, and `hideCard`.
+ * 2. If `showRandom` or `gameArea` elements are not found, exit silently.
+ * 3. Asynchronously initialize feature flags using `initFeatureFlags`.
+ * 4. Determine if the "enableCardInspector" feature is enabled with `isEnabled` and store the result in `inspectorEnabled`, defaulting to `false` on error.
+ * 5. Call `toggleInspectorPanels` with the current `inspectorEnabled` state to update the visibility of inspector panels.
+ * 6. Add an event listener to `featureFlagsEmitter` for "change" events:
+ *    a. Re-evaluate `inspectorEnabled` using `isEnabled("enableCardInspector")`.
+ *    b. Call `toggleInspectorPanels` again with the new `inspectorEnabled` state.
+ * 7. Call `setupCarouselToggle` to wire up the carousel display button, passing `showCarouselButton` and `carouselContainer`.
+ * 8. Call `setupHideCardButton` to wire up the button for toggling card backs, passing `hideCard`.
+ * 9. Call `setupRandomCardButton` to wire up the button for displaying a random card, passing `showRandom` and `gameArea`.
+ * 10. Initialize all tooltips on the page by calling `initTooltips`.
  */
-
-document.addEventListener("DOMContentLoaded", async () => {
+export async function initGame() {
   const showRandom = document.getElementById("showRandom");
   const gameArea = document.getElementById("gameArea");
   const carouselContainer = document.getElementById("carousel-container");
@@ -210,4 +207,4 @@ document.addEventListener("DOMContentLoaded", async () => {
   setupHideCardButton(hideCard);
   setupRandomCardButton(showRandom, gameArea);
   initTooltips();
-});
+}

--- a/src/gameBootstrap.js
+++ b/src/gameBootstrap.js
@@ -1,0 +1,12 @@
+/**
+ * Bootstrap JU-DO-KON! once the DOM is ready.
+ *
+ * @pseudocode
+ * 1. Listen for the `DOMContentLoaded` event.
+ * 2. Invoke `initGame` to wire up the page.
+ */
+import { initGame } from "./game.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+  initGame().catch(console.error);
+});

--- a/tests/helpers/gameRandom.test.js
+++ b/tests/helpers/gameRandom.test.js
@@ -34,9 +34,8 @@ describe("game.js", () => {
       featureFlagsEmitter: new EventTarget()
     }));
 
-    await import("../../src/game.js");
-    document.dispatchEvent(new Event("DOMContentLoaded"));
-    await Promise.resolve();
+    const { initGame } = await import("../../src/game.js");
+    await initGame();
     showRandom.dispatchEvent(new Event("click"));
 
     expect(generateRandomCard).toHaveBeenCalledWith(null, null, gameArea, true, undefined, {


### PR DESCRIPTION
## Summary
- export new `initGame()` that wires DOM and feature flags without relying on `DOMContentLoaded`
- load a tiny `gameBootstrap.js` on `DOMContentLoaded` to call `initGame`
- update tests to invoke `initGame` directly

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab8d8a15f08326a17c5b975f6c699e