### PR TITLE
feat: improve battleCLI accessibility

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -72,7 +72,7 @@ A terminal-style Classic Battle ensures **fast load, consistent behavior, and im
 | **P1** | Pointer Controls | Stats and Next prompts are clickable/tappable for mouse and touch users. |
 | **P1** | Timer Display | Show a 1 Hz textual countdown for stat selection; on expiry, auto-select per `FF_AUTO_SELECT`. |
 | **P1** | Outcome/Score | After decision, print outcome (Win/Loss/Draw), selected stat/value pairs, and updated score. |
-| **P1** | Accessibility Hooks | Provide `aria-live="polite"` for round messages and countdown; maintain focus order for keyboard use. |
+| **P1** | Accessibility Hooks | Provide `aria-live="polite"` for round messages and countdown; maintain focus order for keyboard use, including a skip link and programmatic focus on stat selection and Next prompts. |
 | **P1** | Test Hooks | Expose stable selectors/ids (e.g., `#round-message`, `#cli-score`, `#cli-countdown`, `data-flag`) to support existing tests and new CLI tests. |
 | **P2** | Minimal Settings | Allow selecting win target (5/10/15). Changing the value prompts to reset scores and restart the match; the last choice persists via the shared settings helper. |
 | **P2** | Deterministic Seed | Optional numeric seed via header input or `?seed=` query parameter enables reproducible runs; last seed is stored locally. |

--- a/src/helpers/classicBattle/battleEvents.js
+++ b/src/helpers/classicBattle/battleEvents.js
@@ -94,7 +94,11 @@ export function offBattleEvent(type, handler) {
  * 1. TODO: Add pseudocode
  */
 export function emitBattleEvent(type, detail) {
-  target.dispatchEvent(new CustomEvent(type, { detail }));
+  const event = new CustomEvent(type, { detail });
+  target.dispatchEvent(event);
+  try {
+    document.dispatchEvent(event);
+  } catch {}
 }
 
 export default target;

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -115,9 +115,21 @@
         outline: 2px solid #9ad1ff;
         outline-offset: 2px;
       }
+      .skip-link {
+        position: absolute;
+        top: -40px;
+        left: 0;
+        background: #0b0c0c;
+        color: #f2f2f2;
+        padding: 8px;
+      }
+      .skip-link:focus {
+        top: 0;
+      }
     </style>
   </head>
   <body>
+    <a href="#cli-main" class="skip-link">Skip to main content</a>
     <div id="cli-root" class="cli-root">
       <header id="cli-header" class="cli-header" role="banner">
         <div class="cli-title">

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -148,6 +148,7 @@ function showBottomLine(text) {
       bar.className = "snackbar";
       container.appendChild(bar);
     }
+    bar.setAttribute("tabindex", "0");
     bar.textContent = text || "";
   } catch {}
 }
@@ -916,7 +917,7 @@ function installEventBindings() {
     }
   });
 
-  onBattleEvent("matchOver", () => {
+  const handleMatchOver = () => {
     const main = byId("cli-main");
     if (!main || byId("play-again-button")) return;
     const section = document.createElement("section");
@@ -932,15 +933,22 @@ function installEventBindings() {
     });
     section.append(btn);
     main.append(section);
-  });
+  };
+  onBattleEvent("matchOver", handleMatchOver);
+  document.addEventListener("matchOver", handleMatchOver);
 
   // Track state changes: start/stop countdown and append verbose log
   document.addEventListener("battle:state", (ev) => {
     const { from, to } = ev.detail || {};
     if (to === "waitingForPlayerAction") {
       startSelectionCountdown(5);
+      byId("cli-stats")?.focus();
     } else {
       stopSelectionCountdown();
+    }
+    if (to === "roundOver") {
+      showBottomLine("Press Enter to continue");
+      byId("snackbar-container")?.querySelector(".snackbar")?.focus();
     }
     if (!verboseEnabled) return;
     try {

--- a/tests/pages/battleCLI.a11y.focus.test.js
+++ b/tests/pages/battleCLI.a11y.focus.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readFileSync } from "fs";
+
+async function loadBattleCLI() {
+  const emitter = new EventTarget();
+  vi.doMock("../../src/helpers/featureFlags.js", () => ({
+    initFeatureFlags: vi.fn(),
+    isEnabled: vi.fn(() => false),
+    setFlag: vi.fn(),
+    featureFlagsEmitter: emitter
+  }));
+  vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+    createBattleStore: vi.fn(() => ({})),
+    startRound: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    onBattleEvent: vi.fn(),
+    emitBattleEvent: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: ["speed"] }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    setPointsToWin: vi.fn(),
+    getPointsToWin: vi.fn(() => 10)
+  }));
+  vi.doMock("../../src/helpers/dataUtils.js", () => ({
+    fetchJson: vi.fn().mockResolvedValue([{ statIndex: 1, name: "Speed" }])
+  }));
+  vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+  const mod = await import("../../src/pages/battleCLI.js");
+  await mod.__test.init();
+  return mod.__test;
+}
+
+describe("battleCLI accessibility", () => {
+  it("marks countdown and round message as polite live regions", () => {
+    const html = readFileSync("src/pages/battleCLI.html", "utf8");
+    document.documentElement.innerHTML = html;
+    const roundMsg = document.getElementById("round-message");
+    const countdown = document.getElementById("cli-countdown");
+    expect(roundMsg?.getAttribute("role")).toBe("status");
+    expect(roundMsg?.getAttribute("aria-live")).toBe("polite");
+    expect(countdown?.getAttribute("role")).toBe("status");
+    expect(countdown?.getAttribute("aria-live")).toBe("polite");
+  });
+
+  describe("focus management", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      window.__TEST__ = true;
+      document.body.innerHTML = `
+        <div id="cli-countdown" role="status" aria-live="polite"></div>
+        <div id="round-message" role="status" aria-live="polite"></div>
+        <div id="cli-stats" tabindex="0"></div>
+        <div id="cli-help"></div>
+        <select id="points-select"></select>
+        <section id="cli-verbose-section" hidden>
+          <pre id="cli-verbose-log"></pre>
+        </section>
+        <input id="verbose-toggle" type="checkbox" />
+        <div id="snackbar-container"></div>
+      `;
+      const machine = { dispatch: vi.fn() };
+      window.__getClassicBattleMachine = vi.fn(() => machine);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      document.body.innerHTML = "";
+      delete window.__TEST__;
+      delete window.__getClassicBattleMachine;
+      vi.resetModules();
+      vi.clearAllMocks();
+      vi.doUnmock("../../src/helpers/featureFlags.js");
+      vi.doUnmock("../../src/helpers/classicBattle/roundManager.js");
+      vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+      vi.doUnmock("../../src/helpers/classicBattle/battleEvents.js");
+      vi.doUnmock("../../src/helpers/BattleEngine.js");
+      vi.doUnmock("../../src/helpers/battleEngineFacade.js");
+      vi.doUnmock("../../src/helpers/dataUtils.js");
+      vi.doUnmock("../../src/helpers/constants.js");
+    });
+
+    it("shifts focus between stat list and next prompt", async () => {
+      await loadBattleCLI();
+      document.dispatchEvent(
+        new CustomEvent("battle:state", { detail: { to: "waitingForPlayerAction" } })
+      );
+      expect(document.activeElement?.id).toBe("cli-stats");
+      document.dispatchEvent(new CustomEvent("battle:state", { detail: { to: "roundOver" } }));
+      const bar = document.querySelector("#snackbar-container .snackbar");
+      expect(bar?.textContent).toBe("Press Enter to continue");
+      expect(document.activeElement).toBe(bar);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add skip link and focusable prompts to battleCLI
- shift focus programmatically during stat selection and round transitions
- cover battleCLI focus handling and live regions with tests

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battleCLI round completion, classic battle flow, screenshot suite, skip cooldown)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b35aa257a08326906e9cdd41742e69