### PR TITLE
test: centralize battle link navigation

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -19,11 +19,6 @@ test.describe.parallel("Browse Judoka screen", () => {
     await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
   });
 
-  test("battle link navigates from browse judoka", async ({ page }) => {
-    await page.getByTestId(NAV_CLASSIC_BATTLE).click();
-    await expect(page).toHaveURL(/battleJudoka\.html/);
-  });
-
   test("scroll buttons have labels", async ({ page }) => {
     const left = page.getByRole("button", { name: /prev\./i });
     const right = page.getByRole("button", { name: /next/i });

--- a/playwright/navigation-links.spec.js
+++ b/playwright/navigation-links.spec.js
@@ -1,0 +1,17 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+import { NAV_CLASSIC_BATTLE } from "./fixtures/navigationChecks.js";
+
+const NAV_PAGES = [
+  { url: "/src/pages/browseJudoka.html", linkId: NAV_CLASSIC_BATTLE },
+  { url: "/src/pages/randomJudoka.html", linkId: NAV_CLASSIC_BATTLE }
+];
+
+test.describe.parallel("Navigation links", () => {
+  for (const { url, linkId } of NAV_PAGES) {
+    test(`battle link navigates from ${url}`, async ({ page }) => {
+      await page.goto(url);
+      await page.getByTestId(linkId).click();
+      await expect(page).toHaveURL(/battleJudoka\.html/);
+    });
+  }
+});

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -12,12 +12,6 @@ test.describe.parallel("View Judoka screen", () => {
     await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
   });
 
-  test("battle link navigates from random judoka", async ({ page }) => {
-    const battleLink = page.getByTestId(NAV_CLASSIC_BATTLE);
-    await battleLink.click();
-    await expect(page).toHaveURL(/battleJudoka\.html/);
-  });
-
   test("draw button accessible name constant", async ({ page }) => {
     const btn = page.getByTestId("draw-button");
     await expect(btn).toHaveText(/draw card/i);


### PR DESCRIPTION
## Summary
- add dedicated navigation-links spec for battle link navigation across pages
- remove duplicate battle link tests from browse-judoka and random-judoka specs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/navigation-links.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68acb952e1f883269bd56f9760f04992