### PR TITLE
Handle initTooltips failures in classic battle UI setup

### DIFF
--- a/src/helpers/classicBattle/setupUIBindings.js
+++ b/src/helpers/classicBattle/setupUIBindings.js
@@ -43,7 +43,9 @@ export async function setupUIBindings(view) {
   }
 
   await applyStatLabels().catch(() => {});
-  await initTooltips();
+  await initTooltips().catch((error) => {
+    console.debug("initTooltips failed", error);
+  });
   maybeShowStatHint();
 
   return statButtonControls;


### PR DESCRIPTION
## Summary
- gracefully handle errors in `initTooltips` during classic battle UI setup and log failures for debugging

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b364b9add8832697f6b00ffe40551a