### PR TITLE
feat(cli): allow skipping cooldown

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -81,11 +81,13 @@ Notes:
 2. Keyboard Controls
    - Given the player is in stat selection, when pressing keys 1–9 mapped to visible stats, then the corresponding stat is selected and input is debounced until the next state.
    - Given a round has completed, when pressing Enter/Space, then the flow advances to cooldown/next round.
+   - Given an inter-round cooldown is running, when pressing Enter/Space, then the countdown is skipped and the next round begins immediately.
    - Given an active match, when pressing Q, then a quit confirmation prompt appears; confirming ends or rolls back per engine rules.
 
 3. Timer Behavior
    - Given `waitingForPlayerAction`, when the timer ticks, then `#cli-countdown` updates once per second with remaining time.
    - Given timer expiry and `FF_AUTO_SELECT` enabled, when the countdown reaches zero, then a random stat is selected and printed before decision.
+   - Given `cooldown`, when countdownStart fires, then a fallback timer runs and emits `countdownFinished` after the duration if not skipped.
    - Given the tab is hidden or device sleeps, when focus returns, then the timer resumes without double-firing and remains consistent with the engine PRD.
 
 4. Outcome and Score

--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -46,4 +46,26 @@ test.describe("Classic Battle CLI", () => {
     await toggle.uncheck();
     await expect(page.locator("#cli-verbose-section")).toBeHidden();
   });
+
+  test("plays a full round and skips cooldown", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__NEXT_ROUND_COOLDOWN_MS = 3000;
+    });
+    await page.goto("/src/pages/battleCLI.html");
+    await waitForBattleState(page, "waitingForPlayerAction", 15000);
+
+    const score = page.locator("#cli-score");
+
+    await page.keyboard.press("1");
+    await waitForBattleState(page, "roundOver", 10000);
+    const afterRoundScore = await score.textContent();
+    const cardBefore = await page.locator("#player-card ul").elementHandle();
+
+    await page.keyboard.press("Enter");
+    await waitForBattleState(page, "waitingForPlayerAction", 10000);
+    const cardAfter = await page.locator("#player-card ul").elementHandle();
+
+    await expect(score).toHaveText(afterRoundScore || "");
+    expect(cardAfter).not.toBe(cardBefore);
+  });
 });


### PR DESCRIPTION
## Summary
- allow Enter/Space to skip CLI cooldown and start next round
- show CLI countdown timer and fallback cooldown scheduler
- document cooldown skip in CLI PRD and add round regression test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot comparisons and unrelated UI tests)*
- `npx playwright test playwright/battle-cli.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68af8bc8a4d08326b086846d8e60f9c0