### PR TITLE
refactor: isolate orchestrator debug helpers

### DIFF
--- a/tests/helpers/classicBattle/onTransition.helpers.test.js
+++ b/tests/helpers/classicBattle/onTransition.helpers.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Minimal mocks for modules required by orchestrator
+vi.mock("../../../src/helpers/classicBattle/roundSelectModal.js", () => ({
+  initRoundSelectModal: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+  resetGame: vi.fn(),
+  startRound: vi.fn(),
+  _resetForTest: vi.fn()
+}));
+vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
+  clearMessage: vi.fn(),
+  startCountdown: vi.fn(),
+  showMessage: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
+  updateDebugPanel: vi.fn()
+}));
+
+const engineMock = {
+  getTimerState: () => ({ remaining: 30, paused: false })
+};
+
+vi.mock("../../../src/helpers/classicBattle/stateMachine.js", () => ({
+  BattleStateMachine: {
+    async create(_onEnter, { store }, onTransition) {
+      const machine = {
+        context: { store, engine: engineMock },
+        current: "init",
+        async dispatch(event) {
+          const from = this.current;
+          const to = event;
+          this.current = to;
+          await onTransition({ from, to, event });
+        },
+        getState() {
+          return this.current;
+        }
+      };
+      return machine;
+    }
+  }
+}));
+
+describe("onTransition helpers", () => {
+  let orchestrator;
+  let machine;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    document.body.innerHTML = "";
+    orchestrator = await import("../../../src/helpers/classicBattle/orchestrator.js");
+    await orchestrator.initClassicBattleOrchestrator({});
+    machine = orchestrator.getBattleStateMachine();
+  });
+
+  it("updates debug globals and timer info on transition", async () => {
+    await machine.dispatch("stateA");
+    expect(window.__classicBattleState).toBe("stateA");
+    const el = document.getElementById("machine-state");
+    expect(el).toBeTruthy();
+    expect(el.textContent).toBe("stateA");
+    expect(window.__classicBattleTimerState).toEqual({ remaining: 30, paused: false });
+  });
+});


### PR DESCRIPTION
## Summary
- factor DOM and timer state updates into `updateDebugState` and `updateTimerDebug`
- streamline orchestrator transition logic to use new helpers
- add test ensuring debug helpers expose state after transitions

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68addb895518832682e7a002715fd9a1