### PR TITLE
Enforce timer on repeated cooldowns and drop test-mode auto-advance

### DIFF
--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -143,20 +143,6 @@ export async function cooldownEnter(machine, payload) {
       return;
     }
   } catch {}
-
-  // For other inter-round cooldowns in test mode, auto-advance to the next
-  // round to avoid relying on external UI timers/handlers which can be racy
-  // under CI.
-  try {
-    if (isTestModeEnabled && isTestModeEnabled()) {
-      try {
-        if (machine.getState && machine.getState() === "cooldown") {
-          console.warn("[test] cooldownEnter: auto-advance dispatch ready");
-          machine.dispatch("ready");
-        }
-      } catch {}
-    }
-  } catch {}
 }
 export async function cooldownExit() {}
 


### PR DESCRIPTION
## Summary
- reset Next button before scheduling cooldown to ensure each round uses the timer
- remove test-mode auto-dispatch from `cooldownEnter`
- test stale Next readiness is cleared before new cooldown

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 9)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b0abd91810832699193a8121274b0d