### PR TITLE
refactor: centralize drift test setup

### DIFF
--- a/tests/helpers/classicBattle/driftStarter.js
+++ b/tests/helpers/classicBattle/driftStarter.js
@@ -1,0 +1,21 @@
+import { vi } from "vitest";
+
+/**
+ * Create a starter mock that captures an onDrift callback and exposes a
+ * `triggerDrift` helper.
+ *
+ * @returns {{starter: ReturnType<typeof vi.fn>, triggerDrift: (remaining: number) => void}}
+ */
+export function createDriftStarter() {
+  let onDrift;
+  const starter = vi.fn((onTick, _expired, _dur, driftCb) => {
+    onDrift = driftCb;
+    onTick(3);
+  });
+  return {
+    starter,
+    triggerDrift: (remaining) => {
+      if (typeof onDrift === "function") onDrift(remaining);
+    }
+  };
+}

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { createTimerNodes } from "./domUtils.js";
 import { createMockScheduler } from "../mockScheduler.js";
+import { createDriftStarter } from "./driftStarter.js";
 
 describe("timerService drift handling", () => {
   it("startTimer shows fallback on drift", async () => {
@@ -17,18 +18,15 @@ describe("timerService drift handling", () => {
     vi.doMock("../../../src/helpers/timerUtils.js", () => ({
       getDefaultTimer: () => 30
     }));
-    let onDrift;
-    const startRound = vi.fn(async (onTick, _expired, _dur, driftCb) => {
-      onDrift = driftCb;
-      onTick(3);
-    });
+    const round = createDriftStarter();
+    const startRound = round.starter;
     vi.doMock("../../../src/helpers/battleEngineFacade.js", async () => {
       const actual = await vi.importActual("../../../src/helpers/battleEngineFacade.js");
       return { ...actual, startRound };
     });
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
     await mod.startTimer(async () => {});
-    onDrift(2);
+    round.triggerDrift(2);
     expect(showMessage).toHaveBeenCalledWith("Waiting…");
     // Shared timer restarts via factory
     expect(startRound).toHaveBeenCalledTimes(2);
@@ -50,11 +48,8 @@ describe("timerService drift handling", () => {
       disableNextRoundButton: vi.fn(),
       updateDebugPanel: vi.fn()
     }));
-    let onDrift;
-    const startCoolDown = vi.fn((onTick, _expired, _dur, driftCb) => {
-      onDrift = driftCb;
-      onTick(3);
-    });
+    const cool = createDriftStarter();
+    const startCoolDown = cool.starter;
     vi.doMock("../../../src/helpers/battleEngineFacade.js", async () => {
       const actual = await vi.importActual("../../../src/helpers/battleEngineFacade.js");
       return { ...actual, startCoolDown };
@@ -64,7 +59,7 @@ describe("timerService drift handling", () => {
     createTimerNodes();
     mod.scheduleNextRound({ matchEnded: false }, scheduler);
     scheduler.tick(0);
-    onDrift(1);
+    cool.triggerDrift(1);
     // Cooldown drift displays a non-intrusive fallback; may use snackbar
     // when a round result message is present. Accept scoreboard fallback too.
     const usedScoreboard = showMessage.mock.calls.some((c) => c[0] === "Waiting…");
@@ -72,7 +67,7 @@ describe("timerService drift handling", () => {
     const showSnack = vi.spyOn(snackbar, "showSnackbar");
     // Trigger another drift tick to allow snackbar path in environments
     // where the round message is present.
-    onDrift(1);
+    cool.triggerDrift(1);
     const usedSnackbar = showSnack.mock.calls.some((c) => c[0] === "Waiting…");
     expect(usedScoreboard || usedSnackbar).toBe(true);
     // Factory restarts cooldown timer on each drift (initial + 2 drifts)


### PR DESCRIPTION
## Summary
- reduce duplication in timerService drift tests via `createDriftStarter`
- reuse helper across startTimer and scheduleNextRound drift scenarios

## Testing
- `npx prettier . --check`
- `npx eslint tests/helpers/classicBattle/driftStarter.js tests/helpers/classicBattle/timerService.drift.test.js tests/helpers/TimerController.drift.test.js`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot suite and settings screenshots)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b01d154c2883268460dd160494312a