### PR TITLE
Refactor roundDecisionEnter helpers

### DIFF
--- a/tests/helpers/orchestratorHandlers.roundDecisionEnter.test.js
+++ b/tests/helpers/orchestratorHandlers.roundDecisionEnter.test.js
@@ -7,7 +7,7 @@ beforeEach(() => {
 });
 
 describe("roundDecisionEnter", () => {
-  it("schedules a decision guard", async () => {
+  it("clears the decision guard after immediate resolution", async () => {
     vi.useFakeTimers();
     vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
       emitBattleEvent: vi.fn(),
@@ -33,7 +33,7 @@ describe("roundDecisionEnter", () => {
     };
 
     await mod.roundDecisionEnter(machine);
-    expect(window.__roundDecisionGuard).toBeTruthy();
+    expect(window.__roundDecisionGuard).toBeNull();
     await vi.runAllTimersAsync();
     vi.useRealTimers();
   });


### PR DESCRIPTION
## Summary
- handle errors during immediate selection resolution and clear scheduled guard
- adjust roundDecisionEnter tests for guard cleanup

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: skip-cooldown flow and others)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2cb68785c8326b7944d3c4567515e