### PR TITLE
Handle canceled carousel swipe gestures

### DIFF
--- a/design/productRequirementsDocuments/prdCardCarousel.md
+++ b/design/productRequirementsDocuments/prdCardCarousel.md
@@ -84,6 +84,7 @@ Failure to provide an efficient browsing experience may impact core gameplay —
 - **Network Disconnection**: Display a default judoka card (judoka id=0) instead of an error message.
 - **Missing/Broken Card Images**: Display the default judoka card (judoka id=0) rather than an error message.
 - **Slow Network**: Show a loading spinner.
+- **Canceled Gestures**: If a swipe is canceled (touchcancel/pointercancel), reset the gesture state without navigating so the next swipe starts clean.
 
 ---
 


### PR DESCRIPTION
## Summary
- reset carousel swipe state on touchcancel and pointercancel events
- test carousel controller with touch and pointer cancel scenarios
- note canceled gestures in card carousel PRD

## Testing
- `npx prettier . --check --log-level warn`
- `npx eslint src/helpers/carousel/controller.js tests/helpers/carouselController.test.js`
- `npx vitest run --reporter=basic`
- `npx playwright test` *(fails: Classic battle flow tie message timeout; some tests interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac8ef1eab883269be2ee28a942ae6b