### PR TITLE
Prevent cooldown fallback after initial match start

### DIFF
--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -188,6 +188,7 @@ export async function cooldownEnter(machine, payload) {
         duration * 1000 + 200
       );
     } catch {}
+    return;
   }
   // For inter-round cooldowns with no scheduled next-round timer (e.g., after
   // an interrupt path like timeout/noSelection), emit a countdown so the UI


### PR DESCRIPTION
## Summary
- avoid running fallback cooldown logic after initial match start by returning early in `cooldownEnter`

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battleRoundCompletion.spec.js, classicBattleFlow.spec.js, etc.)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b3502a36c88326b6077d1f4aed7b51