### PR TITLE
Fix snackbar container timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Pages that display snackbars must include a persistent container near the end of
 <div id="snackbar-container" role="status" aria-live="polite"></div>
 ```
 
-`showSnackbar` and `updateSnackbar` reuse this element for notifications.
+Place this element **before** any script that may trigger snackbars during page load to avoid creating a fallback container with duplicate IDs. `showSnackbar` and `updateSnackbar` reuse this element for notifications.
 
 ## Settings API
 

--- a/src/helpers/showSnackbar.js
+++ b/src/helpers/showSnackbar.js
@@ -57,11 +57,6 @@ export function showSnackbar(message) {
     if (typeof document !== "undefined" && !document.getElementById("snackbar-container")) {
       const container = document.createElement("div");
       container.id = "snackbar-container";
-      // Keep the container visually inert when inserted by script.
-      container.style.position = "absolute";
-      container.style.width = "0";
-      container.style.height = "0";
-      container.style.overflow = "visible";
       document.body?.appendChild(container);
     }
   } catch {}
@@ -101,10 +96,6 @@ export function updateSnackbar(message) {
     if (typeof document !== "undefined" && !document.getElementById("snackbar-container")) {
       const container = document.createElement("div");
       container.id = "snackbar-container";
-      container.style.position = "absolute";
-      container.style.width = "0";
-      container.style.height = "0";
-      container.style.overflow = "visible";
       document.body?.appendChild(container);
     }
   } catch {}

--- a/src/pages/battleClassic.html
+++ b/src/pages/battleClassic.html
@@ -158,8 +158,8 @@
           JU-DO-KON! requires JavaScript to run. Please enable JavaScript to play.
         </p>
       </noscript>
-      <script type="module" src="../helpers/classicBattle/bootstrap.js"></script>
     </div>
     <div id="snackbar-container" role="status" aria-live="polite"></div>
+    <script type="module" src="../helpers/classicBattle/bootstrap.js"></script>
   </body>
 </html>

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -158,8 +158,8 @@
           JU-DO-KON! requires JavaScript to run. Please enable JavaScript to play.
         </p>
       </noscript>
-      <script type="module" src="../helpers/classicBattle/bootstrap.js"></script>
     </div>
     <div id="snackbar-container" role="status" aria-live="polite"></div>
+    <script type="module" src="../helpers/classicBattle/bootstrap.js"></script>
   </body>
 </html>

--- a/tests/helpers/snackbarContainerOrder.test.js
+++ b/tests/helpers/snackbarContainerOrder.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const pages = ["battleJudoka.html", "battleClassic.html"];
+
+describe("snackbar container order", () => {
+  it.each(pages)("%s defines snackbar container before bootstrap", (file) => {
+    const html = readFileSync(path.join(__dirname, "../../src/pages", file), "utf8");
+    const containerIndex = html.indexOf('<div id="snackbar-container"');
+    const scriptIndex = html.indexOf("helpers/classicBattle/bootstrap.js");
+    expect(containerIndex).toBeGreaterThan(-1);
+    expect(scriptIndex).toBeGreaterThan(-1);
+    expect(containerIndex).toBeLessThan(scriptIndex);
+  });
+});


### PR DESCRIPTION
## Summary
- Move snackbar container before bootstrap script on battle pages
- Remove inline styles from fallback snackbar container creation
- Test container order and document placement guidance

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: GET https://esm.sh/dompurify@3.2.6 net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2b1c2f8d48326a98f8864b424c4e4