### PR TITLE
fix: swallow start callback errors in round-select modal

### DIFF
--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -31,7 +31,7 @@ import { t } from "../i18n.js";
  * 8. When a button is clicked:
  *    a. Call `setPointsToWin` with the round value and persist it.
  *    b. Close the modal.
- *    c. Invoke the provided start callback and await completion.
+ *    c. Invoke the provided start callback and await completion; log failures.
  *    d. If initialization succeeds, emit `startClicked`.
  *    e. Clean up tooltips and destroy the modal.
  *
@@ -123,7 +123,6 @@ export async function initRoundSelectModal(onStart) {
         emitBattleEvent("startClicked");
       } catch (err) {
         console.error("Failed to start battle:", err);
-        throw err;
       } finally {
         cleanupTooltips();
         modal.destroy();


### PR DESCRIPTION
## Summary
- log start callback failures instead of rethrowing to avoid unhandled promise rejections
- document that start callback failures are logged before cleanup

## Testing
- `npm run check:jsdoc` *(fails: Total missing: 214)*
- `npx prettier src/helpers/classicBattle/roundSelectModal.js --check`
- `npx eslint src/helpers/classicBattle/roundSelectModal.js`
- `npx vitest run` *(fails: tests/pages/battleCLI.countdown.test.js (3 tests | 3 failed), etc.)*
- `npx playwright test` *(fails: 3 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b36ba3835483268e36c320b7c0a130