### PR TITLE
fix game mode grid layout overflowing footer

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -120,7 +120,8 @@ body {
   padding: var(--space-large) var(--space-xl);
   padding-bottom: calc(var(--space-large) + var(--footer-height) + env(safe-area-inset-bottom));
   flex: 1 1 auto;
-  min-height: 100%;
+  height: 100%;
+  overflow-y: auto;
   box-sizing: border-box;
   /* border: 2px solid red; */
 }


### PR DESCRIPTION
## Summary
- ensure game mode grid fills its container without overlapping the footer by using `height: 100%` and enabling vertical scrolling

## Testing
- `npx prettier src/styles/layout.css --write`
- `CI=1 npx prettier . --check`
- `npx eslint .`
- `npx vitest run --reporter=basic`
- `npx playwright test --reporter=line` *(fails: 1 failed, 2 interrupted, 53 did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68af85f449bc8326bf5043b19a16e73d