### PR TITLE
docs: clarify round resolution comment

### DIFF
--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -422,6 +422,7 @@ export async function roundDecisionEnter(machine) {
   scheduleRoundDecisionGuard(store, machine);
 
   try {
+    // Attempt immediate resolution; returns true if round already resolved.
     const resolved = await resolveSelectionIfPresent(store);
     if (resolved) {
       try {


### PR DESCRIPTION
## Summary
- document that `resolveSelectionIfPresent` may end the round early in `roundDecisionEnter`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Browser logs: DBus connection error)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2e37b2690832697cf0f8d841d6787