### PR TITLE
test: remove stat click test and use keyboard for cooldown

### DIFF
--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -35,17 +35,6 @@ test.describe("Classic Battle CLI", () => {
     await expect(badge).toContainText(/State:\s*waitingForPlayerAction/);
   });
 
-  test("clicking a stat advances to round decision", async ({ page }) => {
-    await page.goto("/src/pages/battleCLI.html");
-    await waitForBattleState(page, "waitingForPlayerAction", 15000);
-
-    const firstStat = page.locator(".cli-stat").first();
-    await firstStat.click();
-    await firstStat.click();
-
-    await waitForBattleState(page, "roundDecision", 10000);
-  });
-
   test("verbose log toggles and records transitions", async ({ page }) => {
     await page.goto("/src/pages/battleCLI.html");
     await waitForBattleState(page, "waitingForPlayerAction", 15000);
@@ -84,8 +73,8 @@ test.describe("Classic Battle CLI", () => {
     const cardBefore = await page.locator("#player-card ul").elementHandle();
 
     await waitForBattleState(page, "cooldown", 10000);
-    // Clicking the main surface advances to the next round
-    await page.locator("#cli-main").click();
+    // Pressing Enter advances to the next round
+    await page.keyboard.press("Enter");
     await waitForBattleState(page, "waitingForPlayerAction", 10000);
     const cardAfter = await page.locator("#player-card ul").elementHandle();
 


### PR DESCRIPTION
## Summary
- drop mouse-driven stat selection test from battle CLI suite
- advance CLI rounds via Enter key instead of clicking the surface

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: classicBattleFlow countdown screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2011b55a08326a339d80cdd753889