### PR TITLE
Clear CLI cooldown timers on quit

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -24,6 +24,17 @@ let verboseEnabled = false;
 let cooldownTimer = null;
 let cooldownInterval = null;
 
+// Test hooks to access internal timer state
+export const __test = {
+  setCooldownTimers(timer, interval) {
+    cooldownTimer = timer;
+    cooldownInterval = interval;
+  },
+  getCooldownTimers() {
+    return { cooldownTimer, cooldownInterval };
+  }
+};
+
 function setRetroMode(enabled) {
   document.body.classList.toggle("retro", !!enabled);
 }
@@ -108,6 +119,8 @@ function getStatByIndex(index1Based) {
  *   toggle retro mode
  *   return true
  * if key is 'q':
+ *   clear cooldown timers
+ *   clear bottom line
  *   dispatch 'interrupt' on the machine
  *   return true
  * return false
@@ -123,6 +136,15 @@ export function handleGlobalKey(key) {
     return true;
   }
   if (key === "q") {
+    try {
+      if (cooldownTimer) clearTimeout(cooldownTimer);
+    } catch {}
+    try {
+      if (cooldownInterval) clearInterval(cooldownInterval);
+    } catch {}
+    cooldownTimer = null;
+    cooldownInterval = null;
+    clearBottomLine();
     try {
       const machine = window.__getClassicBattleMachine?.();
       if (machine) machine.dispatch("interrupt", { reason: "quit" });


### PR DESCRIPTION
## Summary
- clear cooldown timers and bottom line when quitting from Battle CLI
- expose test hooks for cooldown timers
- test that global quit cancels cooldown timers

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: dispatchBattleEvent unused, loweredTerms unused, _ unused)*
- `npx vitest run`
- `npx playwright test` *(fails: Skip cooldown flow and classic battle screenshot/flow tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2b83b61fc83269aae05d4f3965a06