### PR TITLE
fix: ensure home screen fits viewport

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -23,6 +23,7 @@ body {
     Match the visible viewport height so the draw controls stay
     above the fixed footer on tablets like iPad.
   */
+  height: 100dvh;
   min-height: calc(100vh - var(--header-height) - var(--footer-height));
   min-height: calc(100svh - var(--header-height) - var(--footer-height));
   min-height: calc(100dvh - var(--header-height) - var(--footer-height));


### PR DESCRIPTION
## Summary
- ensure `.home-screen` spans full viewport height with `height: 100dvh`
- retain `box-sizing: border-box` so top/bottom padding stay within viewport

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Screenshot suite and Settings screenshots)*
- `npx playwright test playwright/homepage-layout.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68affa64160c8326ba927fc0706d622d