### PR TITLE
Allow native vertical scrolling in card carousel

### DIFF
--- a/design/productRequirementsDocuments/prdCardCarousel.md
+++ b/design/productRequirementsDocuments/prdCardCarousel.md
@@ -95,6 +95,7 @@ Failure to provide an efficient browsing experience may impact core gameplay —
 - Carousel should debounce swipe/scroll events to prevent rapid-fire performance hits.
 - Card metadata must be dynamically fetched from `judoka.json`; errors should gracefully fallback to judoka id=0 without showing an error message.
 - Programmatic navigation waits for a `scrollend` event before re-enabling scroll synchronization, preserving accurate page counters.
+- Set `touch-action: pan-y` on the carousel so vertical page scrolling passes through natively while horizontal swipes are custom-handled.
 
 ---
 

--- a/src/helpers/carousel/controller.js
+++ b/src/helpers/carousel/controller.js
@@ -325,8 +325,6 @@ export class CarouselController {
       }
     };
 
-    this.container.style.touchAction = "none";
-
     this._onTouchStart = (e) => {
       if (gestureActive) return;
       gestureActive = true;

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -10,7 +10,7 @@
   /* Disable native touch scrolling during swipe handling to avoid
      double-advancing pages when both native scroll and programmatic
      paging occur from a single gesture. */
-  touch-action: none;
+  touch-action: pan-y;
   width: 100%; /* Ensure carousel doesn't exceed container width */
   /* Safari flexbox quirk: set min-width to 0 so container doesn't expand */
   min-width: 0;

--- a/tests/helpers/swipeNavigation.test.js
+++ b/tests/helpers/swipeNavigation.test.js
@@ -59,4 +59,22 @@ describe("setupSwipeNavigation", () => {
       behavior: "smooth"
     });
   });
+
+  it("ignores vertical swipes so vertical scrolling remains native", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "clientWidth", { value: 300, configurable: true });
+    Object.defineProperty(container, "scrollWidth", { value: 900, configurable: true });
+    container.scrollTo = vi.fn();
+
+    setupSwipeNavigation(container);
+
+    container.dispatchEvent(
+      new PointerEvent("pointerdown", { clientX: 50, clientY: 0, pointerType: "mouse" })
+    );
+    container.dispatchEvent(
+      new PointerEvent("pointerup", { clientX: 50, clientY: 100, pointerType: "mouse" })
+    );
+
+    expect(container.scrollTo).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- allow vertical page scrolling while swiping carousel horizontally
- drop redundant JS `touchAction` override
- document `touch-action: pan-y` and add vertical swipe test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: ReferenceError: process is not defined)
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac96a7bc8c83268f0441158cf0ce1d