### PR TITLE
Refactor Card class helpers and async content tests

### DIFF
--- a/tests/helpers/cardComponent.test.js
+++ b/tests/helpers/cardComponent.test.js
@@ -9,9 +9,11 @@ describe("createCard", () => {
     expect(card.textContent).toBe("Hello");
   });
 
-  it("inserts sanitized HTML when the html flag is true", () => {
-    const sanitize = vi.fn(() => ({ sanitize: (h) => h }));
+  it("inserts sanitized HTML when sanitizer resolves asynchronously", async () => {
+    const promise = Promise.resolve({ sanitize: (h) => h });
+    const sanitize = vi.fn(() => promise);
     const card = createCard("<em>hi</em>", { html: true, sanitize });
+    await promise;
     expect(card.innerHTML).toBe("<em>hi</em>");
     expect(sanitize).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- extract Card helpers for applying classes and inserting content
- add early returns to Card constructor to limit complexity
- test Card with string, node, and asynchronously sanitized HTML

## Testing
- `npx prettier src/components/Card.js tests/helpers/cardComponent.test.js --check`
- `npx eslint .`
- `npx vitest run tests/helpers/cardComponent.test.js`
- `npx playwright test` *(fails: Test timeout of 30000ms exceeded)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ad9e1505f48326b419f9e47178cc85