### PR TITLE
feat: guard round modal start

### DIFF
--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -119,8 +119,10 @@ export async function initRoundSelectModal(onStart) {
       modal.close();
       try {
         if (typeof onStart === "function") await onStart();
-        emitBattleEvent("startClicked");
+      } catch (err) {
+        console.error("Failed to start battle:", err);
       } finally {
+        emitBattleEvent("startClicked");
         cleanupTooltips();
         modal.destroy();
       }


### PR DESCRIPTION
## Summary
- handle errors during round modal start callback
- emit battle start event regardless of callback errors
- keep modal cleanup in finally block

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 10 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b364a622b8832683d555e4ede4bad1