### PR TITLE
feat: add quit modal and match reset to battleCLI

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -164,6 +164,7 @@ export class Modal {
    * 3. Deactivate the focus trap.
    * 4. Remove the keydown event listener for handling the Escape key.
    * 5. If a triggering element was stored, set its 'aria-expanded' attribute to 'false' and return focus to it.
+   * 6. Dispatch a `close` event on the modal backdrop.
    *
    * @returns {void}
    */
@@ -176,6 +177,7 @@ export class Modal {
       this.returnFocus.setAttribute("aria-expanded", "false");
       this.returnFocus.focus();
     }
+    this.element.dispatchEvent(new CustomEvent("close"));
   }
 
   /**

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -40,6 +40,7 @@ let cooldownInterval = null;
 let selectionTimer = null;
 let selectionInterval = null;
 let quitModal = null;
+let isQuitting = false;
 let pausedSelectionRemaining = null;
 let pausedCooldownRemaining = null;
 
@@ -207,7 +208,10 @@ function pauseTimers() {
  * reset stored remaining values
  */
 function resumeTimers() {
-  if (document.body?.dataset?.battleState === "waitingForPlayerAction" && pausedSelectionRemaining) {
+  if (
+    document.body?.dataset?.battleState === "waitingForPlayerAction" &&
+    pausedSelectionRemaining
+  ) {
     startSelectionCountdown(pausedSelectionRemaining);
   }
   if (document.body?.dataset?.battleState === "cooldown" && pausedCooldownRemaining) {
@@ -238,13 +242,15 @@ function resumeTimers() {
  * pauseTimers()
  * if modal not yet created:
  *   build modal with Cancel and Quit buttons
- *   cancel closes modal and resumes timers
- *   quit dispatches interrupt and clears bottom line
+ *   listen for modal 'close' to resume timers when not quitting
+ *   cancel closes modal
+ *   quit sets quitting flag, dispatches interrupt and clears bottom line
  *   append modal to container
  * open modal
  */
 function showQuitModal() {
   pauseTimers();
+  isQuitting = false;
   if (!quitModal) {
     const title = document.createElement("h2");
     title.id = "quit-modal-title";
@@ -264,11 +270,14 @@ function showQuitModal() {
     frag.append(title, actions);
 
     quitModal = createModal(frag, { labelledBy: title });
+    quitModal.element.addEventListener("close", () => {
+      if (!isQuitting) resumeTimers();
+    });
     cancel.addEventListener("click", () => {
       quitModal.close();
-      resumeTimers();
     });
     quit.addEventListener("click", () => {
+      isQuitting = true;
       quitModal.close();
       clearBottomLine();
       try {

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { emitBattleEvent, __resetBattleEventTarget } from "../../src/helpers/classicBattle/battleEvents.js";
+import {
+  emitBattleEvent,
+  __resetBattleEventTarget
+} from "../../src/helpers/classicBattle/battleEvents.js";
 
 describe("battleCLI onKeyDown", () => {
   let onKeyDown, __test;
@@ -68,6 +71,34 @@ describe("battleCLI onKeyDown", () => {
     countdown.dataset.remainingTime = "3";
     onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
     document.getElementById("cancel-quit-button").click();
+    expect(__test.getSelectionTimers().selectionTimer).not.toBeNull();
+  });
+
+  it("resumes timers when quit modal dismissed with Escape", () => {
+    const dispatch = vi.fn();
+    window.__getClassicBattleMachine = () => ({ dispatch });
+    document.body.dataset.battleState = "waitingForPlayerAction";
+    const selT = setTimeout(() => {}, 1000);
+    const selI = setInterval(() => {}, 1000);
+    __test.setSelectionTimers(selT, selI);
+    const countdown = document.getElementById("cli-countdown");
+    countdown.dataset.remainingTime = "3";
+    onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(__test.getSelectionTimers().selectionTimer).not.toBeNull();
+  });
+
+  it("resumes timers when backdrop is clicked", () => {
+    const dispatch = vi.fn();
+    window.__getClassicBattleMachine = () => ({ dispatch });
+    document.body.dataset.battleState = "waitingForPlayerAction";
+    const selT = setTimeout(() => {}, 1000);
+    const selI = setInterval(() => {}, 1000);
+    __test.setSelectionTimers(selT, selI);
+    const countdown = document.getElementById("cli-countdown");
+    countdown.dataset.remainingTime = "3";
+    onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
+    document.querySelector(".modal-backdrop").click();
     expect(__test.getSelectionTimers().selectionTimer).not.toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- resume CLI timers when quit modal closes via Escape or backdrop
- emit `close` event from Modal and handle in battleCLI
- test timer resumption for Escape and backdrop dismissals

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: TimeoutError: page.waitForFunction: Timeout 10000ms exceeded)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b356f6cbdc8326a8ecd7a26a222245