### PR TITLE
feat: expose flushable debounce for settings storage

### DIFF
--- a/tests/utils/debounce.test.js
+++ b/tests/utils/debounce.test.js
@@ -45,4 +45,13 @@ describe("debounce", () => {
     expect(fn).toHaveBeenCalledWith("b");
     vi.useRealTimers();
   });
+
+  it("flush runs pending work immediately", async () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+    const promise = debounced("a");
+    debounced.flush();
+    await expect(promise).resolves.toBeUndefined();
+    expect(fn).toHaveBeenCalledWith("a");
+  });
 });


### PR DESCRIPTION
## Summary
- allow debounce to accept custom timer fns and expose `.flush()`
- forward timer overrides in settingsStorage and export flush helper
- update settings tests to use flush instead of advancing timers

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac59dcc23083268185798a4f770131