### PR TITLE
Use scrollend for carousel scroll sync

### DIFF
--- a/design/productRequirementsDocuments/prdCardCarousel.md
+++ b/design/productRequirementsDocuments/prdCardCarousel.md
@@ -94,6 +94,7 @@ Failure to provide an efficient browsing experience may impact core gameplay —
 - Use hardware-accelerated CSS transforms (e.g., `translate3d`) for smooth scrolling and animations (**≥60 fps**).
 - Carousel should debounce swipe/scroll events to prevent rapid-fire performance hits.
 - Card metadata must be dynamically fetched from `judoka.json`; errors should gracefully fallback to judoka id=0 without showing an error message.
+- Programmatic navigation waits for a `scrollend` event before re-enabling scroll synchronization, preserving accurate page counters.
 
 ---
 


### PR DESCRIPTION
## Summary
- Re-enable carousel scroll synchronization on the `scrollend` event instead of a timeout
- Test programmatic navigation followed by user scroll to ensure page counters stay accurate
- Document scroll-end synchronization in carousel PRD

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: Screenshot suite & statReset tests, network errors)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac92d8a2148326a377cbccbdf38835