### PR TITLE
feat: allow custom observer for opponent card

### DIFF
--- a/src/helpers/battleJudokaPage.js
+++ b/src/helpers/battleJudokaPage.js
@@ -3,26 +3,28 @@
  * or after a timeout.
  *
  * @param {number} [timeoutMs=5000] - Maximum wait time in milliseconds.
+ * @param {typeof MutationObserver} [observe=globalThis.MutationObserver]
+ *   - Observer constructor used to watch DOM mutations.
  * @returns {Promise<void>}
  *
  * @pseudocode
  * 1. Fetch the `#opponent-card` container.
  * 2. Resolve immediately if missing or a `.judoka-card` is already present.
- * 3. Resolve immediately if `MutationObserver` is unavailable.
- * 4. Otherwise observe mutations and resolve once a `.judoka-card` appears.
+ * 3. Resolve immediately if the provided `observe` function is unavailable.
+ * 4. Otherwise instantiate `observe` and resolve once a `.judoka-card` appears.
  * 5. Set a timeout that disconnects the observer and resolves after `timeoutMs`.
  */
-export function waitForOpponentCard(timeoutMs = 5000) {
+export function waitForOpponentCard(timeoutMs = 5000, observe = globalThis.MutationObserver) {
   const container = document.getElementById("opponent-card");
   if (!container) return Promise.resolve();
   if (container.querySelector(".judoka-card")) {
     return Promise.resolve();
   }
-  if (typeof MutationObserver === "undefined") {
+  if (typeof observe === "undefined") {
     return Promise.resolve();
   }
   return new Promise((resolve) => {
-    const observer = new MutationObserver(() => {
+    const observer = new observe(() => {
       if (container.querySelector(".judoka-card")) {
         observer.disconnect();
         clearTimeout(timer);

--- a/tests/helpers/battleJudokaPage.test.js
+++ b/tests/helpers/battleJudokaPage.test.js
@@ -12,12 +12,22 @@ describe("waitForOpponentCard", () => {
     container.id = "opponent-card";
     document.body.append(container);
 
-    const promise = waitForOpponentCard();
+    const callbacks = [];
+    class ObserveStub {
+      constructor(cb) {
+        callbacks.push(cb);
+      }
+      observe() {}
+      disconnect() {}
+    }
 
-    await Promise.resolve();
+    const promise = waitForOpponentCard(undefined, ObserveStub);
+
     const card = document.createElement("div");
     card.className = "judoka-card";
     container.appendChild(card);
+
+    callbacks.forEach((cb) => cb());
 
     await expect(promise).resolves.toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- allow injection of a custom observer into `waitForOpponentCard`
- update unit test to stub observer synchronously

## Testing
- `npx prettier . --check` *(fails: Code style issues in src/helpers/classicBattle/skipHandler.js, src/helpers/classicBattle/timerService.js)*
- `npx eslint .` *(fails: prettier/prettier errors in src/helpers/classicBattle files)*
- `npx vitest run` *(fails: classicBattlePage and timerService tests)*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ab9441a32c832685e92f725916642e