### PR TITLE
Refactor selection handler helpers

### DIFF
--- a/tests/helpers/classicBattle/selectionHandler.resolve.test.js
+++ b/tests/helpers/classicBattle/selectionHandler.resolve.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
+  STATS: ["power"],
+  stopTimer: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
+  emitBattleEvent: vi.fn(),
+  onBattleEvent: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/classicBattle/eventDispatcher.js", () => ({
+  dispatchBattleEvent: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/classicBattle/roundResolver.js", () => ({
+  resolveRound: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/classicBattle/cardStatUtils.js", () => ({
+  getCardStatValue: vi.fn()
+}));
+
+import { handleStatSelection } from "../../../src/helpers/classicBattle.js";
+
+describe("handleStatSelection resolution paths", () => {
+  let store;
+  let dispatchMock;
+  let resolveMock;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.spyOn(global, "setTimeout");
+    store = { selectionMade: false, playerChoice: null, statTimeoutId: null, autoSelectId: null };
+    dispatchMock = (await import("../../../src/helpers/classicBattle/eventDispatcher.js"))
+      .dispatchBattleEvent;
+    resolveMock = (await import("../../../src/helpers/classicBattle/roundResolver.js"))
+      .resolveRound;
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    delete document.body.dataset.battleState;
+  });
+
+  it("uses state machine when available", async () => {
+    document.body.dataset.battleState = "roundDecision";
+    dispatchMock.mockResolvedValue();
+
+    await handleStatSelection(store, "power", { playerVal: 1, opponentVal: 2 });
+
+    expect(dispatchMock).toHaveBeenCalledWith("statSelected");
+    expect(resolveMock).not.toHaveBeenCalled();
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 600);
+    expect(store.playerChoice).toBe("power");
+  });
+
+  it("resolves directly without machine", async () => {
+    resolveMock.mockImplementation(async (s) => {
+      s.playerChoice = null;
+      return "direct";
+    });
+
+    const result = await handleStatSelection(store, "power", { playerVal: 1, opponentVal: 2 });
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(resolveMock).toHaveBeenCalled();
+    expect(result).toBe("direct");
+    expect(store.playerChoice).toBeNull();
+  });
+
+  it("falls back to direct resolution on dispatch error", async () => {
+    document.body.dataset.battleState = "roundDecision";
+    dispatchMock.mockRejectedValue(new Error("fail"));
+    resolveMock.mockImplementation(async (s) => {
+      s.playerChoice = null;
+      return "fallback";
+    });
+
+    const result = await handleStatSelection(store, "power", { playerVal: 1, opponentVal: 2 });
+
+    expect(dispatchMock).toHaveBeenCalled();
+    expect(resolveMock).toHaveBeenCalled();
+    expect(result).toBe("fallback");
+    expect(store.playerChoice).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- extract getPlayerAndOpponentValues helper to read stat values
- split round resolution into resolveRoundViaMachine and resolveRoundDirect with single error handler
- add tests covering machine, direct, and fallback resolution paths

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: ReferenceError process is not defined)*
- `npx vitest run tests/helpers/classicBattle/selectionHandler.resolve.test.js`
- `npx playwright test` *(fails: Test timeout of 30000ms exceeded)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ade1c96b58832683414be1867eef55