### PR TITLE
Refactor next-round timer to return explicit controls

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -10,7 +10,7 @@ import { showResult } from "../battle/index.js";
 import { shouldReduceMotionSync } from "../motionUtils.js";
 import { onFrame as scheduleFrame, cancel as cancelFrame } from "../../utils/scheduler.js";
 import { handleStatSelection } from "./selectionHandler.js";
-import { onNextButtonClick } from "./timerService.js";
+import { onNextButtonClick, getNextRoundControls } from "./timerService.js";
 import { loadStatNames } from "../stats.js";
 import { toggleViewportSimulation } from "../viewportDebug.js";
 import { toggleInspectorPanels } from "../cardUtils.js";
@@ -436,7 +436,7 @@ export function registerRoundStartErrorHandler(retryFn) {
 export function setupNextButton() {
   const btn = document.getElementById("next-button");
   if (!btn) return;
-  btn.addEventListener("click", onNextButtonClick);
+  btn.addEventListener("click", (e) => onNextButtonClick(e, getNextRoundControls()));
 }
 
 /**
@@ -821,7 +821,7 @@ export function resetBattleUI(store) {
     const clone = nextBtn.cloneNode(true);
     clone.disabled = true;
     delete clone.dataset.nextReady;
-    clone.addEventListener("click", onNextButtonClick);
+    clone.addEventListener("click", (e) => onNextButtonClick(e, getNextRoundControls()));
     nextBtn.replaceWith(clone);
   }
 

--- a/tests/helpers/classicBattle/debugPanel.test.js
+++ b/tests/helpers/classicBattle/debugPanel.test.js
@@ -29,7 +29,8 @@ vi.mock("../../../src/helpers/classicBattle/selectionHandler.js", () => ({
   handleStatSelection: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
-  onNextButtonClick: vi.fn()
+  onNextButtonClick: vi.fn(),
+  getNextRoundControls: vi.fn()
 }));
 vi.mock("../../../src/helpers/stats.js", () => ({ loadStatNames: vi.fn() }));
 vi.mock("../../../src/helpers/viewportDebug.js", () => ({ toggleViewportSimulation: vi.fn() }));

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -104,11 +104,11 @@ describe("classicBattle scheduleNextRound", () => {
     await orchestrator.dispatchBattleEvent("continue");
     expect(machine.getState()).toBe("cooldown");
 
-    const readyPromise = battleMod.scheduleNextRound({ matchEnded: false });
+    const controls = battleMod.scheduleNextRound({ matchEnded: false });
 
     timerSpy.advanceTimersByTime(3000);
     await vi.runAllTimersAsync();
-    await readyPromise;
+    await controls.ready;
 
     expect(dispatchSpy).toHaveBeenCalledWith("ready");
     expect(startRoundWrapper).toHaveBeenCalledTimes(1);
@@ -142,9 +142,9 @@ describe("classicBattle scheduleNextRound", () => {
     await orchestrator.dispatchBattleEvent("continue");
     expect(machine.getState()).toBe("cooldown");
 
-    const readyPromise = battleMod.scheduleNextRound({ matchEnded: false });
+    const controls = battleMod.scheduleNextRound({ matchEnded: false });
     document.getElementById("next-button").dispatchEvent(new MouseEvent("click"));
-    await readyPromise;
+    await controls.ready;
     await vi.runAllTimersAsync();
 
     expect(startRoundWrapper).toHaveBeenCalledTimes(1);

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -41,11 +41,11 @@ describe("timerService next round handling", () => {
   it("clicking Next during cooldown skips current phase", async () => {
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
     const { nextButton } = createTimerNodes();
-    nextButton.addEventListener("click", mod.onNextButtonClick);
-    const promise = mod.scheduleNextRound({ matchEnded: false }, scheduler);
+    const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
+    nextButton.addEventListener("click", (e) => mod.onNextButtonClick(e, controls));
     scheduler.tick(0);
     nextButton.click();
-    await promise;
+    await controls.ready;
     // Current flow guarantees at least one dispatch; a second may occur
     // via attribute observation. Accept one or more invocations.
     expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
@@ -58,9 +58,9 @@ describe("timerService next round handling", () => {
     });
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
     createTimerNodes();
-    const promise = mod.scheduleNextRound({ matchEnded: false }, scheduler);
+    const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
     scheduler.tick(0);
-    await promise;
+    await controls.ready;
     expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
     expect(dispatchBattleEvent).toHaveBeenCalledTimes(1);
   });

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -371,7 +371,8 @@ describe("startRoundWrapper failures", () => {
       STATS: []
     }));
     vi.doMock("../../src/helpers/classicBattle/timerService.js", () => ({
-      onNextButtonClick: vi.fn()
+      onNextButtonClick: vi.fn(),
+      getNextRoundControls: vi.fn()
     }));
     vi.doMock("../../src/helpers/classicBattle/skipHandler.js", () => ({
       skipCurrentPhase: vi.fn()

--- a/tests/helpers/timerService.test.js
+++ b/tests/helpers/timerService.test.js
@@ -84,9 +84,9 @@ describe("timerService", () => {
     skip.skipCurrentPhase();
 
     const { scheduleNextRound } = await import("../../src/helpers/classicBattle/timerService.js");
-    const promise = scheduleNextRound({ matchEnded: false }, scheduler);
+    const controls = scheduleNextRound({ matchEnded: false }, scheduler);
     scheduler.tick(0);
-    await promise;
+    await controls.ready;
 
     expect(btn.dataset.nextReady).toBe("true");
     expect(btn.disabled).toBe(false);


### PR DESCRIPTION
## Summary
- Refactor classic battle timer service to encapsulate next-round timer state and expose `getNextRoundControls`
- Update UI helpers and tests to pass timer controls into `onNextButtonClick`
- Adjust scheduleNextRound tests to use returned `ready` promise

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ac9e9703988326a7944869e7ebdcae