### PR TITLE
refactor: split classic battle view init helpers

### DIFF
--- a/src/helpers/classicBattle/setupDebugHooks.js
+++ b/src/helpers/classicBattle/setupDebugHooks.js
@@ -1,0 +1,17 @@
+import { initDebugPanel, registerRoundStartErrorHandler } from "./uiHelpers.js";
+
+/**
+ * Attach debug panels and error hooks.
+ *
+ * @pseudocode
+ * 1. Initialize the debug panel.
+ * 2. Retry round start on `roundStartError`.
+ *
+ * @param {import("./view.js").ClassicBattleView} view
+ */
+export function setupDebugHooks(view) {
+  initDebugPanel();
+  registerRoundStartErrorHandler(() => view.startRound());
+}
+
+export default setupDebugHooks;

--- a/src/helpers/classicBattle/setupScheduler.js
+++ b/src/helpers/classicBattle/setupScheduler.js
@@ -1,0 +1,17 @@
+import { start as startScheduler, stop as stopScheduler } from "../../utils/scheduler.js";
+
+/**
+ * Start the animation scheduler for the battle view.
+ *
+ * @pseudocode
+ * 1. Skip when running under Vitest.
+ * 2. Start the scheduler and stop it on `pagehide`.
+ */
+export function setupScheduler() {
+  if (!(typeof process !== "undefined" && process.env.VITEST)) {
+    startScheduler();
+    window.addEventListener("pagehide", stopScheduler, { once: true });
+  }
+}
+
+export default setupScheduler;

--- a/src/helpers/classicBattle/setupTestHelpers.js
+++ b/src/helpers/classicBattle/setupTestHelpers.js
@@ -1,0 +1,47 @@
+import { resetStatButtons } from "../battle/index.js";
+import { skipCurrentPhase } from "./skipHandler.js";
+import { start as startScheduler, stop as stopScheduler } from "../../utils/scheduler.js";
+
+/**
+ * Install test helpers on the global window.
+ *
+ * @pseudocode
+ * 1. Expose `battleStore` and `skipBattlePhase` on `window`.
+ * 2. Provide overrides to start a round and freeze/resume the header.
+ * 3. Use scheduler helpers when freezing or resuming the header.
+ *
+ * @param {import("./view.js").ClassicBattleView} view
+ */
+export function setupTestHelpers(view) {
+  const store = view.controller.battleStore;
+  window.battleStore = store;
+  window.skipBattlePhase = () => {
+    try {
+      skipCurrentPhase();
+    } catch {}
+    try {
+      resetStatButtons();
+      const c = document.querySelectorAll("#stat-buttons .selected").length;
+      console.warn(`[test] skipBattlePhase: after immediate reset selected=${c}`);
+    } catch {}
+    return Promise.resolve();
+  };
+
+  try {
+    window.startRoundOverride = () => view.startRound();
+    window.freezeBattleHeader = () => {
+      try {
+        view.controller.timerControls.pauseTimer();
+        stopScheduler();
+      } catch {}
+    };
+    window.resumeBattleHeader = () => {
+      try {
+        startScheduler();
+        view.controller.timerControls.resumeTimer();
+      } catch {}
+    };
+  } catch {}
+}
+
+export default setupTestHelpers;

--- a/src/helpers/classicBattle/setupUIBindings.js
+++ b/src/helpers/classicBattle/setupUIBindings.js
@@ -1,0 +1,52 @@
+import { setupScoreboard } from "../setupScoreboard.js";
+import { initQuitButton } from "./quitButton.js";
+import { initInterruptHandlers } from "./interruptHandlers.js";
+import {
+  watchBattleOrientation,
+  setupNextButton,
+  initStatButtons,
+  applyStatLabels,
+  maybeShowStatHint
+} from "./uiHelpers.js";
+import { onBattleEvent } from "./battleEvents.js";
+import { initBattleStateProgress } from "../battleStateProgress.js";
+import { initTooltips } from "../tooltip.js";
+
+/**
+ * Wire up DOM bindings for the classic battle view.
+ *
+ * @pseudocode
+ * 1. Setup scoreboard, quit button and interrupt handlers.
+ * 2. Watch orientation and initialize stat buttons and next button.
+ * 3. Bind stat button state to battle events.
+ * 4. Initialize battle progress, labels, tooltips and hints.
+ * 5. Return `statButtonControls` for later use.
+ *
+ * @param {import("./view.js").ClassicBattleView} view
+ * @returns {Promise<ReturnType<typeof initStatButtons>>}
+ */
+export async function setupUIBindings(view) {
+  const store = view.controller.battleStore;
+  setupScoreboard(view.controller.timerControls);
+  initQuitButton(store);
+  initInterruptHandlers(store);
+  watchBattleOrientation(() => view.applyBattleOrientation());
+
+  setupNextButton();
+  const statButtonControls = initStatButtons(store);
+  onBattleEvent("statButtons:enable", () => statButtonControls?.enable());
+  onBattleEvent("statButtons:disable", () => statButtonControls?.disable());
+
+  const cleanupBattleStateProgress = await initBattleStateProgress();
+  if (cleanupBattleStateProgress) {
+    window.addEventListener("pagehide", cleanupBattleStateProgress, { once: true });
+  }
+
+  await applyStatLabels().catch(() => {});
+  await initTooltips();
+  maybeShowStatHint();
+
+  return statButtonControls;
+}
+
+export default setupUIBindings;

--- a/tests/helpers/classicBattle/view.initHelpers.test.js
+++ b/tests/helpers/classicBattle/view.initHelpers.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from "vitest";
+import setupTestHelpers from "../../../src/helpers/classicBattle/setupTestHelpers.js";
+import setupScheduler from "../../../src/helpers/classicBattle/setupScheduler.js";
+import setupUIBindings from "../../../src/helpers/classicBattle/setupUIBindings.js";
+import setupDebugHooks from "../../../src/helpers/classicBattle/setupDebugHooks.js";
+
+vi.mock("../../../src/helpers/battle/index.js", () => ({
+  resetStatButtons: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/skipHandler.js", () => ({
+  skipCurrentPhase: vi.fn()
+}));
+vi.mock("../../../src/utils/scheduler.js", () => ({
+  onFrame: vi.fn(),
+  onSecondTick: vi.fn(),
+  cancel: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn()
+}));
+vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
+  setupScoreboard: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/quitButton.js", () => ({
+  initQuitButton: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/interruptHandlers.js", () => ({
+  initInterruptHandlers: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", async () => {
+  const actual = await vi.importActual("../../../src/helpers/classicBattle/uiHelpers.js");
+  return {
+    ...actual,
+    watchBattleOrientation: vi.fn(),
+    setupNextButton: vi.fn(),
+    initStatButtons: vi.fn(() => ({ enable: vi.fn(), disable: vi.fn() })),
+    applyStatLabels: vi.fn(() => Promise.resolve()),
+    maybeShowStatHint: vi.fn(),
+    initDebugPanel: vi.fn(),
+    registerRoundStartErrorHandler: vi.fn()
+  };
+});
+const eventHandlers = vi.hoisted(() => ({}));
+vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
+  onBattleEvent: vi.fn((name, cb) => {
+    eventHandlers[name] = cb;
+  }),
+  handlers: eventHandlers
+}));
+vi.mock("../../../src/helpers/battleStateProgress.js", () => ({
+  initBattleStateProgress: vi.fn().mockResolvedValue(() => {})
+}));
+vi.mock("../../../src/helpers/tooltip.js", () => ({
+  initTooltips: vi.fn().mockResolvedValue()
+}));
+
+const scheduler = await import("../../../src/utils/scheduler.js");
+const skipHandler = await import("../../../src/helpers/classicBattle/skipHandler.js");
+const battle = await import("../../../src/helpers/battle/index.js");
+const uiHelpers = await import("../../../src/helpers/classicBattle/uiHelpers.js");
+const events = await import("../../../src/helpers/classicBattle/battleEvents.js");
+
+function makeView() {
+  return {
+    controller: {
+      battleStore: {},
+      timerControls: { pauseTimer: vi.fn(), resumeTimer: vi.fn() },
+      startRound: vi.fn()
+    },
+    startRound: vi.fn(),
+    applyBattleOrientation: vi.fn()
+  };
+}
+
+describe("setupTestHelpers", () => {
+  it("installs globals for tests", async () => {
+    const view = makeView();
+    setupTestHelpers(view);
+    expect(window.battleStore).toBe(view.controller.battleStore);
+    await window.skipBattlePhase();
+    expect(skipHandler.skipCurrentPhase).toHaveBeenCalled();
+    expect(battle.resetStatButtons).toHaveBeenCalled();
+    window.startRoundOverride();
+    expect(view.startRound).toHaveBeenCalled();
+    window.freezeBattleHeader();
+    expect(scheduler.stop).toHaveBeenCalled();
+    window.resumeBattleHeader();
+    expect(scheduler.start).toHaveBeenCalled();
+  });
+});
+
+describe("setupScheduler", () => {
+  it("starts and registers stop handler", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const original = process.env.VITEST;
+    delete process.env.VITEST;
+    setupScheduler();
+    process.env.VITEST = original;
+    expect(scheduler.start).toHaveBeenCalled();
+    expect(add).toHaveBeenCalledWith("pagehide", scheduler.stop, { once: true });
+    add.mockRestore();
+  });
+});
+
+describe("setupUIBindings", () => {
+  it("binds UI helpers and events", async () => {
+    const view = makeView();
+    await setupUIBindings(view);
+    const { setupScoreboard } = await import("../../../src/helpers/setupScoreboard.js");
+    expect(setupScoreboard).toHaveBeenCalledWith(view.controller.timerControls);
+    expect(uiHelpers.watchBattleOrientation).toHaveBeenCalled();
+    const statControls = uiHelpers.initStatButtons.mock.results[0].value;
+    events.handlers["statButtons:enable"]();
+    expect(statControls.enable).toHaveBeenCalled();
+    events.handlers["statButtons:disable"]();
+    expect(statControls.disable).toHaveBeenCalled();
+    const tooltip = await import("../../../src/helpers/tooltip.js");
+    expect(tooltip.initTooltips).toHaveBeenCalled();
+  });
+});
+
+describe("setupDebugHooks", () => {
+  it("initializes debug panel and error handler", () => {
+    const view = makeView();
+    setupDebugHooks(view);
+    expect(uiHelpers.initDebugPanel).toHaveBeenCalled();
+    const cb = uiHelpers.registerRoundStartErrorHandler.mock.calls[0][0];
+    cb();
+    expect(view.startRound).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- split ClassicBattleView init into dedicated helper modules
- cover helpers with focused unit tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/view.initHelpers.test.js`
- `npm run check:contrast`
- `npx vitest run` *(failed: output capture limitations)*
- `npx playwright test` *(failed: terminated after hanging)*

------
https://chatgpt.com/codex/tasks/task_e_68b089885b248326b21b01c57da0de2d