### PR TITLE
feat: inject wait-for-opponent card helper into ClassicBattleView

### DIFF
--- a/src/helpers/classicBattle/bootstrap.js
+++ b/src/helpers/classicBattle/bootstrap.js
@@ -1,4 +1,5 @@
 import { onDomReady } from "../domReady.js";
+import { waitForOpponentCard } from "../battleJudokaPage.js";
 import ClassicBattleController from "./controller.js";
 import ClassicBattleView from "./view.js";
 import "./promises.js";
@@ -9,7 +10,7 @@ import "./roundUI.js";
  * Bootstrap Classic Battle page by wiring controller and view.
  */
 export async function setupClassicBattlePage() {
-  const view = new ClassicBattleView();
+  const view = new ClassicBattleView({ waitForOpponentCard });
   const controller = new ClassicBattleController({
     waitForOpponentCard: view.waitForOpponentCard
   });

--- a/src/helpers/classicBattle/view.js
+++ b/src/helpers/classicBattle/view.js
@@ -1,4 +1,3 @@
-import { waitForOpponentCard } from "../battleJudokaPage.js";
 import { setupScoreboard } from "../setupScoreboard.js";
 import { initQuitButton } from "./quitButton.js";
 import { skipCurrentPhase } from "./skipHandler.js";
@@ -28,7 +27,10 @@ import "../setupClassicBattleHomeLink.js";
  * Handles DOM interactions and binds to controller events.
  */
 export class ClassicBattleView {
-  constructor() {
+  /**
+   * @param {{ waitForOpponentCard?: () => Promise<void> }} [deps]
+   */
+  constructor({ waitForOpponentCard = () => {} } = {}) {
     this.statButtonControls = null;
     this.waitForOpponentCard = waitForOpponentCard;
   }

--- a/tests/helpers/classicBattle/statButtons.state.test.js
+++ b/tests/helpers/classicBattle/statButtons.state.test.js
@@ -5,8 +5,6 @@ import {
   waitingForPlayerActionExit
 } from "../../../src/helpers/classicBattle/orchestratorHandlers.js";
 import { ClassicBattleView } from "../../../src/helpers/classicBattle/view.js";
-
-vi.mock("../../../src/helpers/battleJudokaPage.js", () => ({ waitForOpponentCard: vi.fn() }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({ setupScoreboard: vi.fn() }));
 vi.mock("../../../src/helpers/classicBattle/quitButton.js", () => ({ initQuitButton: vi.fn() }));
 vi.mock("../../../src/helpers/classicBattle/skipHandler.js", () => ({ skipCurrentPhase: vi.fn() }));
@@ -49,7 +47,7 @@ describe("classicBattle stat button state", () => {
   });
 
   it("enables stat buttons only while waiting for player action", async () => {
-    const view = new ClassicBattleView();
+    const view = new ClassicBattleView({ waitForOpponentCard: vi.fn() });
     view.controller = {
       battleStore: {},
       timerControls: {},


### PR DESCRIPTION
## Summary
- inject `waitForOpponentCard` via `ClassicBattleView` constructor
- pass page-specific helper in classic battle bootstrap
- update stat button state test to provide helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac18f346108326a8f0e9d7cf8e3401