### PR TITLE
Refactor round decision guard into helper and add tests

### DIFF
--- a/tests/helpers/classicBattle/roundDecisionGuard.test.js
+++ b/tests/helpers/classicBattle/roundDecisionGuard.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { scheduleRoundDecisionGuard } from "../../../src/helpers/classicBattle/orchestratorHandlers.js";
+
+describe("scheduleRoundDecisionGuard", () => {
+  let timerSpy;
+  let machine;
+  let store;
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    document.body.dataset.battleState = "roundDecision";
+    window.__roundDebug = {};
+    timerSpy = vi.useFakeTimers();
+    store = { playerChoice: null };
+    machine = { dispatch: vi.fn().mockResolvedValue(undefined) };
+  });
+  afterEach(() => {
+    timerSpy.clearAllTimers();
+    vi.restoreAllMocks();
+  });
+  it("interrupts when no selection occurs", async () => {
+    scheduleRoundDecisionGuard(store, machine);
+    timerSpy.advanceTimersByTime(1200);
+    await vi.runAllTimersAsync();
+    expect(machine.dispatch).toHaveBeenCalledWith("interrupt", { reason: "stalledNoSelection" });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract round decision guard into `scheduleRoundDecisionGuard` helper
- Add unit test for guard when no stat is selected

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Test timeout of 30000ms exceeded. 15 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ade754da108326a8473e9944cc3c73