### PR TITLE
chore: streamline helper tests

### DIFF
--- a/tests/helpers/helpers.test.js
+++ b/tests/helpers/helpers.test.js
@@ -3,15 +3,12 @@ import { describe, test, expect } from "vitest";
 import { formatDate, escapeHTML } from "../../src/helpers/utils.js";
 
 describe("formatDate", () => {
-  test.each(["not-a-date", "", null, undefined, 123456, {}, [], true, false, BigInt(123456789)])(
-    'returns "Invalid Date" for input %p',
-    (input) => {
-      expect(() => formatDate(input)).not.toThrow();
-      expect(formatDate(input)).toBe("Invalid Date");
-    }
-  );
+  test.each(["not-a-date", null])('returns "Invalid Date" for input %p', (input) => {
+    expect(() => formatDate(input)).not.toThrow();
+    expect(formatDate(input)).toBe("Invalid Date");
+  });
 
-  test.each(["2025-02-30", "2025-04-31", "2025-13-01", "2025-00-10"])(
+  test.each(["2025-02-30", "2025-13-01"])(
     'returns "Invalid Date" for impossible calendar date %p',
     (input) => {
       expect(formatDate(input)).toBe("Invalid Date");
@@ -20,20 +17,12 @@ describe("formatDate", () => {
 
   test.each([
     ["2025-04-24", "2025-04-24"],
-    ["2025-04-24T15:30:00Z", "2025-04-24"],
-    ["2025-04-24T15:30:00+02:00", "2025-04-24"],
-    ["2025-04-24T15:30:00.123Z", "2025-04-24"],
-    ["2024-02-29", "2024-02-29"],
-    ["1970-01-01", "1970-01-01"],
-    ["9999-12-31", "9999-12-31"],
-    ["0001-01-01", "0001-01-01"]
+    ["2024-02-29", "2024-02-29"]
   ])("formats input %p to %p", (input, expected) => {
     expect(formatDate(input)).toBe(expected);
   });
 
   test.each([
-    ["2025-04-24T00:00:00Z", "2025-04-24"],
-    ["2025-04-24T23:59:59Z", "2025-04-24"],
     ["2025-04-24T12:00:00+05:00", "2025-04-24"],
     ["2025-04-24T12:00:00-05:00", "2025-04-24"]
   ])("handles timezone offsets correctly for input %p", (input, expected) => {
@@ -42,7 +31,6 @@ describe("formatDate", () => {
 
   test.each([
     ["2025-04-24T15:30:00.123456Z", "2025-04-24"],
-    ["2025-04-24T15:30:00.000Z", "2025-04-24"],
     ["2025-04-24T15:30:00.999Z", "2025-04-24"]
   ])("handles sub-second precision correctly for input %p", (input, expected) => {
     expect(formatDate(input)).toBe(expected);
@@ -56,9 +44,7 @@ describe("formatDate", () => {
   test("handles edge cases for valid date strings", () => {
     const edgeCases = [
       ["2025-04-24T00:00:00.000Z", "2025-04-24"],
-      ["2025-04-24T23:59:59.999Z", "2025-04-24"],
-      ["2025-04-24T12:00:00+00:00", "2025-04-24"],
-      ["2025-04-24T12:00:00-00:00", "2025-04-24"]
+      ["2025-04-24T23:59:59.999Z", "2025-04-24"]
     ];
     edgeCases.forEach(([input, expected]) => {
       expect(formatDate(input)).toBe(expected);
@@ -67,7 +53,6 @@ describe("formatDate", () => {
 
   test.each([
     ["2025-04-24T15:30:00.123456789Z", "2025-04-24"],
-    ["2025-04-24T15:30:00.000000000Z", "2025-04-24"],
     ["2025-04-24T15:30:00.999999999Z", "2025-04-24"]
   ])("handles nanosecond precision correctly for input %p", (input, expected) => {
     expect(formatDate(input)).toBe(expected);
@@ -75,8 +60,7 @@ describe("formatDate", () => {
 
   test.each([
     ["2025-04-24T15:30:00Z", "2025-04-24"],
-    ["2025-04-24T15:30:00.123Z", "2025-04-24"],
-    ["2025-04-24T15:30:00.123456Z", "2025-04-24"]
+    ["2025-04-24T15:30:00.123Z", "2025-04-24"]
   ])(
     "does not modify valid ISO date strings with time components for input %p",
     (input, expected) => {
@@ -86,8 +70,7 @@ describe("formatDate", () => {
 
   test.each([
     [new Date("2025-04-24T00:00:00Z"), "2025-04-24"],
-    [new Date("2024-02-29T23:59:59Z"), "2024-02-29"],
-    [new Date("1970-01-01T00:00:00Z"), "1970-01-01"]
+    [new Date("2024-02-29T23:59:59Z"), "2024-02-29"]
   ])("formats Date instance %p to %p", (dateObj, expected) => {
     expect(formatDate(dateObj)).toBe(expected);
   });
@@ -112,11 +95,7 @@ describe("formatDate", () => {
 describe("escapeHTML", () => {
   test.each([
     ["<", "&lt;"],
-    [">", "&gt;"],
-    ["&", "&amp;"],
-    ["'", "&#039;"],
-    ['"', "&quot;"],
-    ["<div>&'\"</div>", "&lt;div&gt;&amp;&#039;&quot;&lt;/div&gt;"]
+    ["<div>&'\"", "&lt;div&gt;&amp;&#039;&quot;"]
   ])("escapes %p", (input, expected) => {
     expect(escapeHTML(input)).toBe(expected);
   });
@@ -125,10 +104,6 @@ describe("escapeHTML", () => {
     expect(escapeHTML("")).toBe("");
     expect(escapeHTML(null)).toBe("");
     expect(escapeHTML(undefined)).toBe("");
-  });
-
-  test("escapes mixed content with all special characters", () => {
-    expect(escapeHTML("<>&'\"")).toBe("&lt;&gt;&amp;&#039;&quot;");
   });
 
   test("does not double-escape already escaped entities", () => {


### PR DESCRIPTION
## Summary
- condense `formatDate` test cases to key valid, invalid, and edge scenarios
- trim `escapeHTML` tests to core escaping examples

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: 'testInfo' unused, 'expect' unused, 'evaluateRoundApi' unused, 'isStateTransition' unused)*
- `npx vitest run`
- `npx playwright test` *(failed: screenshot and reset tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68acab02d794832693070435b7064067