### PR TITLE
test: move high contrast toggle test to settings

### DIFF
--- a/playwright/narrow-layout.spec.js
+++ b/playwright/narrow-layout.spec.js
@@ -1,5 +1,4 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { waitForSettingsReady } from "./fixtures/waits.js";
 
 test.describe("Responsive scenarios", () => {
   test("renders ultra-narrow layout without horizontal scroll", async ({ page }) => {
@@ -7,12 +6,5 @@ test.describe("Responsive scenarios", () => {
     await page.setViewportSize({ width: 260, height: 800 });
     const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
     expect(scrollWidth).toBeLessThanOrEqual(260);
-  });
-
-  test("toggles high-contrast display mode", async ({ page }) => {
-    await page.goto("/src/pages/settings.html");
-    await waitForSettingsReady(page);
-    await page.check("#display-mode-high-contrast");
-    await expect(page.locator("body")).toHaveAttribute("data-theme", "high-contrast");
   });
 });

--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -187,6 +187,11 @@ test.describe("Settings page", () => {
     }
   });
 
+  test("toggles high-contrast display mode", async ({ page }) => {
+    await page.check("#display-mode-high-contrast");
+    await expect(page.locator("body")).toHaveAttribute("data-theme", "high-contrast");
+  });
+
   test("restore defaults resets settings", async ({ page }) => {
     await expect(page.getByRole("checkbox", { name: "Sound" })).toBeChecked();
     const sound = page.getByRole("checkbox", { name: "Sound" });


### PR DESCRIPTION
## Summary
- verify high-contrast mode toggling in settings page tests
- drop high-contrast check from responsive spec and rename remaining file to narrow-layout.spec.js

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battleRoundCompletion.spec.js, screenshot.spec.js)*
- `npx playwright test playwright/narrow-layout.spec.js playwright/settings.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b15e808894832694d6e18768816c7d