### PR TITLE
refactor settings init mappings

### DIFF
--- a/src/helpers/settings/applyInitialValues.js
+++ b/src/helpers/settings/applyInitialValues.js
@@ -1,6 +1,19 @@
 import { DEFAULT_SETTINGS } from "../../config/settingsDefaults.js";
 import { loadSettings } from "../../config/loadSettings.js";
 
+const CONTROL_MAP = [
+  { control: "soundToggle", setting: "sound", descId: "sound-desc" },
+  { control: "motionToggle", setting: "motionEffects", descId: "motion-desc" },
+  { control: "typewriterToggle", setting: "typewriterEffect", descId: "typewriter-desc" },
+  { control: "tooltipsToggle", setting: "tooltips", descId: "tooltips-desc" },
+  { control: "cardOfTheDayToggle", setting: "showCardOfTheDay", descId: "card-of-the-day-desc" },
+  {
+    control: "fullNavigationMapToggle",
+    setting: "fullNavigationMap",
+    descId: "full-navigation-map-desc"
+  }
+];
+
 /**
  * Apply a value to an input or checkbox element.
  *
@@ -12,7 +25,7 @@ import { loadSettings } from "../../config/loadSettings.js";
  * @param {HTMLInputElement|HTMLSelectElement|null} element - Control to update.
  * @param {*} value - Value to apply.
  */
-export function applyInputState(element, value) {
+function applyInputState(element, value) {
   if (!element) return;
   if (element.type === "checkbox") {
     element.checked = Boolean(value);
@@ -25,80 +38,36 @@ export function applyInputState(element, value) {
  * Initialize control states based on a settings object.
  *
  * @pseudocode
- * 1. Call `applyInputState` for each setting-related control.
+ * 1. For each mapping: update value, tooltip ID, label, and description.
+ * 2. Update display mode radio buttons.
  *
  * @param {Object} controls - Collection of form elements.
  * @param {import("../../config/settingsDefaults.js").Settings} settings - Current settings.
  * @param {Record<string, string>} [tooltipMap] - Flattened tooltip lookup.
  */
 export function applyInitialControlValues(controls, settings = DEFAULT_SETTINGS, tooltipMap = {}) {
-  applyInputState(controls.soundToggle, settings.sound);
-  if (controls.soundToggle && settings.tooltipIds?.sound) {
-    controls.soundToggle.dataset.tooltipId = settings.tooltipIds.sound;
-  }
-  const soundLabel = tooltipMap["settings.sound.label"];
-  const soundDesc = tooltipMap["settings.sound.description"];
-  const soundLabelEl = controls.soundToggle?.closest("label")?.querySelector("span");
-  const soundDescEl = document.getElementById("sound-desc");
-  if (soundLabel && soundLabelEl) soundLabelEl.textContent = soundLabel;
-  if (soundDesc && soundDescEl) soundDescEl.textContent = soundDesc;
-  applyInputState(controls.motionToggle, settings.motionEffects);
-  if (controls.motionToggle && settings.tooltipIds?.motionEffects) {
-    controls.motionToggle.dataset.tooltipId = settings.tooltipIds.motionEffects;
-  }
-  const motionLabel = tooltipMap["settings.motionEffects.label"];
-  const motionDesc = tooltipMap["settings.motionEffects.description"];
-  const motionLabelEl = controls.motionToggle?.closest("label")?.querySelector("span");
-  const motionDescEl = document.getElementById("motion-desc");
-  if (motionLabel && motionLabelEl) motionLabelEl.textContent = motionLabel;
-  if (motionDesc && motionDescEl) motionDescEl.textContent = motionDesc;
+  CONTROL_MAP.forEach(({ control, setting, descId }) => {
+    const el = controls[control];
+    applyInputState(el, settings[setting]);
+
+    if (el && settings.tooltipIds?.[setting]) {
+      el.dataset.tooltipId = settings.tooltipIds[setting];
+    }
+
+    const labelEl = el?.closest("label")?.querySelector("span");
+    const descEl = document.getElementById(descId);
+    const label = tooltipMap[`settings.${setting}.label`];
+    const desc = tooltipMap[`settings.${setting}.description`];
+    if (label && labelEl) labelEl.textContent = label;
+    if (desc && descEl) descEl.textContent = desc;
+  });
+
   if (controls.displayRadios) {
     controls.displayRadios.forEach((radio) => {
-      const isSelected = radio.value === settings.displayMode;
-      radio.checked = isSelected;
-      radio.tabIndex = isSelected ? 0 : -1;
+      radio.checked = radio.value === settings.displayMode;
+      radio.tabIndex = radio.checked ? 0 : -1;
     });
   }
-  applyInputState(controls.typewriterToggle, settings.typewriterEffect);
-  if (controls.typewriterToggle && settings.tooltipIds?.typewriterEffect) {
-    controls.typewriterToggle.dataset.tooltipId = settings.tooltipIds.typewriterEffect;
-  }
-  const typeLabel = tooltipMap["settings.typewriterEffect.label"];
-  const typeDesc = tooltipMap["settings.typewriterEffect.description"];
-  const typeLabelEl = controls.typewriterToggle?.closest("label")?.querySelector("span");
-  const typeDescEl = document.getElementById("typewriter-desc");
-  if (typeLabel && typeLabelEl) typeLabelEl.textContent = typeLabel;
-  if (typeDesc && typeDescEl) typeDescEl.textContent = typeDesc;
-  applyInputState(controls.tooltipsToggle, settings.tooltips);
-  if (controls.tooltipsToggle && settings.tooltipIds?.tooltips) {
-    controls.tooltipsToggle.dataset.tooltipId = settings.tooltipIds.tooltips;
-  }
-  const tipsLabel = tooltipMap["settings.tooltips.label"];
-  const tipsDesc = tooltipMap["settings.tooltips.description"];
-  const tipsLabelEl = controls.tooltipsToggle?.closest("label")?.querySelector("span");
-  const tipsDescEl = document.getElementById("tooltips-desc");
-  if (tipsLabel && tipsLabelEl) tipsLabelEl.textContent = tipsLabel;
-  if (tipsDesc && tipsDescEl) tipsDescEl.textContent = tipsDesc;
-  applyInputState(controls.cardOfTheDayToggle, settings.showCardOfTheDay);
-  if (controls.cardOfTheDayToggle && settings.tooltipIds?.showCardOfTheDay) {
-    controls.cardOfTheDayToggle.dataset.tooltipId = settings.tooltipIds.showCardOfTheDay;
-  }
-  const cardLabel = tooltipMap["settings.showCardOfTheDay.label"];
-  const cardDesc = tooltipMap["settings.showCardOfTheDay.description"];
-  const cardLabelEl = controls.cardOfTheDayToggle?.closest("label")?.querySelector("span");
-  const cardDescEl = document.getElementById("card-of-the-day-desc");
-  if (cardLabel && cardLabelEl) cardLabelEl.textContent = cardLabel;
-  if (cardDesc && cardDescEl) cardDescEl.textContent = cardDesc;
-  applyInputState(controls.fullNavigationMapToggle, settings.fullNavigationMap);
-  if (controls.fullNavigationMapToggle && settings.tooltipIds?.fullNavigationMap) {
-    controls.fullNavigationMapToggle.dataset.tooltipId = settings.tooltipIds.fullNavigationMap;
-  }
-  const mapLabel = tooltipMap["settings.fullNavigationMap.label"];
-  const mapDesc = tooltipMap["settings.fullNavigationMap.description"];
-  const mapLabelEl = controls.fullNavigationMapToggle?.closest("label")?.querySelector("span");
-  const mapDescEl = document.getElementById("full-navigation-map-desc");
-  if (mapLabel && mapLabelEl) mapLabelEl.textContent = mapLabel;
-  if (mapDesc && mapDescEl) mapDescEl.textContent = mapDesc;
 }
 
 /**


### PR DESCRIPTION
## Summary
- deduplicate settings control setup using a control-to-setting map
- make applyInputState private and iterate mappings for values, labels, and descriptions

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: 3 unused vars in playwright specs)*
- `npx vitest run`
- `npx playwright test` *(15 failing screenshot-related tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ad8c2673088326b3ba08ac57715f25