### PR TITLE
feat: add stat hotkeys toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ CLI-specific tests live in `playwright/battle-cli.spec.js` and verify the state 
 
 Enable the `battleDebugPanel` feature flag to display a panel above the player and opponent cards with live match data. The panel includes a **Copy** button that copies all text for easy sharing.
 
+### Stat Hotkeys
+
+Enable the `statHotkeys` feature flag to map number keys 1–5 to stat buttons for quicker selection. Disabled by default.
+
 
 Screenshot suites store their baseline images in `playwright/*-snapshots/`. To skip running these comparison tests locally, set the `SKIP_SCREENSHOTS` environment variable:
 

--- a/design/productRequirementsDocuments/prdBattleClassic.md
+++ b/design/productRequirementsDocuments/prdBattleClassic.md
@@ -172,7 +172,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
     dismissal.
   - Tooltips on stat names, country flags, weight indicators, and navigation icons provide accessible explanations.
    - The Scoreboard includes a round counter (`#round-counter`) and a field showing the player's selected stat for the current round.
-  - Optional keyboard shortcuts: When `statHotkeys` feature flag is enabled, allow number keys 1–5 to select the corresponding stat button (left→right order) for power users and tests. Disabled by default.
+   - Optional keyboard shortcuts: When `statHotkeys` feature flag is enabled, allow number keys 1–5 to select the corresponding stat button (left→right order) for power users and tests. Disabled by default. The toggle resides under **Advanced Settings** on the Settings page.
   - **Accessibility:**
   - Minimum text contrast ratio: ≥4.5:1 (per WCAG).
   - Minimum touch target size: ≥44px. See [UI Design Standards](../codeStandards/codeUIDesignStandards.md#9-accessibility--responsiveness) for the full rule.

--- a/progress.md
+++ b/progress.md
@@ -236,3 +236,7 @@
 - Reordered round selection modal start logic so the battle machine receives
   `startClicked` only after initialization, preventing the lobby from hanging in
   `waitingForMatchStart`.
+
+## Milestone 12 — Stat Hotkeys Toggle
+
+- Surfaced `statHotkeys` in Advanced Settings with tooltip coverage and keyboard shortcut tests.

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -53,6 +53,10 @@
       "enabled": false,
       "tooltipId": "settings.skipRoundCooldown"
     },
+    "statHotkeys": {
+      "enabled": false,
+      "tooltipId": "settings.statHotkeys"
+    },
     "cliVerbose": {
       "enabled": false,
       "tooltipId": "settings.cliVerbose"

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -110,6 +110,10 @@
       "label": "Skip Round Cooldown",
       "description": "Start the next round immediately without a cooldown."
     },
+    "statHotkeys": {
+      "label": "Stat Hotkeys",
+      "description": "Use number keys 1–5 to select stats quickly."
+    },
     "cliVerbose": {
       "label": "CLI Verbose Logging",
       "description": "Show state transition logs in the battle CLI."

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -274,6 +274,23 @@
                 Automatically pick a random stat when time runs out.
               </p>
             </div>
+            <div class="settings-item">
+              <label for="feature-stat-hotkeys" class="switch">
+                <input
+                  type="checkbox"
+                  id="feature-stat-hotkeys"
+                  data-flag="statHotkeys"
+                  aria-label="Stat Hotkeys"
+                  aria-describedby="feature-stat-hotkeys-desc"
+                  data-tooltip-id="settings.statHotkeys"
+                />
+                <div class="slider round"></div>
+                <span>Stat Hotkeys</span>
+              </label>
+              <p id="feature-stat-hotkeys-desc" class="settings-description">
+                Use number keys 1–5 to select stats quickly.
+              </p>
+            </div>
           </fieldset>
           <fieldset id="links-container" class="settings-form">
             <legend>Links</legend>

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -63,11 +63,15 @@ describe("classicBattlePage feature flag updates", () => {
       updateSnackbar: vi.fn()
     }));
     vi.doMock("../../src/helpers/tooltip.js", () => ({
+      __esModule: true,
       initTooltips: vi.fn().mockResolvedValue(() => {})
     }));
     vi.doMock("../../src/helpers/testModeUtils.js", () => ({
       setTestMode: vi.fn(),
       isTestModeEnabled: () => true
+    }));
+    vi.doMock("../../src/helpers/tooltip.js", () => ({
+      initTooltips: vi.fn().mockResolvedValue(() => {})
     }));
 
     const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
@@ -122,6 +126,8 @@ describe("classicBattlePage feature flag updates", () => {
       isTestModeEnabled: () => true
     }));
 
+    const tooltip = await import("../../src/helpers/tooltip.js");
+    vi.spyOn(tooltip, "initTooltips").mockResolvedValue(() => {});
     const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
     await setupClassicBattlePage();
 
@@ -141,6 +147,41 @@ describe("classicBattlePage feature flag updates", () => {
     copyBtn.dispatchEvent(new Event("click", { bubbles: true }));
 
     expect(writeText).toHaveBeenCalledWith("battle info");
-    expect(copyBtn.closest("#debug-panel")).toBe(panel);
+      expect(copyBtn.closest("#debug-panel")).toBe(panel);
+  });
+  it("maps number keys to stat buttons only when statHotkeys is enabled", async () => {
+    const stats = document.createElement("div");
+    stats.id = "stat-buttons";
+    const btn = document.createElement("button");
+    btn.dataset.stat = "power";
+    stats.appendChild(btn);
+    document.body.append(stats);
+
+    const currentFlags = { statHotkeys: { enabled: false } };
+    const featureFlagsEmitter = new EventTarget();
+
+    vi.doMock("../../src/helpers/featureFlags.js", () => ({
+      featureFlagsEmitter,
+      isEnabled: (flag) => currentFlags[flag]?.enabled ?? false,
+      initFeatureFlags: vi.fn().mockResolvedValue({ featureFlags: currentFlags })
+    }));
+    vi.doMock("../../src/helpers/testModeUtils.js", () => ({
+      setTestMode: vi.fn(),
+      isTestModeEnabled: () => false
+    }));
+
+    const { initStatButtons } = await import("../../src/helpers/classicBattle/uiHelpers.js");
+    initStatButtons({});
+
+    const clickSpy = vi.spyOn(btn, "click");
+    btn.disabled = false;
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "1" }));
+    expect(clickSpy).not.toHaveBeenCalled();
+
+    currentFlags.statHotkeys.enabled = true;
+    featureFlagsEmitter.dispatchEvent(new CustomEvent("change"));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "1" }));
+    expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- add `statHotkeys` feature flag defaulting disabled with tooltip
- expose Stat Hotkeys toggle in settings page and wire flag
- test stat hotkeys feature flag behavior

## Testing
- `npm run validate:data`
- `npm run check:jsdoc` *(fails: 259 incomplete jsdoc)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/classicBattleFlags.test.js tests/helpers/classicBattle/statButtons.state.test.js`
- `npx vitest run` *(fails: battleStateBadge.test.js, view.initHelpers.test.js)*
- `npx playwright test` *(fails: 10 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b3682fe5d48326a05e3c3dbf097427