### PR TITLE
Use snackbar for stat selection stall and test it

### DIFF
--- a/playwright/classicBattleFlow.spec.js
+++ b/playwright/classicBattleFlow.spec.js
@@ -38,6 +38,10 @@ test.describe("Classic battle flow", () => {
     await roundOptions.first().click();
     await expect(page.locator(".modal-backdrop:not([hidden])")).toHaveCount(0);
     await waitForBattleReady(page);
+    // After stall timeout, show prompt before auto-select triggers the next round.
+    await expect(page.locator(".snackbar")).toHaveText(/Stat selection stalled/, {
+      timeout: 10000
+    });
     // Let the timer expire. Current UX shows the next-round countdown
     // via snackbar after auto-select, rather than a "Time's up!" banner.
     // Assert the countdown appears to confirm expiration + auto-pick.

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -2,7 +2,7 @@ import { getDefaultTimer } from "../timerUtils.js";
 import { startRound as engineStartRound } from "../battleEngineFacade.js";
 import * as scoreboard from "../setupScoreboard.js";
 import { updateDebugPanel } from "./uiHelpers.js";
-import * as snackbar from "../showSnackbar.js";
+import { showSnackbar } from "../showSnackbar.js";
 import { t } from "../i18n.js";
 import { setSkipHandler } from "./skipHandler.js";
 import { autoSelectStat } from "./autoSelectStat.js";
@@ -199,7 +199,7 @@ export async function startTimer(onExpiredSelect) {
   timer.on("drift", () => {
     const msgEl = document.getElementById("round-message");
     if (msgEl && msgEl.textContent) {
-      snackbar.showSnackbar(t("ui.waiting"));
+      showSnackbar(t("ui.waiting"));
     } else {
       scoreboard.showMessage(t("ui.waiting"));
     }
@@ -216,7 +216,7 @@ export async function startTimer(onExpiredSelect) {
  * random stat.
  *
  * @pseudocode
- * 1. Display "Stat selection stalled" via `scoreboard.showMessage`.
+ * 1. Display "Stat selection stalled" via `showSnackbar`.
  * 2. After `timeoutMs` milliseconds call `autoSelectStat(onSelect)`.
  *
  * @param {{autoSelectId: ReturnType<typeof setTimeout> | null}} store
@@ -234,7 +234,7 @@ export function handleStatSelectionTimeout(
   store.autoSelectId = scheduler.setTimeout(() => {
     // If a selection was made in the meantime, do nothing.
     if (store && store.selectionMade) return;
-    scoreboard.showMessage(t("ui.statSelectionStalled"));
+    showSnackbar(t("ui.statSelectionStalled"));
     try {
       emitBattleEvent("statSelectionStalled");
     } catch {}
@@ -382,7 +382,7 @@ export function scheduleNextRound(result, scheduler = realScheduler) {
   timer.on("drift", () => {
     const msgEl = document.getElementById("round-message");
     if (msgEl && msgEl.textContent) {
-      snackbar.showSnackbar("Waiting…");
+      showSnackbar("Waiting…");
     } else {
       scoreboard.showMessage("Waiting…");
     }


### PR DESCRIPTION
## Summary
- show stalled stat selection via snackbar
- verify stall prompt and countdown in classic battle flow

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 11 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b30c7935bc832684b626e932a7457f