### PR TITLE
Consolidate card top bar info test

### DIFF
--- a/playwright/timeout-autoselect-no-stall.spec.js
+++ b/playwright/timeout-autoselect-no-stall.spec.js
@@ -29,9 +29,6 @@ test.describe("Timeout autoselect does not stall", () => {
     await waitForBattleState(page, "waitingForPlayerAction", 10000);
 
     // Sanity: stat buttons enabled again
-    await expect(
-      page.locator("#stat-buttons button").first()
-    ).toBeEnabled({ timeout: 5000 });
+    await expect(page.locator("#stat-buttons button").first()).toBeEnabled({ timeout: 5000 });
   });
 });
-

--- a/tests/card/cardTopBar.test.js
+++ b/tests/card/cardTopBar.test.js
@@ -46,18 +46,10 @@ describe("generateCardTopBar", () => {
     expect(result.outerHTML).toContain('alt="France flag"');
   });
 
-  it("should include judoka's firstname", async () => {
+  it("should include judoka's firstname, surname, and flag URL", async () => {
     const result = await generateCardTopBar(judoka, flagUrl);
     expect(result.outerHTML).toContain("Clarisse");
-  });
-
-  it("should include judoka's surname", async () => {
-    const result = await generateCardTopBar(judoka, flagUrl);
     expect(result.outerHTML).toContain("Agbegnenou");
-  });
-
-  it("should include the flag URL in the HTML", async () => {
-    const result = await generateCardTopBar(judoka, flagUrl);
     expect(result.outerHTML).toContain(flagUrl);
   });
 


### PR DESCRIPTION
## Summary
- combine firstname, surname, and flag URL assertions into one `generateCardTopBar` test
- format `timeout-autoselect-no-stall` Playwright spec with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Failed to load resource; screenshot and timeout failures)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b0d436fd0c832687e607cd00e67cb6