### PR TITLE
Enforce 1s minimum next-round cooldown

### DIFF
--- a/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
+++ b/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
-  computeNextRoundCooldown: vi.fn(() => 0),
+  computeNextRoundCooldown: vi.fn(() => 1),
   getNextRoundControls: vi.fn(() => null)
 }));
 
@@ -20,7 +20,7 @@ describe("cooldownEnter", () => {
     timerSpy.clearAllTimers();
     vi.restoreAllMocks();
   });
-  it("auto dispatches ready after timers for zero cooldown", async () => {
+  it("auto dispatches ready after timers", async () => {
     await cooldownEnter(machine);
     expect(machine.dispatch).not.toHaveBeenCalled();
     vi.runAllTimers();

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -161,7 +161,7 @@ describe("classicBattle scheduleNextRound", () => {
     expect(generateRandomCardMock).toHaveBeenCalledTimes(2);
   });
 
-  it("handles zero-second cooldown fast path", async () => {
+  it("schedules a minimum cooldown in test mode", async () => {
     document.getElementById("next-round-timer")?.remove();
     const { nextButton } = createTimerNodes();
     nextButton.disabled = true;
@@ -173,6 +173,8 @@ describe("classicBattle scheduleNextRound", () => {
     setTestMode(true);
 
     const controls = battleMod.scheduleNextRound({ matchEnded: false });
+    expect(nextButton.dataset.nextReady).toBeUndefined();
+    await vi.runAllTimersAsync();
     await controls.ready;
 
     expect(nextButton.dataset.nextReady).toBe("true");

--- a/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
+++ b/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
@@ -17,8 +17,8 @@ describe("timeout → interruptRound → cooldown auto-advance", () => {
       <button id="next-button" disabled>Next</button>
       <div id="snackbar-container"></div>
     `;
-    // Force zero cooldown for quick auto-advance
-    window.__NEXT_ROUND_COOLDOWN_MS = 0;
+    // Use minimal 1s cooldown for auto-advance
+    window.__NEXT_ROUND_COOLDOWN_MS = 1000;
   });
 
   it("advances from cooldown after interrupt without hanging", async () => {
@@ -44,8 +44,8 @@ describe("timeout → interruptRound → cooldown auto-advance", () => {
     await window.awaitBattleState?.("cooldown", 5000);
 
     // CooldownEnter should emit countdownStart and then auto-dispatch ready via fallback timer.
-    // With test mode, computeNextRoundCooldown() = 0 → auto-advance immediately to roundStart.
-    await new Promise((r) => setTimeout(r, 450));
+    // With the 1s floor, computeNextRoundCooldown() = 1 → auto-advance after ~1s to roundStart.
+    await new Promise((r) => setTimeout(r, 1250));
     const snapshot = window.getBattleStateSnapshot?.();
     expect(["roundStart", "waitingForPlayerAction"]).toContain(snapshot?.state);
   });

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -72,7 +72,7 @@ describe("timerService next round handling", () => {
   it("computeNextRoundCooldown respects test mode", async () => {
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
     const val = mod.computeNextRoundCooldown({ isTestModeEnabled: () => true });
-    expect(val).toBe(0);
+    expect(val).toBe(1);
   });
 
   it("createNextRoundSnackbarRenderer shows and updates", async () => {
@@ -91,15 +91,15 @@ describe("timerService next round handling", () => {
     expect(scoreboardMod.clearTimer).toHaveBeenCalled();
   });
 
-  it("resolves ready immediately in test mode", async () => {
+  it("resolves ready after minimum cooldown in test mode", async () => {
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
     const { nextButton } = createTimerNodes();
     const { setTestMode } = await import("../../../src/helpers/testModeUtils.js");
     setTestMode(true);
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
-    scheduler.tick(0);
-    await expect(controls.ready).resolves.toBeUndefined();
+    scheduler.tick(1100);
+    await controls.ready;
     expect(nextButton.dataset.nextReady).toBe("true");
     expect(nextButton.disabled).toBe(false);
     setTestMode(false);


### PR DESCRIPTION
## Summary
- enforce a one-second floor in `computeNextRoundCooldown` and always run the timer
- drop zero-cooldown fast paths and simplify `cooldownEnter`
- adjust tests for new cooldown semantics

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 8)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b0a30ea35c8326bf0c16dea586e17a