### PR TITLE
refactor stat selection to accept values

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -25,3 +25,4 @@ export {
   nextRoundTimerReadyPromise,
   matchOverPromise
 } from "./classicBattle/promises.js";
+export { getCardStatValue } from "./classicBattle/cardStatUtils.js";

--- a/src/helpers/classicBattle/cardStatUtils.js
+++ b/src/helpers/classicBattle/cardStatUtils.js
@@ -1,0 +1,15 @@
+import { getStatValue } from "../battle/index.js";
+
+/**
+ * Retrieve a stat value from a battle card element.
+ *
+ * @pseudocode
+ * 1. Delegate to `getStatValue` with the provided `container` and `stat`.
+ *
+ * @param {HTMLElement} container - Card element containing stat list items.
+ * @param {string} stat - Stat key to look up.
+ * @returns {number} Parsed stat value or `0` when missing.
+ */
+export function getCardStatValue(container, stat) {
+  return getStatValue(container, stat);
+}

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -10,6 +10,8 @@ import { showResult } from "../battle/index.js";
 import { shouldReduceMotionSync } from "../motionUtils.js";
 import { onFrame as scheduleFrame, cancel as cancelFrame } from "../../utils/scheduler.js";
 import { handleStatSelection } from "./selectionHandler.js";
+import { getCardStatValue } from "./cardStatUtils.js";
+import { getOpponentJudoka } from "./cardSelection.js";
 import { onNextButtonClick, getNextRoundControls } from "./timerService.js";
 import { loadStatNames } from "../stats.js";
 import { toggleViewportSimulation } from "../viewportDebug.js";
@@ -504,7 +506,18 @@ export function selectStat(store, statName) {
   const btn = document.querySelector(`#stat-buttons button[data-stat="${statName}"]`);
   if (!btn || btn.disabled) return;
   try {
-    Promise.resolve(handleStatSelection(store, statName)).catch(() => {});
+    const playerCard = document.getElementById("player-card");
+    const opponentCard = document.getElementById("opponent-card");
+    const playerVal = getCardStatValue(playerCard, statName);
+    let opponentVal = getCardStatValue(opponentCard, statName);
+    try {
+      const opp = getOpponentJudoka();
+      const raw = opp && opp.stats ? Number(opp.stats[statName]) : NaN;
+      opponentVal = Number.isFinite(raw) ? raw : opponentVal;
+    } catch {}
+    Promise.resolve(handleStatSelection(store, statName, { playerVal, opponentVal })).catch(
+      () => {}
+    );
   } catch {}
   try {
     showSnackbar(`You Picked: ${btn.textContent}`);

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -47,7 +47,12 @@ function populateCards() {
 
 async function selectPower(battleMod, store) {
   const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
-  const p = battleMod.handleStatSelection(store, "power");
+  const playerVal = battleMod.getCardStatValue(document.getElementById("player-card"), "power");
+  const opponentVal = battleMod.getCardStatValue(document.getElementById("opponent-card"), "power");
+  const p = battleMod.handleStatSelection(store, "power", {
+    playerVal,
+    opponentVal
+  });
   await vi.advanceTimersByTimeAsync(1000);
   await p;
   return { randomSpy };

--- a/tests/helpers/classicBattle/matchEnd.test.js
+++ b/tests/helpers/classicBattle/matchEnd.test.js
@@ -73,7 +73,12 @@ async function playRound(battleMod, store, playerValue, opponentValue) {
   document.getElementById("opponent-card").innerHTML =
     `<ul><li class="stat"><strong>Power</strong> <span>${opponentValue}</span></li></ul>`;
   store.selectionMade = false;
-  const p = battleMod.handleStatSelection(store, "power");
+  const playerVal = battleMod.getCardStatValue(document.getElementById("player-card"), "power");
+  const opponentVal = battleMod.getCardStatValue(document.getElementById("opponent-card"), "power");
+  const p = battleMod.handleStatSelection(store, "power", {
+    playerVal,
+    opponentVal
+  });
   await vi.runAllTimersAsync();
   await p;
 }

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -87,7 +87,10 @@ describe("classicBattle opponent delay", () => {
 
     showSnackbar = vi.fn();
     const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
-    const promise = mod.handleStatSelection(store, mod.simulateOpponentStat());
+    const promise = mod.handleStatSelection(store, mod.simulateOpponentStat(), {
+      playerVal: 5,
+      opponentVal: 3
+    });
 
     expect(showSnackbar).not.toHaveBeenCalled();
     await vi.runAllTimersAsync();

--- a/tests/helpers/classicBattle/pauseTimer.test.js
+++ b/tests/helpers/classicBattle/pauseTimer.test.js
@@ -88,7 +88,15 @@ describe("classicBattle timer pause", () => {
     document.getElementById("opponent-card").innerHTML =
       '<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>';
 
-    const promise = battleMod.handleStatSelection(store, "power");
+    const playerVal = battleMod.getCardStatValue(document.getElementById("player-card"), "power");
+    const opponentVal = battleMod.getCardStatValue(
+      document.getElementById("opponent-card"),
+      "power"
+    );
+    const promise = battleMod.handleStatSelection(store, "power", {
+      playerVal,
+      opponentVal
+    });
     await timer.runAllTimersAsync();
     await promise;
     timer.advanceTimersByTime(1000);

--- a/tests/helpers/classicBattle/roundResolverOnce.test.js
+++ b/tests/helpers/classicBattle/roundResolverOnce.test.js
@@ -34,6 +34,7 @@ describe.sequential("classicBattle round resolver once", () => {
   let handleStatSelection;
   let createBattleStore;
   let _resetForTest;
+  let getCardStatValue;
 
   beforeEach(async () => {
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -44,7 +45,7 @@ describe.sequential("classicBattle round resolver once", () => {
       <div id="stat-buttons"><button data-stat="power"></button></div>
     `;
     document.body.dataset.battleState = "roundDecision";
-    ({ handleStatSelection, createBattleStore, _resetForTest } = await import(
+    ({ handleStatSelection, createBattleStore, _resetForTest, getCardStatValue } = await import(
       "../../../src/helpers/classicBattle.js"
     ));
   });
@@ -59,7 +60,9 @@ describe.sequential("classicBattle round resolver once", () => {
   it("clears playerChoice after fallback resolve", async () => {
     const store = createBattleStore();
     _resetForTest(store);
-    handleStatSelection(store, "power");
+    const playerVal = getCardStatValue(document.getElementById("player-card"), "power");
+    const opponentVal = getCardStatValue(document.getElementById("opponent-card"), "power");
+    handleStatSelection(store, "power", { playerVal, opponentVal });
     expect(store.playerChoice).toBe("power");
     await vi.advanceTimersByTimeAsync(601);
     expect(store.playerChoice).toBeNull();

--- a/tests/helpers/classicBattle/selectionPrompt.test.js
+++ b/tests/helpers/classicBattle/selectionPrompt.test.js
@@ -67,7 +67,15 @@ describe("classicBattle selection prompt", () => {
     document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     {
-      const p = battleMod.handleStatSelection(store, "power");
+      const playerVal = battleMod.getCardStatValue(document.getElementById("player-card"), "power");
+      const opponentVal = battleMod.getCardStatValue(
+        document.getElementById("opponent-card"),
+        "power"
+      );
+      const p = battleMod.handleStatSelection(store, "power", {
+        playerVal,
+        opponentVal
+      });
       await vi.runAllTimersAsync();
       await p;
     }

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -62,6 +62,7 @@ describe("classicBattle stat selection", () => {
   let handleStatSelection;
   let _resetForTest;
   let createBattleStore;
+  let getCardStatValue;
 
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -95,15 +96,21 @@ describe("classicBattle stat selection", () => {
   beforeEach(async () => {
     document.body.innerHTML +=
       '<div id="stat-buttons" data-tooltip-id="ui.selectStat"><button data-stat="power"></button></div>';
-    ({ createBattleStore, handleStatSelection, simulateOpponentStat, _resetForTest } = await import(
-      "../../../src/helpers/classicBattle.js"
-    ));
+    ({
+      createBattleStore,
+      handleStatSelection,
+      simulateOpponentStat,
+      _resetForTest,
+      getCardStatValue
+    } = await import("../../../src/helpers/classicBattle.js"));
     store = createBattleStore();
     _resetForTest(store);
     const eventDispatcher = await import("../../../src/helpers/classicBattle/eventDispatcher.js");
     eventDispatcher.__reset();
     selectStat = async (stat) => {
-      const p = handleStatSelection(store, stat);
+      const playerVal = getCardStatValue(document.getElementById("player-card"), stat);
+      const opponentVal = getCardStatValue(document.getElementById("opponent-card"), stat);
+      const p = handleStatSelection(store, stat, { playerVal, opponentVal });
       await vi.runAllTimersAsync();
       await p;
     };

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -60,7 +60,11 @@ describe("classicBattlePage stat button interactions", () => {
       b.tabIndex = 0;
     });
     selectStat(store, "power");
-    expect(handleStatSelection).toHaveBeenCalledWith(store, "power");
+    expect(handleStatSelection).toHaveBeenCalledWith(
+      store,
+      "power",
+      expect.objectContaining({ playerVal: expect.any(Number), opponentVal: expect.any(Number) })
+    );
     expect(showSnackbar).toHaveBeenCalledWith("You Picked: Power");
     buttons.forEach((b) => {
       b.disabled = false;
@@ -69,7 +73,11 @@ describe("classicBattlePage stat button interactions", () => {
     handleStatSelection.mockClear();
     showSnackbar.mockClear();
     selectStat(store, "speed");
-    expect(handleStatSelection).toHaveBeenCalledWith(store, "speed");
+    expect(handleStatSelection).toHaveBeenCalledWith(
+      store,
+      "speed",
+      expect.objectContaining({ playerVal: expect.any(Number), opponentVal: expect.any(Number) })
+    );
     expect(showSnackbar).toHaveBeenCalledWith("You Picked: Speed");
     buttons.forEach((b) => {
       b.disabled = false;
@@ -78,7 +86,11 @@ describe("classicBattlePage stat button interactions", () => {
     handleStatSelection.mockClear();
     showSnackbar.mockClear();
     selectStat(store, "technique");
-    expect(handleStatSelection).toHaveBeenCalledWith(store, "technique");
+    expect(handleStatSelection).toHaveBeenCalledWith(
+      store,
+      "technique",
+      expect.objectContaining({ playerVal: expect.any(Number), opponentVal: expect.any(Number) })
+    );
     expect(showSnackbar).toHaveBeenCalledWith("You Picked: Technique");
   });
 


### PR DESCRIPTION
## Summary
- add `getCardStatValue` helper for DOM stat lookups
- extract `computeRoundResult` for eventful round evaluation
- refactor `handleStatSelection` and callers to use precomputed stat values

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot and reset spec mismatches)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ad60ba89d0832682cb635222133596