### PR TITLE
feat(cli): show round progress and highlight stat

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -68,7 +68,7 @@ A terminal-style Classic Battle ensures **fast load, consistent behavior, and im
 |---|---|---|
 | **P1** | Engine Integration | Use the same Classic Battle engine and state machine as battleJudoka; static import for core gameplay modules. |
 | **P1** | Textual Renderer | Render all state changes (countdown, prompts, outcomes, score) as text within a monospace pane; no images/animations. |
-| **P1** | Keyboard Controls | Shortcut keys for stat selection (1–9), Next/Continue (Enter/Space), Quit (Q), Help (H). Display a concise cheat sheet. |
+| **P1** | Keyboard Controls | Shortcut keys for stat selection (1–9), Next/Continue (Enter/Space), Quit (Q), Help (H). Display a multi-line help list. |
 | **P1** | Pointer Controls | Stats and Next prompts are clickable/tappable for mouse and touch users. |
 | **P1** | Timer Display | Show a 1 Hz textual countdown for stat selection; on expiry, auto-select per `FF_AUTO_SELECT`. |
 | **P1** | Outcome/Score | After decision, print outcome (Win/Loss/Draw), selected stat/value pairs, and updated score. |
@@ -76,6 +76,7 @@ A terminal-style Classic Battle ensures **fast load, consistent behavior, and im
 | **P1** | Test Hooks | Expose stable selectors/ids (e.g., `#round-message`, `#cli-score`, `#cli-countdown`, `data-flag`) to support existing tests and new CLI tests. |
 | **P2** | Minimal Settings | Allow selecting win target (5/10/15). Changing the value prompts to reset scores and restart the match; the last choice persists via the shared settings helper. |
 | **P2** | Deterministic Seed | Optional numeric seed via header input or `?seed=` query parameter enables reproducible runs; last seed is stored locally. |
+| **P2** | Round Context | Header shows current round and win target ("Round X of Y"). |
 | **P2** | Observability Mode | Optional verbose logs (controlled by the `cliVerbose` feature flag) that echo internal state transitions. |
 | **P2** | Interrupt Handling | Surface quit/interrupt flows as text prompts; roll back to last completed round consistent with engine PRD. |
 | **P3** | Retro Mode | Optional ASCII borders and simple color accents via CSS classes; disabled by default for maximum contrast. |
@@ -152,23 +153,26 @@ Notes:
 
 ### ASCII Wireframe (Desktop)
 
-| Classic Battle CLI         Target: 5 Wins       |
+| Classic Battle CLI   Round 1 of 5   Target: 5 Wins |
 
-| [Timer: 08]                                     |
-| Choose a stat:                                  |
-|   (1) Strength: 72                              |
-|   (2) Agility: 63                               |
-|   (3) Stamina: 81                               |
+| [Timer: 08]                                        |
+| Choose a stat:                                     |
+|   (1) Strength: 72                                 |
+|   (2) Agility: 63                                  |
+|   (3) Stamina: 81                                  |
 
-| Last Round: You WON! (72 vs 64)                 |
-| Score: Player 2 - Opponent 1                    |
+| Last Round: You WON! (72 vs 64)                    |
+| Score: Player 2 - Opponent 1                       |
 
-| Shortcuts: [1-9] Select | [Enter] Next | [Q] Quit |
-|            [H] Help                             |
+| Shortcuts:                                        |
+|   [1-9] Select Stat                               |
+|   [Enter]/[Space] Next                            |
+|   [Q] Quit                                        |
+|   [H] Toggle Help                                 |
 
 ## UI and Interaction Model
 
-- Layout: A single-column, monospace pane with sections: Header (mode title + win target), Countdown/Prompt area, Stat List with numeric hotkeys, Round Message, Score line, Shortcut cheat sheet.
+- Layout: A single-column, monospace pane with sections: Header (mode title + win target + round context), Countdown/Prompt area, Stat List with numeric hotkeys, Round Message, Score line, multi-line shortcut list.
 - DOM hooks: `#cli-root`, `#cli-header`, `#cli-countdown` (snackbar equivalent), `#cli-stats`, `#round-message`, `#cli-score`, `#cli-shortcuts`.
 - Keyboard map: 1–9 for stat selection; Enter/Space for Next; Q for Quit; H for Help/shortcuts.
 - Focus: Initial focus on the stat list container during selection; after outcome, focus moves to Next instruction hint.

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -46,9 +46,6 @@
         min-width: 30ch; /* reserve width for longest state (prevents wrap/jump) */
         white-space: nowrap;
       }
-      .cli-score {
-        white-space: pre;
-      }
       .cli-controls {
         display: flex;
         gap: 8px;
@@ -83,6 +80,18 @@
         padding: 4px 6px;
         background: #121212;
         border: 1px solid #3a3a3a;
+      }
+      .cli-stat.selected {
+        border-color: #9ad1ff;
+        background: #1a1a1a;
+      }
+      .cli-status {
+        text-align: right;
+        white-space: pre;
+      }
+      #cli-help {
+        margin: 0;
+        padding-left: 16px;
       }
       .cli-footer {
         margin-top: auto;
@@ -145,8 +154,9 @@
             style="width: 6ch"
           />
         </div>
-        <div id="cli-score" class="cli-score" aria-live="polite" aria-atomic="true">
-          You: 0 Opponent: 0
+        <div class="cli-status" aria-live="polite" aria-atomic="true">
+          <div id="cli-round">Round 0 of 0</div>
+          <div id="cli-score">You: 0 Opponent: 0</div>
         </div>
       </header>
 
@@ -168,9 +178,13 @@
         </section>
 
         <section aria-label="Shortcuts" id="cli-shortcuts" class="cli-block">
-          <div id="cli-help">
-            [1–5] Select Stat | [Enter]/[Space] Next | [Q] Quit | [H] Toggle Help | [R] Retro Mode
-          </div>
+          <ul id="cli-help">
+            <li>[1–5] Select Stat</li>
+            <li>[Enter]/[Space] Next</li>
+            <li>[Q] Quit</li>
+            <li>[H] Toggle Help</li>
+            <li>[R] Retro Mode</li>
+          </ul>
         </section>
 
         <section aria-label="Verbose Log" id="cli-verbose-section" class="cli-block" hidden>

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -8,7 +8,7 @@ import {
 import { initClassicBattleOrchestrator } from "../helpers/classicBattle/orchestrator.js";
 import { onBattleEvent, emitBattleEvent } from "../helpers/classicBattle/battleEvents.js";
 import { STATS } from "../helpers/BattleEngine.js";
-import { setPointsToWin } from "../helpers/battleEngineFacade.js";
+import { setPointsToWin, getPointsToWin } from "../helpers/battleEngineFacade.js";
 import { fetchJson } from "../helpers/dataUtils.js";
 import { DATA_DIR } from "../helpers/constants.js";
 import {
@@ -58,7 +58,8 @@ export const __test = {
   init,
   autostartBattle,
   renderStatList,
-  restorePointsToWin
+  restorePointsToWin,
+  startRoundWrapper
 };
 
 function setRetroMode(enabled) {
@@ -69,6 +70,19 @@ function updateScoreLine(player, opponent) {
   const el = byId("cli-score");
   if (!el) return;
   el.textContent = `You: ${player}  Opponent: ${opponent}`;
+}
+
+/**
+ * Update the round counter line in the header.
+ *
+ * @pseudocode
+ * if round element exists:
+ *   set text to `Round ${round} of ${target}`
+ */
+function updateRoundHeader(round, target) {
+  const el = byId("cli-round");
+  if (!el) return;
+  el.textContent = `Round ${round} of ${target}`;
 }
 
 function setRoundMessage(text) {
@@ -165,6 +179,7 @@ function stopSelectionCountdown() {
  *
  * @pseudocode
  * stopSelectionCountdown()
+ * highlight chosen stat
  * update store with selection
  * show bottom line with picked stat
  * dispatch "statSelected" on machine
@@ -172,6 +187,11 @@ function stopSelectionCountdown() {
 function selectStat(stat) {
   if (!stat) return;
   stopSelectionCountdown();
+  const list = byId("cli-stats");
+  list?.querySelectorAll(".selected").forEach((el) => el.classList.remove("selected"));
+  const idx = STATS.indexOf(stat) + 1;
+  const choiceEl = list?.querySelector(`[data-stat-index="${idx}"]`);
+  choiceEl?.classList.add("selected");
   try {
     if (store) {
       store.playerChoice = stat;
@@ -313,7 +333,9 @@ export async function renderStatList() {
             .sort((a, b) => (a.statIndex || 0) - (b.statIndex || 0))
             .map((s) => `[${s.statIndex}] ${s.name}`)
             .join("  ·  ");
-          help.textContent = `${help.textContent}  |  ${mapping}`;
+          const li = document.createElement("li");
+          li.textContent = mapping;
+          help.appendChild(li);
         }
       } catch {}
     }
@@ -382,14 +404,27 @@ function renderHiddenPlayerStats(judoka) {
   container.replaceChildren(ul);
 }
 
+/**
+ * Start a new round and prepare the CLI UI.
+ *
+ * @pseudocode
+ * call core startRound → { judoka, roundNumber }
+ * renderHiddenPlayerStats(judoka)
+ * remove any `.selected` stat classes
+ * clear round message and show prompt
+ * update round header with roundNumber and points target
+ */
 async function startRoundWrapper() {
   // Use the core startRound to select judoka; capture results and prepare hidden values.
-  const { playerJudoka } = await startRoundCore(store);
+  const { playerJudoka, roundNumber } = await startRoundCore(store);
   currentPlayerJudoka = playerJudoka || null;
   if (currentPlayerJudoka) renderHiddenPlayerStats(currentPlayerJudoka);
-  // Prompt user for input in the bottom line
+  // Reset selections and prompt user for input
+  const list = byId("cli-stats");
+  list?.querySelectorAll(".selected").forEach((el) => el.classList.remove("selected"));
   setRoundMessage("");
   showBottomLine("Select your move");
+  updateRoundHeader(roundNumber, getPointsToWin());
 }
 
 function getStatByIndex(index1Based) {
@@ -459,9 +494,7 @@ export function handleGlobalKey(key) {
  * if key is between '1' and '9':
  *   lookup stat by index
  *   if stat missing: return false
- *   record selection on the store if available
- *   show bottom line with picked stat
- *   dispatch 'statSelected'
+ *   selectStat(stat)
  *   return true
  * return false
  */
@@ -489,17 +522,7 @@ export function handleWaitingForPlayerActionKey(key) {
   if (key >= "1" && key <= "9") {
     const stat = getStatByIndex(key);
     if (!stat) return false;
-    try {
-      if (store) {
-        store.playerChoice = stat;
-        store.selectionMade = true;
-      }
-    } catch {}
-    showBottomLine(`You Picked: ${stat.charAt(0).toUpperCase()}${stat.slice(1)}`);
-    try {
-      const machine = window.__getClassicBattleMachine?.();
-      if (machine) machine.dispatch("statSelected");
-    } catch {}
+    selectStat(stat);
     return true;
   }
   return false;

--- a/tests/pages/battleCLI.roundHeader.test.js
+++ b/tests/pages/battleCLI.roundHeader.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+async function loadBattleCLI() {
+  const emitter = new EventTarget();
+  vi.doMock("../../src/helpers/featureFlags.js", () => ({
+    initFeatureFlags: vi.fn(),
+    isEnabled: vi.fn().mockReturnValue(false),
+    setFlag: vi.fn(),
+    featureFlagsEmitter: emitter
+  }));
+  vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+    createBattleStore: vi.fn(),
+    startRound: vi.fn().mockResolvedValue({ playerJudoka: null, roundNumber: 2 })
+  }));
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    onBattleEvent: vi.fn(),
+    emitBattleEvent: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: [] }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    setPointsToWin: vi.fn(),
+    getPointsToWin: vi.fn().mockReturnValue(10)
+  }));
+  vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson: vi.fn().mockResolvedValue([]) }));
+  vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+  const mod = await import("../../src/pages/battleCLI.js");
+  return mod;
+}
+
+describe("battleCLI round header", () => {
+  beforeEach(() => {
+    window.__TEST__ = true;
+    document.body.innerHTML = `
+      <div id="cli-stats"></div>
+      <div id="cli-round"></div>
+      <div id="round-message"></div>
+      <div id="snackbar-container"></div>
+    `;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.__TEST__;
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doUnmock("../../src/helpers/featureFlags.js");
+    vi.doUnmock("../../src/helpers/classicBattle/roundManager.js");
+    vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+    vi.doUnmock("../../src/helpers/classicBattle/battleEvents.js");
+    vi.doUnmock("../../src/helpers/BattleEngine.js");
+    vi.doUnmock("../../src/helpers/battleEngineFacade.js");
+    vi.doUnmock("../../src/helpers/dataUtils.js");
+    vi.doUnmock("../../src/helpers/constants.js");
+  });
+
+  it("updates round header each round", async () => {
+    const mod = await loadBattleCLI();
+    await mod.__test.startRoundWrapper();
+    expect(document.getElementById("cli-round").textContent).toBe("Round 2 of 10");
+  });
+});

--- a/tests/pages/battleCLI.selectedStat.test.js
+++ b/tests/pages/battleCLI.selectedStat.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+async function loadBattleCLI() {
+  const emitter = new EventTarget();
+  vi.doMock("../../src/helpers/featureFlags.js", () => ({
+    initFeatureFlags: vi.fn(),
+    isEnabled: vi.fn().mockReturnValue(false),
+    setFlag: vi.fn(),
+    featureFlagsEmitter: emitter
+  }));
+  vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+    createBattleStore: vi.fn(),
+    startRound: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    onBattleEvent: vi.fn(),
+    emitBattleEvent: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: ["speed", "strength"] }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    setPointsToWin: vi.fn(),
+    getPointsToWin: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson: vi.fn().mockResolvedValue([]) }));
+  vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+  const mod = await import("../../src/pages/battleCLI.js");
+  return mod;
+}
+
+describe("battleCLI stat highlighting", () => {
+  beforeEach(() => {
+    window.__TEST__ = true;
+    document.body.innerHTML = `
+      <div id="cli-stats">
+        <div class="cli-stat" data-stat-index="1">[1] Speed</div>
+        <div class="cli-stat" data-stat-index="2">[2] Strength</div>
+      </div>
+      <div id="snackbar-container"></div>
+    `;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.__TEST__;
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doUnmock("../../src/helpers/featureFlags.js");
+    vi.doUnmock("../../src/helpers/classicBattle/roundManager.js");
+    vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+    vi.doUnmock("../../src/helpers/classicBattle/battleEvents.js");
+    vi.doUnmock("../../src/helpers/BattleEngine.js");
+    vi.doUnmock("../../src/helpers/battleEngineFacade.js");
+    vi.doUnmock("../../src/helpers/dataUtils.js");
+    vi.doUnmock("../../src/helpers/constants.js");
+  });
+
+  it("adds .selected to chosen stat", async () => {
+    const mod = await loadBattleCLI();
+    mod.handleWaitingForPlayerActionKey("1");
+    expect(document.querySelector('[data-stat-index="1"]').classList.contains("selected")).toBe(
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- show current round in CLI header and clean multiline shortcut help
- highlight chosen stat in CLI and reset each round
- document round context and help layout in PRD

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 10 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b3540ed2108326ae54dac4631ebff7