### PR TITLE
refactor: expose stat selection helper

### DIFF
--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -3,7 +3,7 @@ import { resetStatButtons } from "../battle/index.js";
 import { syncScoreDisplay } from "./uiService.js";
 import { startTimer, handleStatSelectionTimeout, scheduleNextRound } from "./timerService.js";
 import * as scoreboard from "../setupScoreboard.js";
-import { handleStatSelection } from "./selectionHandler.js";
+import { selectStat } from "../classicBattlePage.js";
 import { showMatchSummaryModal } from "./uiService.js";
 import { handleReplay } from "./roundManager.js";
 import { onBattleEvent, emitBattleEvent } from "./battleEvents.js";
@@ -30,10 +30,10 @@ export function applyRoundUI(store, roundNumber, stallTimeoutMs = 35000) {
   syncScoreDisplay();
   scoreboard.updateRoundCounter(roundNumber);
   showSelectionPrompt();
-  startTimer((stat, opts) => handleStatSelection(store, stat, opts));
+  startTimer((stat, opts) => selectStat(store, stat, opts));
   store.stallTimeoutMs = stallTimeoutMs;
   store.statTimeoutId = setTimeout(
-    () => handleStatSelectionTimeout(store, (s, opts) => handleStatSelection(store, s, opts)),
+    () => handleStatSelectionTimeout(store, (s, opts) => selectStat(store, s, opts)),
     store.stallTimeoutMs
   );
   updateDebugPanel();

--- a/src/helpers/classicBattle/skipHandler.js
+++ b/src/helpers/classicBattle/skipHandler.js
@@ -28,9 +28,7 @@ export function setSkipHandler(fn) {
     const current = skipHandler;
     skipHandler = null;
     try {
-      window.dispatchEvent(
-        new CustomEvent("skip-handler-change", { detail: { active: false } })
-      );
+      window.dispatchEvent(new CustomEvent("skip-handler-change", { detail: { active: false } }));
     } catch {}
     setTimeout(() => {
       try {

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -255,9 +255,7 @@ export function scheduleNextRound(result, scheduler = realScheduler) {
         ? window.__NEXT_ROUND_COOLDOWN_MS
         : 3000;
     // In test mode, remove cooldown to make transitions deterministic.
-    const cooldownSeconds = isTestModeEnabled()
-      ? 0
-      : Math.max(0, Math.round(overrideMs / 1000));
+    const cooldownSeconds = isTestModeEnabled() ? 0 : Math.max(0, Math.round(overrideMs / 1000));
 
     nextRoundReadyResolve = () => {
       emitBattleEvent("nextRoundTimerReady");

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -9,7 +9,7 @@ import * as scoreboard from "../setupScoreboard.js";
 import { showResult } from "../battle/index.js";
 import { shouldReduceMotionSync } from "../motionUtils.js";
 import { onFrame as scheduleFrame, cancel as cancelFrame } from "../../utils/scheduler.js";
-import { handleStatSelection } from "./selectionHandler.js";
+import { selectStat } from "../classicBattlePage.js";
 import { onNextButtonClick } from "./timerService.js";
 import { loadStatNames } from "../stats.js";
 import { toggleViewportSimulation } from "../viewportDebug.js";
@@ -509,7 +509,7 @@ export function initStatButtons(store) {
         snackbar.showSnackbar(`You Picked: ${btn.textContent}`);
         // Fire-and-forget to avoid blocking the UI thread.
         try {
-          Promise.resolve(handleStatSelection(store, statName)).catch(() => {});
+          Promise.resolve(selectStat(store, statName)).catch(() => {});
         } catch {}
       });
     };

--- a/src/helpers/classicBattlePage.js
+++ b/src/helpers/classicBattlePage.js
@@ -4,7 +4,8 @@
 /**
  * Initialize the Classic Battle page.
  * @pseudocode
- * - Import `setupClassicBattlePage` from classicBattle/bootstrap
- * - Export it for callers expecting `src/helpers/classicBattlePage.js`
+ * - Import `setupClassicBattlePage` from classicBattle/bootstrap.
+ * - Re-export `selectStat` for consumers needing direct stat processing.
  */
 export { setupClassicBattlePage } from "./classicBattle/bootstrap.js";
+export { selectStat } from "./classicBattle.js";

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -47,9 +47,7 @@ function populateCards() {
 
 async function selectPower(battleMod, store) {
   const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
-  const p = battleMod.handleStatSelection(store, "power");
-  await vi.advanceTimersByTimeAsync(1000);
-  await p;
+  await battleMod.selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
   return { randomSpy };
 }
 

--- a/tests/helpers/classicBattle/debugPanel.test.js
+++ b/tests/helpers/classicBattle/debugPanel.test.js
@@ -25,8 +25,9 @@ vi.mock("../../../src/helpers/setupScoreboard.js", () => ({ showMessage: vi.fn()
 vi.mock("../../../src/helpers/battle/index.js", () => ({ showResult: vi.fn() }));
 vi.mock("../../../src/helpers/motionUtils.js", () => ({ shouldReduceMotionSync: () => true }));
 vi.mock("../../../src/utils/scheduler.js", () => ({ onFrame: vi.fn(), cancel: vi.fn() }));
-vi.mock("../../../src/helpers/classicBattle/selectionHandler.js", () => ({
-  handleStatSelection: vi.fn()
+vi.mock("../../../src/helpers/classicBattlePage.js", () => ({
+  selectStat: vi.fn(),
+  setupClassicBattlePage: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
   onNextButtonClick: vi.fn()

--- a/tests/helpers/classicBattle/matchEnd.test.js
+++ b/tests/helpers/classicBattle/matchEnd.test.js
@@ -69,13 +69,11 @@ afterEach(() => {
 
 async function playRound(battleMod, store, playerValue, opponentValue) {
   document.getElementById("player-card").innerHTML =
-    `<ul><li class="stat"><strong>Power</strong> <span>${playerValue}</span></li></ul>`;
+    `<ul><li class=\"stat\"><strong>Power</strong> <span>${playerValue}</span></li></ul>`;
   document.getElementById("opponent-card").innerHTML =
-    `<ul><li class="stat"><strong>Power</strong> <span>${opponentValue}</span></li></ul>`;
+    `<ul><li class=\"stat\"><strong>Power</strong> <span>${opponentValue}</span></li></ul>`;
   store.selectionMade = false;
-  const p = battleMod.handleStatSelection(store, "power");
-  await vi.runAllTimersAsync();
-  await p;
+  await battleMod.selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
 }
 
 async function playerWinsRounds(battleMod, store, count) {

--- a/tests/helpers/classicBattle/mocks.js
+++ b/tests/helpers/classicBattle/mocks.js
@@ -56,9 +56,10 @@ export function mockRoundManager() {
 }
 
 export function mockSelectionHandler() {
-  vi.doMock("../../../src/helpers/classicBattle/selectionHandler.js", () => ({
-    handleStatSelection: vi.fn()
-  }));
+  vi.doMock("../../../src/helpers/classicBattlePage.js", async () => {
+    const actual = await vi.importActual("../../../src/helpers/classicBattlePage.js");
+    return { ...actual, selectStat: vi.fn() };
+  });
 }
 
 export function mockBattleJudokaPage() {

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -87,7 +87,10 @@ describe("classicBattle opponent delay", () => {
 
     showSnackbar = vi.fn();
     const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
-    const promise = mod.handleStatSelection(store, mod.simulateOpponentStat());
+    const promise = mod.selectStat(store, mod.simulateOpponentStat(), {
+      delayMs: 0,
+      sleep: async () => {}
+    });
 
     expect(showSnackbar).not.toHaveBeenCalled();
     await vi.runAllTimersAsync();

--- a/tests/helpers/classicBattle/pauseTimer.test.js
+++ b/tests/helpers/classicBattle/pauseTimer.test.js
@@ -88,9 +88,7 @@ describe("classicBattle timer pause", () => {
     document.getElementById("opponent-card").innerHTML =
       '<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>';
 
-    const promise = battleMod.handleStatSelection(store, "power");
-    await timer.runAllTimersAsync();
-    await promise;
+    await battleMod.selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
     timer.advanceTimersByTime(1000);
     await timer.runAllTimersAsync();
     const messages = showMessage.mock.calls.map((c) => c[0]);

--- a/tests/helpers/classicBattle/selectionPrompt.test.js
+++ b/tests/helpers/classicBattle/selectionPrompt.test.js
@@ -63,14 +63,10 @@ describe("classicBattle selection prompt", () => {
     expect(document.querySelector(".snackbar")).toBeNull();
     expect(document.querySelector("header #round-message").textContent).toBe("");
     document.getElementById("player-card").innerHTML =
-      `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
+      `<ul><li class=\"stat\"><strong>Power</strong> <span>5</span></li></ul>`;
     document.getElementById("opponent-card").innerHTML =
-      `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    {
-      const p = battleMod.handleStatSelection(store, "power");
-      await vi.runAllTimersAsync();
-      await p;
-    }
+      `<ul><li class=\"stat\"><strong>Power</strong> <span>3</span></li></ul>`;
+    await battleMod.selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
     expect(document.querySelector(".snackbar")?.textContent).not.toBe("Select your move");
   });
 });

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -59,7 +59,6 @@ describe("classicBattle stat selection", () => {
   let store;
   let selectStat;
   let simulateOpponentStat;
-  let handleStatSelection;
   let _resetForTest;
   let createBattleStore;
 
@@ -95,18 +94,13 @@ describe("classicBattle stat selection", () => {
   beforeEach(async () => {
     document.body.innerHTML +=
       '<div id="stat-buttons" data-tooltip-id="ui.selectStat"><button data-stat="power"></button></div>';
-    ({ createBattleStore, handleStatSelection, simulateOpponentStat, _resetForTest } = await import(
+    ({ createBattleStore, selectStat, simulateOpponentStat, _resetForTest } = await import(
       "../../../src/helpers/classicBattle.js"
     ));
     store = createBattleStore();
     _resetForTest(store);
     const eventDispatcher = await import("../../../src/helpers/classicBattle/eventDispatcher.js");
     eventDispatcher.__reset();
-    selectStat = async (stat) => {
-      const p = handleStatSelection(store, stat);
-      await vi.runAllTimersAsync();
-      await p;
-    };
   });
 
   afterEach(() => {
@@ -116,14 +110,14 @@ describe("classicBattle stat selection", () => {
   it("clears selected class on stat buttons after each round", async () => {
     const btn = document.querySelector("[data-stat='power']");
     btn.classList.add("selected");
-    await selectStat("power");
+    await selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
     expectDeselected(btn);
   });
 
   it("re-enables stat button after selection", async () => {
     const btn = document.querySelector("[data-stat='power']");
     btn.classList.add("selected");
-    await selectStat("power");
+    await selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
     expectDeselected(btn);
     expect(btn.disabled).toBe(false);
   });
@@ -132,7 +126,7 @@ describe("classicBattle stat selection", () => {
     const btn = document.querySelector("[data-stat='power']");
     btn.classList.add("selected");
     btn.style.backgroundColor = "red";
-    await selectStat("power");
+    await selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
     expectDeselected(btn);
     expect(btn.style.backgroundColor).toBe("");
   });
@@ -142,7 +136,7 @@ describe("classicBattle stat selection", () => {
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    await selectStat("power");
+    await selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
     expect(document.querySelector("header #round-message").textContent).toMatch(/Tie/);
     expect(document.querySelector("header #score-display").textContent).toBe("You: 0\nOpponent: 0");
   });
@@ -164,7 +158,7 @@ describe("classicBattle stat selection", () => {
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
     document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    await selectStat("power");
+    await selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
     expect(document.getElementById("round-result").textContent).toBe("Power – You: 5 Opponent: 3");
   });
 
@@ -174,7 +168,7 @@ describe("classicBattle stat selection", () => {
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
     document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    await selectStat("power");
+    await selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
     expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "evaluate");
     expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "outcome=winPlayer");
     expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(3, "continue");
@@ -191,8 +185,8 @@ describe("classicBattle stat selection", () => {
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
     document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    await selectStat("power");
-    await selectStat("power");
+    await selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
+    await selectStat(store, "power", { delayMs: 0, sleep: async () => {} });
     expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "evaluate");
     expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "outcome=winPlayer");
     expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(3, "matchPointReached");

--- a/tests/helpers/timerService.test.js
+++ b/tests/helpers/timerService.test.js
@@ -19,7 +19,8 @@ vi.mock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
 }));
 
 vi.mock("../../src/helpers/testModeUtils.js", () => ({
-  seededRandom: () => 0
+  seededRandom: () => 0,
+  isTestModeEnabled: () => false
 }));
 
 vi.mock("../../src/helpers/timerUtils.js", () => ({
@@ -68,6 +69,7 @@ describe("timerService", () => {
     const handler = vi.fn();
     mod.skipCurrentPhase();
     mod.setSkipHandler(handler);
+    await vi.runAllTimersAsync();
     expect(handler).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary
- export selectStat from classicBattlePage and route event listeners through it
- allow direct stat selection in tests
- format helper modules

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: classicBattlePage stat button interactions, timerService handlers, battleStateBadge, opponent delay, stat selection)*
- `npx playwright test` *(fails: 7 tests, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab944b2d1c83268726359673332ffb