### PR TITLE
refactor: expose classic battle debug api

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -13,6 +13,7 @@ export { getCardStatValue } from "./classicBattle/cardStatUtils.js";
 export { scheduleNextRound } from "./classicBattle/timerService.js";
 export { applyRoundUI } from "./classicBattle/roundUI.js";
 export { getOpponentCardData } from "./classicBattle/opponentController.js";
+export { createClassicBattleDebugAPI } from "./classicBattle/setupTestHelpers.js";
 export {
   roundOptionsReadyPromise,
   roundPromptPromise,

--- a/src/helpers/classicBattle/bootstrap.js
+++ b/src/helpers/classicBattle/bootstrap.js
@@ -5,6 +5,7 @@ import ClassicBattleView from "./view.js";
 import "./promises.js";
 // Ensure round UI event listeners are registered (roundStarted → showSelectionPrompt)
 import "./roundUI.js";
+import { createClassicBattleDebugAPI } from "./setupTestHelpers.js";
 
 /**
  * Bootstrap Classic Battle page by wiring controller and view.
@@ -17,6 +18,11 @@ export async function setupClassicBattlePage() {
   view.bindController(controller);
   await controller.init();
   await view.init();
+  const debugAPI = createClassicBattleDebugAPI(view);
+  if (typeof process !== "undefined" && process.env.VITEST === "true") {
+    window.__classicBattleDebugAPI = debugAPI;
+  }
+  return debugAPI;
 }
 
 if (typeof process === "undefined" || process.env.VITEST !== "true") {

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -27,8 +27,9 @@ export function createBattleStore() {
 }
 
 function getStartRound(store) {
-  if (typeof window !== "undefined" && window.startRoundOverride) {
-    return window.startRoundOverride;
+  if (typeof window !== "undefined") {
+    const api = window.__classicBattleDebugAPI;
+    if (api?.startRoundOverride) return api.startRoundOverride;
   }
   return () => startRound(store);
 }
@@ -92,7 +93,9 @@ export function _resetForTest(store) {
   battleEngine._resetForTest();
   stopScheduler();
   if (typeof window !== "undefined") {
-    delete window.startRoundOverride;
+    const api = window.__classicBattleDebugAPI;
+    if (api) delete api.startRoundOverride;
+    else delete window.startRoundOverride;
   }
   if (store && typeof store === "object") {
     try {

--- a/src/helpers/classicBattle/view.js
+++ b/src/helpers/classicBattle/view.js
@@ -1,5 +1,4 @@
 import { setBattleStateBadgeEnabled, applyBattleFeatureFlags } from "./uiHelpers.js";
-import setupTestHelpers from "./setupTestHelpers.js";
 import setupScheduler from "./setupScheduler.js";
 import setupUIBindings from "./setupUIBindings.js";
 import setupDebugHooks from "./setupDebugHooks.js";
@@ -46,7 +45,6 @@ export class ClassicBattleView {
    * @returns {Promise<void>}
    */
   async init() {
-    setupTestHelpers(this);
     setupScheduler();
     this.statButtonControls = await setupUIBindings(this);
     setupDebugHooks(this);

--- a/tests/helpers/battleTestUtils.js
+++ b/tests/helpers/battleTestUtils.js
@@ -11,7 +11,10 @@
  */
 export async function _resetForTest() {
   const mod = await import(new URL("/src/helpers/classicBattle.js", window.location.href));
-  mod._resetForTest(window.battleStore);
+  const store = window.__classicBattleDebugAPI
+    ? window.__classicBattleDebugAPI.battleStore
+    : window.battleStore;
+  mod._resetForTest(store);
 }
 
 /**

--- a/tests/helpers/classicBattle/view.initHelpers.test.js
+++ b/tests/helpers/classicBattle/view.initHelpers.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import setupTestHelpers from "../../../src/helpers/classicBattle/setupTestHelpers.js";
+import createClassicBattleDebugAPI from "../../../src/helpers/classicBattle/setupTestHelpers.js";
 import setupScheduler from "../../../src/helpers/classicBattle/setupScheduler.js";
 import setupUIBindings from "../../../src/helpers/classicBattle/setupUIBindings.js";
 import setupDebugHooks from "../../../src/helpers/classicBattle/setupDebugHooks.js";
@@ -71,19 +71,19 @@ function makeView() {
   };
 }
 
-describe("setupTestHelpers", () => {
-  it("installs globals for tests", async () => {
+describe("createClassicBattleDebugAPI", () => {
+  it("returns helpers for tests", async () => {
     const view = makeView();
-    setupTestHelpers(view);
-    expect(window.battleStore).toBe(view.controller.battleStore);
-    await window.skipBattlePhase();
+    const api = createClassicBattleDebugAPI(view);
+    expect(api.battleStore).toBe(view.controller.battleStore);
+    await api.skipBattlePhase();
     expect(skipHandler.skipCurrentPhase).toHaveBeenCalled();
     expect(battle.resetStatButtons).toHaveBeenCalled();
-    window.startRoundOverride();
+    api.startRoundOverride();
     expect(view.startRound).toHaveBeenCalled();
-    window.freezeBattleHeader();
+    api.freezeBattleHeader();
     expect(scheduler.stop).toHaveBeenCalled();
-    window.resumeBattleHeader();
+    api.resumeBattleHeader();
     expect(scheduler.start).toHaveBeenCalled();
   });
 });

--- a/tests/helpers/classicBattlePage.test.js
+++ b/tests/helpers/classicBattlePage.test.js
@@ -421,12 +421,12 @@ describe("startRoundWrapper failures", () => {
     document.body.append(container, battleArea);
 
     const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
-    await setupClassicBattlePage();
+    const api = await setupClassicBattlePage();
 
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const errorSpy = vi.fn();
     document.addEventListener("round-start-error", errorSpy);
-    await window.startRoundOverride();
+    await api.startRoundOverride();
     expect(errorSpy).toHaveBeenCalled();
     expect(showMessage).toHaveBeenCalledWith("Round start error. Please retry.");
     expect(btn.disabled).toBe(false);


### PR DESCRIPTION
## Summary
- expose createClassicBattleDebugAPI to bundle test helpers without mutating window
- attach classic battle debug API in bootstrap only for tests
- update classic battle tests to use returned debug API

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch and network errors)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b08ddc580c83269595aa1d1e59a6bf