### PR TITLE
Expand RAG evaluation queries and docs

### DIFF
--- a/scripts/evaluation/README.md
+++ b/scripts/evaluation/README.md
@@ -1,0 +1,20 @@
+# Evaluation Scripts
+
+This folder provides tools for measuring retrieval quality of the vector search system.
+
+## Running the evaluator
+
+From the project root:
+
+```bash
+node scripts/evaluation/evaluateRAG.js
+```
+
+The script reads `queries.json` and reports:
+
+- **MRR@5** – Mean Reciprocal Rank of the expected document within the top five results.
+- **Recall@3** – Fraction of queries whose expected document appears in the top three results.
+- **Recall@5** – Fraction of queries whose expected document appears in the top five results.
+
+Higher values indicate better retrieval accuracy.
+

--- a/scripts/evaluation/queries.json
+++ b/scripts/evaluation/queries.json
@@ -22,5 +22,45 @@
   {
     "query": "how are judoka stats calculated",
     "expected_source": "src/data/judoka.json"
+  },
+  {
+    "query": "tooltip content coverage guidelines",
+    "expected_source": "design/productRequirementsDocuments/prdTooltipSystem.md"
+  },
+  {
+    "query": "requirements for navigation bar layout",
+    "expected_source": "design/productRequirementsDocuments/prdNavigationBar.md"
+  },
+  {
+    "query": "purpose of the prd viewer tool",
+    "expected_source": "design/productRequirementsDocuments/prdPRDViewer.md"
+  },
+  {
+    "query": "default navigation items",
+    "expected_source": "src/data/navigationItems.json"
+  },
+  {
+    "query": "weight category definitions",
+    "expected_source": "src/data/weightCategories.json"
+  },
+  {
+    "query": "game timer phases",
+    "expected_source": "src/data/gameTimers.json"
+  },
+  {
+    "query": "what does the power stat represent",
+    "expected_source": "src/data/statNames.json"
+  },
+  {
+    "query": "steps to update a judoka profile",
+    "expected_source": "design/productRequirementsDocuments/prdUpdateJudoka.md"
+  },
+  {
+    "query": "goals of the tooltip viewer",
+    "expected_source": "design/productRequirementsDocuments/prdTooltipViewer.md"
+  },
+  {
+    "query": "default sound setting in configuration",
+    "expected_source": "src/data/settings.json"
   }
 ]


### PR DESCRIPTION
## Summary
- add diverse PRD, data, and tooltip coverage to `queries.json`
- document running `evaluateRAG.js` and interpreting MRR/Recall metrics

## Testing
- `npm run validate:data`
- `node scripts/evaluation/evaluateRAG.js` *(fails: connect ENETUNREACH)*
- `npx prettier . --check`
- `npx prettier scripts/evaluation/queries.json README.md --check`
- `npx eslint scripts/evaluation --ext .js`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 2 tests failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc9783f4832683c660e34ae307ab