### PR TITLE
feat: add timeout race for battle state waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ npx playwright test
 - Prefer `await page.evaluate(() => window.battleReadyPromise)` to detect that the Classic Battle page is fully initialized. This resolves when both the “home” and “state” parts finish booting (see `src/helpers/battleInit.js`).
 - Test helper shortcuts are available in `playwright/fixtures/waits.js`:
   - `await waitForBattleReady(page)` and `await waitForSettingsReady(page)`.
-  - `await waitForBattleState(page, "waitingForPlayerAction", 10000)` for machine state assertions.
+  - `await waitForBattleState(page, "waitingForPlayerAction", 10000)` for machine state assertions. This helper rejects if the state isn't reached within the provided timeout, preventing browser deadlocks.
   - `await page.evaluate(() => window.statButtonsReadyPromise)` to wait until stat buttons are re-enabled for a round.
 - Avoid waiting for brittle UI states like the header timer element (`#next-round-timer`) to be visible at page load. The initial pre‑match countdown is rendered via snackbar, not the header timer, and may be empty initially.
 - When targeting round start readiness, it’s fine to wait for the selection prompt snackbar (e.g., “Select your move”) or `#stat-buttons[data-buttons-ready="true"]`.

--- a/playwright/fixtures/waits.js
+++ b/playwright/fixtures/waits.js
@@ -31,8 +31,9 @@ export async function waitForSettingsReady(page) {
  *
  * @pseudocode
  * 1. Evaluate whether `window.onStateTransition` exists on the page.
- * 2. If it does, invoke it with the target state and timeout.
- * 3. Otherwise, expect the body element to have `data-battle-state` equal to `stateName`.
+ * 2. If it does, race its promise against a timeout using `Promise.race`.
+ * 3. Reject with a message including the target state when the timeout wins.
+ * 4. Otherwise, expect the body element to have `data-battle-state` equal to `stateName`.
  *
  * @param {import('@playwright/test').Page} page
  * @param {string} stateName
@@ -41,7 +42,12 @@ export async function waitForSettingsReady(page) {
 export async function waitForBattleState(page, stateName, timeout = 10000) {
   const hasHelper = await page.evaluate(() => typeof window.onStateTransition === "function");
   if (hasHelper) {
-    await page.evaluate(({ s, t }) => window.onStateTransition(s, t), { s: stateName, t: timeout });
+    await Promise.race([
+      page.evaluate(({ s, t }) => window.onStateTransition(s, t), { s: stateName, t: timeout }),
+      page.waitForTimeout(timeout).then(() => {
+        throw new Error(`Timed out waiting for battle state "${stateName}"`);
+      })
+    ]);
     return;
   }
   await expect(page.locator("body")).toHaveAttribute("data-battle-state", stateName, {

--- a/playwright/waits-timeout.spec.js
+++ b/playwright/waits-timeout.spec.js
@@ -1,0 +1,14 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+import { waitForBattleReady, waitForBattleState } from "./fixtures/waits.js";
+
+test("waitForBattleState rejects when state isn't reached", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.onStateTransition = () => new Promise(() => {});
+  });
+  await page.goto("/src/pages/battleJudoka.html");
+  await waitForBattleReady(page);
+  const targetState = "neverAppears";
+  await expect(waitForBattleState(page, targetState, 100)).rejects.toThrow(
+    `Timed out waiting for battle state "${targetState}"`
+  );
+});


### PR DESCRIPTION
## Summary
- prevent Playwright battle state waits from hanging by racing against a timeout
- document the rejection behavior
- test timeout handling when a state never resolves

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `SKIP_SCREENSHOTS=true npx playwright test playwright/waits-timeout.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac96d364748326af365b4e24396a21