### PR TITLE
test: consolidate page basics checks into hooks

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -7,8 +7,8 @@ test.describe.parallel("Browse Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.goto("/src/pages/browseJudoka.html");
-  }); // Close beforeEach
-  // Ensure proper nesting of braces and remove any extra closing brace
+    await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
+  });
 
   test("browse judoka elements visible", async ({ page }) => {
     await expect(page.getByTestId(COUNTRY_TOGGLE_LOCATOR)).toBeVisible();
@@ -16,7 +16,6 @@ test.describe.parallel("Browse Judoka screen", () => {
       "aria-label",
       /country filter/i
     );
-    await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
   });
 
   test("scroll buttons have labels", async ({ page }) => {

--- a/playwright/meditation-screen.spec.js
+++ b/playwright/meditation-screen.spec.js
@@ -13,9 +13,6 @@ test.describe.parallel("Meditation screen", () => {
       )
     );
     await page.goto("/src/pages/meditation.html");
-  });
-
-  test("meditation screen basics", async ({ page }) => {
     await verifyPageBasics(page, []); // Meditation screen has no nav links
   });
 

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -5,11 +5,11 @@ test.describe.parallel("View Judoka screen", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/src/pages/randomJudoka.html");
     await page.locator('body[data-random-judoka-ready="true"]').waitFor();
+    await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
   });
 
   test("random judoka elements visible", async ({ page }) => {
     await expect(page.getByTestId("draw-button")).toBeVisible();
-    await verifyPageBasics(page, [NAV_CLASSIC_BATTLE]);
   });
 
   test("draw button accessible name constant", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Move verifyPageBasics to `beforeEach` in meditation, browse-judoka, and random-judoka specs
- Drop standalone page basics test for meditation screen

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/meditation-screen.spec.js playwright/browse-judoka.spec.js playwright/random-judoka.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68acc10a2cc48326a81971ca6ee6c44a