### PR TITLE
refactor: shift countdown tests to snackbar

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -101,6 +101,6 @@ test.describe("Classic battle flow", () => {
     await waitForSettingsReady(page);
     await page.goBack();
     await expect(page).toHaveURL(/battleJudoka.html/);
-    await expect(page.locator("header #next-round-timer")).toHaveText("");
+    await expect(page.locator(".snackbar")).toHaveCount(0);
   });
 });

--- a/tests/components/Scoreboard.test.js
+++ b/tests/components/Scoreboard.test.js
@@ -58,11 +58,7 @@ describe("Scoreboard component", () => {
     document.body.innerHTML = "";
     const existing = createScoreboardHeader();
     document.body.appendChild(existing);
-    initScoreboard(existing, {
-      startCoolDown: vi.fn(),
-      pauseTimer: vi.fn(),
-      resumeTimer: vi.fn()
-    });
+    initScoreboard(existing);
     showMessage("Hi");
     expect(document.getElementById("round-message").textContent).toBe("Hi");
     updateScore(2, 3);

--- a/tests/helpers/CooldownRenderer.test.js
+++ b/tests/helpers/CooldownRenderer.test.js
@@ -16,6 +16,7 @@ vi.mock("../../src/helpers/classicBattle/battleEvents.js", () => ({
 import { attachCooldownRenderer } from "../../src/helpers/CooldownRenderer.js";
 import { emitBattleEvent } from "../../src/helpers/classicBattle/battleEvents.js";
 import * as snackbar from "../../src/helpers/showSnackbar.js";
+import * as scoreboard from "../../src/helpers/setupScoreboard.js";
 
 describe("attachCooldownRenderer", () => {
   let timer;
@@ -46,5 +47,19 @@ describe("attachCooldownRenderer", () => {
 
     expect(emitBattleEvent).toHaveBeenCalledWith("nextRoundCountdownStarted");
     expect(emitBattleEvent).toHaveBeenCalledWith("nextRoundCountdownTick", { remaining: 5 });
+  });
+
+  it("updates snackbar on tick and clears timer at zero", () => {
+    attachCooldownRenderer(timer);
+
+    timer.emit("tick", 3);
+    expect(snackbar.showSnackbar).toHaveBeenCalledWith("Next round in: 3s");
+
+    timer.emit("tick", 2);
+    expect(snackbar.updateSnackbar).toHaveBeenCalledWith("Next round in: 2s");
+
+    timer.emit("tick", 0);
+    expect(snackbar.updateSnackbar).toHaveBeenCalledWith("Next round in: 0s");
+    expect(scoreboard.clearTimer).toHaveBeenCalled();
   });
 });

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -83,17 +83,6 @@ describe("countdown resets after stat selection", () => {
     battleMod._resetForTest(store);
   });
 
-  it("clears the next round timer after stat selection", async () => {
-    populateCards();
-    const timer = vi.useFakeTimers();
-    const { randomSpy } = await selectPower(battleMod, store);
-    expect(document.getElementById("next-round-timer").textContent).toBe("");
-    await vi.advanceTimersByTimeAsync(3000);
-    expect(document.getElementById("next-round-timer").textContent).toBe("");
-    timer.clearAllTimers();
-    randomSpy.mockRestore();
-  });
-
   it("shows snackbar countdown with sequential updates", async () => {
     populateCards();
     const timer = vi.useFakeTimers();

--- a/tests/helpers/scoreboard.integration.test.js
+++ b/tests/helpers/scoreboard.integration.test.js
@@ -60,18 +60,6 @@ describe("Scoreboard integration without explicit init", () => {
         }, 1000);
         return Promise.resolve();
       },
-      // Cooldown timer (not exercised here)
-      startCoolDown: (onTick, onExpired, duration) => {
-        onTick(duration);
-        const id = setInterval(() => {
-          duration -= 1;
-          onTick(duration);
-          if (duration <= 0) {
-            clearInterval(id);
-            onExpired();
-          }
-        }, 1000);
-      },
       stopTimer: vi.fn(),
       pauseTimer: vi.fn(),
       resumeTimer: vi.fn(),
@@ -85,13 +73,8 @@ describe("Scoreboard integration without explicit init", () => {
       updateSnackbar: vi.fn()
     }));
 
-    const engine = await import("../../src/helpers/battleEngineFacade.js");
     const { initScoreboard } = await import("../../src/components/Scoreboard.js");
-    initScoreboard(undefined, {
-      startCoolDown: engine.startCoolDown,
-      pauseTimer: engine.pauseTimer,
-      resumeTimer: engine.resumeTimer
-    });
+    initScoreboard(undefined);
   });
 
   it("renders messages, score, round counter, and round timer without init", async () => {

--- a/tests/helpers/setupScoreboard.test.js
+++ b/tests/helpers/setupScoreboard.test.js
@@ -18,11 +18,7 @@ describe("setupScoreboard", () => {
   });
 
   function createControls() {
-    return {
-      startCoolDown: vi.fn(),
-      pauseTimer: vi.fn(),
-      resumeTimer: vi.fn()
-    };
+    return {};
   }
 
   it("initializes scoreboard and proxies component methods", async () => {
@@ -40,12 +36,7 @@ describe("setupScoreboard", () => {
 
     expect(initSpy).toHaveBeenCalledWith(
       document.querySelector("header"),
-      expect.objectContaining({
-        startCoolDown: controls.startCoolDown,
-        pauseTimer: controls.pauseTimer,
-        resumeTimer: controls.resumeTimer,
-        scheduler
-      })
+      expect.objectContaining({ scheduler })
     );
 
     mod.showMessage("Hi");
@@ -70,14 +61,6 @@ describe("setupScoreboard", () => {
     const initSpy = vi.spyOn(scoreboard, "initScoreboard");
     const mod = await import("../../src/helpers/setupScoreboard.js");
     mod.setupScoreboard(controls, scheduler);
-    expect(initSpy).toHaveBeenCalledWith(
-      null,
-      expect.objectContaining({
-        startCoolDown: controls.startCoolDown,
-        pauseTimer: controls.pauseTimer,
-        resumeTimer: controls.resumeTimer,
-        scheduler
-      })
-    );
+    expect(initSpy).toHaveBeenCalledWith(null, expect.objectContaining({ scheduler }));
   });
 });


### PR DESCRIPTION
## Summary
- drop obsolete countdown wiring from scoreboard setup tests
- verify CooldownRenderer drives snackbar updates and clears timer
- update classic battle flow tests to assert snackbar, not scoreboard timer

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 7 failing specs, including classic battle flow and screenshot suites)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b1f76eac088326bed5667c7c1952d0