### PR TITLE
test: limit status aria pages to dynamic screens

### DIFF
--- a/playwright/status-aria-attributes.spec.js
+++ b/playwright/status-aria-attributes.spec.js
@@ -2,19 +2,11 @@ import { test, expect } from "./fixtures/commonSetup.js";
 import { waitForSettingsReady } from "./fixtures/waits.js";
 
 const pages = [
-  "/",
-  "/src/pages/browseJudoka.html",
-  "/src/pages/createJudoka.html",
-  "/src/pages/randomJudoka.html",
-  "/src/pages/meditation.html",
-  "/src/pages/updateJudoka.html",
-  "/src/pages/settings.html",
-  "/src/pages/vectorSearch.html",
-  "/src/pages/prdViewer.html",
-  "/src/pages/tooltipViewer.html",
   "/src/pages/battleJudoka.html",
-  "/src/pages/changeLog.html",
-  "/src/pages/mockupViewer.html"
+  "/src/pages/browseJudoka.html",
+  "/src/pages/randomJudoka.html",
+  "/src/pages/settings.html",
+  "/src/pages/vectorSearch.html"
 ];
 
 test.describe.parallel("Status aria attributes", () => {


### PR DESCRIPTION
## Summary
- test: only check dynamic pages for status aria attributes

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/status-aria-attributes.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68acc1056a8c8326968ae98a092d1483