### PR TITLE
fix game mode grid layout overflowing footer

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -122,6 +122,7 @@ body {
   padding-bottom: calc(var(--space-large) + var(--footer-height) + env(safe-area-inset-bottom));
   flex: 1 1 auto;
   height: 100%;
+  min-height: 0;
   overflow-y: auto;
   box-sizing: border-box;
   /* border: 2px solid red; */


### PR DESCRIPTION
## Summary
- prevent game mode grid from overlapping footer by constraining height with `height: 100%` and `min-height: 0`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run --reporter=basic`
- `npx playwright test --reporter=line` *(fails: 6 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2017060fc8326810b86384a0fd207