### PR TITLE
feat: mark battle state ready when progress disabled

### DIFF
--- a/src/helpers/battleStateProgress.js
+++ b/src/helpers/battleStateProgress.js
@@ -58,6 +58,11 @@ if (typeof window !== "undefined") {
 }
 
 if (!isEnabled("battleStateProgress")) {
+  if (typeof document !== "undefined") {
+    document.addEventListener("battle:state", () => markBattlePartReady("state"), { once: true });
+  } else {
+    markBattlePartReady("state");
+  }
   resolveBattleStateProgressReady?.();
 }
 
@@ -86,8 +91,9 @@ if (!isEnabled("battleStateProgress")) {
  *
  * @summary Render core battle states into `#battle-state-progress` and register a
  * `battle:state` listener to update the active item. Returns a cleanup function.
+ * When disabled, `'state'` is still marked ready on the next `battle:state` event.
  * @pseudocode
- * 1. If the feature flag is disabled, hide the element if the DOM exists, resolve the ready promise, and return.
+ * 1. If the feature flag is disabled, hide the element if the DOM exists, ensure `'state'` is marked ready, resolve the ready promise, and return.
  * 2. If `document` is unavailable resolve the ready promise and return.
  * 3. Locate `#battle-state-progress` and either render or skip depending on `CLASSIC_BATTLE_STATES`.
  * 4. Resolve the ready promise and register an event listener to toggle `active` on list items.


### PR DESCRIPTION
## Summary
- ensure `'state'` is marked ready when `battleStateProgress` is disabled
- document that `initBattleStateProgress` still marks state ready in this scenario

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: orchestrator UI events, skipRoundCooldown flag scenarios)
- `npx playwright test` (fails: 11 tests including skip-cooldown flow)
- `npx playwright test playwright/skip-cooldown.spec.js playwright/waits-timeout.spec.js` (fails: skip cooldown flow)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b3779ca8408326999e3b6890c0e26c