### PR TITLE
Buffer classic battle events until machine ready

### DIFF
--- a/design/productRequirementsDocuments/prdClassicBattleEngine.md
+++ b/design/productRequirementsDocuments/prdClassicBattleEngine.md
@@ -133,9 +133,11 @@ When a player quits in the middle of a match, the engine follows a defined seque
 
 - `stateTable.js` defines all match states and transitions.
 - `BattleEngine.js` implements round logic, scoring, timer, and match end conditions.  
-- `orchestrator.js` manages state machine, transitions, and exposes hooks for UI and tests.  
-- `battleStateProgress.js` renders state progress bar and syncs active state.  
+- `orchestrator.js` manages state machine, transitions, and exposes hooks for UI and tests.
+- `battleStateProgress.js` renders state progress bar and syncs active state.
 - Scoreboard UI and accessibility requirements as described in `prdBattleScoreboard.md`.
+- `eventDispatcher.js` buffers battle events until the state machine is
+  initialized so early selections are not lost.
 
 ---
 

--- a/tests/helpers/classicBattle/resolveRoundViaMachine.buffer.test.js
+++ b/tests/helpers/classicBattle/resolveRoundViaMachine.buffer.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { setMachine } from "../../../src/helpers/classicBattle/eventDispatcher.js";
+import * as selectionHandler from "../../../src/helpers/classicBattle/selectionHandler.js";
+
+describe("resolveRoundViaMachine pending events", () => {
+  afterEach(() => {
+    setMachine(null);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("flushes queued statSelected once machine is ready", async () => {
+    vi.useFakeTimers();
+    setMachine(null);
+    const store = { playerChoice: "power" };
+    const directSpy = vi.spyOn(selectionHandler, "resolveRoundDirect").mockResolvedValue();
+    const machine = {
+      dispatch: vi.fn(async () => {
+        store.playerChoice = null;
+      })
+    };
+
+    const promise = selectionHandler.resolveRoundViaMachine(store, "power", 1, 2);
+    expect(vi.getTimerCount()).toBe(1);
+
+    setMachine(machine);
+    await promise;
+
+    expect(machine.dispatch).toHaveBeenCalledWith("statSelected", undefined);
+    expect(store.playerChoice).toBeNull();
+    expect(directSpy).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/tests/helpers/classicBattle/roundResolverOnce.test.js
+++ b/tests/helpers/classicBattle/roundResolverOnce.test.js
@@ -5,7 +5,7 @@ vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
   onBattleEvent: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/eventDispatcher.js", () => ({
-  dispatchBattleEvent: vi.fn().mockResolvedValue()
+  dispatchBattleEvent: vi.fn().mockReturnValue(new Promise(() => {}))
 }));
 vi.mock("../../../src/helpers/classicBattle/cardSelection.js", () => ({
   getOpponentJudoka: vi.fn(() => null),


### PR DESCRIPTION
## Summary
- queue battle events until the state machine is available and flush on set
- safeguard resolveRoundViaMachine by canceling fallback timeout and retaining choice
- document that the dispatcher buffers early events to avoid losing selections
- add regression test for buffered round resolution

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: many classicBattle tests timing out or missing dispatches)*
- `npx playwright test` *(fails: multiple timeouts and screenshot mismatches)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ae1a6ac2cc832689036660abc4f9b3