### PR TITLE
refactor: extract battle dispatcher

### DIFF
--- a/src/helpers/classicBattle/battleDispatcher.js
+++ b/src/helpers/classicBattle/battleDispatcher.js
@@ -1,0 +1,32 @@
+/**
+ * Dispatch a battle event using the orchestrator when available.
+ *
+ * @pseudocode
+ * 1. Try to import `./orchestrator.js` and call its `dispatchBattleEvent` export.
+ * 2. If import or call fails, obtain the live machine via `window.__getClassicBattleMachine` and dispatch on it.
+ * 3. Swallow errors and return `undefined` when no dispatcher is available.
+ *
+ * @param {string} eventName - Event to dispatch.
+ * @param {any} [payload] - Optional event payload.
+ * @returns {Promise<any>} Result of the dispatch when available.
+ */
+export async function dispatchBattleEvent(eventName, payload) {
+  // Prefer orchestrator export when it can be loaded (satisfies test spies)
+  try {
+    const orchestrator = await import("./orchestrator.js");
+    if (orchestrator && typeof orchestrator.dispatchBattleEvent === "function") {
+      if (payload === undefined) return await orchestrator.dispatchBattleEvent(eventName);
+      return await orchestrator.dispatchBattleEvent(eventName, payload);
+    }
+  } catch {}
+  // Fallback to the live machine when present
+  try {
+    if (typeof window !== "undefined") {
+      const getMachine = window.__getClassicBattleMachine;
+      const machine = typeof getMachine === "function" ? getMachine() : null;
+      if (machine && typeof machine.dispatch === "function") {
+        return await machine.dispatch(eventName, payload);
+      }
+    }
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- centralize battle event dispatching with new `battleDispatcher`
- use dispatcher in `timerService` instead of local helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot.spec.js and others)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac9b5a1c788326ba04deea3820bf13