### PR TITLE
fix: schedule stat button reset for next frame

### DIFF
--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -88,6 +88,6 @@ onBattleEvent("roundResolved", (e) => {
     });
     emitBattleEvent("matchOver");
   }
-  resetStatButtons();
+  requestAnimationFrame(() => resetStatButtons());
   updateDebugPanel();
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -6,6 +6,12 @@ if (typeof CustomEvent === "undefined") {
     }
   };
 }
+if (typeof global.requestAnimationFrame === "undefined") {
+  global.requestAnimationFrame = (cb) => setTimeout(() => cb(0), 0);
+}
+if (typeof global.cancelAnimationFrame === "undefined") {
+  global.cancelAnimationFrame = (id) => clearTimeout(id);
+}
 import { expect, afterEach, beforeEach } from "vitest";
 import { resetDom } from "./utils/testUtils.js";
 import { muteConsole, restoreConsole } from "./utils/console.js";


### PR DESCRIPTION
## Summary
- defer `resetStatButtons` until the next animation frame after a round resolves
- stub `requestAnimationFrame`/`cancelAnimationFrame` in test setup for Node environment

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: 15)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ad7f555620832694b50a7a090d894e