### PR TITLE
fix: keep quit shortcut active when flag disabled

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -792,43 +792,6 @@ export function handleCooldownKey(key) {
 }
 
 /**
- * Dispatch keyboard input based on the current battle state.
- * @param {KeyboardEvent} e
- * @pseudocode
- * key = lowercased key from event
- * state = document.body.dataset.battleState
- * table = { waitingForPlayerAction: handleWaitingForPlayerActionKey,
- *           roundOver: handleRoundOverKey,
- *           cooldown: handleCooldownKey }
- * handler = table[state]
- * handled = handleGlobalKey(key) OR (handler ? handler(key) : false)
- * countdown = element '#cli-countdown'
- * if not handled:
- *   if countdown exists: set text to "Invalid key, press H for help"
- * else if countdown has text:
- *   clear countdown text
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
  * Global keyboard handler that routes input based on the current battle state.
  *
  * @summary Normalize keyboard events, run global handlers, then state-specific handlers.
@@ -836,6 +799,7 @@ export function handleCooldownKey(key) {
  * @returns {void}
  * @pseudocode
  * key = lowercased key from event
+ * if cliShortcuts disabled AND key != 'q': return
  * state = document.body.dataset.battleState
  * table = { waitingForPlayerAction: handleWaitingForPlayerActionKey,
  *           roundOver: handleRoundOverKey,
@@ -849,8 +813,8 @@ export function handleCooldownKey(key) {
  *   clear countdown text
  */
 export function onKeyDown(e) {
-  if (!isEnabled("cliShortcuts")) return;
   const key = e.key.toLowerCase();
+  if (!isEnabled("cliShortcuts") && key !== "q") return;
   const state = document.body?.dataset?.battleState || "";
   const table = {
     waitingForPlayerAction: handleWaitingForPlayerActionKey,

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -41,6 +41,7 @@ describe("battleCLI onKeyDown", () => {
     delete window.__TEST__;
     vi.resetModules();
     vi.doUnmock("../../src/components/Button.js");
+    vi.restoreAllMocks();
   });
 
   it("toggles shortcuts with H key", () => {
@@ -164,5 +165,16 @@ describe("battleCLI onKeyDown", () => {
     document.body.dataset.battleState = "cooldown";
     onKeyDown(new KeyboardEvent("keydown", { key: "Enter" }));
     expect(dispatch).toHaveBeenCalledWith("ready");
+  });
+
+  it("allows quitting with Q when cliShortcuts flag is disabled", async () => {
+    const featureFlags = await import("../../src/helpers/featureFlags.js");
+    vi.spyOn(featureFlags, "isEnabled").mockImplementation((flag) =>
+      flag === "cliShortcuts" ? false : featureFlags.isEnabled(flag)
+    );
+    const dispatch = vi.fn();
+    window.__getClassicBattleMachine = () => ({ dispatch });
+    onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
+    expect(document.getElementById("confirm-quit-button")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- always allow the quit shortcut even when `cliShortcuts` flag is off
- test that 'q' opens quit modal with shortcuts disabled

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: ReferenceError: self is not defined)*
- `npx playwright test` *(fails: browser context closed & screenshot diff)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b36cf3db1883268572cfee1532aa0d