### PR TITLE
feat: allow custom timer for stat hint

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -768,19 +768,21 @@ export function setDebugPanelEnabled(enabled) {
  *
  * @pseudocode
  * 1. Skip if `localStorage.statHintShown` is set or unavailable.
- * 2. Trigger hover events on `#stat-help` for `durationMs` milliseconds.
- * 3. Record that the hint has been shown.
+ * 2. Dispatch `mouseenter` on `#stat-help`.
+ * 3. After `durationMs` via `setTimeoutFn`, dispatch `mouseleave`.
+ * 4. Record that the hint has been shown.
  *
  * @param {number} [durationMs=3000] Hover duration in milliseconds.
+ * @param {(fn: () => void, ms: number) => any} [setTimeoutFn=setTimeout] Timer function.
  */
-export function maybeShowStatHint(durationMs = 3000) {
+export function maybeShowStatHint(durationMs = 3000, setTimeoutFn = setTimeout) {
   try {
     if (typeof localStorage === "undefined") return;
     const hintShown = localStorage.getItem("statHintShown");
     if (hintShown) return;
     const help = document.getElementById("stat-help");
     help?.dispatchEvent(new Event("mouseenter"));
-    setTimeout(() => {
+    setTimeoutFn(() => {
       help?.dispatchEvent(new Event("mouseleave"));
     }, durationMs);
     localStorage.setItem("statHintShown", "true");

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -153,17 +153,18 @@ describe("classicBattlePage stat button interactions", () => {
 
 describe("classicBattlePage stat help tooltip", () => {
   it("shows tooltip only once", async () => {
-    vi.useFakeTimers();
-
     const help = document.createElement("button");
     help.id = "stat-help";
     document.body.appendChild(help);
     const spy = vi.spyOn(help, "dispatchEvent");
 
     const { maybeShowStatHint } = await import("../../src/helpers/classicBattle/uiHelpers.js");
+    const setTimeoutStub = vi.fn((fn) => {
+      fn();
+      return 0;
+    });
 
-    maybeShowStatHint(0);
-    vi.runAllTimers();
+    maybeShowStatHint(0, setTimeoutStub);
 
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy.mock.calls[0][0].type).toBe("mouseenter");
@@ -171,8 +172,7 @@ describe("classicBattlePage stat help tooltip", () => {
     expect(localStorage.getItem("statHintShown")).toBe("true");
 
     spy.mockClear();
-    maybeShowStatHint(0);
-    vi.runAllTimers();
+    maybeShowStatHint(0, setTimeoutStub);
     expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- allow maybeShowStatHint to use an injected timer function
- streamline stat help tooltip test by stubbing a zero-delay timer

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Homepage view judoka link navigates, Classic battle flow timers)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac4a7949808326ad4bbb434c2031de