### PR TITLE
refactor timer rendering through scoreboard

### DIFF
--- a/design/productRequirementsDocuments/prdBattleScoreboard.md
+++ b/design/productRequirementsDocuments/prdBattleScoreboard.md
@@ -17,6 +17,14 @@ The Scoreboard reserves the following DOM IDs for its placeholders so other docs
 
 ---
 
+### API
+
+The Scoreboard exposes functions for updating its displays:
+
+- `updateTimer(seconds)` – render countdown text in `#next-round-timer` or clear it when `seconds <= 0`.
+
+---
+
 ## Problem Statement
 
 In battle game modes (e.g. Classic Battle), players have a real need to receive clear visual feedback between or after rounds. Without this info, it will leave users uncertain about match state, leading to confusion, reduced immersion, and increased risk of game abandonment. Players could feel "lost" due to a lack of timely updates about round outcomes, next steps, or overall progress.

--- a/src/components/Scoreboard.js
+++ b/src/components/Scoreboard.js
@@ -196,6 +196,27 @@ export function showAutoSelect(stat) {
 }
 
 /**
+ * Update the countdown display.
+ *
+ * @pseudocode
+ * 1. Ensure the timer element reference is available.
+ * 2. If `seconds` is less than or equal to 0, clear the timer text.
+ * 3. Otherwise, render `"Time Left: <seconds>s"` inside the timer element.
+ *
+ * @param {number} seconds - Remaining seconds in the countdown.
+ * @returns {void}
+ */
+export function updateTimer(seconds) {
+  ensureRefs();
+  if (!timerEl) return;
+  if (seconds <= 0) {
+    timerEl.textContent = "";
+    return;
+  }
+  timerEl.textContent = `Time Left: ${seconds}s`;
+}
+
+/**
  * Clear the countdown display.
  *
  * @pseudocode

--- a/src/helpers/CooldownRenderer.js
+++ b/src/helpers/CooldownRenderer.js
@@ -31,6 +31,7 @@ export function attachCooldownRenderer(timer, initialRemaining) {
       snackbar.updateSnackbar(text);
     }
     lastRendered = clamped;
+    scoreboard.updateTimer(clamped);
     return clamped;
   };
 
@@ -41,9 +42,6 @@ export function attachCooldownRenderer(timer, initialRemaining) {
       emitBattleEvent("nextRoundCountdownStarted");
     }
     emitBattleEvent("nextRoundCountdownTick", { remaining: clamped });
-    if (clamped <= 0) {
-      scoreboard.clearTimer();
-    }
   };
 
   const onExpired = () => onTick(0);
@@ -51,8 +49,7 @@ export function attachCooldownRenderer(timer, initialRemaining) {
   timer.on("tick", onTick);
   timer.on("expired", onExpired);
   if (typeof initialRemaining === "number") {
-    const clamped = render(initialRemaining);
-    if (clamped <= 0) scoreboard.clearTimer();
+    render(initialRemaining);
   }
   return () => {
     timer.off("tick", onTick);

--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -217,8 +217,8 @@ async function emitSelectionEvent(store, stat, playerVal, opponentVal) {
   try {
     if (typeof process !== "undefined" && process.env && process.env.VITEST) {
       try {
-        const el = document.getElementById("next-round-timer");
-        if (el) el.textContent = "";
+        const sb = await import("../setupScoreboard.js");
+        sb.clearTimer();
       } catch {}
       try {
         const msg = document.getElementById("round-message");

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -580,8 +580,7 @@ export function clearRoundInfo() {
     scoreboard.clearMessage();
   } catch {}
   try {
-    const timerEl = document.getElementById("next-round-timer");
-    if (timerEl) timerEl.textContent = "";
+    scoreboard.clearTimer();
   } catch {}
   try {
     const rr = document.getElementById("round-result");
@@ -1036,11 +1035,9 @@ export function resetBattleUI(store) {
   try {
     scoreboard.clearMessage();
   } catch {}
-  let timerEl;
   try {
-    timerEl = document.getElementById ? document.getElementById("next-round-timer") : null;
+    scoreboard.clearTimer();
   } catch {}
-  if (timerEl) timerEl.textContent = "";
   let roundResultEl;
   try {
     roundResultEl = document.getElementById ? document.getElementById("round-result") : null;

--- a/src/helpers/setupScoreboard.js
+++ b/src/helpers/setupScoreboard.js
@@ -5,6 +5,7 @@ import {
   clearMessage,
   showTemporaryMessage,
   clearTimer,
+  updateTimer,
   showAutoSelect,
   updateRoundCounter,
   clearRoundCounter
@@ -37,6 +38,7 @@ export {
   clearMessage,
   showTemporaryMessage,
   clearTimer,
+  updateTimer,
   showAutoSelect,
   updateRoundCounter,
   clearRoundCounter

--- a/tests/helpers/CooldownRenderer.test.js
+++ b/tests/helpers/CooldownRenderer.test.js
@@ -6,7 +6,8 @@ vi.mock("../../src/helpers/showSnackbar.js", () => ({
 }));
 
 vi.mock("../../src/helpers/setupScoreboard.js", () => ({
-  clearTimer: vi.fn()
+  clearTimer: vi.fn(),
+  updateTimer: vi.fn()
 }));
 
 vi.mock("../../src/helpers/classicBattle/battleEvents.js", () => ({
@@ -54,12 +55,14 @@ describe("attachCooldownRenderer", () => {
 
     timer.emit("tick", 3);
     expect(snackbar.showSnackbar).toHaveBeenCalledWith("Next round in: 3s");
+    expect(scoreboard.updateTimer).toHaveBeenCalledWith(3);
 
     timer.emit("tick", 2);
     expect(snackbar.updateSnackbar).toHaveBeenCalledWith("Next round in: 2s");
+    expect(scoreboard.updateTimer).toHaveBeenCalledWith(2);
 
     timer.emit("tick", 0);
     expect(snackbar.updateSnackbar).toHaveBeenCalledWith("Next round in: 0s");
-    expect(scoreboard.clearTimer).toHaveBeenCalled();
+    expect(scoreboard.updateTimer).toHaveBeenCalledWith(0);
   });
 });

--- a/tests/helpers/autoSelectStat.min.test.js
+++ b/tests/helpers/autoSelectStat.min.test.js
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.doMock("../../src/helpers/setupScoreboard.js", () => ({
-  showAutoSelect: vi.fn()
+  showAutoSelect: vi.fn(),
+  updateTimer: vi.fn(),
+  clearTimer: vi.fn()
 }));
 
 describe("autoSelectStat basic path", () => {

--- a/tests/helpers/classicBattle/debugPanel.test.js
+++ b/tests/helpers/classicBattle/debugPanel.test.js
@@ -24,7 +24,11 @@ vi.mock("../../../src/helpers/showSnackbar.js", () => ({
   showSnackbar: vi.fn(),
   updateSnackbar: vi.fn()
 }));
-vi.mock("../../../src/helpers/setupScoreboard.js", () => ({ showMessage: vi.fn() }));
+vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
+  showMessage: vi.fn(),
+  clearTimer: vi.fn(),
+  updateTimer: vi.fn()
+}));
 vi.mock("../../../src/helpers/battle/index.js", () => ({ showResult: vi.fn() }));
 vi.mock("../../../src/helpers/motionUtils.js", () => ({ shouldReduceMotionSync: () => true }));
 vi.mock("../../../src/utils/scheduler.js", () => ({ onFrame: vi.fn(), cancel: vi.fn() }));

--- a/tests/helpers/classicBattle/interruptHandlers.test.js
+++ b/tests/helpers/classicBattle/interruptHandlers.test.js
@@ -11,7 +11,8 @@ vi.mock("../../../src/helpers/classicBattle/orchestrator.js", () => ({
 }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   showMessage: vi.fn(),
-  clearTimer: vi.fn()
+  clearTimer: vi.fn(),
+  updateTimer: vi.fn()
 }));
 vi.mock("../../../src/utils/scheduler.js", () => ({
   stop: vi.fn(),

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -28,6 +28,7 @@ beforeEach(() => {
     showMessage,
     clearMessage,
     clearTimer,
+    updateTimer: vi.fn(),
     updateScore: vi.fn(),
     showAutoSelect: vi.fn()
   }));

--- a/tests/helpers/classicBattle/orchestrator.events.test.js
+++ b/tests/helpers/classicBattle/orchestrator.events.test.js
@@ -16,7 +16,9 @@ describe("classic battle orchestrator UI events", () => {
     updateDebugPanel.mockClear();
     vi.doMock("../../../src/helpers/setupScoreboard.js", () => ({
       clearMessage,
-      showMessage
+      showMessage,
+      clearTimer: vi.fn(),
+      updateTimer: vi.fn()
     }));
     vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
       updateDebugPanel

--- a/tests/helpers/classicBattle/pauseTimer.test.js
+++ b/tests/helpers/classicBattle/pauseTimer.test.js
@@ -63,6 +63,7 @@ describe("classicBattle timer pause", () => {
       showMessage,
       showTemporaryMessage: () => () => {},
       clearTimer: vi.fn(),
+      updateTimer: vi.fn(),
       clearMessage: vi.fn(),
       updateScore: vi.fn(),
       showAutoSelect: vi.fn(),

--- a/tests/helpers/classicBattle/resetBattleUI.helpers.test.js
+++ b/tests/helpers/classicBattle/resetBattleUI.helpers.test.js
@@ -6,7 +6,8 @@ vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
 }));
 
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
-  clearMessage: vi.fn()
+  clearMessage: vi.fn(),
+  clearTimer: vi.fn()
 }));
 
 vi.mock("../../../src/helpers/classicBattle/uiService.js", () => ({
@@ -78,7 +79,7 @@ describe("resetBattleUI helpers", () => {
       clearRoundInfo();
 
       expect(scoreboard.clearMessage).toHaveBeenCalledTimes(1);
-      expect(document.getElementById("next-round-timer").textContent).toBe("");
+      expect(scoreboard.clearTimer).toHaveBeenCalledTimes(1);
       expect(document.getElementById("round-result").textContent).toBe("");
       expect(uiService.syncScoreDisplay).toHaveBeenCalledTimes(1);
     });

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -13,7 +13,9 @@ describe("timerService drift handling", () => {
     vi.doMock("../../../src/helpers/setupScoreboard.js", () => ({
       showMessage,
       showTemporaryMessage: () => () => {},
-      showAutoSelect: vi.fn()
+      showAutoSelect: vi.fn(),
+      clearTimer: vi.fn(),
+      updateTimer: vi.fn()
     }));
     vi.doMock("../../../src/helpers/timerUtils.js", () => ({
       getDefaultTimer: () => 30
@@ -41,7 +43,9 @@ describe("timerService drift handling", () => {
     vi.doMock("../../../src/helpers/setupScoreboard.js", () => ({
       showMessage,
       showTemporaryMessage: () => () => {},
-      showAutoSelect: vi.fn()
+      showAutoSelect: vi.fn(),
+      clearTimer: vi.fn(),
+      updateTimer: vi.fn()
     }));
     vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
       enableNextRoundButton: vi.fn(),

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -15,7 +15,8 @@ describe("timerService next round handling", () => {
       showMessage: vi.fn(),
       showTemporaryMessage: () => () => {},
       showAutoSelect: vi.fn(),
-      clearTimer: vi.fn()
+      clearTimer: vi.fn(),
+      updateTimer: vi.fn()
     }));
     vi.doMock("../../../src/helpers/showSnackbar.js", () => ({
       showSnackbar: vi.fn(),
@@ -109,7 +110,9 @@ describe("timerService next round handling", () => {
 
     expect(snackbarMod.showSnackbar).toHaveBeenCalledWith("Next round in: 3s");
     expect(snackbarMod.updateSnackbar).toHaveBeenCalledWith("Next round in: 2s");
-    expect(scoreboardMod.clearTimer).toHaveBeenCalled();
+    expect(scoreboardMod.updateTimer).toHaveBeenCalledWith(3);
+    expect(scoreboardMod.updateTimer).toHaveBeenCalledWith(2);
+    expect(scoreboardMod.updateTimer).toHaveBeenCalledWith(0);
   });
 
   it("resolves ready after minimum cooldown in test mode", async () => {

--- a/tests/helpers/classicBattle/timerStateExposure.test.js
+++ b/tests/helpers/classicBattle/timerStateExposure.test.js
@@ -11,7 +11,9 @@ vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
 }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   clearMessage: vi.fn(),
-  showMessage: vi.fn()
+  showMessage: vi.fn(),
+  clearTimer: vi.fn(),
+  updateTimer: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
   updateDebugPanel: vi.fn()

--- a/tests/helpers/classicBattlePage.startRoundWrapper.test.js
+++ b/tests/helpers/classicBattlePage.startRoundWrapper.test.js
@@ -28,7 +28,9 @@ describe("startRoundWrapper failures", () => {
     }));
     vi.doMock("../../src/helpers/setupScoreboard.js", () => ({
       setupScoreboard: vi.fn(),
-      showMessage
+      showMessage,
+      updateTimer: vi.fn(),
+      clearTimer: vi.fn()
     }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({
       initTooltips: vi.fn().mockResolvedValue(() => {})

--- a/tests/helpers/classicBattlePage.syncScoreDisplay.test.js
+++ b/tests/helpers/classicBattlePage.syncScoreDisplay.test.js
@@ -53,7 +53,9 @@ describe("syncScoreDisplay", () => {
           document.body.appendChild(el);
         }
         el.textContent = `You: ${p}\nOpponent: ${o}`;
-      }
+      },
+      clearTimer: vi.fn(),
+      updateTimer: vi.fn()
     }));
 
     vi.doMock("../../src/config/loadSettings.js", () => ({

--- a/tests/helpers/scoreboard.integration.test.js
+++ b/tests/helpers/scoreboard.integration.test.js
@@ -96,7 +96,7 @@ describe("Scoreboard integration without explicit init", () => {
     expect(scoreText).toContain("You: 2");
     expect(scoreText).toContain("Opponent: 1");
 
-    // Round timer (selection phase) writes directly to #next-round-timer
+    // Round timer (selection phase) updates #next-round-timer via scoreboard.updateTimer
     const { startTimer } = await import("../../src/helpers/classicBattle/timerService.js");
     const promise = startTimer(async () => {});
     // Initial tick shows 3

--- a/tests/helpers/timerService.ordering.test.js
+++ b/tests/helpers/timerService.ordering.test.js
@@ -13,7 +13,8 @@ describe("timerService timeout ordering", () => {
       clearTimer: () => {},
       showMessage: () => {},
       showAutoSelect: () => {},
-      showTemporaryMessage: () => () => {}
+      showTemporaryMessage: () => () => {},
+      updateTimer: () => {}
     }));
     vi.doMock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
       updateDebugPanel: () => {}

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -12,6 +12,11 @@ const gokyoFixture = JSON.parse(readFileSync(path.join(__dirname, "../fixtures/g
  * 1. Create a <header> element.
  * 2. Inject paragraphs for round message, next round timer, and score display.
  * 3. Return the populated header element.
+ *
+ * @example
+ * const header = createScoreboardHeader();
+ * document.body.appendChild(header);
+ * scoreboard.updateTimer(5); // Renders "Time Left: 5s"
  */
 export function createScoreboardHeader() {
   const header = document.createElement("header");
@@ -30,6 +35,11 @@ export function createScoreboardHeader() {
  * 1. Create a <header> element.
  * 2. Populate it with round message, next round timer, and score display paragraphs.
  * 3. Return the header element.
+ *
+ * @example
+ * const header = createBattleHeader();
+ * document.body.appendChild(header);
+ * scoreboard.updateTimer(10); // Renders "Time Left: 10s"
  */
 export function createBattleHeader() {
   const header = document.createElement("header");


### PR DESCRIPTION
## Summary
- add `updateTimer(seconds)` to Scoreboard to centralize countdown rendering
- route classic battle timers through `scoreboard.updateTimer` instead of direct DOM writes
- document new API and update test helpers/examples

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 6 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2e41942388326837531163b3c40f4