### PR TITLE
feat: emit battle state events

### DIFF
--- a/src/helpers/classicBattle/orchestrator.js
+++ b/src/helpers/classicBattle/orchestrator.js
@@ -105,11 +105,12 @@ export function getBattleStateMachine() {
  * 4. Define the `onTransition` asynchronous function, which executes every time the state machine transitions:
  *    a. If running in a browser environment (`typeof window !== "undefined"`):
  *       i. Update global `window` variables (`__classicBattleState`, `__classicBattlePrevState`, `__classicBattleLastEvent`) for debugging.
- *       ii. Create a log entry with `from`, `to`, `event`, and timestamp.
- *       iii. Maintain a circular log buffer (`__classicBattleStateLog`) of the last 20 state transitions.
- *       iv. Update a hidden DOM element (`#machine-state`) with the current state and transition details for visual debugging.
- *       v. Update a visible badge (`#battle-state-badge`) with the current state.
- *       vi. If a battle engine exists in the machine's context, update global `window` variables (`__classicBattleTimerState`) and a hidden DOM element (`#machine-timer`) with timer state details.
+ *       ii. Update `document.body` data attributes (`battle-state`, `prev-battle-state`) and dispatch a `battle:state` event with the new state.
+ *       iii. Create a log entry with `from`, `to`, `event`, and timestamp.
+ *       iv. Maintain a circular log buffer (`__classicBattleStateLog`) of the last 20 state transitions.
+ *       v. Update a hidden DOM element (`#machine-state`) with the current state and transition details for visual debugging.
+ *       vi. Update a visible badge (`#battle-state-badge`) with the current state.
+ *       vii. If a battle engine exists in the machine's context, update global `window` variables (`__classicBattleTimerState`) and a hidden DOM element (`#machine-timer`) with timer state details.
  *    b. Emit a "debugPanelUpdate" battle event.
  *    c. Retrieve any pending `waiters` for the new `to` state from `stateWaiters`.
  *    d. If `waiters` exist, delete the entry for `to` from `stateWaiters`.
@@ -161,6 +162,13 @@ export async function initClassicBattleOrchestrator(store, startRoundWrapper, op
         window.__classicBattleState = to;
         if (from) window.__classicBattlePrevState = from;
         if (event) window.__classicBattleLastEvent = event;
+        if (typeof document !== "undefined") {
+          try {
+            document.body.dataset.prevBattleState = from || "";
+            document.body.dataset.battleState = to;
+            document.dispatchEvent(new CustomEvent("battle:state", { detail: to }));
+          } catch {}
+        }
         const entry = { from: from || null, to, event: event || null, ts: Date.now() };
         const log = Array.isArray(window.__classicBattleStateLog)
           ? window.__classicBattleStateLog

--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -8,11 +8,13 @@ import { resolveRound } from "./roundResolver.js";
 
 export function isStateTransition(from, to) {
   try {
-    if (typeof window === "undefined") return false;
+    if (typeof document === "undefined") return false;
+    const current = document.body?.dataset.battleState;
+    const prev = document.body?.dataset.prevBattleState;
     if (from === null || from === undefined) {
-      return window.__classicBattleState === to;
+      return current === to;
     }
-    return window.__classicBattlePrevState === from && window.__classicBattleState === to;
+    return prev === from && current === to;
   } catch {
     return false;
   }

--- a/src/helpers/classicBattle/roundResolver.js
+++ b/src/helpers/classicBattle/roundResolver.js
@@ -62,7 +62,7 @@ export async function resolveRound(
   // a deadlock. Only dispatch "evaluate" when not already in that state.
   try {
     const inRoundDecision =
-      typeof window !== "undefined" && window.__classicBattleState === "roundDecision";
+      typeof document !== "undefined" && document.body?.dataset.battleState === "roundDecision";
     if (!inRoundDecision) {
       await dispatchBattleEvent("evaluate");
     }

--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -75,7 +75,7 @@ export async function handleStatSelection(store, stat) {
   // If the orchestrator is active, signal selection; otherwise resolve inline
   // to keep tests and non-orchestrated flows moving.
   try {
-    const hasMachine = typeof window !== "undefined" && !!window.__classicBattleState;
+    const hasMachine = typeof document !== "undefined" && !!document.body?.dataset.battleState;
     if (hasMachine) {
       try {
         console.warn("[test] handleStatSelection: dispatch statSelected to machine");

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -622,7 +622,9 @@ export function setBattleStateBadgeEnabled(enable) {
     if (headerRight) headerRight.appendChild(badge);
     else document.querySelector("header")?.appendChild(badge);
   }
-  updateBattleStateBadge(typeof window !== "undefined" ? window.__classicBattleState : null);
+  updateBattleStateBadge(
+    typeof document !== "undefined" ? document.body?.dataset.battleState || null : null
+  );
 }
 
 /**

--- a/tests/helpers/classicBattle/stateTransitions.test.js
+++ b/tests/helpers/classicBattle/stateTransitions.test.js
@@ -28,12 +28,12 @@ describe("classicBattleStates.json transitions", () => {
     if (!Array.isArray(state.triggers)) continue;
     for (const trigger of state.triggers) {
       it(`${state.name} --${trigger.on}--> ${trigger.target}`, async () => {
-        delete window.__classicBattleState;
-        delete window.__classicBattlePrevState;
+        document.body.dataset.battleState = "";
+        document.body.dataset.prevBattleState = "";
         const spy = vi.fn();
         const onTransition = ({ from, to }) => {
-          window.__classicBattlePrevState = from;
-          window.__classicBattleState = to;
+          document.body.dataset.prevBattleState = from || "";
+          document.body.dataset.battleState = to;
           emitBattleEvent("debugPanelUpdate");
         };
         onBattleEvent("debugPanelUpdate", spy);


### PR DESCRIPTION
## Summary
- emit `battle:state` events and expose `data-battle-state` for transitions
- wait for classic battle state via body attribute instead of polling window
- drop reliance on `window.__classicBattleState` in helpers and tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac0d0cf6888326bf80efa005416852