### PR TITLE
test: verify home screen height

### DIFF
--- a/playwright/homepage-layout.spec.js
+++ b/playwright/homepage-layout.spec.js
@@ -20,6 +20,23 @@ test.describe("Homepage layout", () => {
       expect(columnCount).toBe(2);
     });
 
+    test("home screen matches viewport height", async ({ page }) => {
+      const { homeHeight, headerHeight, footerHeight, viewportHeight } = await page.evaluate(() => {
+        const home = document.querySelector(".home-screen");
+        const header = document.querySelector(".header");
+        const footer = document.querySelector(".bottom-navbar");
+        return {
+          homeHeight: parseFloat(getComputedStyle(home).height),
+          headerHeight: parseFloat(getComputedStyle(header).height),
+          footerHeight: parseFloat(getComputedStyle(footer).height),
+          viewportHeight: window.innerHeight
+        };
+      });
+      expect(
+        Math.abs(homeHeight + headerHeight + footerHeight - viewportHeight)
+      ).toBeLessThanOrEqual(ALLOWED_OFFSET);
+    });
+
     test("grid does not overlap footer (desktop)", async ({ page }) => {
       const grid = page.locator(".game-mode-grid");
       const gridBox = await grid.boundingBox();
@@ -62,6 +79,23 @@ test.describe("Homepage layout", () => {
         return style.gridTemplateColumns.split(/\s+/).filter(Boolean).length;
       });
       expect(columnCount).toBe(1);
+    });
+
+    test("home screen matches viewport height", async ({ page }) => {
+      const { homeHeight, headerHeight, footerHeight, viewportHeight } = await page.evaluate(() => {
+        const home = document.querySelector(".home-screen");
+        const header = document.querySelector(".header");
+        const footer = document.querySelector(".bottom-navbar");
+        return {
+          homeHeight: parseFloat(getComputedStyle(home).height),
+          headerHeight: parseFloat(getComputedStyle(header).height),
+          footerHeight: parseFloat(getComputedStyle(footer).height),
+          viewportHeight: window.innerHeight
+        };
+      });
+      expect(
+        Math.abs(homeHeight + headerHeight + footerHeight - viewportHeight)
+      ).toBeLessThanOrEqual(ALLOWED_OFFSET);
     });
 
     test("grid does not overlap footer (mobile)", async ({ page }) => {


### PR DESCRIPTION
## Summary
- assert that home screen height stays aligned with viewport across desktop and mobile layouts

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: ReferenceError: process is not defined)*
- `SKIP_SCREENSHOTS=true npx playwright test` *(fails: home screen height, grid overlap, PRD reader)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68affaad6ccc8326a54df1bcd6bb57af