### PR TITLE
Refactor roundDecisionEnter helpers

### DIFF
--- a/tests/helpers/orchestratorHandlers.roundDecisionEnter.test.js
+++ b/tests/helpers/orchestratorHandlers.roundDecisionEnter.test.js
@@ -7,34 +7,26 @@ beforeEach(() => {
 });
 
 describe("roundDecisionEnter", () => {
-  it("schedules a decision guard", async () => {
+  it("schedules a decision guard when no selection exists", async () => {
     vi.useFakeTimers();
     vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
       emitBattleEvent: vi.fn(),
       onBattleEvent: vi.fn(),
       offBattleEvent: vi.fn()
     }));
-    vi.doMock("../../src/helpers/classicBattle/roundResolver.js", () => ({
-      resolveRound: vi.fn().mockResolvedValue(undefined)
-    }));
-    vi.doMock("../../src/helpers/battle/index.js", () => ({
-      getStatValue: vi.fn(() => 5)
-    }));
-    vi.doMock("../../src/helpers/classicBattle/cardSelection.js", () => ({
-      getOpponentJudoka: vi.fn(() => ({ stats: { power: 3 } }))
-    }));
 
     const mod = await import("../../src/helpers/classicBattle/orchestratorHandlers.js");
-    const store = { playerChoice: "power" };
+    const store = {};
     const machine = {
       context: { store },
       dispatch: vi.fn(),
       getState: vi.fn(() => "roundDecision")
     };
 
-    await mod.roundDecisionEnter(machine);
-    expect(window.__roundDecisionGuard).toBeTruthy();
+    const p = mod.roundDecisionEnter(machine);
     await vi.runAllTimersAsync();
+    await p;
+    expect(window.__roundDecisionGuard).toBeTruthy();
     vi.useRealTimers();
   });
 
@@ -64,6 +56,43 @@ describe("roundDecisionEnter", () => {
 
     await mod.roundDecisionEnter(machine);
     expect(resolveRound).toHaveBeenCalledOnce();
+    expect(window.__roundDecisionGuard).toBeNull();
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+  });
+
+  it("handles errors during immediate resolution", async () => {
+    vi.useFakeTimers();
+    const emitBattleEvent = vi.fn();
+    vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+      emitBattleEvent,
+      onBattleEvent: vi.fn(),
+      offBattleEvent: vi.fn()
+    }));
+    const resolveRound = vi.fn().mockRejectedValue(new Error("boom"));
+    vi.doMock("../../src/helpers/classicBattle/roundResolver.js", () => ({ resolveRound }));
+    vi.doMock("../../src/helpers/battle/index.js", () => ({
+      getStatValue: vi.fn(() => 5)
+    }));
+    vi.doMock("../../src/helpers/classicBattle/cardSelection.js", () => ({
+      getOpponentJudoka: vi.fn(() => ({ stats: { power: 3 } }))
+    }));
+
+    const mod = await import("../../src/helpers/classicBattle/orchestratorHandlers.js");
+    const store = { playerChoice: "power" };
+    const machine = {
+      context: { store },
+      dispatch: vi.fn(),
+      getState: vi.fn(() => "roundDecision")
+    };
+
+    await mod.roundDecisionEnter(machine);
+    expect(emitBattleEvent).toHaveBeenCalledWith(
+      "scoreboardShowMessage",
+      "Round error. Recovering…"
+    );
+    expect(machine.dispatch).toHaveBeenCalledWith("interrupt", { reason: "roundResolutionError" });
+    expect(window.__roundDecisionGuard).toBeNull();
     await vi.runAllTimersAsync();
     vi.useRealTimers();
   });


### PR DESCRIPTION
## Summary
- clear round decision guard after immediate resolution
- restore error handling for immediate selection path
- expand tests for guard scheduling and error scenarios

## Testing
- `npx prettier . --check`
- `npx eslint .` *(warnings: dispatchBattleEvent unused, loweredTerms unused, _ unused)*
- `npx vitest run`
- `npx playwright test` *(fails: ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2cb7bf72483269191edfa62ff22fd