### PR TITLE
refactor battle UI reset helpers

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -808,17 +808,16 @@ export function maybeShowStatHint(durationMs = 3000, setTimeoutFn = setTimeout) 
 }
 
 /**
- * Reset battle UI elements to their initial state.
+ * Remove modal backdrops and destroy any active quit modal.
  *
  * @pseudocode
- * 1. Remove any active modal backdrops and destroy `store.quitModal`.
- * 2. Replace the Next Round and Quit buttons with fresh clones.
- * 3. Clear scoreboard messages and disable the Next Round button.
+ * 1. Remove all elements with class `.modal-backdrop`.
+ * 2. If `store.quitModal` exists, call its `destroy` method and null it out.
  *
  * @param {ReturnType<import("./roundManager.js").createBattleStore>} [store]
  * - Optional battle state store used to tear down the quit modal.
  */
-export function resetBattleUI(store) {
+export function removeBackdrops(store) {
   try {
     document.querySelectorAll?.(".modal-backdrop").forEach((m) => {
       if (typeof m.remove === "function") m.remove();
@@ -830,7 +829,17 @@ export function resetBattleUI(store) {
     } catch {}
     store.quitModal = null;
   }
+}
 
+/**
+ * Replace battle action buttons with fresh clones.
+ *
+ * @pseudocode
+ * 1. Clone and replace `#next-button`, disabling it and removing `data-next-ready`.
+ * 2. Attach `onNextButtonClick` to the cloned next button.
+ * 3. Clone and replace `#quit-match-button` to drop old listeners.
+ */
+export function resetActionButtons() {
   let nextBtn;
   try {
     nextBtn = document.getElementById ? document.getElementById("next-button") : null;
@@ -850,7 +859,17 @@ export function resetBattleUI(store) {
   if (quitBtn) {
     quitBtn.replaceWith(quitBtn.cloneNode(true));
   }
+}
 
+/**
+ * Clear round messages and refresh the scoreboard display.
+ *
+ * @pseudocode
+ * 1. Invoke `scoreboard.clearMessage`.
+ * 2. Empty `#next-round-timer` and `#round-result` elements.
+ * 3. Call `syncScoreDisplay` and `updateDebugPanel`.
+ */
+export function clearRoundInfo() {
   try {
     scoreboard.clearMessage();
   } catch {}
@@ -868,6 +887,23 @@ export function resetBattleUI(store) {
     syncScoreDisplay();
   } catch {}
   updateDebugPanel();
+}
+
+/**
+ * Reset battle UI elements to their initial state.
+ *
+ * @pseudocode
+ * 1. Call `removeBackdrops` with `store`.
+ * 2. Invoke `resetActionButtons`.
+ * 3. Run `clearRoundInfo`.
+ *
+ * @param {ReturnType<import("./roundManager.js").createBattleStore>} [store]
+ * - Optional battle state store used to tear down the quit modal.
+ */
+export function resetBattleUI(store) {
+  removeBackdrops(store);
+  resetActionButtons();
+  clearRoundInfo();
 }
 
 // --- Event bindings ---

--- a/tests/helpers/classicBattle/resetBattleUI.helpers.test.js
+++ b/tests/helpers/classicBattle/resetBattleUI.helpers.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
+  onNextButtonClick: vi.fn(),
+  getNextRoundControls: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
+  clearMessage: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/classicBattle/uiService.js", () => ({
+  syncScoreDisplay: vi.fn()
+}));
+
+import * as helpers from "../../../src/helpers/classicBattle/uiHelpers.js";
+
+const { removeBackdrops, resetActionButtons, clearRoundInfo } = helpers;
+
+describe("resetBattleUI helpers", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  describe("removeBackdrops", () => {
+    it("removes backdrops and destroys quit modal", () => {
+      document.body.innerHTML =
+        '<div class="modal-backdrop"></div><div class="modal-backdrop"></div>';
+      const destroy = vi.fn();
+      const store = { quitModal: { destroy } };
+      removeBackdrops(store);
+      expect(document.querySelectorAll(".modal-backdrop")).toHaveLength(0);
+      expect(destroy).toHaveBeenCalledTimes(1);
+      expect(store.quitModal).toBeNull();
+    });
+  });
+
+  describe("resetActionButtons", () => {
+    it("replaces buttons and wires next click", async () => {
+      const next = document.createElement("button");
+      next.id = "next-button";
+      next.dataset.nextReady = "true";
+      const quit = document.createElement("button");
+      quit.id = "quit-match-button";
+      const quitListener = vi.fn();
+      quit.addEventListener("click", quitListener);
+      document.body.append(next, quit);
+
+      resetActionButtons();
+
+      const timerSvc = await import("../../../src/helpers/classicBattle/timerService.js");
+
+      const newNext = document.getElementById("next-button");
+      expect(newNext).not.toBe(next);
+      expect(newNext.disabled).toBe(true);
+      expect(newNext.dataset.nextReady).toBeUndefined();
+      newNext.dispatchEvent(new MouseEvent("click"));
+      expect(timerSvc.onNextButtonClick).toHaveBeenCalledTimes(1);
+
+      const newQuit = document.getElementById("quit-match-button");
+      expect(newQuit).not.toBe(quit);
+      newQuit.dispatchEvent(new MouseEvent("click"));
+      expect(quitListener).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe("clearRoundInfo", () => {
+    it("clears round info and syncs scoreboard", async () => {
+      document.body.innerHTML = `
+        <div id="next-round-timer">5</div>
+        <div id="round-result">win</div>
+      `;
+
+      const scoreboard = await import("../../../src/helpers/setupScoreboard.js");
+      const uiService = await import("../../../src/helpers/classicBattle/uiService.js");
+
+      clearRoundInfo();
+
+      expect(scoreboard.clearMessage).toHaveBeenCalledTimes(1);
+      expect(document.getElementById("next-round-timer").textContent).toBe("");
+      expect(document.getElementById("round-result").textContent).toBe("");
+      expect(uiService.syncScoreDisplay).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract helper functions to clear round info, reset buttons, and remove modals
- rework resetBattleUI to orchestrate these helpers
- add unit tests for each new helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Test timeout of 30000ms exceeded)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ae080086708326a5427d01d92d1518