### PR TITLE
feat: expose quote readiness

### DIFF
--- a/src/helpers/quoteBuilder.js
+++ b/src/helpers/quoteBuilder.js
@@ -1,5 +1,5 @@
 import { displayRandomQuote } from "./quotes/quoteService.js";
-import { displayFable, checkAssetsReady } from "./quotes/quoteRenderer.js";
+import { displayFable, checkAssetsReady, quoteReadyPromise } from "./quotes/quoteRenderer.js";
 
 /**
  * @typedef {Object} QuoteLoadState
@@ -52,13 +52,15 @@ async function waitForKgImage(state) {
  * 1. Create a `QuoteLoadState` object.
  * 2. Await `displayRandomQuote()` to retrieve a random fable.
  * 3. Pass the fable and state to `displayFable` for rendering.
- * 4. Await `waitForKgImage(state)` to handle the KG sprite image.
+ * 4. Await both `quoteReadyPromise` and `waitForKgImage(state)` to ensure the
+ *    DOM is updated and the KG sprite image is ready.
  *
- * @returns {Promise<void>} Promise that resolves once the quote is displayed.
+ * @returns {Promise<void>} Promise that resolves once the quote and image are
+ * loaded.
  */
 export async function loadQuote() {
   const state = { kgImageLoaded: false, quoteLoaded: false };
   const fable = await displayRandomQuote();
   displayFable(fable, state);
-  await waitForKgImage(state);
+  await Promise.all([quoteReadyPromise, waitForKgImage(state)]);
 }

--- a/src/helpers/quotes/quoteRenderer.js
+++ b/src/helpers/quotes/quoteRenderer.js
@@ -6,11 +6,17 @@
 import { escapeHTML } from "../utils.js";
 
 let resolveQuoteReady;
-if (typeof window !== "undefined") {
-  window.quoteReadyPromise = new Promise((resolve) => {
-    resolveQuoteReady = resolve;
-  });
-}
+/**
+ * Promise that resolves when quote markup is ready.
+ *
+ * @type {Promise<void>}
+ */
+export const quoteReadyPromise =
+  typeof window !== "undefined"
+    ? (window.quoteReadyPromise = new Promise((resolve) => {
+        resolveQuoteReady = resolve;
+      }))
+    : Promise.resolve();
 
 /**
  * @typedef {Object} QuoteLoadState

--- a/tests/helpers/quoteBuilder.test.js
+++ b/tests/helpers/quoteBuilder.test.js
@@ -1,15 +1,10 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { loadQuote } from "../../src/helpers/quoteBuilder.js";
 import { formatFableStory } from "../../src/helpers/quotes/quoteRenderer.js";
 
 const originalFetch = global.fetch;
 
-beforeEach(() => {
-  vi.useFakeTimers();
-});
-
 afterEach(() => {
-  vi.useRealTimers();
   vi.restoreAllMocks();
   global.fetch = originalFetch;
   document.body.innerHTML = "";
@@ -42,7 +37,6 @@ describe("loadQuote", () => {
     vi.spyOn(Math, "random").mockReturnValue(0);
 
     await loadQuote();
-    await vi.runAllTimersAsync();
 
     const contentHtml = document.getElementById("quote-content").innerHTML;
     expect(contentHtml).toBe("<p>Line1<br>Line2</p><br><p>Line3</p><br>");
@@ -60,7 +54,6 @@ describe("loadQuote", () => {
     global.fetch = vi.fn().mockRejectedValue(new Error("fail"));
 
     await loadQuote();
-    await vi.runAllTimersAsync();
 
     expect(quoteDiv.innerHTML).toBe("<p>Take a breath. Even a still pond reflects the sky.</p>");
     consoleErrorSpy.mockRestore();
@@ -77,13 +70,11 @@ describe("loadQuote", () => {
     // Empty array
     global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: async () => [] }));
     await loadQuote();
-    await vi.runAllTimersAsync();
     expect(quoteDiv.textContent).toContain("Take a breath");
 
     // Invalid data
     global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: async () => [{}] }));
     await loadQuote();
-    await vi.runAllTimersAsync();
     expect(quoteDiv.textContent).toContain("Take a breath");
   });
 
@@ -96,7 +87,6 @@ describe("loadQuote", () => {
       return Promise.resolve({ ok: true, json: async () => [{ id: 1, title: "A" }] });
     });
     await loadQuote();
-    await vi.runAllTimersAsync();
     // Should not throw even if #quote, #quote-loader, or #language-toggle are missing
   });
 });


### PR DESCRIPTION
## Summary
- resolve loadQuote after quote markup and KG image are ready
- export quoteReadyPromise for consumers
- simplify quoteBuilder tests to await loadQuote directly

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac59d3fe648326995a95f42cda8b30