### PR TITLE
feat: add ready events for page helpers

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -58,7 +58,7 @@ test.describe.parallel("Browse Judoka screen", () => {
   test("resetting filter shows all judoka", async ({ page }) => {
     const toggle = page.getByTestId(COUNTRY_TOGGLE_LOCATOR);
 
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     const allCards = page.locator("[data-testid=carousel-container] .judoka-card");
     const initialCount = await allCards.count();
 
@@ -77,7 +77,7 @@ test.describe.parallel("Browse Judoka screen", () => {
   test("displays country flags", async ({ page }) => {
     const toggle = page.getByTestId(COUNTRY_TOGGLE_LOCATOR);
     await toggle.click();
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     const slides = page.locator("#country-list .slide");
     await expect(slides).toHaveCount(4);
     await expect(slides.first().locator("img")).toHaveAttribute("alt", /all countries/i);
@@ -85,7 +85,7 @@ test.describe.parallel("Browse Judoka screen", () => {
 
   test("judoka card enlarges on hover", async ({ page }) => {
     const card = page.locator("#carousel-container .judoka-card").first();
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
 
     const before = await card.boundingBox();
     await card.hover();
@@ -109,7 +109,7 @@ test.describe.parallel("Browse Judoka screen", () => {
     );
     await page.setViewportSize({ width: 320, height: 800 });
     await page.reload();
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     const container = page.locator('[data-testid="carousel"]');
 
     await container.focus();
@@ -140,7 +140,7 @@ test.describe.parallel("Browse Judoka screen", () => {
     );
     await page.setViewportSize({ width: 320, height: 800 });
     await page.reload();
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     const container = page.locator(".card-carousel");
 
     const markers = page.locator(".scroll-marker");
@@ -325,7 +325,7 @@ test.describe.parallel("Browse Judoka screen", () => {
 
     const spinner = page.locator(".loading-spinner");
     await expect(spinner).toBeVisible();
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     await expect(spinner).toBeHidden();
   });
 }); // Closing brace for test.describe.parallel

--- a/playwright/homepage-layout.spec.js
+++ b/playwright/homepage-layout.spec.js
@@ -8,7 +8,7 @@ test.describe.parallel("Homepage layout", () => {
 
     test.beforeEach(async ({ page }) => {
       await page.goto("/index.html");
-      await page.evaluate(() => window.homepageReadyPromise);
+      await page.locator('body[data-homepage-ready="true"]').waitFor();
       await page.evaluate(() => window.navReadyPromise);
     });
 
@@ -52,7 +52,7 @@ test.describe.parallel("Homepage layout", () => {
 
     test.beforeEach(async ({ page }) => {
       await page.goto("/index.html");
-      await page.evaluate(() => window.homepageReadyPromise);
+      await page.locator('body[data-homepage-ready="true"]').waitFor();
       await page.evaluate(() => window.navReadyPromise);
     });
 

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -4,7 +4,7 @@ import { verifyPageBasics, NAV_CLASSIC_BATTLE } from "./fixtures/navigationCheck
 test.describe.parallel("View Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/randomJudoka.html");
-    await page.evaluate(() => window.randomJudokaReadyPromise);
+    await page.locator('body[data-random-judoka-ready="true"]').waitFor();
   });
 
   test("random judoka elements visible", async ({ page }) => {

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -56,7 +56,7 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
   test("@homepage-desktop-layout screenshot", async ({ page }) => {
     await page.goto("/index.html");
     await page.setViewportSize({ width: 1024, height: 800 });
-    await page.evaluate(() => window.homepageReadyPromise);
+    await page.locator('body[data-homepage-ready="true"]').waitFor();
     await page.evaluate(() => window.navReadyPromise);
     await expect(page).toHaveScreenshot("desktop-layout.png", { fullPage: true });
   });
@@ -64,7 +64,7 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
   test("@homepage-mobile-layout screenshot", async ({ page }) => {
     await page.goto("/index.html");
     await page.setViewportSize({ width: 500, height: 800 });
-    await page.evaluate(() => window.homepageReadyPromise);
+    await page.locator('body[data-homepage-ready="true"]').waitFor();
     await page.evaluate(() => window.navReadyPromise);
     await expect(page).toHaveScreenshot("mobile-layout.png", { fullPage: true });
   });
@@ -72,14 +72,14 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
   test("@randomJudoka-signature screenshot", async ({ page }) => {
     await page.goto("/src/pages/randomJudoka.html");
     await page.getByTestId("draw-button").click();
-    await page.evaluate(() => window.signatureMoveReadyPromise);
+    await page.locator('body[data-signature-move-ready="true"]').waitFor();
     const sigMove = page.locator(".signature-move-container");
     await expect(sigMove).toHaveScreenshot("randomJudoka-signature.png");
   });
 
   test("@browseJudoka-signature screenshot", async ({ page }) => {
     await page.goto("/src/pages/browseJudoka.html");
-    await page.evaluate(() => window.signatureMoveReadyPromise);
+    await page.locator('body[data-signature-move-ready="true"]').waitFor();
     const sigMove = page.locator(".signature-move-container").first();
     await expect(sigMove).toHaveScreenshot("browseJudoka-signature.png");
   });

--- a/src/helpers/homePage.js
+++ b/src/helpers/homePage.js
@@ -1,29 +1,27 @@
-let resolveHomepageReady;
-
 /**
- * Resolve when the homepage grid is available.
+ * Signal when the homepage grid is available.
  *
- * @type {Promise<void>}
+ * @pseudocode
+ * 1. If `.game-mode-grid` exists, mark the document as ready.
+ * 2. Otherwise, observe DOM mutations until it appears, then mark ready.
+ *
+ * Marking ready entails:
+ *  - Setting `data-homepage-ready="true"` on `<body>`.
+ *  - Dispatching a `homepage-ready` event on `document`.
  */
-export const homepageReadyPromise =
-  typeof window !== "undefined"
-    ? new Promise((resolve) => {
-        resolveHomepageReady = resolve;
-      })
-    : Promise.resolve();
-
-if (typeof window !== "undefined") {
-  window.homepageReadyPromise = homepageReadyPromise;
+function markHomepageReady() {
+  document.body.setAttribute("data-homepage-ready", "true");
+  document.dispatchEvent(new CustomEvent("homepage-ready"));
 }
 
 if (typeof document !== "undefined") {
   if (document.querySelector(".game-mode-grid")) {
-    resolveHomepageReady?.();
+    markHomepageReady();
   } else {
     const observer = new MutationObserver(() => {
       if (document.querySelector(".game-mode-grid")) {
         observer.disconnect();
-        resolveHomepageReady?.();
+        markHomepageReady();
       }
     });
     observer.observe(document.documentElement, {

--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -307,13 +307,8 @@ export async function setupRandomJudokaPage() {
   initTooltips();
 }
 
-export const randomJudokaReadyPromise = new Promise((resolve) => {
-  onDomReady(async () => {
-    await Promise.all([setupRandomJudokaPage(), window.navReadyPromise]);
-    resolve();
-  });
+onDomReady(async () => {
+  await Promise.all([setupRandomJudokaPage(), window.navReadyPromise]);
+  document.body.setAttribute("data-random-judoka-ready", "true");
+  document.dispatchEvent(new CustomEvent("random-judoka-ready"));
 });
-
-if (typeof window !== "undefined") {
-  window.randomJudokaReadyPromise = randomJudokaReadyPromise;
-}

--- a/src/helpers/signatureMove.js
+++ b/src/helpers/signatureMove.js
@@ -1,25 +1,11 @@
 /**
- * Promise and helpers to signal when signature moves finish rendering.
+ * Signal when signature moves finish rendering.
  *
  * @pseudocode
- * 1. Create a promise and store its resolver in `resolveReady`.
- * 2. Expose the promise on `window.signatureMoveReadyPromise`.
- * 3. Export `markSignatureMoveReady` to invoke the resolver.
- */
-let resolveReady;
-export const signatureMoveReadyPromise = new Promise((resolve) => {
-  resolveReady = resolve;
-});
-if (typeof window !== "undefined") {
-  window.signatureMoveReadyPromise = signatureMoveReadyPromise;
-}
-
-/**
- * Resolve the ready promise when signature moves render.
- *
- * @pseudocode
- * 1. If a resolver exists, invoke it.
+ * 1. Set `data-signature-move-ready="true"` on `<body>`.
+ * 2. Dispatch a `signature-move-ready` event on `document`.
  */
 export function markSignatureMoveReady() {
-  resolveReady?.();
+  document.body.setAttribute("data-signature-move-ready", "true");
+  document.dispatchEvent(new CustomEvent("signature-move-ready"));
 }


### PR DESCRIPTION
## Summary
- mark homepage and other pages ready using data attributes and custom events
- wait on new readiness markers in Playwright specs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run --reporter=basic`
- `npx playwright test` *(fails: Classic battle flow timer auto-selects)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac0d02171883268a2ab4629d5c0fb8