### PR TITLE
docs(agent): add RAG query guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ const embeddings = await vectorSearch.loadEmbeddings();
 const expanded = await vectorSearch.expandQueryWithSynonyms("grip fighting");
 const results = await vectorSearch.findMatches([0, 1, 0], 5, ["prd"], expanded);
 ```
+See [RAG_QUERY_GUIDE.md](design/agentWorkflows/RAG_QUERY_GUIDE.md) for template prompts and tag combinations when querying.
 ## ⚡ Module Loading Policy: Static vs Dynamic Imports
 
 JU-DO-KON! favors **deterministic gameplay and snappy input handling**. Use **static imports** for core gameplay; reserve **dynamic imports** (`import('…')`) for optional screens and heavy tools.

--- a/design/agentWorkflows/RAG_QUERY_GUIDE.md
+++ b/design/agentWorkflows/RAG_QUERY_GUIDE.md
@@ -1,0 +1,36 @@
+# RAG Query Guide
+
+This guide helps agents craft effective vector search queries against `client_embeddings.json`.
+Use it alongside [`exampleVectorQueries.md`](./exampleVectorQueries.md) for practical patterns.
+
+## Template Prompts
+
+- "Search test expectations for [feature]"
+- "UI rendering for [component]"
+- "Locate PRD notes about [topic]"
+
+## Tag Filters
+
+Each embedding can include tags for:
+
+- **Construct type** – `function`, `class`, `variable`, `test`
+- **Role** – `component`, `config`, `utility`, `test`
+- **Source/topic** – `prd`, `data`, `design-doc`, `judoka-data`, `tooltip`
+
+Combine tags to narrow results:
+
+```javascript
+import vectorSearch from "../../src/helpers/vectorSearch/index.js";
+const vec = await vectorSearch.expandQueryWithSynonyms("UI rendering for Scoreboard");
+const matches = await vectorSearch.findMatches(vec, 8, ["component", "function"]);
+```
+
+Filter for specific test helpers:
+
+```javascript
+const q = await vectorSearch.expandQueryWithSynonyms("Search test expectations for battle flow");
+const testMatches = await vectorSearch.findMatches(q, 5, ["test", "function"]);
+```
+
+Tags are passed as an array. A match must include **all** provided tags.
+Mixing construct and role tags makes it easy to target snippets like test functions, UI components, or configuration utilities.

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -1,6 +1,7 @@
 # Example Vector Queries
 
 This document shows how AI agents can search the JU-DO-KON! vector database and provides prompt templates for common workflows.
+See [`RAG_QUERY_GUIDE.md`](./RAG_QUERY_GUIDE.md) for tag references and additional query patterns.
 
 ## Embedding JSON Format
 


### PR DESCRIPTION
## Summary
- add RAG query guide with template prompts and tag filter examples
- cross-link RAG query guide from README and example vector queries doc

## Testing
- `npx prettier . --check --log-level warn`
- `npx eslint .`
- `CI=1 npx vitest run --reporter=dot`
- `npx playwright test` *(fails: no output, environment limitation)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68adc7a9e15c8326afb79584474397fc