### PR TITLE
feat: signal page readiness via dom events

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -59,7 +59,7 @@ test.describe.parallel("Browse Judoka screen", () => {
   test("resetting filter shows all judoka", async ({ page }) => {
     const toggle = page.getByTestId(COUNTRY_TOGGLE_LOCATOR);
 
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     const allCards = page.locator("[data-testid=carousel-container] .judoka-card");
     const initialCount = await allCards.count();
 
@@ -78,7 +78,7 @@ test.describe.parallel("Browse Judoka screen", () => {
   test("displays country flags", async ({ page }) => {
     const toggle = page.getByTestId(COUNTRY_TOGGLE_LOCATOR);
     await toggle.click();
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     const slides = page.locator("#country-list .slide");
     await expect(slides).toHaveCount(4);
     await expect(slides.first().locator("img")).toHaveAttribute("alt", /all countries/i);
@@ -86,7 +86,7 @@ test.describe.parallel("Browse Judoka screen", () => {
 
   test("judoka card sets zoom marker on hover", async ({ page }) => {
     const card = page.locator("#carousel-container .judoka-card").first();
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     await card.hover();
     await expect(card).toHaveAttribute("data-zoomed", "true");
   });
@@ -97,7 +97,7 @@ test.describe.parallel("Browse Judoka screen", () => {
     );
     await page.setViewportSize({ width: 320, height: 800 });
     await page.reload();
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     const container = page.locator('[data-testid="carousel"]');
 
     await container.focus();
@@ -128,7 +128,7 @@ test.describe.parallel("Browse Judoka screen", () => {
     );
     await page.setViewportSize({ width: 320, height: 800 });
     await page.reload();
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     const container = page.locator(".card-carousel");
 
     const markers = page.locator(".scroll-marker");
@@ -313,7 +313,7 @@ test.describe.parallel("Browse Judoka screen", () => {
 
     const spinner = page.locator(".loading-spinner");
     await expect(spinner).toBeVisible();
-    await page.evaluate(() => window.browseJudokaReadyPromise);
+    await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     await expect(spinner).toBeHidden();
   });
 }); // Closing brace for test.describe.parallel

--- a/playwright/homepage-layout.spec.js
+++ b/playwright/homepage-layout.spec.js
@@ -8,7 +8,7 @@ test.describe.parallel("Homepage layout", () => {
 
     test.beforeEach(async ({ page }) => {
       await page.goto("/index.html");
-      await page.evaluate(() => window.homepageReadyPromise);
+      await page.locator('body[data-home-ready="true"]').waitFor();
       await page.evaluate(() => window.navReadyPromise);
     });
 
@@ -52,7 +52,7 @@ test.describe.parallel("Homepage layout", () => {
 
     test.beforeEach(async ({ page }) => {
       await page.goto("/index.html");
-      await page.evaluate(() => window.homepageReadyPromise);
+      await page.locator('body[data-home-ready="true"]').waitFor();
       await page.evaluate(() => window.navReadyPromise);
     });
 

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -4,7 +4,7 @@ import { verifyPageBasics, NAV_CLASSIC_BATTLE } from "./fixtures/navigationCheck
 test.describe.parallel("View Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/randomJudoka.html");
-    await page.evaluate(() => window.randomJudokaReadyPromise);
+    await page.locator('body[data-random-judoka-ready="true"]').waitFor();
   });
 
   test("random judoka elements visible", async ({ page }) => {

--- a/playwright/screenshot.spec.js
+++ b/playwright/screenshot.spec.js
@@ -56,7 +56,7 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
   test("@homepage-desktop-layout screenshot", async ({ page }) => {
     await page.goto("/index.html");
     await page.setViewportSize({ width: 1024, height: 800 });
-    await page.evaluate(() => window.homepageReadyPromise);
+    await page.locator('body[data-home-ready="true"]').waitFor();
     await page.evaluate(() => window.navReadyPromise);
     await expect(page).toHaveScreenshot("desktop-layout.png", { fullPage: true });
   });
@@ -64,7 +64,7 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
   test("@homepage-mobile-layout screenshot", async ({ page }) => {
     await page.goto("/index.html");
     await page.setViewportSize({ width: 500, height: 800 });
-    await page.evaluate(() => window.homepageReadyPromise);
+    await page.locator('body[data-home-ready="true"]').waitFor();
     await page.evaluate(() => window.navReadyPromise);
     await expect(page).toHaveScreenshot("mobile-layout.png", { fullPage: true });
   });
@@ -72,14 +72,14 @@ test.describe.parallel(runScreenshots ? "Screenshot suite" : "Screenshot suite (
   test("@randomJudoka-signature screenshot", async ({ page }) => {
     await page.goto("/src/pages/randomJudoka.html");
     await page.getByTestId("draw-button").click();
-    await page.evaluate(() => window.signatureMoveReadyPromise);
+    await page.locator('body[data-signature-move-ready="true"]').waitFor();
     const sigMove = page.locator(".signature-move-container");
     await expect(sigMove).toHaveScreenshot("randomJudoka-signature.png");
   });
 
   test("@browseJudoka-signature screenshot", async ({ page }) => {
     await page.goto("/src/pages/browseJudoka.html");
-    await page.evaluate(() => window.signatureMoveReadyPromise);
+    await page.locator('body[data-signature-move-ready="true"]').waitFor();
     const sigMove = page.locator(".signature-move-container").first();
     await expect(sigMove).toHaveScreenshot("browseJudoka-signature.png");
   });

--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -13,15 +13,15 @@ import { addHoverZoomMarkers } from "./setupHoverZoom.js";
 
 let resolveBrowseReady;
 export const browseJudokaReadyPromise =
-  typeof window !== "undefined"
+  typeof document !== "undefined"
     ? new Promise((resolve) => {
-        resolveBrowseReady = resolve;
+        resolveBrowseReady = () => {
+          document.body?.setAttribute("data-browse-judoka-ready", "true");
+          document.dispatchEvent(new CustomEvent("browse-judoka-ready", { bubbles: true }));
+          resolve();
+        };
       })
     : Promise.resolve();
-
-if (typeof window !== "undefined") {
-  window.browseJudokaReadyPromise = browseJudokaReadyPromise;
-}
 
 /**
  * Attach listener to switch layout mode of country panel.
@@ -50,7 +50,6 @@ export function setupLayoutToggle(layoutBtn, panel) {
  * 6. Initialize tooltips for interactive elements.
  */
 export async function setupBrowseJudokaPage() {
-  console.log("DEBUG: setupBrowseJudokaPage called."); // Added console.log
   const carouselContainer = document.getElementById("carousel-container");
   if (!carouselContainer) {
     console.error("Carousel container not found. Cannot set up browse Judoka page.");
@@ -136,8 +135,7 @@ export async function setupBrowseJudokaPage() {
       const { allJudoka, gokyoData } = await loadData();
       const render = (list) => renderCarousel(list, gokyoData);
       await renderCarousel(allJudoka, gokyoData);
-      console.log("Resolving browseJudokaReadyPromise (success path)"); // Added console.log
-      resolveBrowseReady?.(); // Resolve the promise before removing the spinner
+      resolveBrowseReady?.();
       spinner.remove();
       if (forceSpinner) {
         delete globalThis.__forceSpinner__;
@@ -167,8 +165,7 @@ export async function setupBrowseJudokaPage() {
         ariaLive
       );
     } catch (error) {
-      console.log("Resolving browseJudokaReadyPromise (error path)"); // Added console.log
-      resolveBrowseReady?.(); // Resolve the promise before removing the spinner
+      resolveBrowseReady?.();
       spinner.remove();
       if (forceSpinner) {
         delete globalThis.__forceSpinner__;

--- a/src/helpers/homePage.js
+++ b/src/helpers/homePage.js
@@ -1,20 +1,20 @@
 let resolveHomepageReady;
 
 /**
- * Resolve when the homepage grid is available.
+ * Resolve when the homepage grid is available and signal readiness.
  *
  * @type {Promise<void>}
  */
 export const homepageReadyPromise =
-  typeof window !== "undefined"
+  typeof document !== "undefined"
     ? new Promise((resolve) => {
-        resolveHomepageReady = resolve;
+        resolveHomepageReady = () => {
+          document.body?.setAttribute("data-home-ready", "true");
+          document.dispatchEvent(new CustomEvent("home-ready", { bubbles: true }));
+          resolve();
+        };
       })
     : Promise.resolve();
-
-if (typeof window !== "undefined") {
-  window.homepageReadyPromise = homepageReadyPromise;
-}
 
 if (typeof document !== "undefined") {
   if (document.querySelector(".game-mode-grid")) {

--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -17,8 +17,8 @@
  * 7. Render a placeholder card in the card container.
  * 8. Create the "Draw Card!" button (min 64px height, 300px width, pill shape, ARIA attributes) and attach its event listener.
  * 9. If data fails to load, disable the Draw button and show an error message or fallback card.
- * 10. Export `initRandomJudokaPage` to perform setup and await navigation readiness; expose `randomJudokaReadyPromise` that
- *     invokes it on DOM content loaded.
+ * 10. Export `initRandomJudokaPage` to perform setup and await navigation readiness; resolve `randomJudokaReadyPromise`
+ *     on DOM content loaded after setting `data-random-judoka-ready` on `<body>` and dispatching `random-judoka-ready`.
  *
  * @returns {Promise<void>} Resolves when the page is fully initialized.
  * @see design/productRequirementsDocuments/prdRandomJudoka.md
@@ -320,10 +320,10 @@ export async function initRandomJudokaPage() {
 
 export const randomJudokaReadyPromise = new Promise((resolve) => {
   onDomReady(() => {
-    initRandomJudokaPage().then(resolve);
+    initRandomJudokaPage().then(() => {
+      document.body?.setAttribute("data-random-judoka-ready", "true");
+      document.dispatchEvent(new CustomEvent("random-judoka-ready", { bubbles: true }));
+      resolve();
+    });
   });
 });
-
-if (typeof window !== "undefined") {
-  window.randomJudokaReadyPromise = randomJudokaReadyPromise;
-}

--- a/src/helpers/signatureMove.js
+++ b/src/helpers/signatureMove.js
@@ -3,23 +3,25 @@
  *
  * @pseudocode
  * 1. Create a promise and store its resolver in `resolveReady`.
- * 2. Expose the promise on `window.signatureMoveReadyPromise`.
- * 3. Export `markSignatureMoveReady` to invoke the resolver.
+ * 2. Export `markSignatureMoveReady` to resolve the promise, set
+ *    `data-signature-move-ready` on `<body>`, and dispatch
+ *    `signature-move-ready`.
  */
 let resolveReady;
 export const signatureMoveReadyPromise = new Promise((resolve) => {
   resolveReady = resolve;
 });
-if (typeof window !== "undefined") {
-  window.signatureMoveReadyPromise = signatureMoveReadyPromise;
-}
 
 /**
  * Resolve the ready promise when signature moves render.
  *
  * @pseudocode
- * 1. If a resolver exists, invoke it.
+ * 1. Set `data-signature-move-ready="true"` on `<body>`.
+ * 2. Dispatch a `signature-move-ready` event on `document`.
+ * 3. If a resolver exists, invoke it.
  */
 export function markSignatureMoveReady() {
+  document.body?.setAttribute("data-signature-move-ready", "true");
+  document.dispatchEvent(new CustomEvent("signature-move-ready", { bubbles: true }));
   resolveReady?.();
 }


### PR DESCRIPTION
## Summary
- add DOM `*-ready` signals for home, browse judoka, random judoka, and signature move helpers
- drop `window.*ReadyPromise` usage in favor of body attributes and custom events
- adjust Playwright specs to wait for readiness attributes

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run --reporter=basic`
- `npx playwright test` *(fails: GET https://esm.sh/dompurify@3.2.6 net::ERR_TUNNEL_CONNECTION_FAILED, 11 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac8b5fee4483269f612b9ab124c7cb