### PR TITLE
Reset player choice after round resolution

### DIFF
--- a/src/helpers/classicBattle/roundResolver.js
+++ b/src/helpers/classicBattle/roundResolver.js
@@ -36,6 +36,16 @@ export function evaluateRound(store, stat, playerVal, opponentVal) {
 /**
  * Resolves the round after a stat has been selected.
  *
+ * @pseudocode
+ * 1. If no stat is provided, return immediately.
+ * 2. Dispatch an "evaluate" event unless already in the "roundDecision" state.
+ * 3. Wait for a randomized delay.
+ * 4. Emit "opponentReveal".
+ * 5. Evaluate the round and emit the outcome event.
+ * 6. Emit "matchPointReached" or "continue" based on match progress.
+ * 7. Emit "roundResolved" with round data and clear `store.playerChoice`.
+ * 8. Return the evaluation result.
+ *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
  * @param {string} stat - Chosen stat key.
  * @param {number} playerVal - Player's stat value.
@@ -89,5 +99,6 @@ export async function resolveRound(
     opponentVal,
     result
   });
+  store.playerChoice = null;
   return result;
 }


### PR DESCRIPTION
## Summary
- document round resolution steps including clearing stored choice
- clear `store.playerChoice` once a round resolves

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings)*
- `npx vitest run`
- `CI=1 npx playwright test --reporter=line` *(failed: classic battle flow tests; network errors and stability issues)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68acc4ccb494832695c7228fe2db650a