### PR TITLE
chore: remove design token check from random judoka spec

### DIFF
--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -66,30 +66,6 @@ test.describe("View Judoka screen", () => {
     expect(marginTop).toBe("0px");
   });
 
-  test("draw button uses design tokens", async ({ page }) => {
-    const btn = page.getByTestId("draw-button");
-    const styles = await btn.evaluate((el) => {
-      const cs = getComputedStyle(el);
-      return { bg: cs.backgroundColor, color: cs.color };
-    });
-    const vars = await page.evaluate(() => {
-      const root = getComputedStyle(document.documentElement);
-      return {
-        bg: root.getPropertyValue("--button-bg").trim(),
-        color: root.getPropertyValue("--button-text-color").trim()
-      };
-    });
-    const hexToRgb = (hex) => {
-      const h = hex.replace("#", "");
-      const r = parseInt(h.slice(0, 2), 16);
-      const g = parseInt(h.slice(2, 4), 16);
-      const b = parseInt(h.slice(4, 6), 16);
-      return `rgb(${r}, ${g}, ${b})`;
-    };
-    expect(styles.bg).toBe(hexToRgb(vars.bg));
-    expect(styles.color).toBe(hexToRgb(vars.color));
-  });
-
   test("draw button remains within viewport", async ({ page }) => {
     const btn = page.getByTestId("draw-button");
     const { bottom, innerHeight } = await btn.evaluate((el) => {


### PR DESCRIPTION
## Summary
- remove design token expectation for draw button in random judoka Playwright spec
- rely on existing screenshot and unit tests for styling regressions

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot/PRD tests)*
- `npx playwright test playwright/random-judoka.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b159c59a28832680336e514b379d77