### PR TITLE
feat: guard round outcomes with data-outcome flag

### DIFF
--- a/design/productRequirementsDocuments/prdBattleScoreboard.md
+++ b/design/productRequirementsDocuments/prdBattleScoreboard.md
@@ -10,7 +10,7 @@ Displays round messages, stat selection timer, and live match score in the page 
 
 The Scoreboard reserves the following DOM IDs for its placeholders so other docs and code can reference them consistently:
 
-- `#round-message` – round outcomes and status messages
+- `#round-message` – round outcomes and status messages (outcome messages set `data-outcome="true"` to prevent placeholders like "Waiting…" from overwriting them)
 - `#next-round-timer` – stat selection timer
 - `#score-display` – player vs opponent score
 - `#round-counter` – current round number

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -107,7 +107,7 @@ export function bindRoundUIEventHandlers() {
     // Update the round message with the resolved outcome to keep #round-message
     // in sync even when uiService is mocked in unit tests.
     try {
-      scoreboard.showMessage(result.message || "");
+      scoreboard.showMessage(result.message || "", { outcome: true });
     } catch {}
     syncScoreDisplay();
     if (result.matchEnded) {
@@ -197,7 +197,7 @@ export function bindRoundUIEventHandlersDynamic() {
     } catch {}
     try {
       const scoreboard = await import("../setupScoreboard.js");
-      scoreboard.showMessage(result.message || "");
+      scoreboard.showMessage(result.message || "", { outcome: true });
       scoreboard.syncScoreDisplay?.();
     } catch {}
     if (result.matchEnded) {

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -315,7 +315,7 @@ export function updateDebugPanel() {
  */
 export function showRoundOutcome(message) {
   showResult(message);
-  scoreboard.showMessage(message);
+  scoreboard.showMessage(message, { outcome: true });
   // Outcome messages belong in the round message region; avoid using snackbar
   // here so countdowns and hints can occupy it consistently.
 }

--- a/tests/components/Scoreboard.test.js
+++ b/tests/components/Scoreboard.test.js
@@ -64,4 +64,23 @@ describe("Scoreboard component", () => {
     updateScore(2, 3);
     expect(document.getElementById("score-display").textContent).toBe("You: 2\nOpponent: 3");
   });
+
+  it("prevents placeholders from overriding localized outcomes", () => {
+    showMessage("¡Ganas la ronda!", { outcome: true });
+    showMessage("Waiting…");
+    const msg = document.getElementById("round-message");
+    expect(msg.textContent).toBe("¡Ganas la ronda!");
+    expect(msg.dataset.outcome).toBe("true");
+    showMessage("Next round");
+    expect(msg.textContent).toBe("Next round");
+    expect(msg.dataset.outcome).toBeUndefined();
+  });
+
+  it("allows fallback placeholder when no outcome is set", () => {
+    showMessage("Some info");
+    showMessage("Waiting…");
+    const msg = document.getElementById("round-message");
+    expect(msg.textContent).toBe("Waiting…");
+    expect(msg.dataset.outcome).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- replace regex-based outcome detection with `data-outcome` flag
- mark outcome messages at call sites and document flag behavior
- expand scoreboard tests for localized outcomes and fallbacks

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 7)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2e40662cc8326ab7e70465785eaf3