### PR TITLE
refactor settings controls

### DIFF
--- a/src/helpers/settings/attachResetListener.js
+++ b/src/helpers/settings/attachResetListener.js
@@ -1,0 +1,18 @@
+/**
+ * Attach a click listener to open the reset modal once.
+ *
+ * @pseudocode
+ * 1. Return early if `resetButton` is absent or already bound.
+ * 2. Add a click handler that opens the modal.
+ * 3. Mark the button as bound to prevent duplicate listeners.
+ *
+ * @param {HTMLElement|null} resetButton - The reset button element.
+ * @param {{ open(trigger?: HTMLElement): void }} modal - Reset modal API.
+ */
+export function attachResetListener(resetButton, modal) {
+  if (!resetButton || resetButton.dataset.resetListenerAttached) return;
+  resetButton.addEventListener("click", () => {
+    modal.open(resetButton);
+  });
+  resetButton.dataset.resetListenerAttached = "true";
+}

--- a/src/helpers/settings/createResetModal.js
+++ b/src/helpers/settings/createResetModal.js
@@ -1,0 +1,54 @@
+import { createModal } from "../../components/Modal.js";
+import { createButton } from "../../components/Button.js";
+import { showSnackbar } from "../showSnackbar.js";
+
+/**
+ * Build a confirmation modal for restoring default settings.
+ *
+ * @pseudocode
+ * 1. Create title and description nodes.
+ * 2. Create Cancel and Yes buttons via `createButton`.
+ * 3. Assemble modal with `createModal` and wire button handlers.
+ *    - Cancel closes the modal.
+ *    - Yes awaits `onConfirm`; on failure shows an error, otherwise closes.
+ * 4. Append the modal element to `document.body`.
+ * 5. Return the modal API.
+ *
+ * @param {Function} onConfirm - Called when user confirms reset.
+ * @returns {{ open(trigger?: HTMLElement): void }} Modal controls.
+ */
+export function createResetModal(onConfirm) {
+  const title = document.createElement("h2");
+  title.id = "reset-modal-title";
+  title.textContent = "Restore default settings?";
+
+  const desc = document.createElement("p");
+  desc.id = "reset-modal-desc";
+  desc.textContent = "This will clear all saved preferences.";
+
+  const actions = document.createElement("div");
+  actions.className = "modal-actions";
+
+  const cancel = createButton("Cancel", {
+    id: "cancel-reset-button",
+    className: "secondary-button"
+  });
+  const yes = createButton("Yes", { id: "confirm-reset-button" });
+  actions.append(cancel, yes);
+
+  const frag = document.createDocumentFragment();
+  frag.append(title, desc, actions);
+
+  const modal = createModal(frag, { labelledBy: title, describedBy: desc });
+  cancel.addEventListener("click", () => modal.close());
+  yes.addEventListener("click", async () => {
+    try {
+      await onConfirm();
+      modal.close();
+    } catch {
+      showSnackbar("Failed to restore default settings");
+    }
+  });
+  document.body.appendChild(modal.element);
+  return modal;
+}

--- a/src/helpers/settings/syncFeatureFlags.js
+++ b/src/helpers/settings/syncFeatureFlags.js
@@ -1,0 +1,21 @@
+import { DEFAULT_SETTINGS } from "../../config/settingsDefaults.js";
+
+/**
+ * Merge current feature flags with defaults.
+ *
+ * @pseudocode
+ * 1. Merge `DEFAULT_SETTINGS.featureFlags` with `currentSettings.featureFlags`.
+ * 2. Update `currentSettings.featureFlags` with the merged map.
+ * 3. Return the merged feature flag map.
+ *
+ * @param {Settings} currentSettings - Mutable settings object.
+ * @returns {object} Synced feature flag map.
+ */
+export function syncFeatureFlags(currentSettings) {
+  const flags = {
+    ...DEFAULT_SETTINGS.featureFlags,
+    ...(currentSettings.featureFlags || {})
+  };
+  currentSettings.featureFlags = flags;
+  return flags;
+}


### PR DESCRIPTION
## Summary
- extract reset modal builder, reset-button listener, and feature flag syncing into dedicated helpers
- streamline initializeControls to expose only a renderSwitches callback
- expand settingsPage tests for reset flow and default flag rendering

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Unhandled rejection in classicBattle tests)*
- `npx playwright test` *(fails: 10 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b386632ef08326bd81ff9b04ab8914