### PR TITLE
test: ensure round resolver clears player choice

### DIFF
--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -19,6 +19,7 @@ This directory contains unit tests for Classic Battle helpers.
 - `playerChoiceReset.test.js`: clears previous player choices on new rounds.
 - `quitModal.test.js`: confirms quitting via a modal dialog.
 - `roundSelectModal.test.js`: selects points-to-win via a modal.
+- `roundResolverOnce.test.js`: clears `playerChoice` after fallback resolution.
 - `roundStartError.test.js`: surfaces round start failures.
 - `scheduleNextRound.test.js`: schedules and auto-dispatches the next round.
 - `selectionPrompt.test.js`: displays the selection prompt until a stat is chosen.

--- a/tests/helpers/classicBattle/roundResolverOnce.test.js
+++ b/tests/helpers/classicBattle/roundResolverOnce.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
+  emitBattleEvent: vi.fn(),
+  onBattleEvent: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/eventDispatcher.js", () => ({
+  dispatchBattleEvent: vi.fn().mockResolvedValue()
+}));
+vi.mock("../../../src/helpers/classicBattle/cardSelection.js", () => ({
+  getOpponentJudoka: vi.fn(() => null),
+  _resetForTest: vi.fn()
+}));
+vi.mock("../../../src/helpers/api/battleUI.js", () => ({
+  evaluateRound: vi.fn(() => ({
+    message: "",
+    matchEnded: false,
+    playerScore: 1,
+    opponentScore: 0,
+    outcome: "winPlayer"
+  })),
+  chooseOpponentStat: vi.fn()
+}));
+vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
+  STATS: ["power", "speed", "technique", "kumikata", "newaza"],
+  stopTimer: vi.fn(),
+  getRoundsPlayed: vi.fn(() => 0),
+  _resetForTest: vi.fn()
+}));
+
+describe.sequential("classicBattle round resolver once", () => {
+  let timer;
+  let warnSpy;
+  let handleStatSelection;
+  let createBattleStore;
+  let _resetForTest;
+
+  beforeEach(async () => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    timer = vi.useFakeTimers();
+    document.body.innerHTML = `
+      <div id="player-card"><ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul></div>
+      <div id="opponent-card"><ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul></div>
+      <div id="stat-buttons"><button data-stat="power"></button></div>
+    `;
+    document.body.dataset.battleState = "roundDecision";
+    ({ handleStatSelection, createBattleStore, _resetForTest } = await import(
+      "../../../src/helpers/classicBattle.js"
+    ));
+  });
+
+  afterEach(() => {
+    timer.clearAllTimers();
+    warnSpy.mockRestore();
+    document.body.innerHTML = "";
+    delete document.body.dataset.battleState;
+  });
+
+  it("clears playerChoice after fallback resolve", async () => {
+    const store = createBattleStore();
+    _resetForTest(store);
+    handleStatSelection(store, "power");
+    expect(store.playerChoice).toBe("power");
+    await vi.advanceTimersByTimeAsync(601);
+    expect(store.playerChoice).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add roundResolverOnce test to ensure fallback clears playerChoice
- document new test in Classic Battle helper README

## Testing
- `npx vitest run tests/helpers/classicBattle/roundResolverOnce.test.js`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68acc7c54438832698222205f03684f9