### PR TITLE
Ensure feature flag fallback and test auto-select accessibility

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -122,6 +122,27 @@ test.describe("Settings page", () => {
     }
   });
 
+  test("auto-select toggle reachable via keyboard tabbing", async ({ page }) => {
+    const autoSelect = page.locator(
+      '#feature-flags-container input[type=checkbox][data-flag="autoSelect"]'
+    );
+    await expect(autoSelect).toHaveCount(1);
+
+    await page.focus("#display-mode-light");
+    let reached = false;
+    for (let i = 0; i < 50; i++) {
+      const isAuto = await page.evaluate(
+        () => document.activeElement?.dataset.flag === "autoSelect"
+      );
+      if (isAuto) {
+        reached = true;
+        break;
+      }
+      await page.keyboard.press("Tab");
+    }
+    expect(reached).toBe(true);
+  });
+
   test("controls meet minimum color contrast", async ({ page }) => {
     const rgbToHex = (rgb) => {
       const [r, g, b] = rgb

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -21,6 +21,7 @@ import { toggleTooltipOverlayDebug } from "./tooltipOverlayDebug.js";
 import { toggleLayoutDebugPanel } from "./layoutDebugPanel.js";
 import { initFeatureFlags, isEnabled } from "./featureFlags.js";
 import { showSnackbar } from "./showSnackbar.js";
+import { DEFAULT_SETTINGS } from "../config/settingsDefaults.js";
 
 import { applyInitialControlValues } from "./settings/applyInitialValues.js";
 import { attachToggleListeners } from "./settings/listenerUtils.js";
@@ -216,9 +217,16 @@ function makeRenderSwitches(controls, getCurrentSettings, handleUpdate) {
     const flagsContainerEl = document.getElementById("feature-flags-container");
     if (flagsContainerEl) {
       clearToggles(flagsContainerEl);
+      const flags =
+        current.featureFlags && Object.keys(current.featureFlags).length > 0
+          ? current.featureFlags
+          : { ...DEFAULT_SETTINGS.featureFlags };
+      if (!current.featureFlags || Object.keys(current.featureFlags).length === 0) {
+        current.featureFlags = flags;
+      }
       renderFeatureFlagSwitches(
         flagsContainerEl,
-        current.featureFlags,
+        flags,
         getCurrentSettings,
         handleUpdate,
         tooltipMap


### PR DESCRIPTION
## Summary
- Default to bundled feature flags when none are present
- Verify Auto-Select toggle is present and reachable via keyboard tabbing

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 11)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b30c7e1ba4832690e07e84811ce6b1