### PR TITLE
fix: guard DOM access in battle state progress

### DIFF
--- a/src/helpers/battleStateProgress.js
+++ b/src/helpers/battleStateProgress.js
@@ -87,17 +87,25 @@ if (!isEnabled("battleStateProgress")) {
  * @summary Render core battle states into `#battle-state-progress` and register a
  * `battle:state` listener to update the active item. Returns a cleanup function.
  * @pseudocode
- * 1. If `document` is unavailable return early.
- * 2. Locate `#battle-state-progress` and either render or skip depending on `CLASSIC_BATTLE_STATES`.
- * 3. Resolve the ready promise and register an event listener to toggle `active` on list items.
- * 4. If an initial state exists on the body, apply it and mark the state part ready.
- * 5. Return a cleanup function that removes the event listener.
+ * 1. If the feature flag is disabled, hide the element if the DOM exists, resolve the ready promise, and return.
+ * 2. If `document` is unavailable resolve the ready promise and return.
+ * 3. Locate `#battle-state-progress` and either render or skip depending on `CLASSIC_BATTLE_STATES`.
+ * 4. Resolve the ready promise and register an event listener to toggle `active` on list items.
+ * 5. If an initial state exists on the body, apply it and mark the state part ready.
+ * 6. Return a cleanup function that removes the event listener.
  *
  * @returns {Promise<(() => void) | undefined>} Resolves with a cleanup function or undefined.
  */
 export async function initBattleStateProgress() {
-  if (!isEnabled("battleStateProgress") || typeof document === "undefined") {
-    document.getElementById("battle-state-progress")?.style.setProperty("display", "none");
+  if (!isEnabled("battleStateProgress")) {
+    if (typeof document !== "undefined") {
+      document.getElementById("battle-state-progress")?.style.setProperty("display", "none");
+    }
+    resolveBattleStateProgressReady?.();
+    return;
+  }
+
+  if (typeof document === "undefined") {
     resolveBattleStateProgressReady?.();
     return;
   }

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -147,7 +147,7 @@ describe("classicBattlePage feature flag updates", () => {
     copyBtn.dispatchEvent(new Event("click", { bubbles: true }));
 
     expect(writeText).toHaveBeenCalledWith("battle info");
-      expect(copyBtn.closest("#debug-panel")).toBe(panel);
+    expect(copyBtn.closest("#debug-panel")).toBe(panel);
   });
   it("maps number keys to stat buttons only when statHotkeys is enabled", async () => {
     const stats = document.createElement("div");


### PR DESCRIPTION
## Summary
- guard `initBattleStateProgress` from referencing `document` when feature flag disabled or DOM unavailable
- update pseudocode and hide progress list only when DOM exists
- format classicBattleFlags test with Prettier

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 3 failed)*
- `npx playwright test` *(fails: 9 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b36f5e014c8326a6f87981a7c17a3a