### PR TITLE
test: add playerChoice reset coverage

### DIFF
--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -16,6 +16,7 @@ This directory contains unit tests for Classic Battle helpers.
 - `matchEnd.test.js`: finishes the match and shows the summary modal.
 - `opponentDelay.test.js`: shows snackbar feedback during opponent delays.
 - `pauseTimer.test.js`: pauses and resumes the round timer.
+- `playerChoiceReset.test.js`: clears previous player choices on new rounds.
 - `quitModal.test.js`: confirms quitting via a modal dialog.
 - `roundSelectModal.test.js`: selects points-to-win via a modal.
 - `roundStartError.test.js`: surfaces round start failures.

--- a/tests/helpers/classicBattle/playerChoiceReset.test.js
+++ b/tests/helpers/classicBattle/playerChoiceReset.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.doMock("../../../src/helpers/classicBattle/cardSelection.js", () => ({
+  drawCards: vi.fn().mockResolvedValue({}),
+  _resetForTest: vi.fn()
+}));
+
+vi.doMock("../../../src/helpers/battleEngineFacade.js", () => ({
+  getRoundsPlayed: vi.fn(() => 0),
+  _resetForTest: vi.fn()
+}));
+
+vi.doMock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
+  emitBattleEvent: vi.fn(),
+  onBattleEvent: vi.fn()
+}));
+
+describe.sequential("classicBattle player choice reset", () => {
+  let timer;
+  let battleMod;
+  beforeEach(async () => {
+    timer = vi.useFakeTimers();
+    battleMod = await import("../../../src/helpers/classicBattle.js");
+  });
+
+  afterEach(() => {
+    timer.clearAllTimers();
+  });
+
+  it("clears store.playerChoice before each round", async () => {
+    const store = battleMod.createBattleStore();
+
+    store.playerChoice = "power";
+    await battleMod.startRound(store);
+    expect(store.playerChoice).toBeNull();
+
+    store.playerChoice = "speed";
+    await battleMod.startRound(store);
+    expect(store.playerChoice).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- verify playerChoice is cleared before each round
- document playerChoice reset test in classicBattle suite

## Testing
- `npx prettier tests/helpers/classicBattle/playerChoiceReset.test.js tests/helpers/classicBattle/README.md --write`
- `npx eslint tests/helpers/classicBattle/playerChoiceReset.test.js tests/helpers/classicBattle/README.md --fix`
- `npx vitest run tests/helpers/classicBattle/playerChoiceReset.test.js`
- `npx playwright test` *(fails: screenshot mismatches, network errors, timeouts)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68acbbaa50308326b4fc676e73a3299f