### PR TITLE
fix: await cooldown before dispatching ready

### DIFF
--- a/src/helpers/classicBattle/awaitCooldownState.js
+++ b/src/helpers/classicBattle/awaitCooldownState.js
@@ -16,7 +16,7 @@ export function awaitCooldownState() {
         typeof window !== "undefined" && window.__classicBattleState
           ? window.__classicBattleState
           : null;
-      if (!state || state === "cooldown" || state === "roundOver") {
+      if (!state || state === "cooldown") {
         resolve();
         return;
       }

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -407,7 +407,9 @@ export function handleStatSelectionTimeout(
  * @pseudocode
  * 1. Clear the skip handler and scoreboard timer.
  * 2. Enable the Next button and mark it as ready.
- * 3. Dispatch "ready", update the debug panel, and resolve the ready promise.
+ * 3. Wait for the battle state to reach "cooldown".
+ * 4. Dispatch "ready" and wait for handlers to complete.
+ * 5. Mark the button as ready again, update the debug panel, and resolve the ready promise.
  *
  * @param {{resolveReady: (() => void) | null}} controls - Timer controls.
  * @param {HTMLButtonElement | null} btn - Next button element.
@@ -419,7 +421,7 @@ export async function handleNextRoundExpiration(controls, btn) {
   markNextReady(btn);
   await awaitCooldownState();
   try {
-    dispatchBattleEvent("ready");
+    await dispatchBattleEvent("ready");
   } catch {}
   markNextReady(btn);
   updateDebugPanel();

--- a/tests/helpers/timerService.awaitCooldownState.test.js
+++ b/tests/helpers/timerService.awaitCooldownState.test.js
@@ -11,9 +11,13 @@ describe("awaitCooldownState", () => {
     await expect(awaitCooldownState()).resolves.toBeUndefined();
   });
 
-  it("resolves immediately when in roundOver", async () => {
+  it("waits for cooldown when in roundOver", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     window.__classicBattleState = "roundOver";
-    await expect(awaitCooldownState()).resolves.toBeUndefined();
+    const p = awaitCooldownState();
+    document.dispatchEvent(new CustomEvent("battle:state", { detail: { to: "cooldown" } }));
+    await expect(p).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
   });
 
   it("waits for cooldown when pre-cooldown", async () => {


### PR DESCRIPTION
## Summary
- ensure `awaitCooldownState` waits for actual cooldown before resolving
- await ready dispatch in `handleNextRoundExpiration` to avoid race
- update `awaitCooldownState` tests for roundOver behavior

## Testing
- `npm run check:jsdoc` *(fails: missing JSDoc in unrelated modules)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: unhandled rejection in statSelection test)*
- `npx playwright test` *(fails: 11 failing specs)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b3eef8da7c8326972afa933e6fb3fc