### PR TITLE
refactor battle state debug helpers

### DIFF
--- a/tests/helpers/orchestrator.updateDebugState.test.js
+++ b/tests/helpers/orchestrator.updateDebugState.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { updateDebugState } from "../../src/helpers/classicBattle/orchestrator.js";
+
+describe("updateDebugState", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete window.__classicBattleState;
+    delete window.__classicBattlePrevState;
+    delete window.__classicBattleLastEvent;
+    delete window.__classicBattleStateLog;
+    delete window.__stateWaiters;
+  });
+
+  it("mirrors state to DOM and logs transition", () => {
+    updateDebugState("a", "b", "go");
+    expect(window.__classicBattleState).toBe("b");
+    expect(window.__classicBattlePrevState).toBe("a");
+    expect(window.__classicBattleLastEvent).toBe("go");
+    expect(document.body.dataset.battleState).toBe("b");
+    expect(document.body.dataset.prevBattleState).toBe("a");
+    const el = document.getElementById("machine-state");
+    expect(el).toBeTruthy();
+    expect(el.textContent).toBe("b");
+    expect(el.dataset.prev).toBe("a");
+    expect(el.dataset.event).toBe("go");
+    const log = window.__classicBattleStateLog;
+    expect(Array.isArray(log)).toBe(true);
+    expect(log[log.length - 1]).toMatchObject({
+      from: "a",
+      to: "b",
+      event: "go"
+    });
+  });
+
+  it("resolves waiters for new state", () => {
+    const resolve = vi.fn();
+    window.__stateWaiters = { b: [{ resolve }] };
+    updateDebugState("a", "b", null);
+    expect(resolve).toHaveBeenCalled();
+    expect(window.__stateWaiters.b).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract mirrorStateToDom, logStateTransition, and resolveWindowWaiters from classic battle orchestrator
- coordinate debug updates via updateDebugState
- add unit tests for DOM mirroring and waiter resolution

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 6 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2bae8a18c8326ac212995e465a932