### PR TITLE
Consolidate homepage navigation assertions

### DIFF
--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -14,15 +14,6 @@ test.describe.parallel("Homepage", () => {
 
   test("homepage loads", async ({ page }) => {
     await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
-  });
-
-  // Navigation: footer links are visible
-  test("navigation links visible", async ({ page }) => {
-    await verifyPageBasics(page, [NAV_RANDOM_JUDOKA, NAV_CLASSIC_BATTLE]);
-  });
-
-  // Navigation: ensure footer has at least one link
-  test("footer navigation links present", async ({ page }) => {
     const footerLinks = page.locator("footer .bottom-navbar a");
     await expect(footerLinks).not.toHaveCount(0);
   });


### PR DESCRIPTION
## Summary
- Merge footer link visibility and presence checks into the `homepage loads` test
- Remove redundant navigation test blocks

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 18 screenshot-related tests)*
- `npx playwright test playwright/homepage.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68acb57caa8c83268f886957803d3675