### PR TITLE
docs: note full-height .home-screen wrappers

### DIFF
--- a/design/productRequirementsDocuments/prdChangeLog.md
+++ b/design/productRequirementsDocuments/prdChangeLog.md
@@ -117,8 +117,9 @@ Players and developers currently lack a simple, in-game method to see which Judo
   Judoka ID, portrait (48×48 px), full name, card code, and formatted date.
 - Portrait images use a fallback source (`judokaPortrait-0.png`) when loading
   fails, with alt text like "Portrait of Judoka Kano".
-- The page follows existing layout conventions: header, `.home-screen` wrapper,
-  and bottom navigation bar. Include a spinner during loading and a friendly
+- The page follows existing layout conventions: header, `.home-screen` wrapper
+  (set `height: 100dvh` so child grids size correctly), and bottom navigation bar.
+  Include a spinner during loading and a friendly
   message if no data is available.
 - Table rows alternate between `--color-surface` and `--color-tertiary` to
   create zebra striping, starting with `odd` for the first row.

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -114,7 +114,7 @@ On load, the Settings page must pre-populate each control with values from
 - All data reads/writes should use asynchronous, promise-based functions with error handling.
 - `settings.json` must persist via the storage utility for session retention.
 - Updates should debounce writes to avoid excessive file operations if toggles are changed rapidly.
-- Wrap the page contents in a `.home-screen` container so the fixed header does not cover the first settings control.
+- Wrap the page contents in a `.home-screen` container so the fixed header does not cover the first settings control. Screen wrappers should set `height: 100dvh` to ensure child grids can size correctly.
 
 ---
 


### PR DESCRIPTION
## Summary
- mention that `.home-screen` wrappers must use `height: 100dvh` so child grids size correctly

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: grid overlap and screenshot diffs)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68affab2b7c48326acfa3fa31025daa5