### PR TITLE
Refactor CLI key handling with dispatch table and tests

### DIFF
--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("battleCLI onKeyDown", () => {
+  let onKeyDown;
+
+  beforeEach(async () => {
+    window.__TEST__ = true;
+    ({ onKeyDown } = await import("../../src/pages/battleCLI.js"));
+    document.body.innerHTML = `
+      <div id="cli-shortcuts" hidden></div>
+      <div id="snackbar-container"></div>
+    `;
+    document.body.className = "";
+    document.body.dataset.battleState = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    document.body.className = "";
+    delete document.body.dataset.battleState;
+    delete window.__getClassicBattleMachine;
+    delete window.__TEST__;
+    vi.resetModules();
+  });
+
+  it("toggles shortcuts with H key", () => {
+    onKeyDown(new KeyboardEvent("keydown", { key: "h" }));
+    expect(document.getElementById("cli-shortcuts").hidden).toBe(false);
+  });
+
+  it("toggles retro mode with R key", () => {
+    onKeyDown(new KeyboardEvent("keydown", { key: "r" }));
+    expect(document.body.classList.contains("retro")).toBe(true);
+  });
+
+  it("quits on Q key", () => {
+    const dispatch = vi.fn();
+    window.__getClassicBattleMachine = () => ({ dispatch });
+    onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
+    expect(dispatch).toHaveBeenCalledWith("interrupt", { reason: "quit" });
+  });
+
+  it("dispatches statSelected in waitingForPlayerAction state", () => {
+    const dispatch = vi.fn();
+    window.__getClassicBattleMachine = () => ({ dispatch });
+    document.body.dataset.battleState = "waitingForPlayerAction";
+    onKeyDown(new KeyboardEvent("keydown", { key: "1" }));
+    expect(dispatch).toHaveBeenCalledWith("statSelected");
+  });
+
+  it("dispatches continue in roundOver state", () => {
+    const dispatch = vi.fn();
+    window.__getClassicBattleMachine = () => ({ dispatch });
+    document.body.dataset.battleState = "roundOver";
+    onKeyDown(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(dispatch).toHaveBeenCalledWith("continue");
+  });
+
+  it("dispatches ready in cooldown state", () => {
+    const dispatch = vi.fn();
+    window.__getClassicBattleMachine = () => ({ dispatch });
+    document.body.dataset.battleState = "cooldown";
+    onKeyDown(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(dispatch).toHaveBeenCalledWith("ready");
+  });
+});


### PR DESCRIPTION
## Summary
- extract battleCLI keyboard handlers into dedicated functions
- dispatch on battle state via lookup table for cleaner onKeyDown
- test global shortcuts and state transitions for CLI

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: skip cooldown, screenshot, and classic battle flow tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2b1ef253483268004ba933af64c38