### PR TITLE
fix: respect auto-select flag on timer expiry

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -126,8 +126,11 @@ async function forceAutoSelectAndDispatch(onExpiredSelect) {
  * 2. Start the timer via `engineStartRound` and monitor for drift.
  *    - On drift trigger auto-select logic and dispatch the outcome event.
  * 3. Register a skip handler that stops the timer and triggers `onExpired`.
- * 4. When expired, dispatch "timeout" and call `autoSelectStat` to pick a stat
- *    and invoke `onExpiredSelect` with `delayOpponentMessage`.
+ * 4. When expired:
+ *    - If `isEnabled('autoSelect')`, dispatch "timeout" and call `autoSelectStat`
+ *      to pick a stat and invoke `onExpiredSelect` with `delayOpponentMessage`.
+ *    - Otherwise, keep waiting for manual selection without dispatching a
+ *      battle event.
  *
  * @param {(stat: string, opts?: { delayOpponentMessage?: boolean }) => Promise<void>} onExpiredSelect
  * - Callback to handle stat auto-selection.
@@ -162,16 +165,18 @@ export async function startTimer(onExpiredSelect) {
     // The roundDecision onEnter waits for a short window for playerChoice;
     // if we await the dispatch first, the guard can interrupt before
     // autoSelect runs. Start auto-select immediately and then await the
-    // timeout dispatch so both proceed concurrently.
-    const selecting = isEnabled("autoSelect")
-      ? (async () => {
-          try {
-            await autoSelectStat(onExpiredSelect);
-          } catch {}
-        })()
-      : Promise.resolve();
-    await dispatchBattleEvent("timeout");
-    await selecting;
+    // timeout dispatch so both proceed concurrently. If auto-select is
+    // disabled, skip the timeout dispatch entirely so the player can
+    // continue selecting manually.
+    if (isEnabled("autoSelect")) {
+      const selecting = (async () => {
+        try {
+          await autoSelectStat(onExpiredSelect);
+        } catch {}
+      })();
+      await dispatchBattleEvent("timeout");
+      await selecting;
+    }
   };
 
   try {

--- a/tests/helpers/timerService.autoSelectDisabled.test.js
+++ b/tests/helpers/timerService.autoSelectDisabled.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+
+describe("timerService without auto-select", () => {
+  it("does not dispatch timeout when autoSelect disabled", async () => {
+    vi.resetModules();
+
+    document.body.innerHTML =
+      '<div id="next-round-timer"></div><div id="stat-buttons"><button data-stat="a"></button></div>';
+
+    vi.doMock("../../src/helpers/setupScoreboard.js", () => ({
+      clearTimer: () => {},
+      showMessage: () => {},
+      showAutoSelect: () => {},
+      showTemporaryMessage: () => () => {},
+      updateTimer: () => {}
+    }));
+    vi.doMock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
+      updateDebugPanel: () => {}
+    }));
+    vi.doMock("../../src/helpers/showSnackbar.js", () => ({
+      showSnackbar: () => {},
+      updateSnackbar: () => {}
+    }));
+
+    vi.doMock("../../src/helpers/timerUtils.js", () => ({
+      getDefaultTimer: () => 1
+    }));
+    vi.doMock("../../src/helpers/featureFlags.js", () => ({
+      isEnabled: () => false
+    }));
+    vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+      emitBattleEvent: () => {}
+    }));
+
+    const dispatchSpy = vi.fn();
+    vi.doMock("../../src/helpers/classicBattle/battleDispatcher.js", () => ({
+      dispatchBattleEvent: dispatchSpy
+    }));
+
+    const autoSelectSpy = vi.fn();
+    vi.doMock("../../src/helpers/classicBattle/autoSelectStat.js", () => ({
+      autoSelectStat: autoSelectSpy
+    }));
+
+    vi.doMock("../../src/helpers/timers/createRoundTimer.js", () => ({
+      createRoundTimer: () => {
+        const handlers = { tick: [], expired: [], drift: [] };
+        return {
+          on: (event, fn) => handlers[event]?.push(fn),
+          start: () => {
+            handlers.tick.forEach((fn) => fn(0));
+            handlers.expired.forEach((fn) => fn());
+          },
+          stop: () => {}
+        };
+      }
+    }));
+
+    const mod = await import("../../src/helpers/classicBattle/timerService.js");
+    await mod.startTimer(async () => {});
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(autoSelectSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- prevent `startTimer` from dispatching `timeout` when `autoSelect` flag is disabled
- cover manual-selection behavior with a new test

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings: dispatchBattleEvent unused, loweredTerms unused, _ unused)
- `npx vitest run`
- `npx playwright test` (fails: 11 tests)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b2fb9c93ec83269d6c48ac079cfd05