### PR TITLE
Add progress test for scheduleNextRound

### DIFF
--- a/tests/helpers/classicBattle/scheduleNextRound.progress.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.progress.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from "vitest";
+import { scheduleNextRound } from "@/helpers/classicBattle/timerService.js";
+import { setTestMode } from "@/helpers/testModeUtils.js";
+import { createTimerNodes } from "./domUtils.js";
+import { setSkipHandler } from "@/helpers/classicBattle/skipHandler.js";
+
+describe("scheduleNextRound progress", () => {
+  it("resolves ready immediately in test mode", async () => {
+    createTimerNodes();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    setTestMode(true);
+    const controls = scheduleNextRound({ matchEnded: false });
+    await expect(controls.ready).resolves.toBeUndefined();
+    setTestMode(false);
+    setSkipHandler(null);
+    vi.restoreAllMocks();
+  });
+});

--- a/tests/helpers/timerService.test.js
+++ b/tests/helpers/timerService.test.js
@@ -19,7 +19,8 @@ vi.mock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
 }));
 
 vi.mock("../../src/helpers/testModeUtils.js", () => ({
-  seededRandom: () => 0
+  seededRandom: () => 0,
+  isTestModeEnabled: () => false
 }));
 
 vi.mock("../../src/helpers/timerUtils.js", () => ({

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,7 +1,16 @@
 // vitest.config.js
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const rootDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(rootDir, "src")
+    }
+  },
   test: {
     globals: true, // Enables global functions like describe and it
     environment: "jsdom", // Use jsdom for DOM-related tests


### PR DESCRIPTION
## Summary
- add progress test ensuring `scheduleNextRound` resolves immediately in test mode
- configure Vitest alias for `@` root imports
- stabilize timerService tests with explicit `isTestModeEnabled` mock

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 15 tests failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68acd098e5748326a2a891c578ae14ec