### PR TITLE
fix: await ready dispatch after cooldown

### DIFF
--- a/src/helpers/classicBattle/awaitCooldownState.js
+++ b/src/helpers/classicBattle/awaitCooldownState.js
@@ -16,7 +16,7 @@ export function awaitCooldownState() {
         typeof window !== "undefined" && window.__classicBattleState
           ? window.__classicBattleState
           : null;
-      if (!state || state === "cooldown" || state === "roundOver") {
+      if (!state || state === "cooldown") {
         resolve();
         return;
       }

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -419,7 +419,7 @@ export async function handleNextRoundExpiration(controls, btn) {
   markNextReady(btn);
   await awaitCooldownState();
   try {
-    dispatchBattleEvent("ready");
+    await dispatchBattleEvent("ready");
   } catch {}
   markNextReady(btn);
   updateDebugPanel();

--- a/tests/helpers/timerService.awaitCooldownState.test.js
+++ b/tests/helpers/timerService.awaitCooldownState.test.js
@@ -11,9 +11,13 @@ describe("awaitCooldownState", () => {
     await expect(awaitCooldownState()).resolves.toBeUndefined();
   });
 
-  it("resolves immediately when in roundOver", async () => {
+  it("waits for cooldown when in roundOver", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     window.__classicBattleState = "roundOver";
-    await expect(awaitCooldownState()).resolves.toBeUndefined();
+    const p = awaitCooldownState();
+    document.dispatchEvent(new CustomEvent("battle:state", { detail: { to: "cooldown" } }));
+    await expect(p).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
   });
 
   it("waits for cooldown when pre-cooldown", async () => {


### PR DESCRIPTION
## Summary
- await ready event dispatch before resolving next-round timer
- defer ready dispatch until battle state reaches `cooldown`
- test waiting behavior for roundOver and pre-cooldown states

## Testing
- `npm run check:jsdoc` *(fails: missing docs in unrelated modules)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: ReferenceError: Cannot access 'currentNextRound' before initialization)*
- `npx playwright test` *(fails: 10 failed tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b3eee9df608326a73e557234cb5d35