### PR TITLE
feat: add queryRag helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,17 @@ Sample queries:
 - "Summarize the classicBattle module"
 - "Outline how settings persistence works"
 
-For deeper guidance, see [example vector queries](design/agentWorkflows/exampleVectorQueries.md).
+- When a prompt starts with question patterns like "Explain X" or "How does Y work?",
+  call [`queryRag(question)`](src/helpers/queryRag.js) to gather context before scanning files.
+- For deeper guidance and code samples, see
+  [example vector queries](design/agentWorkflows/exampleVectorQueries.md#queryrag-helper).
 
 ---
 
 ## 🧪 Prompt Templates
+
+Before applying any template, look for question-style prompts such as
+"Explain X" or "How does Y work?" and run `queryRag` for context.
 
 Use these prompt formats when engaging with AI or testing tools:
 

--- a/design/agentWorkflows/exampleVectorQueries.md
+++ b/design/agentWorkflows/exampleVectorQueries.md
@@ -76,6 +76,20 @@ You debug UI issues. Find references about the navigation bar animation timing.
 Query: "navbar button transition duration"
 ```
 
+## `queryRag` Helper
+
+Use the `queryRag(question)` helper to expand a natural-language question and
+fetch the most relevant vector matches before digging through files.
+
+```javascript
+import queryRag from "../../src/helpers/queryRag.js";
+
+const matches = await queryRag("How does the battle engine work?");
+```
+
+The function handles synonym expansion, embedding generation, and ranking so
+agents start with focused context.
+
 ## Updating Embeddings
 
 Run `npm run generate:embeddings` whenever you update any PRD, files in

--- a/src/helpers/queryRag.js
+++ b/src/helpers/queryRag.js
@@ -1,0 +1,32 @@
+import vectorSearch from "./vectorSearch/index.js";
+import { getExtractor } from "./api/vectorSearchPage.js";
+
+function isIterable(value) {
+  return value !== null && value !== undefined && typeof value[Symbol.iterator] === "function";
+}
+
+/**
+ * Query the vector database for a natural language question.
+ *
+ * @pseudocode
+ * 1. Expand `question` with domain-specific synonyms.
+ * 2. Load the MiniLM feature extractor and embed the expanded text.
+ * 3. Convert the embedding to a plain array.
+ * 4. Use `vectorSearch.findMatches` to retrieve the top results for the original question.
+ * 5. Return the matches array.
+ *
+ * @param {string} question - Natural language question to look up.
+ * @returns {Promise<Array<{score:number} & Record<string, any>>|null>} Top matches or null if data missing.
+ */
+export async function queryRag(question) {
+  const expanded = await vectorSearch.expandQueryWithSynonyms(question);
+  const extractor = await getExtractor();
+  const embedding = await extractor(expanded, { pooling: "mean" });
+  const source =
+    embedding && typeof embedding === "object" && "data" in embedding ? embedding.data : embedding;
+  if (!isIterable(source)) return [];
+  const vector = Array.from(source);
+  return vectorSearch.findMatches(vector, 5, [], question);
+}
+
+export default queryRag;


### PR DESCRIPTION
## Summary
- add queryRag helper to expand questions and query vector search
- document queryRag usage for agents and link from AGENTS guide
- instruct agents to call queryRag for question-style prompts before scanning files

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: countdownReset and statSelection tests)
- `npx playwright test` (fails: multiple screenshot and vector search tests)


------
https://chatgpt.com/codex/tasks/task_e_68aee88a0870832685b6736b2da235b8