### PR TITLE
Refactor card accessibility test

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,7 @@
   "features": {},
   "customizations": {
     "vscode": {
-      "extensions": [
-        "openai.chatgpt"
-      ]
+      "extensions": ["openai.chatgpt"]
     }
   }
 }

--- a/tests/card/judokaCardAccessibility.test.js
+++ b/tests/card/judokaCardAccessibility.test.js
@@ -30,13 +30,6 @@ const gokyoLookup = {
 
 describe("judoka card accessibility attributes", () => {
   it("applies role and aria-label to judoka-card element", async () => {
-    const container = await new JudokaCard(judoka, gokyoLookup).render();
-    const card = container.querySelector(".judoka-card");
-    expect(card).toHaveAttribute("role", "button");
-    expect(card).toHaveAttribute("aria-label", `${judoka.firstname} ${judoka.surname} card`);
-  });
-
-  it("retains accessibility attributes when added to DOM", async () => {
     const containerEl = document.createElement("div");
     const cardEl = await new JudokaCard(judoka, gokyoLookup).render();
     containerEl.appendChild(cardEl);


### PR DESCRIPTION
## Summary
- combine duplicate Judoka card accessibility tests into one
- format devcontainer settings for prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 7 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b0c2f38d308326bf56344df19a6f38