### PR TITLE
test: restore viewport descriptors

### DIFF
--- a/tests/helpers/orientation.test.js
+++ b/tests/helpers/orientation.test.js
@@ -2,19 +2,32 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { getOrientation } from "../../src/helpers/orientation.js";
 
 const originalMatchMedia = window.matchMedia;
+const originalWidthDescriptor = Object.getOwnPropertyDescriptor(window, "innerWidth");
+const originalHeightDescriptor = Object.getOwnPropertyDescriptor(window, "innerHeight");
 const originalWidth = window.innerWidth;
 const originalHeight = window.innerHeight;
 
 const mockMatchMedia = (matches) => vi.fn().mockReturnValue({ matches });
 
 const setViewport = (width, height) => {
-  Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
-  Object.defineProperty(window, "innerHeight", { configurable: true, value: height });
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: height
+  });
 };
 
 afterEach(() => {
   window.matchMedia = originalMatchMedia;
-  setViewport(originalWidth, originalHeight);
+  Object.defineProperty(window, "innerWidth", originalWidthDescriptor);
+  Object.defineProperty(window, "innerHeight", originalHeightDescriptor);
+  window.innerWidth = originalWidth;
+  window.innerHeight = originalHeight;
 });
 
 describe("getOrientation", () => {


### PR DESCRIPTION
## Summary
- restore `innerWidth`/`innerHeight` property descriptors after orientation tests
- ensure viewport overrides remain writable during tests

## Testing
- `npx prettier tests/helpers/orientation.test.js --check`
- `npx eslint .`
- `npx vitest run tests/helpers/orientation.test.js`
- `npx playwright test` *(fails: Battle orientation behavior & state progress suites, run interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b09c0593508326980315c9a0db0e33