### PR TITLE
Cover all data sources in embeddings allowlist

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -205,6 +205,15 @@ let codeGraphs = { modules: {} };
 const MAX_OUTPUT_SIZE = 9.8 * 1024 * 1024;
 
 const JSON_FIELD_ALLOWLIST = {
+  "aesopsFables.json": false,
+  "aesopsMeta.json": false,
+  "battleRounds.json": ["label", "description", "category"],
+  "codeGraphs.json": false,
+  "countryCodeMapping.json": false,
+  "gameModes.json": ["name", "japaneseName", "description", "rules"],
+  "gameTimers.json": ["description", "category"],
+  "gokyo.json": ["name", "japanese", "description", "style", "category", "subCategory"],
+  "japaneseConverter.json": false,
   "judoka.json": [
     "firstname",
     "surname",
@@ -215,19 +224,14 @@ const JSON_FIELD_ALLOWLIST = {
     "rarity",
     "stats"
   ],
-  "tooltips.json": true, // Allow all fields
-  "gameModes.json": ["name", "japaneseName", "description", "rules"],
-  "battleRounds.json": ["label", "description", "category"],
-  "gameTimers.json": ["description", "category"],
-  "gokyo.json": ["name", "japanese", "description", "style", "category", "subCategory"],
   "locations.json": ["name", "japaneseName", "description"],
   "navigationItems.json": ["url", "category"],
   "settings.json": ["displayMode", "aiDifficulty"],
   "statNames.json": ["name", "japanese", "description", "category"],
   "svgCodes.json": ["name", "category"],
   "synonyms.json": true,
+  "tooltips.json": true, // Allow all fields
   "weightCategories.json": ["gender", "description", "categories.descriptor"],
-  "codeGraphs.json": false,
   default: ["name", "description", "label"]
 };
 


### PR DESCRIPTION
## Summary
- document all game data JSON files in the embeddings allowlist
- verify every data file is covered and boilerplate text is filtered

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: 3 warnings)*
- `npx vitest run`
- `npx playwright test` *(fails: 5 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b23282539c832683b1efaf88298861