### PR TITLE
chore(test): isolate script tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "node scripts/playwrightServer.js",
     "test": "vitest",
     "test:screenshot": "playwright test",
+    "test:scripts": "vitest run -c vitest.scripts.config.js",
     "lint": "npx prettier . --check && npx eslint .",
     "check:contrast": "node scripts/runPa11y.js",
     "prepare": "husky install",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -33,6 +33,7 @@ export default defineConfig({
       ".cache/**",
       "tests/e2e/**",
       "tests/playwright/**",
+      "tests/scripts/**",
       "playwright/**",
       "scripts/**/*.spec.*"
     ],

--- a/vitest.scripts.config.js
+++ b/vitest.scripts.config.js
@@ -1,0 +1,9 @@
+import config from "./vitest.config.js";
+
+config.test = {
+  ...config.test,
+  include: ["tests/scripts/**/*.test.js"],
+  exclude: config.test.exclude.filter((p) => p !== "tests/scripts/**")
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add `test:scripts` npm command for tooling scripts
- exclude script tests from standard vitest run
- provide dedicated Vitest config for script tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npm run test:scripts`
- `npx playwright test` *(fails: screenshot mismatch for battleJudoka-narrow)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b171b4dac88326a4db1c2991dbdb86