### PR TITLE
test: exercise CLI stat clicks and round advances

### DIFF
--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -35,6 +35,17 @@ test.describe("Classic Battle CLI", () => {
     await expect(badge).toContainText(/State:\s*waitingForPlayerAction/);
   });
 
+  test("clicking a stat advances to round decision", async ({ page }) => {
+    await page.goto("/src/pages/battleCLI.html");
+    await waitForBattleState(page, "waitingForPlayerAction", 15000);
+
+    const firstStat = page.locator(".cli-stat").first();
+    await firstStat.click();
+    await firstStat.click();
+
+    await waitForBattleState(page, "roundDecision", 10000);
+  });
+
   test("verbose log toggles and records transitions", async ({ page }) => {
     await page.goto("/src/pages/battleCLI.html");
     await waitForBattleState(page, "waitingForPlayerAction", 15000);
@@ -72,7 +83,9 @@ test.describe("Classic Battle CLI", () => {
     const afterRoundScore = await score.textContent();
     const cardBefore = await page.locator("#player-card ul").elementHandle();
 
-    await page.keyboard.press("Enter");
+    await waitForBattleState(page, "cooldown", 10000);
+    // Clicking the main surface advances to the next round
+    await page.locator("#cli-main").click();
     await waitForBattleState(page, "waitingForPlayerAction", 10000);
     const cardAfter = await page.locator("#player-card ul").elementHandle();
 


### PR DESCRIPTION
## Summary
- add Playwright test for clicking a stat and reaching round decision
- advance rounds via surface click instead of Enter

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatches and new CLI tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b009ab9da48326957cef82925e6cf9