### PR TITLE
fix: prefer viewport over stale matchMedia

### DIFF
--- a/src/helpers/classicBattle/view.js
+++ b/src/helpers/classicBattle/view.js
@@ -2,6 +2,7 @@ import { setBattleStateBadgeEnabled, applyBattleFeatureFlags } from "./uiHelpers
 import setupScheduler from "./setupScheduler.js";
 import setupUIBindings from "./setupUIBindings.js";
 import setupDebugHooks from "./setupDebugHooks.js";
+import { getOrientation } from "../orientation.js";
 import "../setupBottomNavbar.js";
 import "../setupDisplaySettings.js";
 import "../setupSvgFallback.js";
@@ -50,41 +51,20 @@ export class ClassicBattleView {
     setupDebugHooks(this);
   }
 
-  /** @returns {"portrait"|"landscape"} */
-  getOrientation() {
-    try {
-      const portrait = window.innerHeight >= window.innerWidth;
-      if (typeof window.matchMedia === "function") {
-        const mm = window.matchMedia("(orientation: portrait)");
-        if (typeof mm.matches === "boolean" && mm.matches !== portrait) {
-          return portrait ? "portrait" : "landscape";
-        }
-        return mm.matches ? "portrait" : "landscape";
-      }
-      return portrait ? "portrait" : "landscape";
-    } catch {
-      return window.innerHeight >= window.innerWidth ? "portrait" : "landscape";
-    }
-  }
-
   /**
    * Applies current orientation to header.
    *
    * @pseudocode
    * 1. Query `.battle-header`; resolve `false` if missing.
-   * 2. Determine orientation via `getOrientation`.
-   * 3. Update `data-orientation` when changed.
-   * 4. Resolve `true` once attributes are set.
+   * 2. Update `data-orientation` with {@link getOrientation}.
+   * 3. Resolve `true` once attributes are set.
    *
    * @returns {Promise<boolean>} Resolves `true` when applied, `false` if header missing.
    */
   async applyBattleOrientation() {
     const header = document.querySelector(".battle-header");
     if (header) {
-      const next = this.getOrientation();
-      if (header.dataset.orientation !== next) {
-        header.dataset.orientation = next;
-      }
+      header.dataset.orientation = getOrientation();
       return true;
     }
     return false;

--- a/src/helpers/orientation.js
+++ b/src/helpers/orientation.js
@@ -2,17 +2,25 @@
  * Determine the current screen orientation.
  *
  * @pseudocode
- * 1. Use `matchMedia('(orientation: portrait)')` to check if portrait.
- * 2. If `matchMedia` throws, compare `innerHeight` and `innerWidth`.
- * 3. Return "portrait" when portrait, otherwise "landscape".
+ * 1. Determine the viewport orientation via `innerHeight`/`innerWidth`.
+ * 2. Try `matchMedia('(orientation: portrait)')` to check if portrait.
+ * 3. When `matchMedia` disagrees with the viewport, prefer the viewport.
+ * 4. If `matchMedia` throws, use the viewport value.
+ * 5. Return "portrait" when portrait, otherwise "landscape".
  *
  * @returns {"portrait"|"landscape"}
  */
 export function getOrientation() {
+  const viewportOrientation = window.innerHeight >= window.innerWidth ? "portrait" : "landscape";
+
   try {
-    return window.matchMedia("(orientation: portrait)").matches ? "portrait" : "landscape";
+    const mediaOrientation = window.matchMedia("(orientation: portrait)").matches
+      ? "portrait"
+      : "landscape";
+
+    return mediaOrientation === viewportOrientation ? mediaOrientation : viewportOrientation;
   } catch {
-    return window.innerHeight >= window.innerWidth ? "portrait" : "landscape";
+    return viewportOrientation;
   }
 }
 

--- a/src/helpers/orientation.js
+++ b/src/helpers/orientation.js
@@ -1,0 +1,19 @@
+/**
+ * Determine the current screen orientation.
+ *
+ * @pseudocode
+ * 1. Use `matchMedia('(orientation: portrait)')` to check if portrait.
+ * 2. If `matchMedia` throws, compare `innerHeight` and `innerWidth`.
+ * 3. Return "portrait" when portrait, otherwise "landscape".
+ *
+ * @returns {"portrait"|"landscape"}
+ */
+export function getOrientation() {
+  try {
+    return window.matchMedia("(orientation: portrait)").matches ? "portrait" : "landscape";
+  } catch {
+    return window.innerHeight >= window.innerWidth ? "portrait" : "landscape";
+  }
+}
+
+export default getOrientation;

--- a/tests/helpers/orientation.test.js
+++ b/tests/helpers/orientation.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { getOrientation } from "../../src/helpers/orientation.js";
+
+const originalMatchMedia = window.matchMedia;
+
+const mockMatchMedia = (matches) => vi.fn().mockReturnValue({ matches });
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+});
+
+describe("getOrientation", () => {
+  it("returns portrait when matchMedia matches", () => {
+    window.matchMedia = mockMatchMedia(true);
+    expect(getOrientation()).toBe("portrait");
+  });
+
+  it("returns landscape when matchMedia does not match", () => {
+    window.matchMedia = mockMatchMedia(false);
+    expect(getOrientation()).toBe("landscape");
+  });
+});

--- a/tests/helpers/orientation.test.js
+++ b/tests/helpers/orientation.test.js
@@ -2,21 +2,39 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { getOrientation } from "../../src/helpers/orientation.js";
 
 const originalMatchMedia = window.matchMedia;
+const originalWidth = window.innerWidth;
+const originalHeight = window.innerHeight;
 
 const mockMatchMedia = (matches) => vi.fn().mockReturnValue({ matches });
 
+const setViewport = (width, height) => {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: height });
+};
+
 afterEach(() => {
   window.matchMedia = originalMatchMedia;
+  setViewport(originalWidth, originalHeight);
 });
 
 describe("getOrientation", () => {
-  it("returns portrait when matchMedia matches", () => {
+  it("returns portrait when matchMedia and viewport match", () => {
     window.matchMedia = mockMatchMedia(true);
+    setViewport(600, 800);
     expect(getOrientation()).toBe("portrait");
   });
 
-  it("returns landscape when matchMedia does not match", () => {
-    window.matchMedia = mockMatchMedia(false);
+  it("prefers viewport when matchMedia is stale", () => {
+    window.matchMedia = mockMatchMedia(true);
+    setViewport(800, 600);
     expect(getOrientation()).toBe("landscape");
+  });
+
+  it("falls back to viewport when matchMedia throws", () => {
+    window.matchMedia = () => {
+      throw new Error("no matchMedia");
+    };
+    setViewport(600, 800);
+    expect(getOrientation()).toBe("portrait");
   });
 });


### PR DESCRIPTION
## Summary
- prefer viewport dimensions when `matchMedia` orientation is stale
- test `getOrientation` against stale and missing `matchMedia`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle orientation behavior and screenshot suites)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b097df723883268ab2734daed54385