### PR TITLE
Expose browse helper logic for direct tests

### DIFF
--- a/src/helpers/browse/setupCountryFilter.js
+++ b/src/helpers/browse/setupCountryFilter.js
@@ -1,19 +1,103 @@
 import { toggleCountryPanel } from "../countryPanel.js";
-
 /**
- * Update selected state on flag buttons.
+ * Highlight the selected flag button within a container.
  *
  * @pseudocode
- * 1. Remove 'selected' class from all flag buttons in the container.
- * 2. Add 'selected' class to the provided button.
+ * 1. Remove `selected` class from all flag buttons in the container.
+ * 2. Add `selected` class to the provided button.
  *
  * @param {Element} container
  * @param {HTMLButtonElement} button
  */
-function highlightSelection(container, button) {
+export function highlightSelection(container, button) {
   const buttons = container.querySelectorAll("button.flag-button");
   buttons.forEach((b) => b.classList.remove("selected"));
   button.classList.add("selected");
+}
+
+/**
+ * Clear the country filter and reset judoka list.
+ *
+ * @pseudocode
+ * 1. Deselect all country buttons.
+ * 2. Render the full judoka list.
+ * 3. Update the live region to show all countries.
+ * 4. Close the country panel.
+ *
+ * @param {Element} listContainer
+ * @param {Array<Judoka>} judokaList
+ * @param {Function} render
+ * @param {HTMLButtonElement} toggleButton
+ * @param {Element} panel
+ * @param {(count: number, country: string) => void} updateLiveRegion
+ * @returns {Promise<void>}
+ */
+export async function clearCountryFilter(
+  listContainer,
+  judokaList,
+  render,
+  toggleButton,
+  panel,
+  updateLiveRegion
+) {
+  const buttons = listContainer.querySelectorAll("button.flag-button");
+  buttons.forEach((b) => b.classList.remove("selected"));
+  await render(judokaList);
+  updateLiveRegion(judokaList.length, "all countries");
+  toggleCountryPanel(toggleButton, panel, false);
+}
+
+/**
+ * Apply a country filter and render the resulting judoka list.
+ *
+ * @pseudocode
+ * 1. Highlight the selected flag button.
+ * 2. Filter judoka by the button's country value.
+ * 3. Render the filtered list.
+ * 4. Update the live region with the result count.
+ * 5. Remove existing no-results message.
+ * 6. If no results, append a no-results message.
+ * 7. Close the country panel.
+ *
+ * @param {HTMLButtonElement} button
+ * @param {Element} listContainer
+ * @param {Array<Judoka>} judokaList
+ * @param {Function} render
+ * @param {HTMLButtonElement} toggleButton
+ * @param {Element} panel
+ * @param {Element} carouselEl
+ * @param {(count: number, country: string) => void} updateLiveRegion
+ * @returns {Promise<void>}
+ */
+export async function applyCountryFilter(
+  button,
+  listContainer,
+  judokaList,
+  render,
+  toggleButton,
+  panel,
+  carouselEl,
+  updateLiveRegion
+) {
+  const selected = button.value;
+  highlightSelection(listContainer, button);
+  const filtered =
+    selected === "all" ? judokaList : judokaList.filter((j) => j.country === selected);
+  await render(filtered);
+  updateLiveRegion(filtered.length, selected === "all" ? "all countries" : selected);
+  const existingMessage = carouselEl.querySelector(".no-results-message");
+  if (existingMessage) {
+    existingMessage.remove();
+  }
+  if (filtered.length === 0) {
+    const noResultsMessage = document.createElement("div");
+    noResultsMessage.className = "no-results-message";
+    noResultsMessage.setAttribute("role", "status");
+    noResultsMessage.setAttribute("aria-live", "polite");
+    noResultsMessage.textContent = "No judoka available for this country";
+    carouselEl.appendChild(noResultsMessage);
+  }
+  toggleCountryPanel(toggleButton, panel, false);
 }
 
 /**
@@ -64,35 +148,29 @@ export function setupCountryFilter(
   }
 
   clearButton.addEventListener("click", async () => {
-    const buttons = listContainer.querySelectorAll("button.flag-button");
-    buttons.forEach((b) => b.classList.remove("selected"));
-    await render(judokaList);
-    updateLiveRegion(judokaList.length, "all countries");
-    toggleCountryPanel(toggleButton, panel, false);
+    await clearCountryFilter(
+      listContainer,
+      judokaList,
+      render,
+      toggleButton,
+      panel,
+      updateLiveRegion
+    );
   });
 
   listContainer.addEventListener("click", async (e) => {
     const button = e.target.closest("button.flag-button");
     if (!button) return;
-    const selected = button.value;
-    highlightSelection(listContainer, button);
-    const filtered =
-      selected === "all" ? judokaList : judokaList.filter((j) => j.country === selected);
-    await render(filtered);
-    updateLiveRegion(filtered.length, selected === "all" ? "all countries" : selected);
-    const existingMessage = carouselEl.querySelector(".no-results-message");
-    if (existingMessage) {
-      existingMessage.remove();
-    }
-    if (filtered.length === 0) {
-      const noResultsMessage = document.createElement("div");
-      noResultsMessage.className = "no-results-message";
-      noResultsMessage.setAttribute("role", "status");
-      noResultsMessage.setAttribute("aria-live", "polite");
-      noResultsMessage.textContent = "No judoka available for this country";
-      carouselEl.appendChild(noResultsMessage);
-    }
-    toggleCountryPanel(toggleButton, panel, false);
+    await applyCountryFilter(
+      button,
+      listContainer,
+      judokaList,
+      render,
+      toggleButton,
+      panel,
+      carouselEl,
+      updateLiveRegion
+    );
   });
 }
 

--- a/src/helpers/browse/setupCountryToggle.js
+++ b/src/helpers/browse/setupCountryToggle.js
@@ -3,15 +3,54 @@ import { toggleCountryPanel } from "../countryPanel.js";
 import { handleKeyboardNavigation } from "./handleKeyboardNavigation.js";
 
 /**
+ * Handle a click on the country toggle button.
+ *
+ * @pseudocode
+ * 1. Determine if panel was open.
+ * 2. Toggle the panel state.
+ * 3. If opening for the first time, load country slider.
+ *
+ * @param {HTMLButtonElement} toggleButton
+ * @param {Element} panel
+ * @param {Element} listContainer
+ * @returns {Promise<void>}
+ */
+export async function handleToggleClick(toggleButton, panel, listContainer) {
+  const wasOpen = panel.classList.contains("open");
+  toggleCountryPanel(toggleButton, panel);
+  if (!wasOpen && listContainer.children.length === 0) {
+    await createCountrySlider(listContainer);
+  }
+}
+
+/**
+ * Handle keydown interactions within the country panel.
+ *
+ * @pseudocode
+ * 1. If Escape, close the panel.
+ * 2. If ArrowRight/ArrowLeft, delegate to keyboard navigation helper.
+ *
+ * @param {KeyboardEvent} event
+ * @param {HTMLButtonElement} toggleButton
+ * @param {Element} panel
+ * @param {Element} listContainer
+ */
+export function handlePanelKeydown(event, toggleButton, panel, listContainer) {
+  if (event.key === "Escape") {
+    toggleCountryPanel(toggleButton, panel, false);
+  }
+
+  if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+    handleKeyboardNavigation(event, listContainer, "flag-button");
+  }
+}
+
+/**
  * Set up the country selection panel toggle behavior.
  *
  * @pseudocode
- * 1. On toggleButton click:
- *    a. Toggle panel open state.
- *    b. If opening for the first time, initialize country slider.
- * 2. On panel keydown:
- *    a. Close panel on 'Escape'.
- *    b. Navigate slider buttons with ArrowLeft/ArrowRight.
+ * 1. Attach click handler for toggle button.
+ * 2. Attach keydown handler for panel interactions.
  * 3. Return a function indicating if countries are loaded.
  *
  * @param {HTMLButtonElement} toggleButton
@@ -22,23 +61,13 @@ import { handleKeyboardNavigation } from "./handleKeyboardNavigation.js";
 export function setupCountryToggle(toggleButton, panel, listContainer) {
   const countriesLoaded = () => listContainer.children.length > 0;
 
-  toggleButton.addEventListener("click", async () => {
-    const wasOpen = panel.classList.contains("open");
-    toggleCountryPanel(toggleButton, panel);
-    if (!wasOpen && !countriesLoaded()) {
-      await createCountrySlider(listContainer);
-    }
-  });
+  toggleButton.addEventListener("click", () =>
+    handleToggleClick(toggleButton, panel, listContainer)
+  );
 
-  panel.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") {
-      toggleCountryPanel(toggleButton, panel, false);
-    }
-
-    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
-      handleKeyboardNavigation(e, listContainer, "flag-button");
-    }
-  });
+  panel.addEventListener("keydown", (e) =>
+    handlePanelKeydown(e, toggleButton, panel, listContainer)
+  );
 
   return countriesLoaded;
 }


### PR DESCRIPTION
## Summary
- expose country filter internals as `highlightSelection`, `clearCountryFilter`, and `applyCountryFilter`
- add `handleToggleClick` and `handlePanelKeydown` exports for country panel toggle
- rewrite browse judoka helper tests to invoke these functions directly

## Testing
- `npx prettier . --check` *(fails: Code style issues found in 2 files)*
- `npx eslint .` *(fails: prettier errors in classicBattle files)*
- `npx vitest run` *(fails: 3 tests failing, plus unhandled rejections)*
- `npx playwright test`
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68ab943c38e48326b68b779ed9ac0f5c