### PR TITLE
test: streamline settings page load assertion

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -50,10 +50,6 @@ test.describe.parallel("Settings page", () => {
     await waitForSettingsReady(page);
   });
 
-  test("settings page loads", async ({ page }) => {
-    await verifyPageBasics(page, [NAV_CLASSIC_BATTLE, NAV_RANDOM_JUDOKA]);
-  });
-
   test("mode toggle visible", async ({ page }) => {
     const toggle = page.getByRole("checkbox", { name: "Classic Battle" });
     await expect(toggle).toBeVisible();


### PR DESCRIPTION
## Summary
- remove standalone `settings page loads` test
- rely on `settings elements visible` for page-load verification

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/settings.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68acb5811a508326943cab26d7986c73