### PR TITLE
Dispatch zero-cooldown ready asynchronously

### DIFF
--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -2,6 +2,7 @@ import { initRoundSelectModal } from "./roundSelectModal.js";
 import { getDefaultTimer } from "../timerUtils.js";
 import { computeNextRoundCooldown, getNextRoundControls } from "./timerService.js";
 import { isTestModeEnabled } from "../testModeUtils.js";
+import { realScheduler } from "../scheduler.js";
 import { getOpponentJudoka } from "./cardSelection.js";
 import { getStatValue } from "../battle/index.js";
 import { emitBattleEvent, onBattleEvent, offBattleEvent } from "./battleEvents.js";
@@ -137,7 +138,11 @@ export async function cooldownEnter(machine, payload) {
           emitBattleEvent("nextRoundTimerReady");
         } catch {}
         try {
-          machine.dispatch("ready");
+          realScheduler.setTimeout(() => {
+            try {
+              machine.dispatch("ready");
+            } catch {}
+          }, 0);
         } catch {}
         return;
       }

--- a/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
+++ b/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
+  computeNextRoundCooldown: vi.fn(() => 0),
+  getNextRoundControls: vi.fn(() => null)
+}));
+
+import { cooldownEnter } from "../../../src/helpers/classicBattle/orchestratorHandlers.js";
+
+describe("cooldownEnter", () => {
+  let timerSpy;
+  let machine;
+  beforeEach(() => {
+    timerSpy = vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    machine = { dispatch: vi.fn(), getState: vi.fn(() => "cooldown"), context: {} };
+  });
+  afterEach(() => {
+    timerSpy.clearAllTimers();
+    vi.restoreAllMocks();
+  });
+  it("auto dispatches ready after timers for zero cooldown", async () => {
+    await cooldownEnter(machine);
+    expect(machine.dispatch).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(machine.dispatch).toHaveBeenCalledWith("ready");
+  });
+});


### PR DESCRIPTION
## Summary
- schedule `ready` dispatch with a timer when cooldown duration is zero
- cover zero-cooldown path with a fake-timer test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: playwright/battleRoundCompletion.spec.js:15:3, playwright/classicBattleFlow.spec.js:35:3, playwright/prd-reader.spec.js:17:3, playwright/screenshot.spec.js:37:5, playwright/screenshot.spec.js:37:5, playwright/screenshot.spec.js:37:5, playwright/screenshot.spec.js:43:3, playwright/settings-screenshot.spec.js:13:5, playwright/settings-screenshot.spec.js:13:5, playwright/settings-screenshot.spec.js:13:5)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b09d58dbe48326be444aa417388a1c