### PR TITLE
docs: clarify test mode cooldown logging

### DIFF
--- a/src/helpers/testModeUtils.js
+++ b/src/helpers/testModeUtils.js
@@ -5,6 +5,10 @@
  * 1. Track whether test mode is active and a numeric seed.
  * 2. When active, `seededRandom()` returns a predictable pseudo-random number.
  * 3. Provide helpers to enable/disable test mode and query current state.
+ *
+ * `computeNextRoundCooldown` logs the resolved cooldown with a `[test]` prefix
+ * when Test Mode is enabled. Override the cooldown for manual testing by
+ * setting `window.__NEXT_ROUND_COOLDOWN_MS`.
  */
 let active = false;
 let seed = 1;


### PR DESCRIPTION
## Summary
- document that computeNextRoundCooldown logs the cooldown with a `[test]` prefix when Test Mode is enabled
- note that the next-round cooldown can be overridden via `window.__NEXT_ROUND_COOLDOWN_MS`

## Testing
- `npx prettier . --check`


------
https://chatgpt.com/codex/tasks/task_e_68ad59e784a88326b10e479b089cff32