### PR TITLE
refactor: add timer events and renderer

### DIFF
--- a/src/helpers/CooldownRenderer.js
+++ b/src/helpers/CooldownRenderer.js
@@ -1,0 +1,55 @@
+import * as snackbar from "./showSnackbar.js";
+import * as scoreboard from "./setupScoreboard.js";
+
+/**
+ * Attach snackbar + scoreboard rendering to a timer.
+ *
+ * @pseudocode
+ * 1. Subscribe to timer `tick` and `expired` events.
+ * 2. On `tick`, show or update snackbar with remaining seconds.
+ * 3. On `expired`, render final 0s and clear scoreboard timer.
+ * 4. Optionally render initial remaining immediately when provided.
+ *
+ * @param {{on: Function, off: Function}} timer - Timer with event API.
+ * @param {number} [initialRemaining] - Seconds remaining to render initially.
+ * @returns {() => void} Detach function.
+ */
+export function attachCooldownRenderer(timer, initialRemaining) {
+  let started = false;
+  let lastRendered = -1;
+
+  const onTick = (remaining) => {
+    if (remaining <= 0) {
+      const text = "Next round in: 0s";
+      if (!started) {
+        snackbar.showSnackbar(text);
+        started = true;
+      } else {
+        snackbar.updateSnackbar(text);
+      }
+      scoreboard.clearTimer();
+      return;
+    }
+    if (remaining === lastRendered) return;
+    const text = `Next round in: ${remaining}s`;
+    if (!started) {
+      snackbar.showSnackbar(text);
+      started = true;
+    } else {
+      snackbar.updateSnackbar(text);
+    }
+    lastRendered = remaining;
+  };
+
+  const onExpired = () => onTick(0);
+
+  timer.on("tick", onTick);
+  timer.on("expired", onExpired);
+  if (typeof initialRemaining === "number") {
+    onTick(initialRemaining);
+  }
+  return () => {
+    timer.off("tick", onTick);
+    timer.off("expired", onExpired);
+  };
+}

--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -1,6 +1,7 @@
 import { initRoundSelectModal } from "./roundSelectModal.js";
 import { getDefaultTimer } from "../timerUtils.js";
-import { computeNextRoundCooldown, getNextRoundControls } from "./timerService.js";
+import { getNextRoundControls } from "./timerService.js";
+import { computeNextRoundCooldown } from "../timers/computeNextRoundCooldown.js";
 import { isTestModeEnabled } from "../testModeUtils.js";
 import { getOpponentJudoka } from "./cardSelection.js";
 import { getStatValue } from "../battle/index.js";

--- a/src/helpers/timers/computeNextRoundCooldown.js
+++ b/src/helpers/timers/computeNextRoundCooldown.js
@@ -1,0 +1,42 @@
+import { isTestModeEnabled } from "../testModeUtils.js";
+
+const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
+
+/**
+ * Determine the cooldown duration before the next round.
+ *
+ * @pseudocode
+ * 1. Read `window.__NEXT_ROUND_COOLDOWN_MS` or default to 3000ms.
+ * 2. If test mode is enabled via `utils.isTestModeEnabled()`, force cooldown to 1.
+ * 3. Otherwise convert to whole seconds and clamp to \>=1.
+ * 4. Log test mode state and resolved cooldown; wrap each warn in try.
+ *
+ * @param {{isTestModeEnabled: () => boolean}} [utils] - Test mode utilities (for injection).
+ * @returns {number} Cooldown in seconds.
+ */
+export function computeNextRoundCooldown(utils = { isTestModeEnabled }) {
+  const overrideMs =
+    typeof window !== "undefined" && typeof window.__NEXT_ROUND_COOLDOWN_MS === "number"
+      ? window.__NEXT_ROUND_COOLDOWN_MS
+      : 3000;
+  let cooldownSeconds;
+  try {
+    const enabled =
+      typeof utils.isTestModeEnabled === "function" ? utils.isTestModeEnabled() : false;
+    cooldownSeconds = enabled ? 1 : Math.max(1, Math.round(overrideMs / 1000));
+  } catch {
+    cooldownSeconds = Math.max(1, Math.round(overrideMs / 1000));
+  }
+  if (!IS_VITEST) {
+    if (isTestModeEnabled()) {
+      try {
+        console.warn(`[test] scheduleNextRound: testMode=true cooldown=${cooldownSeconds}`);
+      } catch {}
+    } else {
+      try {
+        console.warn(`[test] scheduleNextRound: testMode=false cooldown=${cooldownSeconds}`);
+      } catch {}
+    }
+  }
+  return cooldownSeconds;
+}

--- a/src/helpers/timers/createRoundTimer.js
+++ b/src/helpers/timers/createRoundTimer.js
@@ -1,0 +1,87 @@
+import { startCoolDown, stopTimer } from "../battleEngineFacade.js";
+
+/**
+ * Create a round timer that emits tick, drift, and expiration events.
+ *
+ * @pseudocode
+ * 1. Register listeners for `tick`, `expired`, and `drift` events.
+ * 2. Start underlying engine timer via `starter` with internal handlers.
+ * 3. On each tick, emit `tick(remaining)`.
+ * 4. On drift, emit `drift(remaining)` and retry up to 3 times; on failure call `onDriftFail` or expire.
+ * 5. On expiration or manual stop, emit `expired` once.
+ *
+ * @param {{
+ *   starter?: (
+ *     onTick: (remaining: number) => void,
+ *     onExpired: () => void,
+ *     dur: number,
+ *     onDrift: (remaining: number) => void
+ *   ) => void | Promise<void>,
+ *   onDriftFail?: () => Promise<void> | void
+ * }} [opts]
+ * @returns {{
+ *   start: (dur: number) => void | Promise<void>,
+ *   stop: () => void,
+ *   on: (event: "tick" | "expired" | "drift", handler: Function) => () => void,
+ *   off: (event: "tick" | "expired" | "drift", handler: Function) => void
+ * }}
+ */
+export function createRoundTimer({ starter = startCoolDown, onDriftFail } = {}) {
+  const MAX_DRIFT_RETRIES = 3;
+  const listeners = {
+    tick: new Set(),
+    expired: new Set(),
+    drift: new Set()
+  };
+  let retries = 0;
+
+  function emit(event, payload) {
+    for (const fn of listeners[event]) {
+      try {
+        fn(payload);
+      } catch {}
+    }
+  }
+
+  function on(event, handler) {
+    listeners[event].add(handler);
+    return () => off(event, handler);
+  }
+
+  function off(event, handler) {
+    listeners[event].delete(handler);
+  }
+
+  function start(dur) {
+    return starter(emitTick, emitExpired, dur, handleDrift);
+  }
+
+  function emitTick(remaining) {
+    emit("tick", remaining);
+  }
+
+  async function emitExpired() {
+    emit("expired");
+  }
+
+  async function handleDrift(remaining) {
+    retries += 1;
+    if (retries > MAX_DRIFT_RETRIES) {
+      if (typeof onDriftFail === "function") {
+        await onDriftFail();
+      } else {
+        await emitExpired();
+      }
+      return;
+    }
+    emit("drift", remaining);
+    await start(remaining);
+  }
+
+  function stop() {
+    stopTimer();
+    emitExpired();
+  }
+
+  return { start, stop, on, off };
+}

--- a/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
+++ b/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
-  computeNextRoundCooldown: vi.fn(() => 1),
   getNextRoundControls: vi.fn(() => null)
+}));
+vi.mock("../../../src/helpers/timers/computeNextRoundCooldown.js", () => ({
+  computeNextRoundCooldown: vi.fn(() => 1)
 }));
 
 import { cooldownEnter } from "../../../src/helpers/classicBattle/orchestratorHandlers.js";

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -85,21 +85,27 @@ describe("timerService next round handling", () => {
   });
 
   it("computeNextRoundCooldown respects test mode", async () => {
-    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const mod = await import("../../../src/helpers/timers/computeNextRoundCooldown.js");
     const val = mod.computeNextRoundCooldown({ isTestModeEnabled: () => true });
     expect(val).toBe(1);
   });
 
-  it("createNextRoundSnackbarRenderer shows and updates", async () => {
-    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
-    const renderer = mod.createNextRoundSnackbarRenderer();
+  it("CooldownRenderer shows and updates", async () => {
+    const timerMod = await import("../../../src/helpers/timers/createRoundTimer.js");
+    const { attachCooldownRenderer } = await import("../../../src/helpers/CooldownRenderer.js");
     const snackbarMod = await import("../../../src/helpers/showSnackbar.js");
     const scoreboardMod = await import("../../../src/helpers/setupScoreboard.js");
 
-    renderer(3);
-    renderer(2);
-    renderer(2);
-    renderer(0);
+    const timer = timerMod.createRoundTimer({
+      starter: (onTick, onExpired) => {
+        onTick(3);
+        onTick(2);
+        onTick(0);
+        onExpired();
+      }
+    });
+    attachCooldownRenderer(timer);
+    timer.start(3);
 
     expect(snackbarMod.showSnackbar).toHaveBeenCalledWith("Next round in: 3s");
     expect(snackbarMod.updateSnackbar).toHaveBeenCalledWith("Next round in: 2s");

--- a/tests/helpers/timers/createRoundTimer.test.js
+++ b/tests/helpers/timers/createRoundTimer.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { createRoundTimer } from "../../../src/helpers/timers/createRoundTimer.js";
+
+describe("createRoundTimer events", () => {
+  it("emits tick and expired", () => {
+    const events = [];
+    const timer = createRoundTimer({
+      starter: (onTick, onExpired) => {
+        onTick(2);
+        onTick(1);
+        onTick(0);
+        onExpired();
+      }
+    });
+    timer.on("tick", (r) => events.push(["tick", r]));
+    let expired = 0;
+    timer.on("expired", () => {
+      expired += 1;
+    });
+    timer.start(2);
+    expect(events).toEqual([
+      ["tick", 2],
+      ["tick", 1],
+      ["tick", 0]
+    ]);
+    expect(expired).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- move timer utilities into dedicated folder
- emit timer events for tick, drift, and expiration
- add CooldownRenderer to drive snackbar and scoreboard updates

## Testing
- `npx prettier . --check`
- `npx eslint .` (fails: warning 'dispatchBattleEvent' unused, '_' unused)
- `npx vitest run`
- `npx playwright test` (fails: 8 tests)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf1527b88326854478fd4878587c