### PR TITLE
feat: add auto-select feature flag

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -81,6 +81,8 @@ A terminal-style Classic Battle ensures **fast load, consistent behavior, and im
 
 ### Feature Flags
 - `cliVerbose` – toggles the verbose log section on the CLI page; disabled by default.
+- `autoSelect` – when enabled (default), the match auto-picks a random stat when the selection timer expires.
+  When disabled, the CLI waits for manual input after timeout.
 
 Notes:
 - Core gameplay and timers must not use dynamic imports in hot paths. Optional features (e.g., Retro Mode) may be dynamically imported but preloaded during idle if enabled.  

--- a/design/productRequirementsDocuments/prdBattleClassic.md
+++ b/design/productRequirementsDocuments/prdBattleClassic.md
@@ -223,6 +223,7 @@ This section lists small, implementer-facing contracts to reduce ambiguity betwe
   List of feature flags and their intended defaults for Classic Battle. Implementations should read these from the global feature-flag service or `src/config/battleDefaults.js` when available.
 
   - `autoSelect` — boolean, default: `true`. When enabled, the system auto-selects a random stat on timer expiry.
+    When disabled, the timer expires without choosing a stat and the player must pick manually.
   - `battleDebugPanel` — boolean, default: `false`. When enabled, show debug panel above the cards with copy/export controls.
   - `testMode` — boolean, default: `false` (test-only). When enabled, allow `battle.testRandomSeed` and fast AI delays for deterministic tests.
   - `statHotkeys` — boolean, default: `false`. When enabled, number keys 1–5 map to stat buttons (left→right).

--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -49,6 +49,31 @@ test.describe("Classic battle flow", () => {
     await expect(page.locator("#stat-buttons button").first()).toBeEnabled({ timeout: 5000 });
   });
 
+  test("does not auto-select when flag disabled", async ({ page }) => {
+    test.setTimeout(45000);
+    await page.addInitScript(() => {
+      window.__NEXT_ROUND_COOLDOWN_MS = 0;
+      localStorage.setItem(
+        "settings",
+        JSON.stringify({
+          featureFlags: {
+            enableTestMode: { enabled: false },
+            autoSelect: { enabled: false }
+          }
+        })
+      );
+    });
+    await page.goto("/src/pages/battleJudoka.html");
+    const roundOptions = page.locator(".round-select-buttons button");
+    await roundOptions.first().click();
+    await expect(page.locator(".modal-backdrop:not([hidden])")).toHaveCount(0);
+    await waitForBattleReady(page);
+    await expect(page.locator(".snackbar")).toHaveText(/Stat selection stalled/, {
+      timeout: 45000
+    });
+    await expect(page.locator("#stat-buttons button").first()).toBeEnabled();
+  });
+
   test("tie message appears on equal stats", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html");
     await page.locator("#round-select-1").click();

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -52,6 +52,10 @@
     "cliVerbose": {
       "enabled": false,
       "tooltipId": "settings.cliVerbose"
+    },
+    "autoSelect": {
+      "enabled": true,
+      "tooltipId": "settings.autoSelect"
     }
   }
 }

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -109,6 +109,10 @@
     "cliVerbose": {
       "label": "CLI Verbose Logging",
       "description": "Show state transition logs in the battle CLI."
+    },
+    "autoSelect": {
+      "label": "Auto-Select",
+      "description": "Automatically pick a random stat when time runs out."
     }
   },
   "card": {

--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -192,10 +192,12 @@ function applySelectionToStore(store, stat, playerVal, opponentVal) {
  *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
  */
-function cleanupTimers(store) {
+export function cleanupTimers(store) {
   stopTimer();
   clearTimeout(store.statTimeoutId);
+  store.statTimeoutId = null;
   clearTimeout(store.autoSelectId);
+  store.autoSelectId = null;
 }
 
 /**

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -312,6 +312,12 @@ function installEventBindings() {
   });
   onBattleEvent("scoreboardClearMessage", () => setRoundMessage(""));
 
+  onBattleEvent("statSelectionStalled", () => {
+    if (!isEnabled("autoSelect")) {
+      showBottomLine("Stat selection stalled. Pick a stat.");
+    }
+  });
+
   // CLI-specific countdown handler
   onBattleEvent("countdownStart", (e) => {
     const duration = Number(e.detail?.duration) || 0;

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -239,6 +239,24 @@
                 Show state transition logs in the battle CLI.
               </p>
             </div>
+            <div class="settings-item">
+              <label for="feature-auto-select" class="switch">
+                <input
+                  type="checkbox"
+                  id="feature-auto-select"
+                  data-flag="autoSelect"
+                  aria-label="Auto-Select"
+                  aria-describedby="feature-auto-select-desc"
+                  data-tooltip-id="settings.autoSelect"
+                  checked
+                />
+                <div class="slider round"></div>
+                <span>Auto-Select</span>
+              </label>
+              <p id="feature-auto-select-desc" class="settings-description">
+                Automatically pick a random stat when time runs out.
+              </p>
+            </div>
           </fieldset>
           <fieldset id="links-container" class="settings-form">
             <legend>Links</legend>

--- a/tests/helpers/classicBattle/autoSelect.test.js
+++ b/tests/helpers/classicBattle/autoSelect.test.js
@@ -69,4 +69,18 @@ describe("classicBattle auto select", () => {
     // Ensure we surfaced the win message; cooldown drift hints must not overwrite it
     expect(msg).toMatch(/win the round/i);
   });
+
+  it("does not auto-select when feature flag disabled", async () => {
+    currentFlags.autoSelect.enabled = false;
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { initClassicBattleTest } = await import("./initClassicBattle.js");
+    const battleMod = await initClassicBattleTest({ afterMock: true });
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+    await battleMod.startRound(store, battleMod.applyRoundUI);
+    await vi.advanceTimersByTimeAsync(30000);
+    await vi.runAllTimersAsync();
+    const score = document.querySelector("header #score-display").textContent;
+    expect(score).toBe("You: 0\nOpponent: 0");
+  });
 });

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -42,7 +42,8 @@ describe("classicBattle stalled stat selection recovery", () => {
       fetchJsonMock,
       generateRandomCardMock,
       getRandomJudokaMock,
-      renderMock
+      renderMock,
+      currentFlags: { autoSelect: { enabled: true } }
     });
     vi.spyOn(Math, "random").mockReturnValue(0);
   });

--- a/tests/helpers/classicBattle/utils.js
+++ b/tests/helpers/classicBattle/utils.js
@@ -44,7 +44,7 @@ export function setupClassicBattleDom() {
     el.innerHTML = `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     return el;
   });
-  const currentFlags = {};
+  const currentFlags = { autoSelect: { enabled: true } };
 
   return {
     timerSpy,

--- a/tests/helpers/selectionHandler.test.js
+++ b/tests/helpers/selectionHandler.test.js
@@ -36,6 +36,8 @@ vi.mock("../../src/helpers/i18n.js", () => ({
 }));
 
 import { handleStatSelection } from "../../src/helpers/classicBattle.js";
+import { cleanupTimers } from "../../src/helpers/classicBattle/selectionHandler.js";
+import { setFlag } from "../../src/helpers/featureFlags.js";
 
 describe("handleStatSelection helpers", () => {
   let store;
@@ -70,5 +72,16 @@ describe("handleStatSelection helpers", () => {
     expect(document.getElementById("next-round-timer").textContent).toBe("");
     expect(document.getElementById("round-message").textContent).toBe("");
     expect(showSnackbar).toHaveBeenCalledWith("ui.opponentChoosing");
+  });
+
+  it("clears autoSelectId even when feature flag disabled", async () => {
+    const timeout = setTimeout(() => {}, 1000);
+    store.autoSelectId = timeout;
+    await setFlag("autoSelect", false);
+    const spy = vi.spyOn(global, "clearTimeout");
+    cleanupTimers(store);
+    expect(spy).toHaveBeenCalledWith(timeout);
+    expect(store.autoSelectId).toBeNull();
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- add `autoSelect` feature flag and settings toggle
- gate auto-selection timers with `isEnabled("autoSelect")`
- document and test new flag

## Testing
- `npm run validate:data`
- `npx prettier . --check`
- `npx eslint .` (warnings: autoSelectStat.js dispatchBattleEvent unused, scorer.js loweredTerms unused, tests/setup.js _ unused)
- `npx vitest run`
- `npx playwright test` (fails: 11 tests including screenshot and battle flows)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2f4a3729c8326a227c735d152100d