### PR TITLE
feat: add CLI verbose flag

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -75,11 +75,14 @@ A terminal-style Classic Battle ensures **fast load, consistent behavior, and im
 | **P1** | Accessibility Hooks | Provide `aria-live="polite"` for round messages and countdown; maintain focus order for keyboard use. |
 | **P1** | Test Hooks | Expose stable selectors/ids (e.g., `#round-message`, `#cli-score`, `#cli-countdown`, `data-flag`) to support existing tests and new CLI tests. |
 | **P2** | Minimal Settings | Allow selecting win target (5/10/15) at start; persist last choice using existing settings helper. |
-| **P2** | Observability Mode | Optional verbose logs (guarded by `data-flag="FF_CLI_VERBOSE"`) that echo internal state transitions. |
+| **P2** | Observability Mode | Optional verbose logs (controlled by the `cliVerbose` feature flag) that echo internal state transitions. |
 | **P2** | Interrupt Handling | Surface quit/interrupt flows as text prompts; roll back to last completed round consistent with engine PRD. |
 | **P3** | Retro Mode | Optional ASCII borders and simple color accents via CSS classes; disabled by default for maximum contrast. |
 
-Notes:  
+### Feature Flags
+- `cliVerbose` – toggles the verbose log section on the CLI page; disabled by default.
+
+Notes:
 - Core gameplay and timers must not use dynamic imports in hot paths. Optional features (e.g., Retro Mode) may be dynamically imported but preloaded during idle if enabled.  
 - Maintain the scoreboard/snackbar surface contract where feasible: `#round-message` for outcomes and a dedicated area for countdown/prompts to keep tests consistent.  
 

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -48,6 +48,10 @@
     "battleStateBadge": {
       "enabled": false,
       "tooltipId": "settings.battleStateBadge"
+    },
+    "cliVerbose": {
+      "enabled": false,
+      "tooltipId": "settings.cliVerbose"
     }
   }
 }

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -105,6 +105,10 @@
     "battleStateBadge": {
       "label": "Battle State Badge",
       "description": "Show the current match state in the header for testing."
+    },
+    "cliVerbose": {
+      "label": "CLI Verbose Logging",
+      "description": "Show state transition logs in the battle CLI."
     }
   },
   "card": {

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -222,6 +222,23 @@
           <fieldset id="feature-flags-container" class="game-mode-toggle-container settings-form">
             <legend>Advanced Settings</legend>
             <!-- Flag toggles are inserted here dynamically -->
+            <div class="settings-item">
+              <label for="feature-cli-verbose" class="switch">
+                <input
+                  type="checkbox"
+                  id="feature-cli-verbose"
+                  data-flag="cliVerbose"
+                  aria-label="CLI Verbose Logging"
+                  aria-describedby="feature-cli-verbose-desc"
+                  data-tooltip-id="settings.cliVerbose"
+                />
+                <div class="slider round"></div>
+                <span>CLI Verbose Logging</span>
+              </label>
+              <p id="feature-cli-verbose-desc" class="settings-description">
+                Show state transition logs in the battle CLI.
+              </p>
+            </div>
           </fieldset>
           <fieldset id="links-container" class="settings-form">
             <legend>Links</legend>

--- a/tests/pages/battleCLI.verboseFlag.test.js
+++ b/tests/pages/battleCLI.verboseFlag.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+async function loadBattleCLI(flagEnabled) {
+  const emitter = new EventTarget();
+  vi.doMock("../../src/helpers/featureFlags.js", () => ({
+    initFeatureFlags: vi
+      .fn()
+      .mockResolvedValue({ featureFlags: { cliVerbose: { enabled: flagEnabled } } }),
+    isEnabled: vi.fn().mockReturnValue(flagEnabled),
+    setFlag: vi.fn(),
+    featureFlagsEmitter: emitter
+  }));
+  vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+    createBattleStore: vi.fn(() => ({})),
+    startRound: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    onBattleEvent: vi.fn(),
+    emitBattleEvent: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: [] }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({ setPointsToWin: vi.fn() }));
+  vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson: vi.fn().mockResolvedValue([]) }));
+  vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+  const mod = await import("../../src/pages/battleCLI.js");
+  return mod;
+}
+
+describe("battleCLI verbose flag", () => {
+  beforeEach(() => {
+    window.__TEST__ = true;
+    document.body.innerHTML = `
+      <section id="cli-verbose-section" hidden>
+        <pre id="cli-verbose-log"></pre>
+      </section>
+      <input id="verbose-toggle" type="checkbox" />
+    `;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.__TEST__;
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doUnmock("../../src/helpers/featureFlags.js");
+    vi.doUnmock("../../src/helpers/classicBattle/roundManager.js");
+    vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+    vi.doUnmock("../../src/helpers/classicBattle/battleEvents.js");
+    vi.doUnmock("../../src/helpers/BattleEngine.js");
+    vi.doUnmock("../../src/helpers/battleEngineFacade.js");
+    vi.doUnmock("../../src/helpers/dataUtils.js");
+    vi.doUnmock("../../src/helpers/constants.js");
+  });
+
+  it("does not log state changes when cliVerbose is disabled", async () => {
+    const mod = await loadBattleCLI(false);
+    await mod.__test.init();
+    document.dispatchEvent(new CustomEvent("battle:state", { detail: { from: "a", to: "b" } }));
+    expect(document.getElementById("cli-verbose-log").textContent).toBe("");
+  });
+
+  it("logs state changes when cliVerbose is enabled", async () => {
+    const mod = await loadBattleCLI(true);
+    await mod.__test.init();
+    document.dispatchEvent(
+      new CustomEvent("battle:state", { detail: { from: "start", to: "end" } })
+    );
+    expect(document.getElementById("cli-verbose-log").textContent).toMatch(/start -> end/);
+  });
+});


### PR DESCRIPTION
## Summary
- add `cliVerbose` feature flag with tooltip and settings toggle
- wire battleCLI verbose section to feature flag updates
- document CLI verbose mode and test log visibility

## Testing
- `npm run validate:data`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 9)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2ea0f3fa483269b216c2589619bba