### PR TITLE
refactor: extract next button helpers

### DIFF
--- a/tests/helpers/timerService.onNextButtonClick.test.js
+++ b/tests/helpers/timerService.onNextButtonClick.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/helpers/classicBattle/battleDispatcher.js", () => ({
+  dispatchBattleEvent: vi.fn(() => Promise.resolve())
+}));
+
+vi.mock("../../src/helpers/classicBattle/skipHandler.js", () => ({
+  setSkipHandler: vi.fn()
+}));
+
+describe("onNextButtonClick", () => {
+  let btn;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<button id="next-button"></button>';
+    btn = document.getElementById("next-button");
+    vi.clearAllMocks();
+  });
+
+  it("advances when button is marked ready", async () => {
+    const { onNextButtonClick } = await import("../../src/helpers/classicBattle/timerService.js");
+    btn.dataset.nextReady = "true";
+    window.__classicBattleState = "cooldown";
+    const resolveReady = vi.fn();
+    await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady });
+    const dispatcher = await import("../../src/helpers/classicBattle/battleDispatcher.js");
+    expect(btn.disabled).toBe(true);
+    expect(btn.dataset.nextReady).toBeUndefined();
+    expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
+    expect(resolveReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops timer when not ready", async () => {
+    const { onNextButtonClick } = await import("../../src/helpers/classicBattle/timerService.js");
+    const stop = vi.fn();
+    window.__classicBattleState = "roundDecision";
+    await onNextButtonClick(new MouseEvent("click"), { timer: { stop }, resolveReady: null });
+    const dispatcher = await import("../../src/helpers/classicBattle/battleDispatcher.js");
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(dispatcher.dispatchBattleEvent).not.toHaveBeenCalled();
+  });
+
+  it("advances immediately when no timer and in cooldown", async () => {
+    const { onNextButtonClick } = await import("../../src/helpers/classicBattle/timerService.js");
+    window.__classicBattleState = "cooldown";
+    const resolveReady = vi.fn();
+    await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady });
+    const dispatcher = await import("../../src/helpers/classicBattle/battleDispatcher.js");
+    expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
+    expect(resolveReady).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- extract `advanceWhenReady` and `cancelTimerOrAdvance` helpers for next button logic
- streamline `onNextButtonClick` using early return and new helpers
- cover both branches with `timerService.onNextButtonClick` tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (fails: 11 failing)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b31f441750832694d60042c3ceab5e