### PR TITLE
fix: honor pending skips before starting fallback timer

### DIFF
--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -158,6 +158,10 @@ onBattleEvent("countdownStart", (e) => {
       } catch {}
       activeCountdown = null;
     });
+    if (!activeCountdown) {
+      // A pending skip consumed the countdown before it began
+      return;
+    }
     timer.start(duration);
   } catch (err) {
     console.error("Error in countdownStart event handler:", err);


### PR DESCRIPTION
## Summary
- avoid starting countdown timer if a pending skip clears it immediately

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Skip cooldown flow, Classic battle flow, Classic battle round completion, screenshot suite)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b206bddb988326a881ac42d9974580