### PR TITLE
refactor: extract next round helpers

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattle.md
+++ b/design/productRequirementsDocuments/prdClassicBattle.md
@@ -124,7 +124,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - After selection, the correct comparison is made, and the score updates based on round outcome.
 - After the player selects a stat, the Scoreboard shows "Opponent is choosing..." until the opponent's stat is revealed.
 - If the selected stats are equal, a tie message displays and the round ends.
-- After round results, a 3s countdown is displayed via snackbar (`Next round in: Xs`). The **Next** button becomes active once the countdown ends or when skipped. Reference [timerService.js](../../src/helpers/classicBattle/timerService.js) for exact durations to keep design and code aligned.
+- After round results, `computeNextRoundCooldown` and `createNextRoundSnackbarRenderer` run a 3s countdown via snackbar (`Next round in: Xs`). The **Next** button becomes active when `handleNextRoundExpiration` fires or immediately via `handleZeroCooldownFastPath` in test mode. Reference [timerService.js](../../src/helpers/classicBattle/timerService.js) for exact durations to keep design and code aligned.
 - After the match ends, a modal appears showing the final result and score with **Quit Match** and **Next Match** buttons; **Quit Match** exits to the main menu and **Next Match** starts a new match.
 - Player can quit mid-match; confirmation prompt appears; if confirmed, match ends with player loss recorded.
 - After confirming the quit action, the player is returned to the main menu (index.html).

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -113,6 +113,9 @@ describe("classicBattle scheduleNextRound", () => {
     expect(dispatchSpy).toHaveBeenCalledWith("ready");
     expect(startRoundWrapper).toHaveBeenCalledTimes(1);
     expect(machine.getState()).toBe("waitingForPlayerAction");
+    const btn = document.getElementById("next-button");
+    expect(btn?.dataset.nextReady).toBe("true");
+    expect(btn?.disabled).toBe(false);
   });
 
   it("transitions roundOver → cooldown → roundStart without duplicates", async () => {
@@ -150,5 +153,25 @@ describe("classicBattle scheduleNextRound", () => {
     expect(startRoundWrapper).toHaveBeenCalledTimes(1);
     expect(machine.getState()).toBe("waitingForPlayerAction");
     expect(generateRandomCardMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles zero-second cooldown fast path", async () => {
+    document.getElementById("next-round-timer")?.remove();
+    const { nextButton } = createTimerNodes();
+    nextButton.disabled = true;
+
+    mockBattleData();
+
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const { setTestMode } = await import("../../../src/helpers/testModeUtils.js");
+    setTestMode(true);
+
+    const controls = battleMod.scheduleNextRound({ matchEnded: false });
+    await controls.ready;
+
+    expect(nextButton.dataset.nextReady).toBe("true");
+    expect(nextButton.disabled).toBe(false);
+
+    setTestMode(false);
   });
 });

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -17,6 +17,10 @@ describe("timerService next round handling", () => {
       showAutoSelect: vi.fn(),
       clearTimer: vi.fn()
     }));
+    vi.doMock("../../../src/helpers/showSnackbar.js", () => ({
+      showSnackbar: vi.fn(),
+      updateSnackbar: vi.fn()
+    }));
     vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
       enableNextRoundButton: vi.fn(),
       disableNextRoundButton: vi.fn(),
@@ -63,5 +67,27 @@ describe("timerService next round handling", () => {
     await controls.ready;
     expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
     expect(dispatchBattleEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("computeNextRoundCooldown respects test mode", async () => {
+    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const val = mod.computeNextRoundCooldown({ isTestModeEnabled: () => true });
+    expect(val).toBe(0);
+  });
+
+  it("createNextRoundSnackbarRenderer shows and updates", async () => {
+    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const renderer = mod.createNextRoundSnackbarRenderer();
+    const snackbarMod = await import("../../../src/helpers/showSnackbar.js");
+    const scoreboardMod = await import("../../../src/helpers/setupScoreboard.js");
+
+    renderer(3);
+    renderer(2);
+    renderer(2);
+    renderer(0);
+
+    expect(snackbarMod.showSnackbar).toHaveBeenCalledWith("Next round in: 3s");
+    expect(snackbarMod.updateSnackbar).toHaveBeenCalledWith("Next round in: 2s");
+    expect(scoreboardMod.clearTimer).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- extract cooldown, snackbar, expiration, and zero-cooldown fast path into helper functions
- document countdown helpers in PRD
- add tests for cooldown helpers and zero-cooldown path

## Testing
- `npx prettier src/helpers/classicBattle/timerService.js tests/helpers/classicBattle/timerService.nextRound.test.js tests/helpers/classicBattle/scheduleNextRound.test.js design/productRequirementsDocuments/prdClassicBattle.md --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/timerService.nextRound.test.js tests/helpers/classicBattle/scheduleNextRound.test.js`
- `npx vitest run` *(failed: process hung)*
- `npx playwright test` *(failed: classicBattleFlow.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68aca6859f80832692cf77c1afb42806