### PR TITLE
docs: clarify stat selection delegation

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -491,13 +491,12 @@ function setStatButtonsEnabled(enable = true) {
 }
 
 /**
- * Select a stat for the current round.
+ * Delegate stat selection logic to the core handler.
+ *
+ * UI updates are handled by the `statSelected` listener in `roundUI.js`.
  *
  * @pseudocode
- * 1. Find the button for the requested stat; exit if missing or disabled.
- * 2. Delegate to `handleStatSelection` with the provided store and stat.
- * 3. Show a snackbar with the chosen stat name.
- * 4. Disable all stat buttons and mark the chosen one on the next frame.
+ * 1. Delegate to `handleStatSelection` with the provided store and stat.
  *
  * @param {ReturnType<typeof import('./roundManager.js').createBattleStore>} store - Battle store.
  * @param {string} statName - Key of the selected stat.


### PR DESCRIPTION
## Summary
- clarify that `selectStat` delegates to `handleStatSelection`
- note that UI updates are handled by `statSelected` listener in `roundUI.js`

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: 3 warnings)*
- `npx vitest run`
- `npx playwright test` *(fails: 16 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ad9e378e188326b4b0ddcbf3c61f52