### PR TITLE
test: enforce 1s cooldown in classic battle timers

### DIFF
--- a/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
+++ b/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
@@ -20,10 +20,10 @@ describe("cooldownEnter", () => {
     timerSpy.clearAllTimers();
     vi.restoreAllMocks();
   });
-  it("auto dispatches ready after timers", async () => {
+  it("auto dispatches ready after 1s timer", async () => {
     await cooldownEnter(machine);
     expect(machine.dispatch).not.toHaveBeenCalled();
-    vi.runAllTimers();
+    timerSpy.advanceTimersByTime(1000);
     expect(machine.dispatch).toHaveBeenCalledWith("ready");
   });
 });

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -82,12 +82,13 @@ describe("classicBattle scheduleNextRound", () => {
     });
   }
 
-  it("auto-dispatches ready after cooldown", async () => {
+  it("auto-dispatches ready after 1s cooldown", async () => {
     document.getElementById("next-round-timer")?.remove();
     const { nextButton } = createTimerNodes();
     nextButton.disabled = true;
 
     mockBattleData();
+    window.__NEXT_ROUND_COOLDOWN_MS = 1000;
 
     const orchestrator = await import("../../../src/helpers/classicBattle/orchestrator.js");
     const dispatchSpy = vi.spyOn(orchestrator, "dispatchBattleEvent");
@@ -108,7 +109,7 @@ describe("classicBattle scheduleNextRound", () => {
 
     const controls = battleMod.scheduleNextRound({ matchEnded: false });
 
-    timerSpy.advanceTimersByTime(3000);
+    timerSpy.advanceTimersByTime(1000);
     await vi.runAllTimersAsync();
     await controls.ready;
     // Wait for the orchestrator to reach the expected state to avoid races
@@ -120,6 +121,7 @@ describe("classicBattle scheduleNextRound", () => {
     const btn = document.getElementById("next-button");
     expect(btn?.dataset.nextReady).toBe("true");
     expect(btn?.disabled).toBe(false);
+    delete window.__NEXT_ROUND_COOLDOWN_MS;
   });
 
   it("transitions roundOver → cooldown → roundStart without duplicates", async () => {
@@ -161,7 +163,7 @@ describe("classicBattle scheduleNextRound", () => {
     expect(generateRandomCardMock).toHaveBeenCalledTimes(2);
   });
 
-  it("schedules a minimum cooldown in test mode", async () => {
+  it("schedules a 1s minimum cooldown in test mode", async () => {
     document.getElementById("next-round-timer")?.remove();
     const { nextButton } = createTimerNodes();
     nextButton.disabled = true;
@@ -174,6 +176,7 @@ describe("classicBattle scheduleNextRound", () => {
 
     const controls = battleMod.scheduleNextRound({ matchEnded: false });
     expect(nextButton.dataset.nextReady).toBeUndefined();
+    timerSpy.advanceTimersByTime(1000);
     await vi.runAllTimersAsync();
     await controls.ready;
 

--- a/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
+++ b/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
@@ -21,7 +21,7 @@ describe("timeout → interruptRound → cooldown auto-advance", () => {
     window.__NEXT_ROUND_COOLDOWN_MS = 1000;
   });
 
-  it("advances from cooldown after interrupt without hanging", async () => {
+  it("advances from cooldown after interrupt with 1s auto-advance", async () => {
     const { initClassicBattleOrchestrator } = await import(
       "../../../src/helpers/classicBattle/orchestrator.js"
     );

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -47,7 +47,7 @@ describe("timerService next round handling", () => {
     const { nextButton } = createTimerNodes();
     const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
     nextButton.addEventListener("click", (e) => mod.onNextButtonClick(e, controls));
-    scheduler.tick(0);
+    scheduler.tick(100);
     nextButton.dispatchEvent(new MouseEvent("click"));
     await controls.ready;
     // Current flow guarantees at least one dispatch; a second may occur
@@ -56,14 +56,14 @@ describe("timerService next round handling", () => {
     expect(dispatchBattleEvent.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("auto-dispatches ready when cooldown finishes", async () => {
+  it("auto-dispatches ready after 1s cooldown", async () => {
     startCoolDown.mockImplementation((_t, onExpired) => {
       onExpired();
     });
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
     createTimerNodes();
     const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
-    scheduler.tick(0);
+    scheduler.tick(1100);
     await controls.ready;
     expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
     expect(dispatchBattleEvent).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- ensure classic battle timer tests use 1s minimum cooldown
- wait at least one second before asserting next-round dispatches
- clarify auto-advance behaviour in cooldown tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 1 failed, 707 passed)*
- `npx playwright test` *(fails: 2 interrupted, 15 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b0b155086083268e42eba5edd7f676