### PR TITLE
refactor: emit round start step events

### DIFF
--- a/tests/helpers/classicBattle/controller.startRound.test.js
+++ b/tests/helpers/classicBattle/controller.startRound.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("ClassicBattleController.startRound", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("emits roundStarted and opponentCardReady", async () => {
+    const startRound = vi.fn().mockResolvedValue();
+    vi.doMock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+      createBattleStore: () => ({}),
+      startRound
+    }));
+    const waitForOpponentCard = vi.fn().mockResolvedValue();
+    const { ClassicBattleController } = await import(
+      "../../../src/helpers/classicBattle/controller.js"
+    );
+    const controller = new ClassicBattleController({ waitForOpponentCard });
+    const events = [];
+    controller.addEventListener("roundStarted", () => events.push("roundStarted"));
+    controller.addEventListener("opponentCardReady", () => events.push("opponentCardReady"));
+    await controller.startRound();
+    expect(events).toEqual(["roundStarted", "opponentCardReady"]);
+    expect(startRound).toHaveBeenCalled();
+    expect(waitForOpponentCard).toHaveBeenCalled();
+  });
+
+  it("emits roundStartError when startRound fails", async () => {
+    const startRound = vi.fn().mockRejectedValue(new Error("fail"));
+    vi.doMock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+      createBattleStore: () => ({}),
+      startRound
+    }));
+    const { ClassicBattleController } = await import(
+      "../../../src/helpers/classicBattle/controller.js"
+    );
+    const controller = new ClassicBattleController();
+    const errorSpy = vi.fn();
+    const opponentSpy = vi.fn();
+    controller.addEventListener("roundStartError", errorSpy);
+    controller.addEventListener("opponentCardReady", opponentSpy);
+    await expect(controller.startRound()).rejects.toThrow("fail");
+    expect(errorSpy).toHaveBeenCalled();
+    expect(opponentSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits roundStartError when opponent card wait fails", async () => {
+    const startRound = vi.fn().mockResolvedValue();
+    vi.doMock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+      createBattleStore: () => ({}),
+      startRound
+    }));
+    const waitForOpponentCard = vi.fn().mockRejectedValue(new Error("no card"));
+    const { ClassicBattleController } = await import(
+      "../../../src/helpers/classicBattle/controller.js"
+    );
+    const controller = new ClassicBattleController({ waitForOpponentCard });
+    const events = { roundStarted: 0, opponentCardReady: 0, error: 0 };
+    controller.addEventListener("roundStarted", () => events.roundStarted++);
+    controller.addEventListener("opponentCardReady", () => events.opponentCardReady++);
+    controller.addEventListener("roundStartError", () => events.error++);
+    await expect(controller.startRound()).rejects.toThrow("no card");
+    expect(events.roundStarted).toBe(1);
+    expect(events.opponentCardReady).toBe(0);
+    expect(events.error).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- split ClassicBattleController.startRound into `_performStartRound` and `_awaitOpponentCard`
- dispatch `roundStarted` and `opponentCardReady` for better observability
- add tests covering success and failure paths for startRound steps

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Battle orientation data attribute expectation)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b0b9dc009c8326af62373dfeb0c514