### PR TITLE
Ensure scheduler runs outside Vitest

### DIFF
--- a/src/helpers/classicBattle/setupScheduler.js
+++ b/src/helpers/classicBattle/setupScheduler.js
@@ -1,34 +1,15 @@
 import { start as startScheduler, stop as stopScheduler } from "../../utils/scheduler.js";
 
 /**
- * Start the animation scheduler for the battle view.
+ * @summary Start the animation scheduler for the battle view.
  *
  * @pseudocode
- * 1. Skip when running under Vitest.
- * 2. Start the scheduler and stop it on `pagehide`.
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
+ * 1. If `process.env.VITEST` is "true", exit early.
+ * 2. Otherwise start the scheduler and stop it on `pagehide`.
+ * @returns {void}
  */
 export function setupScheduler() {
-  if (!(typeof process !== "undefined" && process.env.VITEST)) {
+  if (!(typeof process !== "undefined" && process.env.VITEST === "true")) {
     startScheduler();
     window.addEventListener("pagehide", stopScheduler, { once: true });
   }


### PR DESCRIPTION
## Summary
- start battle animation scheduler unless VITEST is explicitly set to "true"
- document scheduler setup logic

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 10 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b37c8eda5c83268f0085fcbaada1f9