### PR TITLE
fix: keep Next button enabled during cooldown

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -359,7 +359,7 @@ export function scheduleNextRound(result, scheduler = realScheduler) {
   // Reset any leftover ready state so each cooldown runs through the timer
   // path even after an auto-advance.
   if (btn) {
-    btn.disabled = true;
+    btn.disabled = false;
     delete btn.dataset.nextReady;
   }
 

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -152,7 +152,7 @@ describe("classicBattle scheduleNextRound", () => {
     expect(machine.getState()).toBe("cooldown");
 
     const controls = battleMod.scheduleNextRound({ matchEnded: false });
-    document.getElementById("next-button").dispatchEvent(new MouseEvent("click"));
+    document.getElementById("next-button").click();
     await controls.ready;
     // Ensure state progressed before assertions
     await orchestrator.onStateTransition("waitingForPlayerAction");

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -48,7 +48,7 @@ describe("timerService next round handling", () => {
     const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
     nextButton.addEventListener("click", (e) => mod.onNextButtonClick(e, controls));
     scheduler.tick(100);
-    nextButton.dispatchEvent(new MouseEvent("click"));
+    nextButton.click();
     await controls.ready;
     // Current flow guarantees at least one dispatch; a second may occur
     // via attribute observation. Accept one or more invocations.
@@ -77,7 +77,7 @@ describe("timerService next round handling", () => {
     window.__NEXT_ROUND_COOLDOWN_MS = 1000;
     const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
     expect(nextButton.dataset.nextReady).toBeUndefined();
-    expect(nextButton.disabled).toBe(true);
+    expect(nextButton.disabled).toBe(false);
     scheduler.tick(1100);
     await controls.ready;
     expect(nextButton.dataset.nextReady).toBe("true");


### PR DESCRIPTION
## Summary
- keep Next button enabled when scheduling cooldown to preserve manual skip
- use native `.click()` in cooldown tests to honor disabled state

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: dispatchBattleEvent unused, loweredTerms unused, _ unused)*
- `npx vitest run`
- `npx playwright test` *(fails: 6)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2009a355c8326b8b4244eac41724a