### PR TITLE
Delay stat button reset by one frame

### DIFF
--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -102,6 +102,8 @@ onBattleEvent("roundResolved", (e) => {
     });
     emitBattleEvent("matchOver");
   }
-  requestAnimationFrame(() => resetStatButtons());
+  // Wait two frames so the "selected" class remains visible for one paint
+  // Event order: roundResolved → rAF → rAF → resetStatButtons
+  requestAnimationFrame(() => requestAnimationFrame(() => resetStatButtons()));
   updateDebugPanel();
 });

--- a/tests/helpers/classicBattle/roundResolved.statButton.test.js
+++ b/tests/helpers/classicBattle/roundResolved.statButton.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+
+const resetSpy = vi.fn(() => {
+  document
+    .querySelectorAll("#stat-buttons button")
+    .forEach((btn) => btn.classList.remove("selected"));
+});
+
+vi.mock("../../../src/helpers/battle/index.js", () => ({
+  resetStatButtons: resetSpy
+}));
+vi.mock("../../../src/helpers/classicBattle/uiService.js", () => ({
+  syncScoreDisplay: vi.fn(),
+  showMatchSummaryModal: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+  handleReplay: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
+  startTimer: vi.fn(),
+  handleStatSelectionTimeout: vi.fn(),
+  scheduleNextRound: vi.fn()
+}));
+vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
+  clearRoundCounter: vi.fn(),
+  updateRoundCounter: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
+  disableNextRoundButton: vi.fn(),
+  showSelectionPrompt: vi.fn(),
+  updateDebugPanel: vi.fn()
+}));
+vi.mock("../../../src/helpers/showSnackbar.js", () => ({
+  showSnackbar: vi.fn()
+}));
+
+describe("roundResolved stat button reset", () => {
+  it("keeps .selected for one frame before clearing", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    document.body.innerHTML =
+      '<div id="stat-buttons"><button data-stat="power" class="selected"></button></div>';
+    await import("../../../src/helpers/classicBattle/roundUI.js");
+    const { emitBattleEvent } = await import("../../../src/helpers/classicBattle/battleEvents.js");
+    const btn = document.querySelector("#stat-buttons button");
+    emitBattleEvent("roundResolved", { store: {}, result: { matchEnded: false } });
+    expect(btn.classList.contains("selected")).toBe(true);
+    await vi.advanceTimersByTimeAsync(16);
+    expect(btn.classList.contains("selected")).toBe(true);
+    expect(resetSpy).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(16);
+    expect(resetSpy).toHaveBeenCalledOnce();
+    expect(btn.classList.contains("selected")).toBe(false);
+    warn.mockRestore();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- delay stat button reset until two rAF cycles so selection persists for a paint
- add unit test checking selected state lasts one frame after round resolution

## Testing
- `npx prettier src/helpers/classicBattle/roundUI.js tests/helpers/classicBattle/roundResolved.statButton.test.js --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/roundResolved.statButton.test.js`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ad9dfa9ae08326bb8a6b6707044367