### PR TITLE
Clear playerChoice before fallback round resolution

### DIFF
--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -32,7 +32,8 @@ export function simulateOpponentStat(stats, difficulty = "easy") {
  * 4. Coerce the stat values to numbers.
  * 5. Stop running timers and clear pending timeouts on the store.
  * 6. Emit a `statSelected` event with the provided values.
- * 7. Resolve the round either via the state machine or directly.
+ * 7. Resolve the round either via the state machine or directly, clearing
+ *    `playerChoice` before fallback resolution.
  *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
  * @param {string} stat - Chosen stat key.
@@ -76,7 +77,12 @@ export async function handleStatSelection(store, stat, { playerVal, opponentVal,
         setTimeout(() => {
           // Only run if still awaiting resolution and selection remains.
           if (store.playerChoice) {
-            resolveRound(store, stat, playerVal, opponentVal, opts).catch(() => {});
+            store.playerChoice = null;
+            resolveRound(store, stat, playerVal, opponentVal, opts)
+              .catch(() => {})
+              .finally(() => {
+                store.playerChoice = null;
+              });
           }
         }, 600);
       } catch {}


### PR DESCRIPTION
## Summary
- Clear `playerChoice` before triggering fallback round resolution and ensure it's reset even if `resolveRound` rejects
- Document the fallback clearing behavior in selection handler pseudocode

## Testing
- `npx prettier . --check`
- `npx eslint src/helpers/classicBattle/selectionHandler.js`
- `npx vitest run`
- `npx playwright test` *(fails: 15 failing screenshot and button reset tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ad6cc6b1a483269892f40341bed448