### PR TITLE
fix: restore DOM battle state syncing

### DIFF
--- a/src/helpers/classicBattle/orchestrator.js
+++ b/src/helpers/classicBattle/orchestrator.js
@@ -188,6 +188,20 @@ export async function initClassicBattleOrchestrator(store, startRoundWrapper, op
           }
         }
       }
+      if (typeof document !== "undefined") {
+        try {
+          const ds = document.body?.dataset;
+          if (ds) {
+            ds.battleState = to;
+            if (from) ds.prevBattleState = from;
+          }
+        } catch {}
+        document.dispatchEvent(
+          new CustomEvent("battle:state", {
+            detail: { from: from || null, to, event: event || null }
+          })
+        );
+      }
     } catch {}
     updateTimerDebug(machine);
     emitBattleEvent("debugPanelUpdate");

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -147,7 +147,7 @@ describe("classicBattlePage feature flag updates", () => {
     copyBtn.dispatchEvent(new Event("click", { bubbles: true }));
 
     expect(writeText).toHaveBeenCalledWith("battle info");
-      expect(copyBtn.closest("#debug-panel")).toBe(panel);
+    expect(copyBtn.closest("#debug-panel")).toBe(panel);
   });
   it("maps number keys to stat buttons only when statHotkeys is enabled", async () => {
     const stats = document.createElement("div");


### PR DESCRIPTION
## Summary
- mirror classic battle state onto `document.body.dataset` and dispatch legacy `battle:state` DOM events
- fix Prettier formatting in `classicBattleFlags.test.js`

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: ReferenceError: setRetroMode is not defined)*
- `npx playwright test` *(fails: Timed out waiting for state badge and other expectations)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b36eec47248326933057bf3a83e045