### PR TITLE
chore: remove aesops fables embeddings

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -205,8 +205,6 @@ let codeGraphs = { modules: {} };
 const MAX_OUTPUT_SIZE = 9.8 * 1024 * 1024;
 
 const JSON_FIELD_ALLOWLIST = {
-  "aesopsFables.json": false,
-  "aesopsMeta.json": false,
   "battleRounds.json": ["label", "description", "category"],
   "codeGraphs.json": false,
   "countryCodeMapping.json": false,

--- a/tests/scripts/generateEmbeddings.test.js
+++ b/tests/scripts/generateEmbeddings.test.js
@@ -12,7 +12,11 @@ describe("JSON_FIELD_ALLOWLIST", () => {
   it("covers all data JSON files", async () => {
     const dataDir = path.resolve(__dirname, "../../src/data");
     const files = (await readdir(dataDir)).filter(
-      (f) => f.endsWith(".json") && !f.startsWith("client_embeddings.")
+      (f) =>
+        f.endsWith(".json") &&
+        !f.startsWith("client_embeddings.") &&
+        f !== "aesopsFables.json" &&
+        f !== "aesopsMeta.json"
     );
     for (const file of files) {
       expect(JSON_FIELD_ALLOWLIST).toHaveProperty(file);


### PR DESCRIPTION
## Summary
- drop aesops fables/meta JSON from embedding allowlist
- adjust embedding tests to ignore aesops files

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battleRoundCompletion, classicBattleFlow x2, screenshot x2, skip-cooldown)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2b6b267ac83269ad150bfc5adfcdc