### PR TITLE
feat: add ready promise to carousel cards

### DIFF
--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -163,7 +163,7 @@ function validateGokyoData(gokyoData) {
  *    b. Create a `spinner` instance using `createSpinner(wrapper)`, setting `delay` to 0 if forced, otherwise `undefined`.
  *    c. If `forceSpinner` is true, immediately set `spinner.element.style.display` to "block".
  *    d. Otherwise, call `spinner.show()` to display it after its configured delay.
- * 5. Asynchronously append cards to the `container` using `appendCards(container, judokaList, gokyoLookup)`.
+ * 5. Asynchronously append cards to the `container` using `appendCards(container, judokaList, gokyoLookup)` and await its `ready` promise.
  * 6. Set up responsive sizing for the `container` using `setupResponsiveSizing(container)`.
  * 7. Remove the `spinner` from the DOM.
  * 8. If `forceSpinner` was true, delete the global flags `__showSpinnerImmediately__` and `__forceSpinner__`.
@@ -202,7 +202,8 @@ export async function buildCardCarousel(judokaList, gokyoData) {
     spinner.show();
   }
 
-  await appendCards(container, judokaList, gokyoLookup);
+  const { ready } = appendCards(container, judokaList, gokyoLookup);
+  await ready;
   setupResponsiveSizing(container);
 
   spinner.remove();

--- a/tests/helpers/appendCards.test.js
+++ b/tests/helpers/appendCards.test.js
@@ -23,13 +23,12 @@ describe("appendCards", () => {
 
     const container = document.createElement("div");
     const judokaList = [{ id: 1, firstname: "Real", surname: "Judoka" }];
-    const replacementPromise = appendCards(container, judokaList, {});
-    await Promise.resolve();
+    const { ready } = appendCards(container, judokaList, {});
 
     const initialCard = container.firstElementChild;
     const img = initialCard.querySelector("img");
-    img.dispatchEvent(new Event("error"));
-    await replacementPromise;
+    queueMicrotask(() => img.dispatchEvent(new Event("error")));
+    await ready;
 
     expect(getFallbackJudoka).toHaveBeenCalled();
     expect(container.children.length).toBe(1);

--- a/tests/helpers/carouselBuilder.test.js
+++ b/tests/helpers/carouselBuilder.test.js
@@ -5,12 +5,13 @@ vi.mock("../../src/helpers/carousel/index.js", async () => {
   const actual = await vi.importActual("../../src/helpers/carousel/index.js");
   return {
     ...actual,
-    appendCards: vi.fn(async (container, list) => {
+    appendCards: vi.fn((container, list) => {
       list.forEach(() => {
         const card = document.createElement("div");
         card.className = "judoka-card";
         container.appendChild(card);
       });
+      return { ready: Promise.resolve() };
     }),
     setupResponsiveSizing: vi.fn()
   };


### PR DESCRIPTION
## Summary
- return `ready` promise from `appendCards`
- await `ready` in carousel builder and tests
- queue microtask for image error in appendCards test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED and screenshot diffs)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab8d80a2748326a5762a7f71fa9759