### PR TITLE
feat: add CLI shortcuts flag

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -83,6 +83,7 @@ A terminal-style Classic Battle ensures **fast load, consistent behavior, and im
 
 ### Feature Flags
 - `cliVerbose` – toggles the verbose log section on the CLI page; disabled by default.
+- `cliShortcuts` – enables single-key shortcuts (e.g., H for help) in the CLI; enabled by default.
 - `battleStateBadge` – shows a header badge reflecting the current match state; disabled by default.
 - `autoSelect` – when enabled (default), the match auto-picks a random stat when the selection timer expires.
   When disabled, the CLI waits for manual input after timeout.

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -57,6 +57,10 @@
       "enabled": false,
       "tooltipId": "settings.cliVerbose"
     },
+    "cliShortcuts": {
+      "enabled": true,
+      "tooltipId": "settings.cliShortcuts"
+    },
     "autoSelect": {
       "enabled": true,
       "tooltipId": "settings.autoSelect"

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -114,6 +114,10 @@
       "label": "CLI Verbose Logging",
       "description": "Show state transition logs in the battle CLI."
     },
+    "cliShortcuts": {
+      "label": "CLI Shortcuts",
+      "description": "Enable single-key shortcuts in the battle CLI."
+    },
     "autoSelect": {
       "label": "Auto-Select",
       "description": "Automatically pick a random stat when time runs out."

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -189,7 +189,12 @@
           </div>
         </section>
 
-        <section aria-label="Shortcuts" id="cli-shortcuts" class="cli-block">
+        <section
+          aria-label="Shortcuts"
+          id="cli-shortcuts"
+          class="cli-block"
+          data-flag="cliShortcuts"
+        >
           <ul id="cli-help">
             <li>[1–5] Select Stat</li>
             <li>[Enter]/[Space] Next</li>

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -138,6 +138,18 @@ function updateStateBadgeVisibility() {
   if (badge) badge.style.display = isEnabled("battleStateBadge") ? "" : "none";
 }
 
+/**
+ * Show or hide the CLI shortcuts section based on feature flag.
+ *
+ * @pseudocode
+ * if shortcuts section exists:
+ *   set hidden to !isEnabled("cliShortcuts")
+ */
+function updateCliShortcutsVisibility() {
+  const section = byId("cli-shortcuts");
+  if (section) section.hidden = !isEnabled("cliShortcuts");
+}
+
 function showBottomLine(text) {
   // Render as a single bottom line using the snackbar container
   try {
@@ -796,6 +808,7 @@ export function handleCooldownKey(key) {
  * 1. TODO: Add pseudocode
  */
 export function onKeyDown(e) {
+  if (!isEnabled("cliShortcuts")) return;
   const key = e.key.toLowerCase();
   const state = document.body?.dataset?.battleState || "";
   const table = {
@@ -1019,6 +1032,7 @@ async function init() {
   } catch {}
   updateVerbose();
   updateStateBadgeVisibility();
+  updateCliShortcutsVisibility();
   checkbox?.addEventListener("change", () => {
     setFlag("cliVerbose", !!checkbox.checked);
   });
@@ -1029,6 +1043,9 @@ async function init() {
     }
     if (!flag || flag === "battleStateBadge") {
       updateStateBadgeVisibility();
+    }
+    if (!flag || flag === "cliShortcuts") {
+      updateCliShortcutsVisibility();
     }
   });
   // Install CLI event bridges

--- a/tests/pages/battleCLI.cliShortcutsFlag.test.js
+++ b/tests/pages/battleCLI.cliShortcutsFlag.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+async function loadBattleCLI(flagEnabled) {
+  const emitter = new EventTarget();
+  vi.doMock("../../src/helpers/featureFlags.js", () => ({
+    initFeatureFlags: vi
+      .fn()
+      .mockResolvedValue({ featureFlags: { cliShortcuts: { enabled: flagEnabled } } }),
+    isEnabled: vi.fn((flag) => (flag === "cliShortcuts" ? flagEnabled : false)),
+    setFlag: vi.fn(),
+    featureFlagsEmitter: emitter
+  }));
+  vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+    createBattleStore: vi.fn(() => ({})),
+    startRound: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    onBattleEvent: vi.fn(),
+    emitBattleEvent: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: [] }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({ setPointsToWin: vi.fn() }));
+  vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson: vi.fn().mockResolvedValue([]) }));
+  vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+  const mod = await import("../../src/pages/battleCLI.js");
+  return mod;
+}
+
+describe("battleCLI cliShortcuts flag", () => {
+  beforeEach(() => {
+    window.__TEST__ = true;
+    document.body.innerHTML = `
+      <div id="cli-stats"></div>
+      <div id="cli-help"></div>
+      <select id="points-select"></select>
+      <section id="cli-verbose-section" hidden>
+        <pre id="cli-verbose-log"></pre>
+      </section>
+      <input id="verbose-toggle" type="checkbox" />
+      <section id="cli-shortcuts"></section>
+    `;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.__TEST__;
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doUnmock("../../src/helpers/featureFlags.js");
+    vi.doUnmock("../../src/helpers/classicBattle/roundManager.js");
+    vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+    vi.doUnmock("../../src/helpers/classicBattle/battleEvents.js");
+    vi.doUnmock("../../src/helpers/BattleEngine.js");
+    vi.doUnmock("../../src/helpers/battleEngineFacade.js");
+    vi.doUnmock("../../src/helpers/dataUtils.js");
+    vi.doUnmock("../../src/helpers/constants.js");
+  });
+
+  it("hides shortcuts section when cliShortcuts is disabled", async () => {
+    const mod = await loadBattleCLI(false);
+    await mod.__test.init();
+    expect(document.getElementById("cli-shortcuts").hidden).toBe(true);
+  });
+
+  it("shows shortcuts section when cliShortcuts is enabled", async () => {
+    const mod = await loadBattleCLI(true);
+    await mod.__test.init();
+    expect(document.getElementById("cli-shortcuts").hidden).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `cliShortcuts` feature flag with default on and tooltip
- gate battle CLI shortcuts section behind new flag and observe changes
- document CLI shortcuts flag and add unit tests

## Testing
- `npm run validate:data`
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Cannot read properties of undefined (reading 'catch') in classicBattle tests)*
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED and screenshot diffs)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b36843a9348326b5119b987dd5c2fe