### PR TITLE
feat: add skip round cooldown flag

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -84,6 +84,7 @@ A terminal-style Classic Battle ensures **fast load, consistent behavior, and im
 - `battleStateBadge` – shows a header badge reflecting the current match state; disabled by default.
 - `autoSelect` – when enabled (default), the match auto-picks a random stat when the selection timer expires.
   When disabled, the CLI waits for manual input after timeout.
+- `skipRoundCooldown` – when enabled, the CLI skips the inter-round countdown and immediately begins the next round.
 
 Notes:
 - Core gameplay and timers must not use dynamic imports in hot paths. Optional features (e.g., Retro Mode) may be dynamically imported but preloaded during idle if enabled.  
@@ -105,7 +106,8 @@ Notes:
 3. Timer Behavior  
    - Given `waitingForPlayerAction`, when the timer ticks, then `#cli-countdown` updates once per second with remaining time.  
    - Given timer expiry and `FF_AUTO_SELECT` enabled, when the countdown reaches zero, then a random stat is selected and printed before decision.  
-   - Given `cooldown`, when countdownStart fires, then a fallback timer runs and emits `countdownFinished` after the duration if not skipped.  
+   - Given `cooldown`, when countdownStart fires, then a fallback timer runs and emits `countdownFinished` after the duration if not skipped.
+   - Given `skipRoundCooldown` enabled, when `countdownStart` fires, then the next round begins immediately without showing countdown text.
    - Given the tab is hidden or device sleeps, when focus returns, then the timer resumes without double-firing and remains consistent with the engine PRD.  
 
 4. Outcome and Score  

--- a/design/productRequirementsDocuments/prdBattleClassic.md
+++ b/design/productRequirementsDocuments/prdBattleClassic.md
@@ -227,6 +227,7 @@ This section lists small, implementer-facing contracts to reduce ambiguity betwe
   - `battleDebugPanel` — boolean, default: `false`. When enabled, show debug panel above the cards with copy/export controls.
   - `testMode` — boolean, default: `false` (test-only). When enabled, allow `battle.testRandomSeed` and fast AI delays for deterministic tests.
   - `statHotkeys` — boolean, default: `false`. When enabled, number keys 1–5 map to stat buttons (left→right).
+  - `skipRoundCooldown` — boolean, default: `false`. When enabled, bypass inter-round cooldown and begin the next round immediately.
 
   Implementations should read these flags via the global feature-flag service or from `src/config/battleDefaults.js`. The PRD and tests should reference the camelCase keys above (not `FF_*` prefixes) to avoid mismatches between code and documentation.
 

--- a/design/productRequirementsDocuments/prdSettingsMenu.md
+++ b/design/productRequirementsDocuments/prdSettingsMenu.md
@@ -96,6 +96,7 @@ On load, the Settings page must pre-populate each control with values from
 - **Tooltip overlay debug feature flag (binary):** ON/OFF (default: OFF) – Outline tooltip targets to debug placement.
 - **Layout debug outlines feature flag (binary):** ON/OFF (default: OFF) – Show element outlines to inspect page layout.
 - **Navigation cache reset feature flag (binary):** ON/OFF (default: OFF) – Add a button to clear cached navigation data.
+- **Skip round cooldown feature flag (binary):** ON/OFF (default: OFF) – Begin the next round immediately without waiting for the cooldown timer.
 - **Motion effects (binary):** ON/OFF (default: ON) – Disable animations for a calmer interface.
 - **Typewriter effect (binary):** ON/OFF (default: ON, not currently used on the meditation screen) – Toggle the quote typing animation.
 - **Tooltips (binary):** ON/OFF (default: ON) – Show or hide helpful tooltips.

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -49,6 +49,10 @@
       "enabled": false,
       "tooltipId": "settings.battleStateBadge"
     },
+    "skipRoundCooldown": {
+      "enabled": false,
+      "tooltipId": "settings.skipRoundCooldown"
+    },
     "cliVerbose": {
       "enabled": false,
       "tooltipId": "settings.cliVerbose"

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -106,6 +106,10 @@
       "label": "Battle State Badge",
       "description": "Show the current match state in the header for testing."
     },
+    "skipRoundCooldown": {
+      "label": "Skip Round Cooldown",
+      "description": "Start the next round immediately without a cooldown."
+    },
     "cliVerbose": {
       "label": "CLI Verbose Logging",
       "description": "Show state transition logs in the battle CLI."

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -21,6 +21,19 @@ import { createButton } from "../../components/Button.js";
 import { syncScoreDisplay } from "./uiService.js";
 import { onBattleEvent, emitBattleEvent } from "./battleEvents.js";
 
+/**
+ * Skip the inter-round cooldown when the corresponding feature flag is enabled.
+ *
+ * @returns {boolean} `true` if the cooldown was skipped.
+ */
+export function skipRoundCooldownIfEnabled() {
+  if (!isEnabled("skipRoundCooldown")) return false;
+  try {
+    emitBattleEvent("countdownFinished");
+  } catch {}
+  return true;
+}
+
 // Ensure a global statButtonsReadyPromise exists synchronously so tests
 // and early code can safely await it even before `initStatButtons` runs.
 if (typeof window !== "undefined") {

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -3,7 +3,7 @@ import * as scoreboard from "../setupScoreboard.js";
 import { createModal } from "../../components/Modal.js";
 import { createButton } from "../../components/Button.js";
 import { navigateToHome } from "../navUtils.js";
-import { updateDebugPanel } from "./uiHelpers.js";
+import { updateDebugPanel, skipRoundCooldownIfEnabled } from "./uiHelpers.js";
 import { onBattleEvent, emitBattleEvent } from "./battleEvents.js";
 import { attachCooldownRenderer } from "../CooldownRenderer.js";
 import { createRoundTimer } from "../timers/createRoundTimer.js";
@@ -126,6 +126,7 @@ onBattleEvent("debugPanelUpdate", () => {
 });
 
 onBattleEvent("countdownStart", (e) => {
+  if (skipRoundCooldownIfEnabled()) return;
   const { duration } = e.detail || {};
   if (typeof duration !== "number") return;
   try {

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -17,6 +17,7 @@ import {
   setFlag,
   featureFlagsEmitter
 } from "../helpers/featureFlags.js";
+import { skipRoundCooldownIfEnabled } from "../helpers/classicBattle/uiHelpers.js";
 
 /**
  * Minimal DOM utils for the CLI page
@@ -409,6 +410,7 @@ function installEventBindings() {
 
   // CLI-specific countdown handler
   onBattleEvent("countdownStart", (e) => {
+    if (skipRoundCooldownIfEnabled()) return;
     const duration = Number(e.detail?.duration) || 0;
     try {
       if (cooldownTimer) clearTimeout(cooldownTimer);

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -240,6 +240,23 @@
               </p>
             </div>
             <div class="settings-item">
+              <label for="feature-skip-round-cooldown" class="switch">
+                <input
+                  type="checkbox"
+                  id="feature-skip-round-cooldown"
+                  data-flag="skipRoundCooldown"
+                  aria-label="Skip Round Cooldown"
+                  aria-describedby="feature-skip-round-cooldown-desc"
+                  data-tooltip-id="settings.skipRoundCooldown"
+                />
+                <div class="slider round"></div>
+                <span>Skip Round Cooldown</span>
+              </label>
+              <p id="feature-skip-round-cooldown-desc" class="settings-description">
+                Start the next round immediately without a cooldown.
+              </p>
+            </div>
+            <div class="settings-item">
               <label for="feature-auto-select" class="switch">
                 <input
                   type="checkbox"

--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -29,6 +29,7 @@ This directory contains unit tests for Classic Battle helpers.
 - `stateTransitions.test.js`: validates `src/helpers/classicBattle/stateTable.js` transitions.
 - `timerService.drift.test.js`: falls back to messaging when timers drift.
 - `timerService.nextRound.test.js`: manages cooldown and Next button interaction.
+- `skipRoundCooldown.test.js`: skips the inter-round countdown when the feature flag is enabled.
 - `timerStateExposure.test.js`: exposes timer state to window and DOM.
 - `mockSetup.js`: shared mock helper to reduce duplication.
 - `utils.js` / `mocks.js`: shared DOM setup and legacy mocks for these suites.

--- a/tests/helpers/classicBattle/skipRoundCooldown.test.js
+++ b/tests/helpers/classicBattle/skipRoundCooldown.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock timer and renderer to observe calls without real timers
+vi.mock("../../../src/helpers/CooldownRenderer.js", () => ({
+  attachCooldownRenderer: vi.fn()
+}));
+vi.mock("../../../src/helpers/timers/createRoundTimer.js", () => ({
+  createRoundTimer: vi.fn(() => ({
+    on: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn()
+  }))
+}));
+
+describe("skipRoundCooldown feature flag", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("skips countdown when flag enabled", async () => {
+    vi.doMock("../../../src/helpers/featureFlags.js", () => ({
+      isEnabled: (flag) => flag === "skipRoundCooldown"
+    }));
+    const battleEvents = await import("../../../src/helpers/classicBattle/battleEvents.js");
+    const emitSpy = vi.spyOn(battleEvents, "emitBattleEvent");
+    await import("../../../src/helpers/classicBattle/uiService.js");
+    await battleEvents.emitBattleEvent("countdownStart", { duration: 3 });
+    const { attachCooldownRenderer } = await import("../../../src/helpers/CooldownRenderer.js");
+    expect(attachCooldownRenderer).not.toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledWith("countdownFinished");
+  });
+
+  it("shows countdown when flag disabled", async () => {
+    vi.doMock("../../../src/helpers/featureFlags.js", () => ({ isEnabled: () => false }));
+    const battleEvents = await import("../../../src/helpers/classicBattle/battleEvents.js");
+    const emitSpy = vi.spyOn(battleEvents, "emitBattleEvent");
+    await import("../../../src/helpers/classicBattle/uiService.js");
+    await battleEvents.emitBattleEvent("countdownStart", { duration: 3 });
+    const { attachCooldownRenderer } = await import("../../../src/helpers/CooldownRenderer.js");
+    expect(attachCooldownRenderer).toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledTimes(1); // only countdownStart
+  });
+});


### PR DESCRIPTION
## Summary
- add `skipRoundCooldown` feature flag and settings toggle
- skip inter-round countdown in UI and CLI when flag enabled
- document flag in PRDs and tests, add coverage

## Testing
- `npm run validate:data`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattle/skipRoundCooldown.test.js`
- `npx playwright test` *(fails: classic battle flow and others)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b3254ed0348326a7349ddc90822e71