### PR TITLE
chore: remove unused expect import

### DIFF
--- a/playwright/static-pages.spec.js
+++ b/playwright/static-pages.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "./fixtures/commonSetup.js";
+import { test } from "./fixtures/commonSetup.js";
 import {
   verifyPageBasics,
   NAV_RANDOM_JUDOKA,


### PR DESCRIPTION
## Summary
- remove unused `expect` import in Playwright static pages spec

## Testing
- `npx prettier . --check`
- `npx eslint playwright/static-pages.spec.js`
- `npx eslint .` *(fails: home page layout spec has `testInfo` unused)*
- `npx vitest run`
- `npx playwright test` *(fails: 15 tests timed out)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68ae20b25df48326a8edbc61b7f93058