### PR TITLE
docs: mention RAG evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ Sample output:
 - The round resolver compares chosen stats to decide a winner.
 - Each round alternates between player choice and resolver phases.
 ```
+
+### Evaluate retrieval quality
+
+Measure how well the vector search performs by running the evaluator:
+
+```bash
+node scripts/evaluation/evaluateRAG.js
+```
+
+It reads `scripts/evaluation/queries.json` and reports **MRR@5**, **Recall@3**, and **Recall@5** for the expected sources.
 ## ⚡ Module Loading Policy: Static vs Dynamic Imports
 
 JU-DO-KON! favors **deterministic gameplay and snappy input handling**. Use **static imports** for core gameplay; reserve **dynamic imports** (`import('…')`) for optional screens and heavy tools.

--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -190,6 +190,14 @@ No user settings or toggles are included. This is appropriate since the feature 
 - Do we want a UI search tool for developers and designers, or agent-only access?
 - Should embedding versioning be tracked per file (`v1_embeddings.json`)?
 
+## Retrieval Quality Evaluation
+
+Run `node scripts/evaluation/evaluateRAG.js` from the project root to measure retrieval performance. The script reads the representative queries in `scripts/evaluation/queries.json` and reports:
+
+- **MRR@5** – Mean Reciprocal Rank of the expected document within the top five results.
+- **Recall@3** – Fraction of queries whose expected document appears in the top three results.
+- **Recall@5** – Fraction of queries whose expected document appears in the top five results.
+
 ## Tasks
 
 - [x] 1.0 Build Embedding Generation System

--- a/scripts/evaluation/evaluateRAG.js
+++ b/scripts/evaluation/evaluateRAG.js
@@ -166,7 +166,7 @@ async function loadModel() {
   return pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", { quantized: true });
 }
 
-async function evaluate() {
+export async function evaluate() {
   const model = await loadModel();
 
   const queriesPath = path.join(rootDir, "scripts/evaluation/queries.json");
@@ -213,4 +213,8 @@ async function evaluate() {
   console.log(`Recall@5: ${recall5 / queries.length}`);
 }
 
-await evaluate();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await evaluate();
+}
+
+export { createSparseVector };

--- a/tests/scripts/evaluateRAG.test.js
+++ b/tests/scripts/evaluateRAG.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@xenova/transformers", () => ({
+  pipeline: vi.fn(async () => async () => ({ data: new Float32Array([0, 0, 0]) }))
+}));
+
+const findMatches = vi.hoisted(() => vi.fn(async () => [{ source: "design/doc.md" }]));
+vi.mock("../../src/helpers/vectorSearch/index.js", () => ({
+  default: { findMatches }
+}));
+
+import { evaluate } from "../../scripts/evaluation/evaluateRAG.js";
+
+describe("evaluateRAG", () => {
+  it("runs without throwing", async () => {
+    await evaluate();
+    expect(findMatches).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- document evaluateRAG.js in README and PRD, clarifying it reports MRR@5 and Recall@3/5
- export evaluate function for reuse and add a test ensuring evaluator runs without throwing

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warn: unused vars)*
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED, screenshot mismatches)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2329cf5648326bc8e56f2d7d7ceec