### PR TITLE
Refactor vector search tests to share mock dataset

### DIFF
--- a/tests/helpers/vectorSearch.loader.test.js
+++ b/tests/helpers/vectorSearch.loader.test.js
@@ -1,32 +1,17 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { withAllowedConsole } from "../utils/console.js";
+import { setupMockDataset, sample } from "./vectorSearch/mockDataset.js";
 
 vi.mock("../../src/helpers/dataUtils.js", () => ({
   fetchJson: vi.fn(),
   validateWithSchema: vi.fn().mockResolvedValue(undefined)
 }));
 
-const sample = [
-  { id: "a", text: "A", embedding: [1, 0], source: "doc1", tags: ["foo"] },
-  { id: "b", text: "B", embedding: [0, 1], source: "doc2", tags: ["bar"] }
-];
-
 let fetchJsonMock;
 
 beforeEach(async () => {
-  vi.resetModules();
-  fetchJsonMock = (await import("../../src/helpers/dataUtils.js")).fetchJson;
-  fetchJsonMock.mockReset();
-  fetchJsonMock.mockImplementation((url) => {
-    if (url.endsWith("client_embeddings.manifest.json")) {
-      return Promise.resolve({ shards: ["shard1.json"] });
-    }
-    if (url.endsWith("shard1.json")) {
-      return Promise.resolve(sample);
-    }
-    return Promise.resolve([]);
-  });
+  fetchJsonMock = await setupMockDataset();
 });
 
 afterEach(() => {
@@ -41,29 +26,6 @@ describe("vectorSearch loader", () => {
     expect(first).toEqual(sample);
     expect(second).toBe(first);
     expect(fetchJsonMock).toHaveBeenCalledTimes(2); // manifest + shard
-  });
-
-  it("ensures embeddings use three-decimal precision", async () => {
-    const decimalSample = [
-      { id: "c", text: "C", embedding: [0.123, 0.456, 0.789], source: "doc3" }
-    ];
-    fetchJsonMock.mockImplementation((url) => {
-      if (url.endsWith("client_embeddings.manifest.json")) {
-        return Promise.resolve({ shards: ["shard1.json"] });
-      }
-      if (url.endsWith("shard1.json")) {
-        return Promise.resolve(decimalSample);
-      }
-      return Promise.resolve([]);
-    });
-    const { loadEmbeddings } = await import("../../src/helpers/vectorSearch/loader.js");
-    const embeddings = await loadEmbeddings();
-    for (const entry of embeddings ?? []) {
-      for (const value of entry.embedding) {
-        const decimals = value.toString().split(".")[1];
-        expect(decimals ? decimals.length : 0).toBeLessThanOrEqual(3);
-      }
-    }
   });
 
   it("returns null when loading fails", async () => {

--- a/tests/helpers/vectorSearch.test.js
+++ b/tests/helpers/vectorSearch.test.js
@@ -1,32 +1,17 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { withAllowedConsole } from "../utils/console.js";
+import { setupMockDataset } from "./vectorSearch/mockDataset.js";
 
 vi.mock("../../src/helpers/dataUtils.js", () => ({
   fetchJson: vi.fn(),
   validateWithSchema: vi.fn().mockResolvedValue(undefined)
 }));
 
-const sample = [
-  { id: "a", text: "A", embedding: [1, 0], source: "doc1", tags: ["foo"] },
-  { id: "b", text: "B", embedding: [0, 1], source: "doc2", tags: ["bar"] }
-];
-
 let fetchJsonMock;
 
 beforeEach(async () => {
-  vi.resetModules();
-  fetchJsonMock = (await import("../../src/helpers/dataUtils.js")).fetchJson;
-  fetchJsonMock.mockReset();
-  fetchJsonMock.mockImplementation((url) => {
-    if (url.endsWith("client_embeddings.manifest.json")) {
-      return Promise.resolve({ shards: ["shard1.json"] });
-    }
-    if (url.endsWith("shard1.json")) {
-      return Promise.resolve(sample);
-    }
-    return Promise.resolve([]);
-  });
+  fetchJsonMock = await setupMockDataset();
 });
 
 afterEach(() => {
@@ -80,5 +65,20 @@ describe("vectorSearch scoring", () => {
     const { findMatches } = await import("../../src/helpers/vectorSearch/scorer.js");
     const res = await findMatches([1, 0, 0], 1);
     expect(res).toEqual([]);
+  });
+
+  it("ensures embeddings use three-decimal precision", async () => {
+    const decimalSample = [
+      { id: "c", text: "C", embedding: [0.123, 0.456, 0.789], source: "doc3" }
+    ];
+    fetchJsonMock = await setupMockDataset(decimalSample);
+    const { loadEmbeddings } = await import("../../src/helpers/vectorSearch/loader.js");
+    const embeddings = await loadEmbeddings();
+    for (const entry of embeddings ?? []) {
+      for (const value of entry.embedding) {
+        const decimals = value.toString().split(".")[1];
+        expect(decimals ? decimals.length : 0).toBeLessThanOrEqual(3);
+      }
+    }
   });
 });

--- a/tests/helpers/vectorSearch/mockDataset.js
+++ b/tests/helpers/vectorSearch/mockDataset.js
@@ -1,0 +1,28 @@
+import { vi } from "vitest";
+
+export const sample = [
+  { id: "a", text: "A", embedding: [1, 0], source: "doc1", tags: ["foo"] },
+  { id: "b", text: "B", embedding: [0, 1], source: "doc2", tags: ["bar"] }
+];
+
+/**
+ * Set up mocked embedding dataset for vector search tests.
+ *
+ * @param {Array} dataset Embeddings to serve from the loader.
+ * @returns {Promise<import('vitest').Mock>} fetchJson mock used by the loader.
+ */
+export async function setupMockDataset(dataset = sample) {
+  vi.resetModules();
+  const { fetchJson } = await import("../../../src/helpers/dataUtils.js");
+  fetchJson.mockReset();
+  fetchJson.mockImplementation((url) => {
+    if (url.endsWith("client_embeddings.manifest.json")) {
+      return Promise.resolve({ shards: ["shard1.json"] });
+    }
+    if (url.endsWith("shard1.json")) {
+      return Promise.resolve(dataset);
+    }
+    return Promise.resolve([]);
+  });
+  return fetchJson;
+}


### PR DESCRIPTION
## Summary
- centralize vector search test dataset mocking in `tests/helpers/vectorSearch/mockDataset.js`
- use shared mock dataset in loader and scoring tests and drop duplication
- move loader precision check into scoring tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Classic Battle CLI and screenshot suite)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b15eaef35c8326abdb0ef29d1e7315