### PR TITLE
refactor: lazy load debug panel update

### DIFF
--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -345,13 +345,9 @@ export async function roundStartEnter(machine) {
     guard(() => {
       if (fallback) clearTimeout(fallback);
     });
-    guard(() =>
-      emitBattleEvent("scoreboardShowMessage", "Round start error. Recovering…")
-    );
+    guard(() => emitBattleEvent("scoreboardShowMessage", "Round start error. Recovering…"));
     guard(() => emitBattleEvent("debugPanelUpdate"));
-    await guardAsync(() =>
-      machine.dispatch("interrupt", { reason: "roundStartError" })
-    );
+    await guardAsync(() => machine.dispatch("interrupt", { reason: "roundStartError" }));
   }
 
   let startPromise;

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -1,7 +1,6 @@
 import { getDefaultTimer } from "../timerUtils.js";
 import { startRound as engineStartRound } from "../battleEngineFacade.js";
 import * as scoreboard from "../setupScoreboard.js";
-import { updateDebugPanel } from "./uiHelpers.js";
 import { showSnackbar } from "../showSnackbar.js";
 import { t } from "../i18n.js";
 import { setSkipHandler } from "./skipHandler.js";
@@ -424,7 +423,10 @@ export async function handleNextRoundExpiration(controls, btn) {
     await dispatchBattleEvent("ready");
   } catch {}
   markNextReady(btn);
-  updateDebugPanel();
+  try {
+    const { updateDebugPanel } = await import("./uiHelpers.js");
+    updateDebugPanel();
+  } catch {}
   if (typeof controls.resolveReady === "function") {
     controls.resolveReady();
   }


### PR DESCRIPTION
## Summary
- remove static `updateDebugPanel` import from timer service
- lazily import and invoke `updateDebugPanel` on next-round expiration
- prettier-format orchestratorHandlers to satisfy repo style

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot suite and battle flow tests)*
- `npm run check:contrast`
- `npm test -- --run` *(interrupted during run)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f8a7a0a88326ba8dfc31164bb23f