### PR TITLE
fix: ensure modal cleanup on start error

### DIFF
--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -117,10 +117,13 @@ export async function initRoundSelectModal(onStart) {
         logEvent("battle.start", { pointsToWin: r.value, source: "modal" });
       } catch {}
       modal.close();
-      if (typeof onStart === "function") await onStart();
-      emitBattleEvent("startClicked");
-      cleanupTooltips();
-      modal.destroy();
+      try {
+        if (typeof onStart === "function") await onStart();
+        emitBattleEvent("startClicked");
+      } finally {
+        cleanupTooltips();
+        modal.destroy();
+      }
     });
     btnWrap.appendChild(btn);
   });

--- a/tests/helpers/classicBattle/roundSelectModal.test.js
+++ b/tests/helpers/classicBattle/roundSelectModal.test.js
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   fetchJson: vi.fn(),
   setPointsToWin: vi.fn(),
   initTooltips: vi.fn(),
-  modal: { open: vi.fn(), close: vi.fn() },
+  modal: { open: vi.fn(), close: vi.fn(), destroy: vi.fn() },
   emit: vi.fn()
 }));
 
@@ -32,7 +32,12 @@ vi.mock("../../../src/components/Modal.js", () => ({
   createModal: (content) => {
     const element = document.createElement("div");
     element.appendChild(content);
-    return { element, open: mocks.modal.open, close: mocks.modal.close, destroy: vi.fn() };
+    return {
+      element,
+      open: mocks.modal.open,
+      close: mocks.modal.close,
+      destroy: mocks.modal.destroy
+    };
   }
 }));
 vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({


### PR DESCRIPTION
## Summary
- ensure round selection modal always cleans up tooltips and destroys modal even if start callback rejects
- expose modal destroy spy in roundSelectModal tests

## Testing
- `npm run check:jsdoc` *(fails: Total missing: 258)*
- `npx prettier . --check`
- `npx eslint .` *(warnings: no-unused-vars)*
- `npx vitest run` *(fails: ReferenceError: document is not defined)*
- `npx vitest run tests/helpers/classicBattle/roundSelectModal.test.js`
- `npx playwright test` *(fails: 3 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b352049f4c8326ac978a044be5eb86