### PR TITLE
feat: add auto-select feature flag

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -168,7 +168,13 @@ Notes:
 - Reuse hooks: Keep `#round-message` and a countdown/prompt surface matching Classic Battle test expectations to minimize new test code.  
 - Accessibility: Use `role="status"`/`aria-live="polite"` for prompts and outcomes; ensure semantic headings and landmarks.  
 - Data and settings: Use existing settings defaults for win target; persist locally via the shared helper.  
-- Logging: Route verbose/diagnostic output through a muted logger helper in tests to keep CI clean.  
+- Logging: Route verbose/diagnostic output through a muted logger helper in tests to keep CI clean.
+
+---
+
+## Feature flags & defaults
+
+- `autoSelect` — boolean, default: `true`. When enabled, the timer auto-selects a random stat on expiry. Players can toggle this in Settings.
 
 ---
 

--- a/design/productRequirementsDocuments/prdBattleClassic.md
+++ b/design/productRequirementsDocuments/prdBattleClassic.md
@@ -222,7 +222,7 @@ This section lists small, implementer-facing contracts to reduce ambiguity betwe
 
   List of feature flags and their intended defaults for Classic Battle. Implementations should read these from the global feature-flag service or `src/config/battleDefaults.js` when available.
 
-  - `autoSelect` — boolean, default: `true`. When enabled, the system auto-selects a random stat on timer expiry.
+  - `autoSelect` — boolean, default: `true`. When enabled, the system auto-selects a random stat on timer expiry. The setting can be toggled from the Settings page.
   - `battleDebugPanel` — boolean, default: `false`. When enabled, show debug panel above the cards with copy/export controls.
   - `testMode` — boolean, default: `false` (test-only). When enabled, allow `battle.testRandomSeed` and fast AI delays for deterministic tests.
   - `statHotkeys` — boolean, default: `false`. When enabled, number keys 1–5 map to stat buttons (left→right).

--- a/playwright/auto-select-disabled.spec.js
+++ b/playwright/auto-select-disabled.spec.js
@@ -1,0 +1,21 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+import { waitForBattleState } from "./fixtures/waits.js";
+
+test("does not auto-select when flag disabled", async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({
+        featureFlags: {
+          enableTestMode: { enabled: true },
+          autoSelect: { enabled: false }
+        }
+      })
+    );
+    window.__NEXT_ROUND_COOLDOWN_MS = 0;
+  });
+  await page.goto("/src/pages/battleCLI.html");
+  await waitForBattleState(page, "waitingForPlayerAction", 15000);
+  await waitForBattleState(page, "interruptRound", 10000);
+  await expect(page.locator("#round-message")).toContainText(/Round interrupted/i);
+});

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -17,6 +17,10 @@
   },
   "gameModes": {},
   "featureFlags": {
+    "autoSelect": {
+      "enabled": true,
+      "tooltipId": "settings.autoSelect"
+    },
     "battleDebugPanel": {
       "enabled": false,
       "tooltipId": "settings.battleDebugPanel"

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -105,6 +105,10 @@
     "battleStateBadge": {
       "label": "Battle State Badge",
       "description": "Show the current match state in the header for testing."
+    },
+    "autoSelect": {
+      "label": "Auto Select",
+      "description": "Automatically choose a stat when the timer expires."
     }
   },
   "card": {

--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -5,6 +5,7 @@ import { dispatchBattleEvent } from "./eventDispatcher.js";
 import { resolveRound } from "./roundResolver.js";
 import { getCardStatValue } from "./cardStatUtils.js";
 import { getBattleState } from "./eventBus.js";
+import { isEnabled } from "../featureFlags.js";
 const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
 
 /**
@@ -195,7 +196,9 @@ function applySelectionToStore(store, stat, playerVal, opponentVal) {
 function cleanupTimers(store) {
   stopTimer();
   clearTimeout(store.statTimeoutId);
-  clearTimeout(store.autoSelectId);
+  if (isEnabled("autoSelect")) {
+    clearTimeout(store.autoSelectId);
+  }
 }
 
 /**

--- a/src/helpers/settings/featureFlagSwitches.js
+++ b/src/helpers/settings/featureFlagSwitches.js
@@ -87,11 +87,26 @@ export function renderFeatureFlagSwitches(
 ) {
   if (!container || !flags) return;
   Object.keys(flags).forEach((flag) => {
-    const kebab = flag.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
     const info = flags[flag];
     const tipId = info.tooltipId || `settings.${flag}`;
     const label = tooltipMap[`${tipId}.label`] || formatFlagLabel(flag);
+    const existing = container.querySelector(`[data-flag="${flag}"]`);
     const getDescription = () => tooltipMap[`${tipId}.description`] || "";
+    if (existing) {
+      existing.checked = Boolean(getCurrentSettings().featureFlags[flag]?.enabled);
+      existing.addEventListener("change", () =>
+        handleFeatureFlagChange({
+          input: existing,
+          flag,
+          info,
+          label: tooltipMap[`${tipId}.label`] || flag,
+          getCurrentSettings,
+          handleUpdate
+        })
+      );
+      return;
+    }
+    const kebab = flag.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
     const description = getDescription();
     const toggle = new ToggleSwitch(label, {
       id: `feature-${kebab}`,

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -11,6 +11,7 @@ import { STATS } from "../helpers/BattleEngine.js";
 import { setPointsToWin } from "../helpers/battleEngineFacade.js";
 import { fetchJson } from "../helpers/dataUtils.js";
 import { DATA_DIR } from "../helpers/constants.js";
+import { isEnabled } from "../helpers/featureFlags.js";
 
 /**
  * Minimal DOM utils for the CLI page
@@ -326,6 +327,7 @@ function installEventBindings() {
       } catch {}
       try {
         cooldownTimer = setTimeout(() => {
+          if (!isEnabled("autoSelect")) return;
           try {
             emitBattleEvent("countdownFinished");
           } catch {}

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -221,6 +221,25 @@
           </fieldset>
           <fieldset id="feature-flags-container" class="game-mode-toggle-container settings-form">
             <legend>Advanced Settings</legend>
+            <div class="settings-item">
+              <label for="feature-auto-select" class="switch">
+                <input
+                  type="checkbox"
+                  id="feature-auto-select"
+                  name="autoSelect"
+                  aria-label="Auto Select"
+                  aria-describedby="feature-auto-select-desc"
+                  data-flag="autoSelect"
+                  data-tooltip-id="settings.autoSelect"
+                  checked
+                />
+                <div class="slider round"></div>
+                <span>Auto Select</span>
+              </label>
+              <p id="feature-auto-select-desc" class="settings-description">
+                Automatically choose a stat when the timer expires.
+              </p>
+            </div>
             <!-- Flag toggles are inserted here dynamically -->
           </fieldset>
           <fieldset id="links-container" class="settings-form">

--- a/tests/fixtures/gameTimers.json
+++ b/tests/fixtures/gameTimers.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": 1,
+    "skill": 1,
+    "value": 60,
+    "default": false,
+    "required": true,
+    "category": "roundTimer",
+    "description": "A LOW round timer that IS required"
+  },
+  {
+    "id": 2,
+    "skill": 2,
+    "value": 1,
+    "default": true,
+    "required": true,
+    "category": "roundTimer",
+    "description": "A MEDIUM round timer that IS required"
+  },
+  {
+    "id": 3,
+    "skill": 3,
+    "value": 10,
+    "default": false,
+    "required": true,
+    "category": "roundTimer",
+    "description": "A HIGH round timer that IS required"
+  },
+  {
+    "id": 4,
+    "skill": 1,
+    "value": 5,
+    "default": false,
+    "required": true,
+    "category": "coolDownTimer",
+    "description": "A LOW cooldown timer that IS required"
+  },
+  {
+    "id": 5,
+    "skill": 2,
+    "value": 3,
+    "default": true,
+    "required": true,
+    "category": "coolDownTimer",
+    "description": "A MEDIUM cooldown timer that IS required"
+  },
+  {
+    "id": 6,
+    "skill": 3,
+    "value": 0,
+    "default": false,
+    "required": false,
+    "category": "coolDownTimer",
+    "description": "A HIGH cooldown timer that IS NOT required"
+  },
+  {
+    "id": 7,
+    "skill": 1,
+    "value": 5,
+    "default": false,
+    "required": true,
+    "category": "matchStartTimer",
+    "description": "A LOW match start timer that IS required"
+  },
+  {
+    "id": 8,
+    "skill": 2,
+    "value": 3,
+    "default": true,
+    "required": true,
+    "category": "matchStartTimer",
+    "description": "A MEDIUM match start timer that IS required"
+  },
+  {
+    "id": 9,
+    "skill": 3,
+    "value": 0,
+    "default": false,
+    "required": false,
+    "category": "matchStartTimer",
+    "description": "A HIGH match start timer that IS NOT required"
+  }
+]

--- a/tests/helpers/timerService.autoSelectFlag.test.js
+++ b/tests/helpers/timerService.autoSelectFlag.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockScheduler } from "./mockScheduler.js";
+let scheduler;
+
+vi.mock("../../src/helpers/showSnackbar.js", () => ({
+  showSnackbar: () => {},
+  updateSnackbar: () => {}
+}));
+
+vi.mock("../../src/helpers/setupScoreboard.js", () => ({
+  clearTimer: vi.fn(),
+  showMessage: () => {},
+  showAutoSelect: () => {},
+  showTemporaryMessage: () => () => {},
+  updateTimer: vi.fn()
+}));
+
+vi.mock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
+  updateDebugPanel: () => {}
+}));
+
+vi.mock("../../src/helpers/testModeUtils.js", () => ({
+  seededRandom: () => 0,
+  isTestModeEnabled: () => false
+}));
+
+vi.mock("../../src/helpers/timerUtils.js", () => ({
+  getDefaultTimer: () => Promise.resolve(1)
+}));
+
+vi.mock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+  dispatchBattleEvent: () => Promise.resolve()
+}));
+
+describe("timerService autoSelect flag", () => {
+  beforeEach(() => {
+    scheduler = createMockScheduler();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.doMock("../../src/helpers/battleEngineFacade.js", () => {
+      const makeTimer = (onTick, onExpired, duration) => {
+        onTick(duration);
+        for (let i = 1; i <= duration; i++) {
+          scheduler.setTimeout(() => {
+            const remaining = duration - i;
+            onTick(remaining);
+            if (remaining <= 0) onExpired();
+          }, i * 1000);
+        }
+      };
+      return {
+        startRound: makeTimer,
+        startCoolDown: makeTimer,
+        stopTimer: vi.fn(),
+        STATS: ["a", "b"]
+      };
+    });
+  });
+
+  it("auto-select triggers when flag enabled", async () => {
+    const mockAuto = vi.fn();
+    vi.doMock("../../src/helpers/featureFlags.js", () => ({ isEnabled: () => true }));
+    vi.doMock("../../src/helpers/classicBattle/autoSelectStat.js", () => ({
+      autoSelectStat: mockAuto
+    }));
+    const { startTimer } = await import("../../src/helpers/classicBattle/timerService.js");
+    await startTimer(async () => {});
+    scheduler.tick(1000);
+    expect(mockAuto).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips auto-select when flag disabled", async () => {
+    const mockAuto = vi.fn();
+    vi.doMock("../../src/helpers/featureFlags.js", () => ({ isEnabled: () => false }));
+    vi.doMock("../../src/helpers/classicBattle/autoSelectStat.js", () => ({
+      autoSelectStat: mockAuto
+    }));
+    const { startTimer } = await import("../../src/helpers/classicBattle/timerService.js");
+    await startTimer(async () => {});
+    scheduler.tick(1000);
+    expect(mockAuto).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `autoSelect` feature flag with tooltip and Settings toggle
- guard auto-selection logic in timer and CLI via `isEnabled('autoSelect')`
- document flag and cover with Vitest & Playwright

## Testing
- `npm run validate:data`
- `npx prettier . --check`
- `npx eslint .` *(warnings: unused vars in unrelated files)*
- `npx vitest run`
- `npx playwright test` *(fails: timed out waiting for battle state; resource fetch ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2ea15949483268d2af7bd276d9556