### PR TITLE
feat(cli): add stat selection countdown

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -86,6 +86,8 @@ A terminal-style Classic Battle ensures **fast load, consistent behavior, and im
   When disabled, the CLI waits for manual input after timeout.
 - `skipRoundCooldown` – when enabled, the CLI skips the inter-round countdown and immediately begins the next round.
 
+`skipRoundCooldown` may also be enabled via the `?skipRoundCooldown=1` query parameter, which sets the feature flag at startup.
+
 Notes:
 - Core gameplay and timers must not use dynamic imports in hot paths. Optional features (e.g., Retro Mode) may be dynamically imported but preloaded during idle if enabled.  
 - Maintain the scoreboard/snackbar surface contract where feasible: `#round-message` for outcomes and a dedicated area for countdown/prompts to keep tests consistent.  
@@ -104,8 +106,8 @@ Notes:
    - Given an active match, when pressing Q, then a quit confirmation prompt appears; confirming ends or rolls back per engine rules.  
 
 3. Timer Behavior  
-   - Given `waitingForPlayerAction`, when the timer ticks, then `#cli-countdown` updates once per second with remaining time.  
-   - Given timer expiry and `FF_AUTO_SELECT` enabled, when the countdown reaches zero, then a random stat is selected and printed before decision.  
+  - Given `waitingForPlayerAction`, when the timer ticks, then `#cli-countdown` updates once per second with remaining time and exposes the value via `data-remaining-time`.
+- Given timer expiry and `FF_AUTO_SELECT` enabled, when the countdown reaches zero, then a random stat is selected and printed before decision.
    - Given `cooldown`, when countdownStart fires, then a fallback timer runs and emits `countdownFinished` after the duration if not skipped.
    - Given `skipRoundCooldown` enabled, when `countdownStart` fires, then the next round begins immediately without showing countdown text.
    - Given the tab is hidden or device sleeps, when focus returns, then the timer resumes without double-firing and remains consistent with the engine PRD.  

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -145,6 +145,7 @@
       <main id="cli-main" class="cli-main" role="main">
         <section aria-label="Round Status" class="cli-block">
           <div id="round-message" role="status" aria-live="polite" aria-atomic="true"></div>
+          <div id="cli-countdown" role="status" aria-live="polite"></div>
         </section>
 
         <section aria-label="Stat Selection" class="cli-block">

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -18,6 +18,7 @@ import {
   featureFlagsEmitter
 } from "../helpers/featureFlags.js";
 import { skipRoundCooldownIfEnabled } from "../helpers/classicBattle/uiHelpers.js";
+import { autoSelectStat } from "../helpers/classicBattle/autoSelectStat.js";
 
 /**
  * Minimal DOM utils for the CLI page
@@ -30,6 +31,8 @@ let store = null;
 let verboseEnabled = false;
 let cooldownTimer = null;
 let cooldownInterval = null;
+let selectionTimer = null;
+let selectionInterval = null;
 
 // Test hooks to access internal timer state
 export const __test = {
@@ -39,6 +42,13 @@ export const __test = {
   },
   getCooldownTimers() {
     return { cooldownTimer, cooldownInterval };
+  },
+  setSelectionTimers(timer, interval) {
+    selectionTimer = timer;
+    selectionInterval = interval;
+  },
+  getSelectionTimers() {
+    return { selectionTimer, selectionInterval };
   },
   installEventBindings,
   init,
@@ -92,6 +102,97 @@ function showBottomLine(text) {
 
 function clearBottomLine() {
   showBottomLine("");
+}
+
+/**
+ * Clear active stat selection countdown timers and reset the countdown UI.
+ *
+ * @pseudocode
+ * if timer exists: clearTimeout(timer)
+ * if interval exists: clearInterval(interval)
+ * null timers and remove countdown text/attribute
+ */
+function stopSelectionCountdown() {
+  try {
+    if (selectionTimer) clearTimeout(selectionTimer);
+  } catch {}
+  try {
+    if (selectionInterval) clearInterval(selectionInterval);
+  } catch {}
+  selectionTimer = null;
+  selectionInterval = null;
+  const el = byId("cli-countdown");
+  if (el) {
+    el.textContent = "";
+    delete el.dataset.remainingTime;
+  }
+}
+
+/**
+ * Apply the chosen stat and notify the state machine.
+ *
+ * @pseudocode
+ * stopSelectionCountdown()
+ * update store with selection
+ * show bottom line with picked stat
+ * dispatch "statSelected" on machine
+ */
+function selectStat(stat) {
+  if (!stat) return;
+  stopSelectionCountdown();
+  try {
+    if (store) {
+      store.playerChoice = stat;
+      store.selectionMade = true;
+    }
+  } catch {}
+  showBottomLine(`You Picked: ${stat.charAt(0).toUpperCase()}${stat.slice(1)}`);
+  try {
+    const machine = window.__getClassicBattleMachine?.();
+    if (machine) machine.dispatch("statSelected");
+  } catch {}
+}
+
+/**
+ * Start a countdown for stat selection and handle expiry.
+ *
+ * @param {number} [seconds=5]
+ * @pseudocode
+ * stopSelectionCountdown()
+ * set remaining=seconds and update countdown element
+ * every 1s: decrement remaining and update element
+ * after seconds: stop countdown and
+ *   if autoSelect enabled: autoSelectStat(selectStat)
+ *   else emit "statSelectionStalled"
+ */
+function startSelectionCountdown(seconds = 5) {
+  const el = byId("cli-countdown");
+  if (!el) return;
+  stopSelectionCountdown();
+  let remaining = seconds;
+  el.dataset.remainingTime = String(remaining);
+  el.textContent = `Time remaining: ${remaining}`;
+  try {
+    selectionInterval = setInterval(() => {
+      remaining -= 1;
+      if (remaining > 0) {
+        el.dataset.remainingTime = String(remaining);
+        el.textContent = `Time remaining: ${remaining}`;
+      }
+    }, 1000);
+  } catch {}
+  try {
+    selectionTimer = setTimeout(() => {
+      stopSelectionCountdown();
+      if (isEnabled("autoSelect")) {
+        autoSelectStat(selectStat);
+      } else {
+        try {
+          emitBattleEvent("statSelectionStalled");
+        } catch {}
+      }
+    }, seconds * 1000);
+  } catch {}
 }
 
 /**
@@ -300,8 +401,16 @@ export function handleGlobalKey(key) {
     try {
       if (cooldownInterval) clearInterval(cooldownInterval);
     } catch {}
+    try {
+      if (selectionTimer) clearTimeout(selectionTimer);
+    } catch {}
+    try {
+      if (selectionInterval) clearInterval(selectionInterval);
+    } catch {}
     cooldownTimer = null;
     cooldownInterval = null;
+    selectionTimer = null;
+    selectionInterval = null;
     clearBottomLine();
     try {
       const machine = window.__getClassicBattleMachine?.();
@@ -346,17 +455,7 @@ export function handleWaitingForPlayerActionKey(key) {
   if (key >= "1" && key <= "9") {
     const stat = getStatByIndex(key);
     if (!stat) return;
-    try {
-      if (store) {
-        store.playerChoice = stat;
-        store.selectionMade = true;
-      }
-    } catch {}
-    showBottomLine(`You Picked: ${stat.charAt(0).toUpperCase()}${stat.slice(1)}`);
-    try {
-      const machine = window.__getClassicBattleMachine?.();
-      if (machine) machine.dispatch("statSelected");
-    } catch {}
+    selectStat(stat);
   }
 }
 
@@ -497,17 +596,7 @@ function handleStatClick(event) {
   if (state !== "waitingForPlayerAction") return;
   const stat = getStatByIndex(idx);
   if (!stat) return;
-  try {
-    if (store) {
-      store.playerChoice = stat;
-      store.selectionMade = true;
-    }
-  } catch {}
-  showBottomLine(`You Picked: ${stat.charAt(0).toUpperCase()}${stat.slice(1)}`);
-  try {
-    const machine = window.__getClassicBattleMachine?.();
-    if (machine) machine.dispatch("statSelected");
-  } catch {}
+  selectStat(stat);
 }
 
 function onClickAdvance(event) {
@@ -606,11 +695,16 @@ function installEventBindings() {
     }
   });
 
-  // Append state changes to the verbose log when enabled
+  // Track state changes: start/stop countdown and append verbose log
   document.addEventListener("battle:state", (ev) => {
+    const { from, to } = ev.detail || {};
+    if (to === "waitingForPlayerAction") {
+      startSelectionCountdown(5);
+    } else {
+      stopSelectionCountdown();
+    }
     if (!verboseEnabled) return;
     try {
-      const { from, to } = ev.detail || {};
       const pre = byId("cli-verbose-log");
       if (!pre) return;
       const ts = new Date();
@@ -618,12 +712,10 @@ function installEventBindings() {
       const mm = String(ts.getMinutes()).padStart(2, "0");
       const ss = String(ts.getSeconds()).padStart(2, "0");
       const line = `[${hh}:${mm}:${ss}] ${from || "(init)"} -> ${to}`;
-      // Keep last 50 lines
       const existing = pre.textContent ? pre.textContent.split("\n").filter(Boolean) : [];
       existing.push(line);
       while (existing.length > 50) existing.shift();
       pre.textContent = existing.join("\n");
-      // Auto-scroll to the latest entry
       pre.scrollTop = pre.scrollHeight;
     } catch {}
   });
@@ -670,6 +762,10 @@ async function init() {
   };
   try {
     await initFeatureFlags();
+  } catch {}
+  try {
+    const skip = new URLSearchParams(location.search).get("skipRoundCooldown");
+    if (skip === "1") setFlag("skipRoundCooldown", true);
   } catch {}
   updateVerbose();
   updateStateBadgeVisibility();

--- a/tests/pages/battleCLI.countdown.test.js
+++ b/tests/pages/battleCLI.countdown.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+async function loadBattleCLI(autoSelect = true, withSkip = false) {
+  const emitter = new EventTarget();
+  const autoSelectStat = vi.fn();
+  const emitBattleEvent = vi.fn();
+  const setFlag = vi.fn();
+  vi.doMock("../../src/helpers/featureFlags.js", () => ({
+    initFeatureFlags: vi.fn(),
+    isEnabled: vi.fn((flag) => (flag === "autoSelect" ? autoSelect : false)),
+    setFlag,
+    featureFlagsEmitter: emitter
+  }));
+  vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+    createBattleStore: vi.fn(() => ({})),
+    startRound: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    onBattleEvent: vi.fn(),
+    emitBattleEvent
+  }));
+  vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: ["speed"] }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({ setPointsToWin: vi.fn() }));
+  vi.doMock("../../src/helpers/dataUtils.js", () => ({
+    fetchJson: vi.fn().mockResolvedValue([{ statIndex: 1, name: "Speed" }])
+  }));
+  vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+  vi.doMock("../../src/helpers/classicBattle/autoSelectStat.js", () => ({ autoSelectStat }));
+  const url = new URL(window.location.href);
+  if (withSkip) {
+    url.search = "?skipRoundCooldown=1";
+  } else {
+    url.search = "";
+  }
+  window.history.replaceState({}, "", url);
+  const mod = await import("../../src/pages/battleCLI.js");
+  await mod.__test.init();
+  return { __test: mod.__test, autoSelectStat, emitBattleEvent, setFlag };
+}
+
+describe("battleCLI countdown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.__TEST__ = true;
+    document.body.innerHTML = `
+      <div id="cli-countdown"></div>
+      <div id="cli-stats"></div>
+      <div id="cli-help"></div>
+      <select id="points-select"></select>
+      <section id="cli-verbose-section" hidden>
+        <pre id="cli-verbose-log"></pre>
+      </section>
+      <input id="verbose-toggle" type="checkbox" />
+      <div id="snackbar-container"></div>
+    `;
+    const machine = { dispatch: vi.fn() };
+    window.__getClassicBattleMachine = vi.fn(() => machine);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+    delete window.__TEST__;
+    delete window.__getClassicBattleMachine;
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doUnmock("../../src/helpers/featureFlags.js");
+    vi.doUnmock("../../src/helpers/classicBattle/roundManager.js");
+    vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+    vi.doUnmock("../../src/helpers/classicBattle/battleEvents.js");
+    vi.doUnmock("../../src/helpers/BattleEngine.js");
+    vi.doUnmock("../../src/helpers/battleEngineFacade.js");
+    vi.doUnmock("../../src/helpers/dataUtils.js");
+    vi.doUnmock("../../src/helpers/constants.js");
+    vi.doUnmock("../../src/helpers/classicBattle/autoSelectStat.js");
+  });
+
+  it("updates countdown and auto-selects on expiry", async () => {
+    const { autoSelectStat } = await loadBattleCLI(true);
+    document.dispatchEvent(
+      new CustomEvent("battle:state", { detail: { to: "waitingForPlayerAction" } })
+    );
+    const cd = document.getElementById("cli-countdown");
+    expect(cd.dataset.remainingTime).toBe("5");
+    vi.advanceTimersByTime(1000);
+    expect(cd.dataset.remainingTime).toBe("4");
+    vi.advanceTimersByTime(4000);
+    expect(autoSelectStat).toHaveBeenCalled();
+  });
+
+  it("emits statSelectionStalled when auto-select disabled", async () => {
+    const { autoSelectStat, emitBattleEvent } = await loadBattleCLI(false);
+    document.dispatchEvent(
+      new CustomEvent("battle:state", { detail: { to: "waitingForPlayerAction" } })
+    );
+    vi.advanceTimersByTime(5000);
+    expect(autoSelectStat).not.toHaveBeenCalled();
+    expect(emitBattleEvent).toHaveBeenCalledWith("statSelectionStalled");
+  });
+
+  it("parses skipRoundCooldown query param", async () => {
+    const { setFlag } = await loadBattleCLI(true, true);
+    expect(setFlag).toHaveBeenCalledWith("skipRoundCooldown", true);
+  });
+});

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -40,18 +40,24 @@ describe("battleCLI onKeyDown", () => {
     expect(dispatch).toHaveBeenCalledWith("interrupt", { reason: "quit" });
   });
 
-  it("clears cooldown timers when quitting", () => {
+  it("clears timers when quitting", () => {
     const dispatch = vi.fn();
     window.__getClassicBattleMachine = () => ({ dispatch });
-    const timer = setTimeout(() => {}, 1000);
-    const interval = setInterval(() => {}, 1000);
+    const cooldownT = setTimeout(() => {}, 1000);
+    const cooldownI = setInterval(() => {}, 1000);
+    const selT = setTimeout(() => {}, 1000);
+    const selI = setInterval(() => {}, 1000);
     const spyTimeout = vi.spyOn(globalThis, "clearTimeout");
     const spyInterval = vi.spyOn(globalThis, "clearInterval");
-    __test.setCooldownTimers(timer, interval);
+    __test.setCooldownTimers(cooldownT, cooldownI);
+    __test.setSelectionTimers(selT, selI);
     onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
-    expect(spyTimeout).toHaveBeenCalledWith(timer);
-    expect(spyInterval).toHaveBeenCalledWith(interval);
+    expect(spyTimeout).toHaveBeenCalledWith(cooldownT);
+    expect(spyInterval).toHaveBeenCalledWith(cooldownI);
+    expect(spyTimeout).toHaveBeenCalledWith(selT);
+    expect(spyInterval).toHaveBeenCalledWith(selI);
     expect(__test.getCooldownTimers()).toEqual({ cooldownTimer: null, cooldownInterval: null });
+    expect(__test.getSelectionTimers()).toEqual({ selectionTimer: null, selectionInterval: null });
     spyTimeout.mockRestore();
     spyInterval.mockRestore();
   });


### PR DESCRIPTION
## Summary
- add #cli-countdown status element and parse skipRoundCooldown query flag
- show stat-selection countdown with auto-select or stall handling
- test countdown, auto-select, and query parameter behavior

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/pages/battleCLI.onKeyDown.test.js tests/pages/battleCLI.countdown.test.js`
- `npx playwright test` *(fails: Classic battle round completion > plays a round to completion without hanging, Classic battle flow > shows countdown before first round, Classic battle flow > timer auto-selects when expired, Classic battle flow > does not auto-select when flag disabled, Screenshot suite > @vectorSearch screenshot /src/pages/vectorSearch.html, Screenshot suite > @settings-light screenshot, Screenshot suite > @settings-dark screenshot, Screenshot suite > @settings-high-contrast screenshot, Screenshot suite > @battleJudoka-narrow screenshot, Settings page > tab order follows expected sequence, Skip cooldown flow > clicking Next button skips cooldown timer)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b3466e6f708326a06a2604c1d4f931