### PR TITLE
feat(cli): gate state badge with feature flag

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -81,6 +81,7 @@ A terminal-style Classic Battle ensures **fast load, consistent behavior, and im
 
 ### Feature Flags
 - `cliVerbose` – toggles the verbose log section on the CLI page; disabled by default.
+- `battleStateBadge` – shows a header badge reflecting the current match state; disabled by default.
 - `autoSelect` – when enabled (default), the match auto-picks a random stat when the selection timer expires.
   When disabled, the CLI waits for manual input after timeout.
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -44,6 +44,7 @@ Players need to easily adjust game settings to personalize their experience, imp
 | P1       | Full Navigation Map Toggle          | Enable or disable the full navigation map via general setting; updates `settings.json` live on change. |
 | P3       | Test Mode Feature Flag              | Enables deterministic battles for automated testing.                                                   |
 | P3       | Battle Debug Panel Feature Flag     | Adds a collapsible debug `<pre>` beside the opponent's card showing match state.                       |
+| P3       | Battle State Badge Feature Flag     | Displays the current battle state in a header badge on battle pages.                                   |
 | P3       | Card Inspector Feature Flag         | Reveals a panel on each card with its raw JSON for debugging.                                          |
 | P3       | Viewport Simulation Feature Flag    | Choose preset sizes to simulate different devices.                                                     |
 | P3       | Tooltip Overlay Debug Feature Flag  | Outline tooltip targets to debug placement.                                                            |
@@ -89,6 +90,7 @@ On load, the Settings page must pre-populate each control with values from
 - **Full navigation map (binary):** ON/OFF (default: ON) – Display an overlay map linking to every page.
 - **Test mode feature flag (binary):** ON/OFF (default: OFF) – Run deterministic matches for testing.
 - **Battle debug panel feature flag (binary):** ON/OFF (default: OFF) – Show a panel above the cards with live match data and a copy button for debugging.
+- **Battle state badge feature flag (binary):** ON/OFF (default: OFF) – Display the current battle state in a header badge.
 - **Card inspector feature flag (binary):** ON/OFF (default: OFF) – Reveal raw card JSON in a collapsible panel.
 - **Viewport simulation feature flag (binary):** ON/OFF (default: OFF) – Choose preset sizes to simulate different devices.
 - **Tooltip overlay debug feature flag (binary):** ON/OFF (default: OFF) – Outline tooltip targets to debug placement.
@@ -165,6 +167,12 @@ On load, the Settings page must pre-populate each control with values from
 - The panel is keyboard accessible and hidden by default.
   - The panel appears above the player and opponent cards rather than at the page bottom.
 - The panel stays visible for the whole match once enabled.
+- Setting persists across page refreshes and sessions.
+
+### Battle State Badge Feature Flag
+
+- Enabling the flag shows a badge with the current battle state on battle pages.
+- The badge updates as the state machine transitions.
 - Setting persists across page refreshes and sessions.
 
 ### Card Inspector Feature Flag

--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -27,11 +27,25 @@ test.describe("Classic Battle CLI", () => {
     expect(errors).toEqual([]);
   });
 
-  test("shows state badge with current state", async ({ page }) => {
+  test("state badge hidden when flag disabled", async ({ page }) => {
     await page.goto("/src/pages/battleCLI.html");
-    // Wait until the player can act
+    await waitForBattleState(page, "waitingForPlayerAction", 15000);
+    await expect(page.locator("#battle-state-badge")).toBeHidden();
+  });
+
+  test("state badge visible when flag enabled", async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem(
+          "settings",
+          JSON.stringify({ featureFlags: { battleStateBadge: { enabled: true } } })
+        );
+      } catch {}
+    });
+    await page.goto("/src/pages/battleCLI.html");
     await waitForBattleState(page, "waitingForPlayerAction", 15000);
     const badge = page.locator("#battle-state-badge");
+    await expect(badge).toBeVisible();
     await expect(badge).toContainText(/State:\s*waitingForPlayerAction/);
   });
 

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -114,7 +114,14 @@
         <div class="cli-title">
           <a href="../../index.html" data-testid="home-link" aria-label="Return to home">Home</a>
           &nbsp;|&nbsp; Classic Battle (CLI)
-          <span id="battle-state-badge" class="state-badge" aria-live="polite">State: —</span>
+          <span
+            id="battle-state-badge"
+            data-flag="battleStateBadge"
+            class="state-badge"
+            aria-live="polite"
+            style="display: none"
+            >State: —</span
+          >
         </div>
         <div class="cli-controls" role="group" aria-label="Match Settings">
           <label for="points-select">Win target:</label>

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -58,6 +58,18 @@ function setRoundMessage(text) {
   if (el) el.textContent = text || "";
 }
 
+/**
+ * Show or hide the battle state badge based on feature flag.
+ *
+ * @pseudocode
+ * if badge element exists:
+ *   set hidden to !isEnabled("battleStateBadge")
+ */
+function updateStateBadgeVisibility() {
+  const badge = byId("battle-state-badge");
+  if (badge) badge.style.display = isEnabled("battleStateBadge") ? "" : "none";
+}
+
 function showBottomLine(text) {
   // Render as a single bottom line using the snackbar container
   try {
@@ -500,12 +512,17 @@ async function init() {
     await initFeatureFlags();
   } catch {}
   updateVerbose();
+  updateStateBadgeVisibility();
   checkbox?.addEventListener("change", () => {
     setFlag("cliVerbose", !!checkbox.checked);
   });
   featureFlagsEmitter.addEventListener("change", (e) => {
-    if (!e.detail?.flag || e.detail.flag === "cliVerbose") {
+    const flag = e.detail?.flag;
+    if (!flag || flag === "cliVerbose") {
       updateVerbose();
+    }
+    if (!flag || flag === "battleStateBadge") {
+      updateStateBadgeVisibility();
     }
   });
   // Install CLI event bridges


### PR DESCRIPTION
## Summary
- hide battle state badge by default and show when `battleStateBadge` flag is on
- document battle state badge flag in Battle CLI and settings PRDs
- test state badge visibility toggled by feature flag

## Testing
- `npx prettier . --check`
- `npx eslint .` (warn)
- `npx vitest run`
- `npx playwright test playwright/battle-cli.spec.js`
- `npx playwright test` *(fails: 12 failing)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b31aa87c908326946063070e49982e