### PR TITLE
fix: defer countdown finished event

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -24,13 +24,25 @@ import { onBattleEvent, emitBattleEvent } from "./battleEvents.js";
 /**
  * Skip the inter-round cooldown when the corresponding feature flag is enabled.
  *
+ * @pseudocode
+ * 1. Exit early if the `skipRoundCooldown` flag is disabled.
+ * 2. Schedule a microtask that emits `countdownFinished`.
+ * 3. Return `true` when the cooldown will be skipped.
+ *
  * @returns {boolean} `true` if the cooldown was skipped.
  */
 export function skipRoundCooldownIfEnabled() {
   if (!isEnabled("skipRoundCooldown")) return false;
+  const run = () => {
+    try {
+      emitBattleEvent("countdownFinished");
+    } catch {}
+  };
   try {
-    emitBattleEvent("countdownFinished");
-  } catch {}
+    queueMicrotask(run);
+  } catch {
+    setTimeout(run, 0);
+  }
   return true;
 }
 

--- a/tests/helpers/classicBattle/skipRoundCooldown.test.js
+++ b/tests/helpers/classicBattle/skipRoundCooldown.test.js
@@ -25,6 +25,7 @@ describe("skipRoundCooldown feature flag", () => {
     const emitSpy = vi.spyOn(battleEvents, "emitBattleEvent");
     await import("../../../src/helpers/classicBattle/uiService.js");
     await battleEvents.emitBattleEvent("countdownStart", { duration: 3 });
+    await Promise.resolve();
     const { attachCooldownRenderer } = await import("../../../src/helpers/CooldownRenderer.js");
     expect(attachCooldownRenderer).not.toHaveBeenCalled();
     expect(emitSpy).toHaveBeenCalledWith("countdownFinished");
@@ -36,6 +37,7 @@ describe("skipRoundCooldown feature flag", () => {
     const emitSpy = vi.spyOn(battleEvents, "emitBattleEvent");
     await import("../../../src/helpers/classicBattle/uiService.js");
     await battleEvents.emitBattleEvent("countdownStart", { duration: 3 });
+    await Promise.resolve();
     const { attachCooldownRenderer } = await import("../../../src/helpers/CooldownRenderer.js");
     expect(attachCooldownRenderer).toHaveBeenCalled();
     expect(emitSpy).toHaveBeenCalledTimes(1); // only countdownStart


### PR DESCRIPTION
## Summary
- schedule `countdownFinished` event on a microtask when skipping round cooldown
- update skip-round-cooldown tests to await deferred event

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: interruptHandlers.test.js)*
- `npx playwright test` *(fails: 11 failed tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b338d6f3d48326ace7778e35dda10e