### PR TITLE
Clamp match start cooldown and add zero-duration test

### DIFF
--- a/tests/helpers/classicBattle/cooldownEnter.zeroDuration.test.js
+++ b/tests/helpers/classicBattle/cooldownEnter.zeroDuration.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
+  emitBattleEvent: vi.fn(),
+  onBattleEvent: vi.fn(),
+  offBattleEvent: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/timerUtils.js", () => ({
+  getDefaultTimer: vi.fn(async () => 0)
+}));
+
+vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
+  getNextRoundControls: vi.fn(() => ({ timer: true }))
+}));
+
+import {
+  cooldownEnter,
+  waitingForPlayerActionEnter
+} from "../../../src/helpers/classicBattle/orchestratorHandlers.js";
+import { emitBattleEvent } from "../../../src/helpers/classicBattle/battleEvents.js";
+import { BattleStateMachine } from "../../../src/helpers/classicBattle/stateMachine.js";
+
+describe("cooldownEnter zero duration", () => {
+  let timer;
+  beforeEach(() => {
+    timer = vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    timer.clearAllTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("enables stat buttons after zero-second matchStart cooldown", async () => {
+    const states = new Map([
+      [
+        "cooldown",
+        { name: "cooldown", triggers: [{ on: "ready", target: "waitingForPlayerAction" }] }
+      ],
+      ["waitingForPlayerAction", { name: "waitingForPlayerAction", triggers: [] }]
+    ]);
+    const machine = new BattleStateMachine(
+      states,
+      "cooldown",
+      { waitingForPlayerAction: waitingForPlayerActionEnter },
+      { store: {} }
+    );
+
+    await cooldownEnter(machine, { initial: true });
+    expect(emitBattleEvent).toHaveBeenCalledWith("countdownStart", { duration: 1 });
+
+    await timer.advanceTimersByTimeAsync(1200);
+    expect(emitBattleEvent).toHaveBeenCalledWith("statButtons:enable");
+  });
+});


### PR DESCRIPTION
## Summary
- Clamp match-start countdown to a minimum of one second and ensure fallback dispatch
- Keep stat buttons enabled by confirming waiting-for-player-action state after zero-duration cooldown
- Add unit test for zero-second cooldown path

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: page.waitForFunction timeout; locator('.snackbar') not found; context dispose error)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b30c6f915083268dc41846bf21ea8f