### PR TITLE
test(settings): include full navigation map in tab order

### DIFF
--- a/playwright/settings.spec.js
+++ b/playwright/settings.spec.js
@@ -37,6 +37,7 @@ function getLabelData() {
     "Typewriter Effect",
     "Tooltips",
     "Card of the Day",
+    "Full Navigation Map",
     ...sortedNames,
     ...flagLabels
   ];


### PR DESCRIPTION
## Summary
- include "Full Navigation Map" label in settings tab sequence

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: ReferenceError: Cannot access '__vite_ssr_import_14__' before initialization)*
- `npx playwright test playwright/settings.spec.js` *(passes but network errors: net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npx playwright test` *(fails: 10 failed tests)
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68b3502f74a88326b2d314c9cba20df3