### PR TITLE
feat: mark enlarged cards after hover

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -78,11 +78,11 @@ test.describe.parallel("Browse Judoka screen", () => {
     await expect(slides.first().locator("img")).toHaveAttribute("alt", /all countries/i);
   });
 
-  test("judoka card sets zoom marker on hover", async ({ page }) => {
+  test("judoka card sets enlarged marker on hover", async ({ page }) => {
     const card = page.locator("#carousel-container .judoka-card").first();
     await page.locator('body[data-browse-judoka-ready="true"]').waitFor();
     await card.hover();
-    await expect(card).toHaveAttribute("data-zoomed", "true");
+    await expect(card).toHaveAttribute("data-enlarged", "true");
   });
 
   test("carousel responds to arrow keys", async ({ page }) => {

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -41,10 +41,10 @@ test.describe.parallel("Homepage", () => {
     await expect(page).toHaveURL(/randomJudoka\.html/);
   });
 
-  test("tile hover zoom and cursor", async ({ page }) => {
+  test("tile hover enlarges and shows pointer", async ({ page }) => {
     const tile = page.locator(".card").first();
     await tile.hover();
-    await expect(tile).toHaveAttribute("data-zoomed", "true");
+    await expect(tile).toHaveAttribute("data-enlarged", "true");
     const scale = await tile.evaluate((el) => {
       const transform = getComputedStyle(el).transform;
       const match = transform.match(/matrix\(([^)]+)\)/);

--- a/src/helpers/setupHoverZoom.js
+++ b/src/helpers/setupHoverZoom.js
@@ -7,31 +7,34 @@ import { onDomReady } from "./domReady.js";
  * 1. Select all elements with the `.card` or `.judoka-card` class.
  * 2. For each card:
  *    a. Skip if listeners already attached.
- *    b. Remove the `data-zoomed` marker on `mouseenter` and `mouseleave`.
- *    c. When a `transitionend` event for `transform` fires, set `data-zoomed="true"`.
- *    d. If `prefers-reduced-motion` is enabled, set `data-zoomed="true"` immediately on `mouseenter`.
+ *    b. Remove the `data-enlarged` marker on `mouseenter` and `mouseleave`.
+ *    c. On `mouseenter`, if animations are disabled, set `data-enlarged="true"` immediately.
+ *    d. When a `transitionend` event for `transform` fires, set `data-enlarged="true"`.
  */
 export function addHoverZoomMarkers() {
   if (typeof document === "undefined") return;
   const cards = document.querySelectorAll(".card, .judoka-card");
   cards.forEach((card) => {
-    if (card.dataset.zoomListenerAttached) return;
-    card.dataset.zoomListenerAttached = "true";
+    if (card.dataset.enlargeListenerAttached) return;
+    card.dataset.enlargeListenerAttached = "true";
     const reset = () => {
-      delete card.dataset.zoomed;
+      delete card.dataset.enlarged;
     };
     card.addEventListener("mouseenter", () => {
       reset();
       try {
-        if (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-          card.dataset.zoomed = "true";
+        const reduceMotion =
+          window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        const disableAnimations = document.body?.hasAttribute("data-test-disable-animations");
+        if (reduceMotion || disableAnimations) {
+          card.dataset.enlarged = "true";
         }
       } catch {}
     });
     card.addEventListener("mouseleave", reset);
     card.addEventListener("transitionend", (event) => {
       if (event.propertyName === "transform") {
-        card.dataset.zoomed = "true";
+        card.dataset.enlarged = "true";
       }
     });
   });

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -27,6 +27,18 @@
   box-shadow: var(--shadow-hover);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .judoka-card {
+    transition: none !important;
+  }
+}
+
+body[data-test-disable-animations] .card,
+body[data-test-disable-animations] .judoka-card {
+  transition: none !important;
+}
+
 .tile-content h2 {
   padding: 1vh var(--space-large, 1rem);
   font-size: var(--font-large);

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -47,6 +47,16 @@
   transform: scale(1.05); /* Interactive feedback */
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .judoka-card {
+    transition: none !important;
+  }
+}
+
+body[data-test-disable-animations] .judoka-card {
+  transition: none !important;
+}
+
 /* Styles for tablets */
 @media (max-width: 1024px) {
   .judoka-card {


### PR DESCRIPTION
## Summary
- add data-enlarged marker after card hover transitions
- disable card zoom transitions for reduced-motion or test environments
- verify card enlargement in homepage and browse judoka tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Screenshot suite, Settings screenshots, Classic battle button reset)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ad8c6283a08326864588641d00f6ad