### PR TITLE
refactor: centralize chunking constants

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -41,6 +41,7 @@ import { glob } from "glob";
 import { pipeline } from "@xenova/transformers";
 import * as acorn from "acorn";
 import { walk } from "estree-walker";
+import { CHUNK_SIZE, OVERLAP_RATIO } from "../src/helpers/vectorSearch/chunkConfig.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
@@ -201,9 +202,6 @@ function createSparseVector(text) {
 
 let codeGraphs = { modules: {} };
 
-// Target chunk ≈ 350 tokens (≈ 1,400 chars), overlap ≈ 15%
-const CHUNK_SIZE = 1400;
-// Removed unused constant OVERLAP
 const MAX_OUTPUT_SIZE = 9.8 * 1024 * 1024;
 
 const JSON_FIELD_ALLOWLIST = {
@@ -341,7 +339,7 @@ function chunkMarkdown(text) {
   for (let i = 0; i < finalChunks.length; i++) {
     if (i > 0) {
       const previous = finalChunks[i - 1].split(" ");
-      const overlap = previous.slice(-Math.floor(previous.length * 0.15)).join(" ");
+      const overlap = previous.slice(-Math.floor(previous.length * OVERLAP_RATIO)).join(" ");
       overlappedChunks.push(overlap + " " + finalChunks[i]);
     } else {
       overlappedChunks.push(finalChunks[i]);

--- a/src/helpers/vectorSearch/chunkConfig.js
+++ b/src/helpers/vectorSearch/chunkConfig.js
@@ -1,0 +1,5 @@
+/**
+ * Shared chunking configuration for embeddings and vector search.
+ */
+export const CHUNK_SIZE = 1400;
+export const OVERLAP_RATIO = 0.15;

--- a/src/helpers/vectorSearch/context.js
+++ b/src/helpers/vectorSearch/context.js
@@ -1,5 +1,4 @@
-const CHUNK_SIZE = 1400;
-const OVERLAP_RATIO = 0.15;
+import { CHUNK_SIZE, OVERLAP_RATIO } from "./chunkConfig.js";
 
 function splitIntoSections(lines) {
   const heading = /^(#{1,6})\s+/;

--- a/tests/helpers/vectorSearch.test.js
+++ b/tests/helpers/vectorSearch.test.js
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { withAllowedConsole } from "../utils/console.js";
+import { CHUNK_SIZE, OVERLAP_RATIO } from "../../src/helpers/vectorSearch/chunkConfig.js";
 
 vi.mock("../../src/helpers/dataUtils.js", () => ({
   fetchJson: vi.fn(),
@@ -198,7 +199,7 @@ describe("vectorSearch", () => {
     const expected = chunkMarkdown(md).slice(1, 4);
     expect(result).toEqual(expected);
     for (const chunk of result) {
-      expect(chunk.length).toBeLessThanOrEqual(1400);
+      expect(chunk.length).toBeLessThanOrEqual(CHUNK_SIZE);
     }
   });
 
@@ -215,9 +216,9 @@ describe("vectorSearch", () => {
     const { chunkMarkdown } = await import("../../src/helpers/vectorSearch/context.js");
     const chunks = chunkMarkdown(md);
     expect(chunks.length).toBeGreaterThan(1);
-    expect(chunks[0].length).toBeLessThanOrEqual(1400);
-    expect(chunks[1].length).toBeLessThanOrEqual(1400);
-    const overlapSize = Math.floor(1400 * 0.15);
+    expect(chunks[0].length).toBeLessThanOrEqual(CHUNK_SIZE);
+    expect(chunks[1].length).toBeLessThanOrEqual(CHUNK_SIZE);
+    const overlapSize = Math.floor(CHUNK_SIZE * OVERLAP_RATIO);
     const overlap = chunks[0].slice(-overlapSize);
     expect(chunks[1].startsWith(overlap)).toBe(true);
     expect(chunks[0].endsWith(".")).toBe(true);


### PR DESCRIPTION
## Summary
- centralize vector search chunk size/overlap into new chunkConfig module
- use shared chunkConfig in embedding generation and context helpers
- update vector search tests to use shared chunk constants

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 8 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf00e3748326a23581c62a9bb2b9