### PR TITLE
refactor: await stat buttons readiness

### DIFF
--- a/playwright/battleRoundCompletion.spec.js
+++ b/playwright/battleRoundCompletion.spec.js
@@ -24,26 +24,12 @@ test.describe("Classic battle round completion", () => {
     await waitForBattleReady(page);
 
     // 1. Wait for the stat buttons to be enabled
-    await page.waitForFunction(
-      () => {
-        const statButtons = document.querySelectorAll("#stat-buttons button");
-        return Array.from(statButtons).every((btn) => !btn.disabled);
-      },
-      null,
-      { timeout: 10000 }
-    );
+    await page.evaluate(() => window.statButtonsReadyPromise);
 
     // 2. Click a stat button
     await page.locator("button[data-stat='power']").click();
 
     // 3. Wait for the stat buttons to be disabled (indicating the round is processing)
-    await page.waitForFunction(
-      () => {
-        const statButtons = document.querySelectorAll("#stat-buttons button");
-        return Array.from(statButtons).every((btn) => btn.disabled);
-      },
-      null,
-      { timeout: 10000 }
-    );
+    await page.locator("#stat-buttons[data-buttons-ready='false']").waitFor();
   });
 });

--- a/playwright/skip-cooldown.spec.js
+++ b/playwright/skip-cooldown.spec.js
@@ -17,10 +17,7 @@ test.describe("Skip cooldown flow", () => {
   test("clicking Next button skips cooldown timer", async ({ page }) => {
     await page.locator("#round-select-1").click();
     await waitForBattleReady(page);
-    await page.waitForFunction(() => {
-      const btn = document.querySelector("#stat-buttons button");
-      return btn && !btn.disabled;
-    });
+    await page.evaluate(() => window.statButtonsReadyPromise);
 
     // Click a stat to finish the round
     await page.locator("button[data-stat='power']").click();


### PR DESCRIPTION
## Summary
- await `window.statButtonsReadyPromise` before stat button interactions
- rely on `data-buttons-ready` attribute instead of manual polling

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 10 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b37c9973a48326ae1a481c1bb67029