### PR TITLE
test: cover round reset and interactions

### DIFF
--- a/tests/helpers/classicBattle/drawNextRound.test.js
+++ b/tests/helpers/classicBattle/drawNextRound.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setupClassicBattleDom } from "./utils.js";
+import { applyMockSetup } from "./mockSetup.js";
+
+describe("classicBattle draw next round", () => {
+  let timerSpy;
+  let warnSpy;
+  let fetchJsonMock;
+  let generateRandomCardMock;
+  let getRandomJudokaMock;
+  let renderMock;
+  let currentFlags;
+
+  beforeEach(() => {
+    ({
+      timerSpy,
+      fetchJsonMock,
+      generateRandomCardMock,
+      getRandomJudokaMock,
+      renderMock,
+      currentFlags
+    } = setupClassicBattleDom());
+    applyMockSetup({
+      fetchJsonMock,
+      generateRandomCardMock,
+      getRandomJudokaMock,
+      renderMock,
+      currentFlags
+    });
+    const nextBtn = document.createElement("button");
+    nextBtn.id = "next-button";
+    document.body.appendChild(nextBtn);
+    window.__NEXT_ROUND_COOLDOWN_MS = 0;
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    timerSpy.clearAllTimers();
+    warnSpy.mockRestore();
+    vi.restoreAllMocks();
+    delete window.__NEXT_ROUND_COOLDOWN_MS;
+    document.body.innerHTML = "";
+  });
+
+  async function playRound(battleMod, store, playerValue, opponentValue) {
+    document.getElementById("player-card").innerHTML =
+      `<ul><li class="stat"><strong>Power</strong> <span>${playerValue}</span></li></ul>`;
+    document.getElementById("opponent-card").innerHTML =
+      `<ul><li class="stat"><strong>Power</strong> <span>${opponentValue}</span></li></ul>`;
+    store.selectionMade = false;
+    const p = battleMod.handleStatSelection(store, "power");
+    await vi.runAllTimersAsync();
+    return p;
+  }
+
+  it("enables Next after draw and continues match", async () => {
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+
+    const result = await playRound(battleMod, store, 5, 5);
+    battleMod.scheduleNextRound(result);
+    await vi.runAllTimersAsync();
+    const nextBtn = document.getElementById("next-button");
+    expect(nextBtn.disabled).toBe(false);
+    expect(nextBtn.dataset.nextReady).toBe("true");
+
+    const { onNextButtonClick } = await import(
+      "../../../src/helpers/classicBattle/timerService.js"
+    );
+    onNextButtonClick(new MouseEvent("click"));
+    const result2 = await playRound(battleMod, store, 6, 4);
+    expect(result2.playerScore).toBe(1);
+  });
+});

--- a/tests/helpers/classicBattle/roundReset.test.js
+++ b/tests/helpers/classicBattle/roundReset.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { roundOverEnter } from "../../../src/helpers/classicBattle/orchestratorHandlers.js";
+
+describe("classicBattle round reset", () => {
+  it("clears player choice and selection flag", async () => {
+    const store = { playerChoice: "power", selectionMade: true };
+    const machine = { context: { store } };
+    await roundOverEnter(machine);
+    expect(store.playerChoice).toBeNull();
+    expect(store.selectionMade).toBe(false);
+  });
+});

--- a/tests/helpers/classicBattle/statDoubleClick.test.js
+++ b/tests/helpers/classicBattle/statDoubleClick.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setupClassicBattleDom } from "./utils.js";
+import { applyMockSetup } from "./mockSetup.js";
+
+describe("classicBattle stat double-click", () => {
+  let timerSpy;
+  let warnSpy;
+  let fetchJsonMock;
+  let generateRandomCardMock;
+  let getRandomJudokaMock;
+  let renderMock;
+  let currentFlags;
+
+  beforeEach(() => {
+    ({
+      timerSpy,
+      fetchJsonMock,
+      generateRandomCardMock,
+      getRandomJudokaMock,
+      renderMock,
+      currentFlags
+    } = setupClassicBattleDom());
+    applyMockSetup({
+      fetchJsonMock,
+      generateRandomCardMock,
+      getRandomJudokaMock,
+      renderMock,
+      currentFlags
+    });
+    const nextBtn = document.createElement("button");
+    nextBtn.id = "next-button";
+    document.body.appendChild(nextBtn);
+    window.__NEXT_ROUND_COOLDOWN_MS = 0;
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    timerSpy.clearAllTimers();
+    warnSpy.mockRestore();
+    vi.restoreAllMocks();
+    delete window.__NEXT_ROUND_COOLDOWN_MS;
+    document.body.innerHTML = "";
+  });
+
+  async function playDoubleClickRound(battleMod, store, playerValue, opponentValue) {
+    document.getElementById("player-card").innerHTML =
+      `<ul><li class="stat"><strong>Power</strong> <span>${playerValue}</span></li></ul>`;
+    document.getElementById("opponent-card").innerHTML =
+      `<ul><li class="stat"><strong>Power</strong> <span>${opponentValue}</span></li></ul>`;
+    store.selectionMade = false;
+    const p = battleMod.handleStatSelection(store, "power");
+    battleMod.handleStatSelection(store, "power");
+    await vi.runAllTimersAsync();
+    return p;
+  }
+
+  it("ignores rapid double-clicks without ending match", async () => {
+    const battleMod = await import("../../../src/helpers/classicBattle.js");
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+
+    const result1 = await playDoubleClickRound(battleMod, store, 5, 3);
+    expect(result1.playerScore).toBe(1);
+    expect(result1.matchEnded).toBe(false);
+
+    battleMod.scheduleNextRound(result1);
+    await vi.runAllTimersAsync();
+    const { onNextButtonClick } = await import(
+      "../../../src/helpers/classicBattle/timerService.js"
+    );
+    onNextButtonClick(new MouseEvent("click"));
+
+    const result2 = await playDoubleClickRound(battleMod, store, 5, 3);
+    expect(result2.playerScore).toBe(2);
+    expect(result2.matchEnded).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- test roundOverEnter resets player state
- ensure draw enables Next for subsequent round
- guard against rapid double-click stat selections

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: testInfo unused, expect unused, evaluateRoundApi unused, isStateTransition unused)*
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED, screenshot spec)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ad5ccf08ac8326bec40a8b844a4748