### PR TITLE
Handle missing classic battle stat values

### DIFF
--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -3,6 +3,7 @@ import { chooseOpponentStat } from "../api/battleUI.js";
 import { emitBattleEvent } from "./battleEvents.js";
 import { dispatchBattleEvent } from "./eventDispatcher.js";
 import { resolveRound } from "./roundResolver.js";
+import { getCardStatValue } from "./cardStatUtils.js";
 
 /**
  * Determine the opponent's stat choice based on difficulty.
@@ -27,9 +28,11 @@ export function simulateOpponentStat(stats, difficulty = "easy") {
  * @pseudocode
  * 1. Ignore if a selection was already made.
  * 2. Record the chosen stat.
- * 3. Stop running timers and clear pending timeouts on the store.
- * 4. Emit a `statSelected` event with the provided values.
- * 5. Resolve the round either via the state machine or directly.
+ * 3. If values are missing, read them from the player and opponent cards.
+ * 4. Coerce the stat values to numbers.
+ * 5. Stop running timers and clear pending timeouts on the store.
+ * 6. Emit a `statSelected` event with the provided values.
+ * 7. Resolve the round either via the state machine or directly.
  *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
  * @param {string} stat - Chosen stat key.
@@ -41,6 +44,12 @@ export async function handleStatSelection(store, stat, { playerVal, opponentVal,
   }
   store.selectionMade = true;
   store.playerChoice = stat;
+  if (playerVal === undefined || Number.isNaN(playerVal)) {
+    playerVal = getCardStatValue(document.querySelector("#player-card"), stat);
+  }
+  if (opponentVal === undefined || Number.isNaN(opponentVal)) {
+    opponentVal = getCardStatValue(document.querySelector("#opponent-card"), stat);
+  }
   playerVal = Number(playerVal);
   opponentVal = Number(opponentVal);
   stopTimer();


### PR DESCRIPTION
## Summary
- derive missing player/opponent stat values from battle cards before processing
- update selection handler pseudocode to document new fallback behavior

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 14 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ad69a9e7c08326a8ec0ce6af73328f