### PR TITLE
test: update timerService mocks for dispatcher

### DIFF
--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -18,6 +18,7 @@ This directory contains unit tests for Classic Battle helpers.
 - `pauseTimer.test.js`: pauses and resumes the round timer.
 - `quitModal.test.js`: confirms quitting via a modal dialog.
 - `roundSelectModal.test.js`: selects points-to-win via a modal.
+- `roundStartError.test.js`: surfaces round start failures.
 - `scheduleNextRound.test.js`: schedules and auto-dispatches the next round.
 - `selectionPrompt.test.js`: displays the selection prompt until a stat is chosen.
 - `stallRecovery.test.js`: recovers when stat selection stalls.

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -5,6 +5,9 @@ import { createMockScheduler } from "../mockScheduler.js";
 describe("timerService drift handling", () => {
   it("startTimer shows fallback on drift", async () => {
     vi.resetModules();
+    vi.doMock("../../../src/helpers/classicBattle/battleDispatcher.js", () => ({
+      dispatchBattleEvent: vi.fn()
+    }));
     const showMessage = vi.fn();
     vi.doMock("../../../src/helpers/setupScoreboard.js", () => ({
       showMessage,
@@ -33,6 +36,9 @@ describe("timerService drift handling", () => {
 
   it("scheduleNextRound shows fallback on drift", async () => {
     vi.resetModules();
+    vi.doMock("../../../src/helpers/classicBattle/battleDispatcher.js", () => ({
+      dispatchBattleEvent: vi.fn()
+    }));
     const showMessage = vi.fn();
     vi.doMock("../../../src/helpers/setupScoreboard.js", () => ({
       showMessage,

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -33,7 +33,7 @@ describe("timerService next round handling", () => {
       STATS: []
     }));
     dispatchBattleEvent = vi.fn();
-    vi.doMock("../../../src/helpers/classicBattle/orchestrator.js", () => ({
+    vi.doMock("../../../src/helpers/classicBattle/battleDispatcher.js", () => ({
       dispatchBattleEvent
     }));
   });
@@ -89,5 +89,18 @@ describe("timerService next round handling", () => {
     expect(snackbarMod.showSnackbar).toHaveBeenCalledWith("Next round in: 3s");
     expect(snackbarMod.updateSnackbar).toHaveBeenCalledWith("Next round in: 2s");
     expect(scoreboardMod.clearTimer).toHaveBeenCalled();
+  });
+
+  it("scheduleNextRound handles zero-second cooldown fast path", async () => {
+    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const { nextButton } = createTimerNodes();
+    const { setTestMode } = await import("../../../src/helpers/testModeUtils.js");
+    setTestMode(true);
+    const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
+    scheduler.tick(0);
+    await controls.ready;
+    expect(nextButton.dataset.nextReady).toBe("true");
+    expect(nextButton.disabled).toBe(false);
+    setTestMode(false);
   });
 });


### PR DESCRIPTION
## Summary
- update timerService drift and next-round suites to mock new battle dispatcher
- cover zero-second cooldown fast path for scheduleNextRound
- document roundStartError test in classic battle README

## Testing
- `npx prettier tests/helpers/classicBattle/timerService.drift.test.js tests/helpers/classicBattle/timerService.nextRound.test.js tests/helpers/classicBattle/README.md --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68acaad749b08326aff79530403deb71