### PR TITLE
refactor: export settings handlers for direct testing

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -389,3 +389,6 @@ function showLoadSettingsError() {
 }
 
 onDomReady(initializeSettingsPage);
+
+export { handleGameModeChange } from "./settings/gameModeSwitches.js";
+export { handleFeatureFlagChange } from "./settings/featureFlagSwitches.js";

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -121,13 +121,19 @@ describe("renderSettingsControls", () => {
       loadNavigationItems: vi.fn()
     }));
     vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar: vi.fn() }));
-    const { renderSettingsControls } = await import("../../src/helpers/settingsPage.js");
+    const { renderSettingsControls, handleGameModeChange } = await import(
+      "../../src/helpers/settingsPage.js"
+    );
     renderSettingsControls(baseSettings, gameModes, tooltipMap);
     const input = document.getElementById("mode-1");
     input.checked = false;
-    input.dispatchEvent(new Event("change"));
-    await Promise.resolve();
-    await Promise.resolve();
+    await handleGameModeChange({
+      input,
+      mode: gameModes[0],
+      label: gameModes[0].name,
+      getCurrentSettings: () => baseSettings,
+      handleUpdate: updateSetting
+    });
     expect(updateNavigationItemHidden).toHaveBeenCalledWith(1, true);
   });
 
@@ -139,17 +145,28 @@ describe("renderSettingsControls", () => {
       resetSettings: vi.fn()
     }));
     vi.doMock("../../src/helpers/showSnackbar.js", () => ({ showSnackbar: vi.fn() }));
-    const { renderSettingsControls } = await import("../../src/helpers/settingsPage.js");
+    const { renderSettingsControls, handleFeatureFlagChange } = await import(
+      "../../src/helpers/settingsPage.js"
+    );
     renderSettingsControls(baseSettings, [], tooltipMap);
     const input = document.querySelector("#feature-battle-debug-panel");
     input.checked = true;
-    input.dispatchEvent(new Event("change"));
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(updateSetting).toHaveBeenCalledWith("featureFlags", {
-      ...baseSettings.featureFlags,
-      battleDebugPanel: { enabled: true }
+    await handleFeatureFlagChange({
+      input,
+      flag: "battleDebugPanel",
+      info: baseSettings.featureFlags.battleDebugPanel,
+      label: "battleDebugPanel",
+      getCurrentSettings: () => baseSettings,
+      handleUpdate: updateSetting
     });
+    expect(updateSetting).toHaveBeenCalledWith(
+      "featureFlags",
+      {
+        ...baseSettings.featureFlags,
+        battleDebugPanel: { enabled: true }
+      },
+      expect.any(Function)
+    );
   });
 
   it("adds navigation cache reset button when flag enabled", async () => {


### PR DESCRIPTION
## Summary
- extract `handleGameModeChange` and `handleFeatureFlagChange` async handlers and use them in settings toggles
- re-export handlers from `settingsPage.js`
- update settings page tests to invoke handlers directly

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab8d86767483269019d39b3878f6c5