### PR TITLE
fix: resolve battleCLI style conflict and add CLI smoke test

### DIFF
--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -16,6 +16,17 @@ test.describe("Classic Battle CLI", () => {
     });
   });
 
+  test("loads without console errors", async ({ page }) => {
+    const errors = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+    await page.goto("/src/pages/battleCLI.html");
+    await waitForBattleState(page, "waitingForPlayerAction", 15000);
+    expect(errors).toEqual([]);
+  });
+
   test("shows state badge with current state", async ({ page }) => {
     await page.goto("/src/pages/battleCLI.html");
     // Wait until the player can act

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -36,7 +36,7 @@
       .cli-title {
         font-weight: 700;
       }
-      <<<<<<< HEAD .state-badge {
+      .state-badge {
         font-size: 12px;
         opacity: 0.8;
         margin-left: 8px;
@@ -49,15 +49,7 @@
         gap: 8px;
         align-items: center;
       }
-      ======= .cli-score {
-        white-space: pre;
-      }
-      .cli-controls {
-        display: flex;
-        gap: 8px;
-        align-items: center;
-      }
-      >>>>>>>01733594a44d8342ec37a88c617ebdc820e9de41 .cli-main {
+      .cli-main {
         flex: 1;
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
## Summary
- clean up merge conflict markers and restore CLI badge and controls styles
- add Playwright smoke test ensuring battleCLI loads without console errors

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: playwright/homepage-layout.spec.js, playwright/screenshot.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68af8bd355888326840381acea83d620