### PR TITLE
fix: defer countdown-start emission until timer tick

### DIFF
--- a/tests/helpers/CooldownRenderer.test.js
+++ b/tests/helpers/CooldownRenderer.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/helpers/showSnackbar.js", () => ({
+  showSnackbar: vi.fn(),
+  updateSnackbar: vi.fn()
+}));
+
+vi.mock("../../src/helpers/setupScoreboard.js", () => ({
+  clearTimer: vi.fn()
+}));
+
+vi.mock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+  emitBattleEvent: vi.fn()
+}));
+
+import { attachCooldownRenderer } from "../../src/helpers/CooldownRenderer.js";
+import { emitBattleEvent } from "../../src/helpers/classicBattle/battleEvents.js";
+import * as snackbar from "../../src/helpers/showSnackbar.js";
+
+describe("attachCooldownRenderer", () => {
+  let timer;
+
+  beforeEach(() => {
+    timer = {
+      handlers: { tick: [], expired: [] },
+      on(event, fn) {
+        this.handlers[event].push(fn);
+      },
+      off(event, fn) {
+        this.handlers[event] = this.handlers[event].filter((h) => h !== fn);
+      },
+      emit(event, value) {
+        for (const fn of this.handlers[event]) fn(value);
+      }
+    };
+    vi.clearAllMocks();
+  });
+
+  it("defers countdown-start until timer ticks", () => {
+    attachCooldownRenderer(timer, 5);
+
+    expect(snackbar.showSnackbar).toHaveBeenCalledWith("Next round in: 5s");
+    expect(emitBattleEvent).not.toHaveBeenCalled();
+
+    timer.emit("tick", 5);
+
+    expect(emitBattleEvent).toHaveBeenCalledWith("nextRoundCountdownStarted");
+    expect(emitBattleEvent).toHaveBeenCalledWith("nextRoundCountdownTick", { remaining: 5 });
+  });
+});


### PR DESCRIPTION
## Summary
- avoid emitting `nextRoundCountdownStarted` before the timer actually ticks
- cover start event timing with `attachCooldownRenderer` test

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warn: 2 warnings)*
- `npx vitest run`
- `npx playwright test` *(fail: Screenshot suite › @battleJudoka-narrow screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc87253c8326bb50f58e744146f4