### PR TITLE
test: ensure embedding precision

### DIFF
--- a/tests/helpers/vectorSearch.test.js
+++ b/tests/helpers/vectorSearch.test.js
@@ -76,6 +76,7 @@ describe("vectorSearch scoring", () => {
     const embeddings = await loadEmbeddings();
     for (const entry of embeddings ?? []) {
       for (const value of entry.embedding) {
+        expect(Number(value.toFixed(3))).toBe(value);
         const decimals = value.toString().split(".")[1];
         expect(decimals ? decimals.length : 0).toBeLessThanOrEqual(3);
       }


### PR DESCRIPTION
## Summary
- check that vectorSearch embeddings match three-decimal rounding
- retain three-decimal rounding logic in embedding generation

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: 3 warnings)*
- `npx vitest run`
- `npx playwright test` *(fails: 5)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b23290b250832683b93ce8ce4f573c