### PR TITLE
feat: mark enlarged cards after hover

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -89,13 +89,7 @@ test.describe.parallel("Browse Judoka screen", () => {
 
     const before = await card.boundingBox();
     await card.hover();
-    await page.waitForFunction((selector) => {
-      const cardElement = document.querySelector(selector);
-      if (!cardElement) return false; // Element not found yet
-      const style = window.getComputedStyle(cardElement);
-      return style.transform !== "none";
-    }, "#carousel-container .judoka-card");
-    await page.waitForTimeout(200); // Allow animation to complete
+    await expect(card).toHaveAttribute("data-enlarged", "true");
     const after = await card.boundingBox();
 
     const widthRatio = after.width / before.width;

--- a/playwright/fixtures/commonSetup.js
+++ b/playwright/fixtures/commonSetup.js
@@ -7,7 +7,8 @@
  * 3. Extend the base test's page fixture to:
  *    a. Clear localStorage and enable test-mode settings.
  *    b. Remove unexpected modal backdrops once after DOMContentLoaded.
- *    c. Register common routes.
+ *    c. Disable animations for tests via a `data-test-disable-animations` attribute.
+ *    d. Register common routes.
  * 4. Export the extended test and expect.
  */
 import { test as base, expect } from "@playwright/test";
@@ -65,6 +66,9 @@ export const test = base.extend({
         () => document.querySelectorAll(".modal-backdrop").forEach((el) => el.remove()),
         { once: true }
       );
+    });
+    await page.addInitScript(() => {
+      document.documentElement.setAttribute("data-test-disable-animations", "");
     });
     await registerCommonRoutes(page);
     await use(page);

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -53,7 +53,7 @@ test.describe.parallel("Homepage", () => {
   test("tile hover zoom and cursor", async ({ page }) => {
     const tile = page.locator(".card").first();
     await tile.hover();
-    await expect(tile).toHaveAttribute("data-zoomed", "true");
+    await expect(tile).toHaveAttribute("data-enlarged", "true");
     const scale = await tile.evaluate((el) => {
       const transform = getComputedStyle(el).transform;
       const match = transform.match(/matrix\(([^)]+)\)/);

--- a/src/helpers/setupHoverZoom.js
+++ b/src/helpers/setupHoverZoom.js
@@ -1,33 +1,45 @@
 import { onDomReady } from "./domReady.js";
 
 /**
- * Mark cards when their hover zoom transition completes.
+ * Mark cards when their hover enlargement transition completes.
  *
  * @pseudocode
  * 1. Select all elements with the `.card` class.
- * 2. For each card:
- *    a. Remove the `data-zoomed` marker on `mouseenter` and `mouseleave`.
- *    b. When a `transitionend` event for `transform` fires, set `data-zoomed="true"`.
+ * 2. Detect whether reduced motion is preferred or tests disable animations.
+ * 3. For each card:
+ *    a. Optionally disable transition when animations are disabled.
+ *    b. Remove the `data-enlarged` marker on `mouseenter` and `mouseleave`.
+ *    c. Immediately set `data-enlarged="true"` on `mouseenter` when animations are disabled.
+ *    d. When a `transitionend` event for `transform` fires, set `data-enlarged="true"`.
  */
 export function addHoverZoomMarkers() {
   if (typeof document === "undefined") return;
   const cards = document.querySelectorAll(".card");
+
+  let prefersReducedMotion = false;
+  try {
+    prefersReducedMotion =
+      window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {}
+  const disableAnimations = document.documentElement.hasAttribute("data-test-disable-animations");
+
   cards.forEach((card) => {
+    if (prefersReducedMotion || disableAnimations) {
+      card.style.transition = "none";
+    }
     const reset = () => {
-      delete card.dataset.zoomed;
+      delete card.dataset.enlarged;
     };
     card.addEventListener("mouseenter", () => {
       reset();
-      try {
-        if (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-          card.dataset.zoomed = "true";
-        }
-      } catch {}
+      if (prefersReducedMotion || disableAnimations) {
+        card.dataset.enlarged = "true";
+      }
     });
     card.addEventListener("mouseleave", reset);
     card.addEventListener("transitionend", (event) => {
       if (event.propertyName === "transform") {
-        card.dataset.zoomed = "true";
+        card.dataset.enlarged = "true";
       }
     });
   });


### PR DESCRIPTION
## Summary
- mark cards with `data-enlarged="true"` after hover completes or immediately when animations are disabled
- auto-disable hover transitions during tests via `data-test-disable-animations`
- rely on Playwright's `toHaveAttribute` for hover enlargement tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: output too long to capture)*
- `npx playwright test playwright/homepage.spec.js playwright/browse-judoka.spec.js --reporter line` *(fails: test run stalled)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac0d07d6308326af6b95db7ea19b2e