### PR TITLE
Fix interruption handler to call battleEngine API

### DIFF
--- a/src/helpers/battleEngineFacade.js
+++ b/src/helpers/battleEngineFacade.js
@@ -2,7 +2,7 @@ import { BattleEngine, STATS } from "./BattleEngine.js";
 
 export { BattleEngine, STATS } from "./BattleEngine.js";
 
-const battleEngine = new BattleEngine();
+export const battleEngine = new BattleEngine();
 
 /**
  * Set the number of points required to win a match.

--- a/src/helpers/classicBattle/interruptHandlers.js
+++ b/src/helpers/classicBattle/interruptHandlers.js
@@ -1,4 +1,4 @@
-import { interruptMatch } from "../battleEngineFacade.js";
+import { battleEngine } from "../battleEngineFacade.js";
 import { dispatchBattleEvent } from "./orchestrator.js";
 import { showMessage, clearTimer } from "../setupScoreboard.js";
 import { stop as stopScheduler, cancel as cancelFrame } from "../../utils/scheduler.js";
@@ -75,7 +75,7 @@ export function initInterruptHandlers(store) {
   function handleNavigation() {
     cleanup();
     try {
-      interruptMatch("navigation");
+      battleEngine.interruptMatch("navigation");
     } catch {}
     try {
       showMessage("Match interrupted: navigation");
@@ -101,7 +101,7 @@ export function initInterruptHandlers(store) {
     const msg = e?.reason?.message || e?.reason || e?.message || "Unknown error";
     cleanup();
     try {
-      interruptMatch("error");
+      battleEngine.interruptMatch("error");
     } catch {}
     showErrorDialog(msg);
     try {


### PR DESCRIPTION
## Summary
- expose `battleEngine` instance from battleEngineFacade
- use `battleEngine.interruptMatch` in classic battle interrupt handlers

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 11 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b33a14b2d08326bdb1426641249480