### PR TITLE
refactor: decouple round UI invocation

### DIFF
--- a/tests/helpers/classicBattle/autoSelect.test.js
+++ b/tests/helpers/classicBattle/autoSelect.test.js
@@ -59,7 +59,7 @@ describe("classicBattle auto select", () => {
     const battleMod = await initClassicBattleTest({ afterMock: true });
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
-    await battleMod.startRound(store);
+    await battleMod.startRound(store, battleMod.applyRoundUI);
     const pending = battleMod.__triggerRoundTimeoutNow(store);
     await vi.runAllTimersAsync();
     await pending;

--- a/tests/helpers/classicBattle/selectionPrompt.test.js
+++ b/tests/helpers/classicBattle/selectionPrompt.test.js
@@ -62,7 +62,7 @@ describe("classicBattle selection prompt", () => {
     const battleMod = await initClassicBattleTest({ afterMock: true });
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
-    await battleMod.startRound(store);
+    await battleMod.startRound(store, battleMod.applyRoundUI);
     expect(document.querySelector(".snackbar").textContent).toBe("Select your move");
     timerSpy.advanceTimersByTime(5000);
     expect(document.querySelector(".snackbar")).toBeNull();

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -57,7 +57,7 @@ describe("classicBattle stalled stat selection recovery", () => {
     await battleMod.__ensureClassicBattleBindings();
     const store = battleMod.createBattleStore();
     battleMod._resetForTest(store);
-    await battleMod.startRound(store);
+    await battleMod.startRound(store, battleMod.applyRoundUI);
     await battleMod.__triggerStallPromptNow(store);
     expect(document.querySelector("header #round-message").textContent).toMatch(/stalled/i);
     timerSpy.advanceTimersByTime(5000);


### PR DESCRIPTION
## Summary
- decouple roundManager from roundUI by using optional callback
- update classic battle tests to inject applyRoundUI for deterministic UI updates

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 14 failed, 1 interrupted, 2 did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68af360875608326ae42ada3bd3a878f