### PR TITLE
refactor: privatize card helpers

### DIFF
--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -19,8 +19,9 @@ import { markSignatureMoveReady } from "./signatureMove.js";
  * @param {HTMLElement} element - DOM element to contain the card.
  * @param {HTMLElement} card - The card element to display.
  * @param {boolean} [skipAnimation=false] - Skip the entry animation when true.
+ * @private
  */
-export function displayCard(element, card, skipAnimation = false) {
+function displayCard(element, card, skipAnimation = false) {
   if (!element || !card) return;
   element.innerHTML = "";
   element.appendChild(card);
@@ -47,8 +48,9 @@ export function displayCard(element, card, skipAnimation = false) {
  * @param {HTMLElement} containerEl - Element to contain the card.
  * @param {boolean} prefersReducedMotion - Motion preference flag.
  * @returns {Promise<void>} Resolves when the card is displayed.
+ * @private
  */
-export async function createCardForJudoka(judoka, gokyoLookup, containerEl, prefersReducedMotion) {
+async function createCardForJudoka(judoka, gokyoLookup, containerEl, prefersReducedMotion) {
   const card = await new JudokaCard(judoka, gokyoLookup).render();
   if (card) {
     displayCard(containerEl, card, prefersReducedMotion);

--- a/src/helpers/settings/applyInitialValues.js
+++ b/src/helpers/settings/applyInitialValues.js
@@ -15,26 +15,6 @@ const CONTROL_MAP = [
 ];
 
 /**
- * Apply a value to an input or checkbox element.
- *
- * @pseudocode
- * 1. Exit early when `element` is null or undefined.
- * 2. For checkboxes, set the `checked` property based on `value`.
- * 3. For other inputs, assign the `value` directly.
- *
- * @param {HTMLInputElement|HTMLSelectElement|null} element - Control to update.
- * @param {*} value - Value to apply.
- */
-function applyInputState(element, value) {
-  if (!element) return;
-  if (element.type === "checkbox") {
-    element.checked = Boolean(value);
-  } else {
-    element.value = value;
-  }
-}
-
-/**
  * Initialize control states based on a settings object.
  *
  * @pseudocode
@@ -46,6 +26,27 @@ function applyInputState(element, value) {
  * @param {Record<string, string>} [tooltipMap] - Flattened tooltip lookup.
  */
 export function applyInitialControlValues(controls, settings = DEFAULT_SETTINGS, tooltipMap = {}) {
+  /**
+   * Apply a value to an input or checkbox element.
+   *
+   * @private
+   * @pseudocode
+   * 1. Exit early when `element` is null or undefined.
+   * 2. For checkboxes, set the `checked` property based on `value`.
+   * 3. For other inputs, assign the `value` directly.
+   *
+   * @param {HTMLInputElement|HTMLSelectElement|null} element - Control to update.
+   * @param {*} value - Value to apply.
+   */
+  function applyInputState(element, value) {
+    if (!element) return;
+    if (element.type === "checkbox") {
+      element.checked = Boolean(value);
+    } else {
+      element.value = value;
+    }
+  }
+
   CONTROL_MAP.forEach(({ control, setting, descId }) => {
     const el = controls[control];
     applyInputState(el, settings[setting]);

--- a/src/helpers/settings/index.js
+++ b/src/helpers/settings/index.js
@@ -5,7 +5,7 @@
  * 1. Re-export common settings utilities for initialization and listeners.
  * 2. Keep this module focused on the public settings API surface.
  */
-export * from "./applyInitialValues.js";
+export { applyInitialControlValues, applyInitialValues } from "./applyInitialValues.js";
 export * from "./listenerUtils.js";
 export * from "./gameModeSwitches.js";
 export * from "./featureFlagSwitches.js";


### PR DESCRIPTION
## Summary
- make displayCard and createCardForJudoka internal helpers
- scope applyInputState within applyInitialControlValues
- explicitly re-export settings initialization utilities

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings: 3)
- `npx vitest run`
- `npx playwright test` (fails: 17)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68adbe6e5360832680208447d199a219