### PR TITLE
Refactor round start fallback handling

### DIFF
--- a/src/helpers/classicBattle/guard.js
+++ b/src/helpers/classicBattle/guard.js
@@ -8,3 +8,15 @@ export function guard(fn) {
     fn();
   } catch {}
 }
+
+/**
+ * Execute an async function and suppress any thrown errors or rejections.
+ *
+ * @param {() => Promise<any>|any} fn - Callback returning a promise or value.
+ * @returns {Promise<void>}
+ */
+export async function guardAsync(fn) {
+  try {
+    await fn();
+  } catch {}
+}

--- a/tests/helpers/classicBattlePage.startRoundWrapper.test.js
+++ b/tests/helpers/classicBattlePage.startRoundWrapper.test.js
@@ -112,6 +112,107 @@ describe("startRoundWrapper failures", () => {
     consoleError.mockRestore();
     vi.doUnmock("../../src/helpers/setupScoreboard.js");
   });
+
+  it("dispatches error when opponent card fails to render", async () => {
+    const showMessage = vi.fn();
+    const startRound = vi.fn().mockResolvedValue();
+    const waitForOpponentCard = vi.fn().mockRejectedValue(new Error("no card"));
+
+    vi.doMock("../../src/helpers/domReady.js", () => ({ onDomReady: () => {} }));
+    vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+      createBattleStore: () => ({}),
+      startRound
+    }));
+    vi.doMock("../../src/helpers/battleJudokaPage.js", () => ({ waitForOpponentCard }));
+    vi.doMock("../../src/helpers/classicBattle/selectionHandler.js", () => ({
+      handleStatSelection: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/setupScoreboard.js", () => ({
+      setupScoreboard: vi.fn(),
+      showMessage,
+      updateTimer: vi.fn(),
+      clearTimer: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/tooltip.js", () => ({
+      initTooltips: vi.fn().mockResolvedValue(() => {})
+    }));
+    vi.doMock("../../src/helpers/testModeUtils.js", () => ({
+      setTestMode: vi.fn(),
+      isTestModeEnabled: () => true
+    }));
+    vi.doMock("../../src/helpers/stats.js", () => ({
+      loadStatNames: vi.fn().mockResolvedValue([])
+    }));
+    vi.doMock("../../src/helpers/showSnackbar.js", () => ({
+      showSnackbar: vi.fn(),
+      updateSnackbar: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/featureFlags.js", () => ({
+      initFeatureFlags: vi.fn(),
+      isEnabled: vi.fn().mockReturnValue(false),
+      featureFlagsEmitter: new EventTarget()
+    }));
+    vi.doMock("../../src/helpers/battleStateProgress.js", () => ({
+      initBattleStateProgress: vi.fn().mockResolvedValue()
+    }));
+    vi.doMock("../../src/helpers/classicBattle/interruptHandlers.js", () => ({
+      initInterruptHandlers: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/cardUtils.js", () => ({ toggleInspectorPanels: vi.fn() }));
+    vi.doMock("../../src/helpers/viewportDebug.js", () => ({ toggleViewportSimulation: vi.fn() }));
+    vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+      startCoolDown: vi.fn(),
+      pauseTimer: vi.fn(),
+      resumeTimer: vi.fn(),
+      STATS: [],
+      setPointsToWin: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/classicBattle/timerService.js", () => ({
+      onNextButtonClick: vi.fn(),
+      getNextRoundControls: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/classicBattle/skipHandler.js", () => ({
+      skipCurrentPhase: vi.fn()
+    }));
+    vi.doMock("../../src/components/Modal.js", () => ({
+      createModal: (content) => {
+        const element = document.createElement("div");
+        element.appendChild(content);
+        return { element, open: vi.fn(), close: vi.fn(), destroy: vi.fn() };
+      }
+    }));
+    vi.doMock("../../src/components/Button.js", () => ({
+      createButton: (label, opts = {}) => {
+        const btn = document.createElement("button");
+        btn.textContent = label;
+        Object.assign(btn, opts);
+        return btn;
+      }
+    }));
+
+    const container = document.createElement("div");
+    container.id = "stat-buttons";
+    const btn = document.createElement("button");
+    btn.disabled = true;
+    container.appendChild(btn);
+    const battleArea = document.createElement("div");
+    battleArea.id = "battle-area";
+    document.body.append(container, battleArea);
+
+    const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
+    const api = await setupClassicBattlePage();
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = vi.fn();
+    document.addEventListener("round-start-error", errorSpy);
+    await api.startRoundOverride();
+    expect(errorSpy).toHaveBeenCalled();
+    expect(showMessage).toHaveBeenCalledWith("Round start error. Please retry.");
+    expect(btn.disabled).toBe(false);
+    document.removeEventListener("round-start-error", errorSpy);
+    consoleError.mockRestore();
+    vi.doUnmock("../../src/helpers/setupScoreboard.js");
+  });
 });
 
 describe("startRoundWrapper success", () => {


### PR DESCRIPTION
## Summary
- Extract round-start fallback and invocation into pure helpers
- Add async guard utility and guard-based error handling
- Cover opponent-card failure path in startRoundWrapper tests

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` (failed: net::ERR_TUNNEL_CONNECTION_FAILED)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b38628574c83269b0c8e67b1f26299