### PR TITLE
feat(cli): add deterministic seed option

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -75,6 +75,7 @@ A terminal-style Classic Battle ensures **fast load, consistent behavior, and im
 | **P1** | Accessibility Hooks | Provide `aria-live="polite"` for round messages and countdown; maintain focus order for keyboard use. |
 | **P1** | Test Hooks | Expose stable selectors/ids (e.g., `#round-message`, `#cli-score`, `#cli-countdown`, `data-flag`) to support existing tests and new CLI tests. |
 | **P2** | Minimal Settings | Allow selecting win target (5/10/15) at start; persist last choice using existing settings helper. |
+| **P2** | Deterministic Seed | Optional numeric seed via header input or `?seed=` query parameter enables reproducible runs; last seed is stored locally. |
 | **P2** | Observability Mode | Optional verbose logs (controlled by the `cliVerbose` feature flag) that echo internal state transitions. |
 | **P2** | Interrupt Handling | Surface quit/interrupt flows as text prompts; roll back to last completed round consistent with engine PRD. |
 | **P3** | Retro Mode | Optional ASCII borders and simple color accents via CSS classes; disabled by default for maximum contrast. |
@@ -123,12 +124,15 @@ Notes:
    - Given a fresh load on average hardware, when opening `battleCLI.html`, then the page is interactive in ≤500 ms after network idle (no heavy assets).  
    - No runtime use of `await import()` on stat selection, round decision, event dispatch, or render loops.  
 
-7. Testability  
-   - Given the CLI page loads, when running Playwright/Vitest, then selectors `#round-message`, `#cli-countdown`, and `#cli-score` are present and update as the engine advances.  
-   - Given verbose mode is enabled (`FF_CLI_VERBOSE`), when state transitions occur, then logs are emitted via a muted logger during tests (no unsilenced console.error/warn in CI).  
+7. Testability
+   - Given the CLI page loads, when running Playwright/Vitest, then selectors `#round-message`, `#cli-countdown`, and `#cli-score` are present and update as the engine advances.
+   - Given verbose mode is enabled (`FF_CLI_VERBOSE`), when state transitions occur, then logs are emitted via a muted logger during tests (no unsilenced console.error/warn in CI).
 
-8. Interrupts  
-   - Given an unexpected error, when the engine triggers rollback, then the UI prints an error message and returns to the last completed round/lobby per engine PRD.  
+8. Interrupts
+   - Given an unexpected error, when the engine triggers rollback, then the UI prints an error message and returns to the last completed round/lobby per engine PRD.
+
+9. Deterministic Seed
+   - Given a `seed` is provided via query parameter or header input, when the match is run repeatedly with that seed, then pseudo-random choices follow the same sequence each time.
 
 ---
 
@@ -191,9 +195,8 @@ Notes:
 
 ## Open Questions
 
-- Should the CLI mirror snackbar semantics exactly or consolidate to a single `#cli-countdown` area? If consolidated, update tests accordingly.  
-- Do we expose a “seed” input to make deterministic runs selectable from the UI, or keep seed-only via dev tools?  
-- Is Retro Mode desired by default on desktop, or opt-in only?  
+- Should the CLI mirror snackbar semantics exactly or consolidate to a single `#cli-countdown` area? If consolidated, update tests accordingly.
+- Is Retro Mode desired by default on desktop, or opt-in only?
 
 ---
 

--- a/src/helpers/testModeUtils.js
+++ b/src/helpers/testModeUtils.js
@@ -14,73 +14,44 @@ let active = false;
 let seed = 1;
 
 /**
- * @summary TODO: Add summary
+ * Enable or disable deterministic test mode.
+ *
  * @pseudocode
- * 1. TODO: Add pseudocode
+ * if input is object:
+ *   active = Boolean(input.enabled)
+ *   seed = Number(input.seed) or 1
+ * else:
+ *   active = Boolean(enable)
+ *   seed = initialSeed or 1
  */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-export function setTestMode(enable, initialSeed = 1) {
-  active = Boolean(enable);
-  seed = initialSeed;
+export function setTestMode(enableOrOptions, initialSeed = 1) {
+  if (typeof enableOrOptions === "object") {
+    active = Boolean(enableOrOptions.enabled);
+    seed = Number(enableOrOptions.seed) || 1;
+  } else {
+    active = Boolean(enableOrOptions);
+    seed = initialSeed;
+  }
 }
 
 /**
- * @summary TODO: Add summary
+ * Check whether deterministic test mode is active.
+ *
  * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
+ * return active
  */
 export function isTestModeEnabled() {
   return active;
 }
 
 /**
- * @summary TODO: Add summary
+ * Return a pseudo-random number.
+ *
  * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
+ * if not active: return Math.random()
+ * x = sin(seed) * 10000
+ * seed += 1
+ * return fractional part of x
  */
 export function seededRandom() {
   if (!active) return Math.random();
@@ -89,24 +60,10 @@ export function seededRandom() {
 }
 
 /**
- * @summary TODO: Add summary
+ * Get the current seed value.
+ *
  * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
+ * return seed
  */
 export function getCurrentSeed() {
   return seed;

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -136,6 +136,14 @@
           </select>
           <label for="verbose-toggle">Verbose:</label>
           <input id="verbose-toggle" type="checkbox" aria-label="Toggle verbose logging" />
+          <label for="seed-input">Seed:</label>
+          <input
+            id="seed-input"
+            type="number"
+            inputmode="numeric"
+            aria-label="Deterministic seed (optional)"
+            style="width: 6ch"
+          />
         </div>
         <div id="cli-score" class="cli-score" aria-live="polite" aria-atomic="true">
           You: 0 Opponent: 0

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -18,6 +18,7 @@ import {
   featureFlagsEmitter
 } from "../helpers/featureFlags.js";
 import { skipRoundCooldownIfEnabled } from "../helpers/classicBattle/uiHelpers.js";
+import { setTestMode } from "../helpers/testModeUtils.js";
 
 /**
  * Minimal DOM utils for the CLI page
@@ -60,6 +61,34 @@ function updateScoreLine(player, opponent) {
 function setRoundMessage(text) {
   const el = byId("round-message");
   if (el) el.textContent = text || "";
+}
+
+function initSeed() {
+  const input = byId("seed-input");
+  let seed = null;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    seed = params.get("seed") || input?.value || localStorage.getItem("battleCLI.seed");
+  } catch {}
+  const apply = (n) => {
+    setTestMode({ enabled: true, seed: n });
+    try {
+      localStorage.setItem("battleCLI.seed", String(n));
+    } catch {}
+  };
+  if (seed !== null && seed !== "") {
+    const num = Number(seed);
+    if (!Number.isNaN(num)) {
+      apply(num);
+      if (input) input.value = String(num);
+    }
+  }
+  input?.addEventListener("change", () => {
+    const val = Number(input.value);
+    if (!Number.isNaN(val)) {
+      apply(val);
+    }
+  });
 }
 
 /**
@@ -647,6 +676,7 @@ function installRetroStyles() {
 
 async function init() {
   installRetroStyles();
+  initSeed();
   store = createBattleStore();
   // Expose store for debug panels if needed
   try {

--- a/tests/pages/battleCLI.seed.test.js
+++ b/tests/pages/battleCLI.seed.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+async function loadBattleCLI(seed) {
+  const emitter = new EventTarget();
+  vi.doMock("../../src/helpers/featureFlags.js", () => ({
+    initFeatureFlags: vi
+      .fn()
+      .mockResolvedValue({ featureFlags: { cliVerbose: { enabled: false } } }),
+    isEnabled: vi.fn().mockReturnValue(false),
+    setFlag: vi.fn(),
+    featureFlagsEmitter: emitter
+  }));
+  vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+    createBattleStore: vi.fn(() => ({})),
+    startRound: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    onBattleEvent: vi.fn(),
+    emitBattleEvent: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: [] }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({ setPointsToWin: vi.fn() }));
+  vi.doMock("../../src/helpers/dataUtils.js", () => ({
+    fetchJson: vi.fn().mockResolvedValue([{ statIndex: 1, name: "Speed" }])
+  }));
+  vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+  vi.stubGlobal("location", new URL(`http://localhost/battleCLI.html?seed=${seed}`));
+  const mod = await import("../../src/pages/battleCLI.js");
+  return mod;
+}
+
+describe("battleCLI deterministic seed", () => {
+  beforeEach(() => {
+    window.__TEST__ = true;
+    document.body.innerHTML = `
+      <div id="cli-stats"></div>
+      <div id="cli-help"></div>
+      <select id="points-select"></select>
+      <section id="cli-verbose-section" hidden>
+        <pre id="cli-verbose-log"></pre>
+      </section>
+      <input id="verbose-toggle" type="checkbox" />
+      <input id="seed-input" type="number" />
+    `;
+    const machine = { dispatch: vi.fn() };
+    window.__getClassicBattleMachine = vi.fn(() => machine);
+    window.__TEST_MACHINE__ = machine;
+    localStorage.setItem("battleCLI.pointsToWin", "5");
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.__TEST__;
+    delete window.__getClassicBattleMachine;
+    delete window.__TEST_MACHINE__;
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doUnmock("../../src/helpers/featureFlags.js");
+    vi.doUnmock("../../src/helpers/classicBattle/roundManager.js");
+    vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+    vi.doUnmock("../../src/helpers/classicBattle/battleEvents.js");
+    vi.doUnmock("../../src/helpers/BattleEngine.js");
+    vi.doUnmock("../../src/helpers/battleEngineFacade.js");
+    vi.doUnmock("../../src/helpers/dataUtils.js");
+    vi.doUnmock("../../src/helpers/constants.js");
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("applies seed for deterministic random", async () => {
+    const mod = await loadBattleCLI(5);
+    await mod.__test.init();
+    const { seededRandom } = await import("../../src/helpers/testModeUtils.js");
+    const first = seededRandom();
+    const second = seededRandom();
+    const expected = (start, count) => {
+      const out = [];
+      let s = start;
+      for (let i = 0; i < count; i++) {
+        const x = Math.sin(s++) * 10000;
+        out.push(x - Math.floor(x));
+      }
+      return out;
+    };
+    const [e1, e2] = expected(5, 2);
+    expect(first).toBeCloseTo(e1);
+    expect(second).toBeCloseTo(e2);
+    expect(localStorage.getItem("battleCLI.seed")).toBe("5");
+  });
+});


### PR DESCRIPTION
## Summary
- allow battle CLI to accept optional seed via query or header input and persist it
- support object-based setTestMode
- document deterministic seed option in PRD and add seed test

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: classic battle flow and round completion specs)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b34690da8483269625be1fefe2881d