### PR TITLE
docs: clarify selectStat delegation

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -491,13 +491,12 @@ function setStatButtonsEnabled(enable = true) {
 }
 
 /**
- * Select a stat for the current round.
+ * Delegate stat selection to `handleStatSelection`.
+ * UI updates are handled by the `statSelected` listener in `roundUI.js`.
  *
  * @pseudocode
- * 1. Find the button for the requested stat; exit if missing or disabled.
- * 2. Delegate to `handleStatSelection` with the provided store and stat.
- * 3. Show a snackbar with the chosen stat name.
- * 4. Disable all stat buttons and mark the chosen one on the next frame.
+ * 1. Verify the requested stat button exists and is enabled.
+ * 2. Gather player and opponent values and pass them to `handleStatSelection`.
  *
  * @param {ReturnType<typeof import('./roundManager.js').createBattleStore>} store - Battle store.
  * @param {string} statName - Key of the selected stat.


### PR DESCRIPTION
## Summary
- document `selectStat` to highlight delegation to `handleStatSelection`
- note that UI updates occur via `statSelected` listener in `roundUI.js`

## Testing
- ⚠️ `npx prettier . --check` (flagged playwright/statReset.spec.js)
- ⚠️ `npx eslint .` (flagged playwright/statReset.spec.js)
- ✅ `npx prettier src/helpers/classicBattle/uiHelpers.js --check`
- ✅ `npx eslint src/helpers/classicBattle/uiHelpers.js`

------
https://chatgpt.com/codex/tasks/task_e_68ad96fd30c08326acd93001f88fedc4