### PR TITLE
Refactor settings rendering helpers

### DIFF
--- a/src/helpers/settings/renderFeatureFlags.js
+++ b/src/helpers/settings/renderFeatureFlags.js
@@ -1,0 +1,25 @@
+import { renderFeatureFlagSwitches } from "./featureFlagSwitches.js";
+import { syncFeatureFlags } from "./syncFeatureFlags.js";
+
+/**
+ * @summary Render feature flag toggle switches.
+ * @pseudocode
+ * 1. Locate the feature-flags container element.
+ * 2. Remove existing `.settings-item` children.
+ * 3. Sync feature flags via `syncFeatureFlags`.
+ * 4. Delegate rendering to `renderFeatureFlagSwitches`.
+ *
+ * @param {Settings} current - Current settings object.
+ * @param {() => Settings} getCurrentSettings - Getter for current settings.
+ * @param {Function} handleUpdate - Persist helper for settings.
+ * @param {object} tooltipMap - Mapping of tooltip text.
+ * @returns {void}
+ */
+
+export function renderFeatureFlags(current, getCurrentSettings, handleUpdate, tooltipMap) {
+  const container = document.getElementById("feature-flags-container");
+  if (!container) return;
+  container.querySelectorAll(".settings-item").forEach((el) => el.remove());
+  const flags = syncFeatureFlags(current);
+  renderFeatureFlagSwitches(container, flags, getCurrentSettings, handleUpdate, tooltipMap);
+}

--- a/src/helpers/settings/renderGameModes.js
+++ b/src/helpers/settings/renderGameModes.js
@@ -1,0 +1,21 @@
+import { renderGameModeSwitches } from "./gameModeSwitches.js";
+
+/**
+ * @summary Render game mode toggle switches.
+ * @pseudocode
+ * 1. Find the game-mode container element.
+ * 2. Remove existing `.settings-item` children.
+ * 3. When `gameModes` is an array, delegate to `renderGameModeSwitches`.
+ *
+ * @param {Array} gameModes - List of game mode definitions.
+ * @param {() => Settings} getCurrentSettings - Getter for current settings.
+ * @param {Function} handleUpdate - Persist helper for settings.
+ * @returns {void}
+ */
+
+export function renderGameModes(gameModes, getCurrentSettings, handleUpdate) {
+  const container = document.getElementById("game-mode-toggle-container");
+  if (!container || !Array.isArray(gameModes)) return;
+  container.querySelectorAll(".settings-item").forEach((el) => el.remove());
+  renderGameModeSwitches(container, gameModes, getCurrentSettings, handleUpdate);
+}

--- a/src/helpers/settings/renderNavCacheReset.js
+++ b/src/helpers/settings/renderNavCacheReset.js
@@ -1,0 +1,19 @@
+import { addNavResetButton } from "./addNavResetButton.js";
+
+/**
+ * @summary Render the Navigation Cache reset button when enabled.
+ * @pseudocode
+ * 1. Attempt to inject the reset button via `addNavResetButton`.
+ * 2. Find the corresponding feature flag toggle.
+ * 3. Bind a change listener once to rerender the button on toggle.
+ * @returns {void}
+ */
+
+export function renderNavCacheReset() {
+  addNavResetButton();
+  const toggle = document.getElementById("feature-nav-cache-reset-button");
+  if (toggle && !toggle.dataset.listenerBound) {
+    toggle.addEventListener("change", addNavResetButton);
+    toggle.dataset.listenerBound = "true";
+  }
+}

--- a/src/helpers/settings/syncDisplayMode.js
+++ b/src/helpers/settings/syncDisplayMode.js
@@ -1,0 +1,22 @@
+import { applyDisplayMode } from "../displayMode.js";
+import { withViewTransition } from "../viewTransition.js";
+
+/**
+ * @summary Sync the selected display mode with persisted settings.
+ * @pseudocode
+ * 1. Locate the checked `display-mode` radio input.
+ * 2. If it differs from `current.displayMode`, apply and persist the value.
+ * 3. Return the updated settings object.
+ *
+ * @param {Settings} current - Current settings object.
+ * @param {(key: string, value: string, onError: Function) => Promise<void>} handleUpdate
+ *   Persist helper for settings.
+ * @returns {Settings} Updated settings.
+ */
+export function syncDisplayMode(current, handleUpdate) {
+  const radio = document.querySelector('input[name="display-mode"]:checked');
+  if (!radio || radio.value === current.displayMode) return current;
+  withViewTransition(() => applyDisplayMode(radio.value));
+  handleUpdate("displayMode", radio.value, () => {}).catch(() => {});
+  return { ...current, displayMode: radio.value };
+}

--- a/tests/helpers/settingsRenderers.test.js
+++ b/tests/helpers/settingsRenderers.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createSettingsDom, resetDom } from "../utils/testUtils.js";
+
+beforeEach(() => {
+  resetDom();
+  document.body.appendChild(createSettingsDom());
+});
+
+describe("syncDisplayMode", () => {
+  it("applies selected mode without touching other sections", async () => {
+    vi.mock("../../src/helpers/displayMode.js", () => ({
+      applyDisplayMode: vi.fn()
+    }));
+    vi.mock("../../src/helpers/viewTransition.js", () => ({
+      withViewTransition: vi.fn((fn) => fn())
+    }));
+    const { syncDisplayMode } = await import("../../src/helpers/settings/syncDisplayMode.js");
+    document.getElementById("display-mode-dark").checked = true;
+    const handleUpdate = vi.fn().mockResolvedValue();
+    const updated = syncDisplayMode({ displayMode: "light" }, handleUpdate);
+    expect(updated.displayMode).toBe("dark");
+    expect(handleUpdate).toHaveBeenCalledWith("displayMode", "dark", expect.any(Function));
+    const { applyDisplayMode } = await import("../../src/helpers/displayMode.js");
+    expect(applyDisplayMode).toHaveBeenCalledWith("dark");
+    expect(document.querySelectorAll("#game-mode-toggle-container .settings-item")).toHaveLength(0);
+    expect(document.querySelectorAll("#feature-flags-container .settings-item")).toHaveLength(0);
+  });
+});
+
+describe("renderGameModes", () => {
+  it("updates only the game mode container", async () => {
+    vi.mock("../../src/helpers/settings/gameModeSwitches.js", () => ({
+      renderGameModeSwitches: vi.fn((container) => {
+        const item = document.createElement("div");
+        item.className = "settings-item";
+        container.appendChild(item);
+      })
+    }));
+    const { renderGameModes } = await import("../../src/helpers/settings/renderGameModes.js");
+    renderGameModes([{ id: 1 }], () => ({}), vi.fn());
+    const { renderGameModeSwitches } = await import(
+      "../../src/helpers/settings/gameModeSwitches.js"
+    );
+    expect(renderGameModeSwitches).toHaveBeenCalled();
+    expect(document.querySelectorAll("#game-mode-toggle-container .settings-item")).toHaveLength(1);
+    expect(document.querySelectorAll("#feature-flags-container .settings-item")).toHaveLength(0);
+  });
+});
+
+describe("renderFeatureFlags", () => {
+  it("updates only the feature flag container", async () => {
+    vi.mock("../../src/helpers/settings/featureFlagSwitches.js", () => ({
+      renderFeatureFlagSwitches: vi.fn((container, flags) => {
+        Object.keys(flags).forEach(() => {
+          const item = document.createElement("div");
+          item.className = "settings-item";
+          container.appendChild(item);
+        });
+      })
+    }));
+    vi.mock("../../src/helpers/settings/syncFeatureFlags.js", () => ({
+      syncFeatureFlags: vi.fn(() => ({ testFlag: { enabled: true } }))
+    }));
+    const { renderFeatureFlags } = await import("../../src/helpers/settings/renderFeatureFlags.js");
+    renderFeatureFlags({ featureFlags: {} }, () => ({}), vi.fn(), {});
+    const { syncFeatureFlags } = await import("../../src/helpers/settings/syncFeatureFlags.js");
+    const { renderFeatureFlagSwitches } = await import(
+      "../../src/helpers/settings/featureFlagSwitches.js"
+    );
+    expect(syncFeatureFlags).toHaveBeenCalled();
+    expect(renderFeatureFlagSwitches).toHaveBeenCalled();
+    expect(document.querySelectorAll("#feature-flags-container .settings-item")).toHaveLength(1);
+    expect(document.querySelectorAll("#game-mode-toggle-container .settings-item")).toHaveLength(0);
+  });
+});
+
+describe("renderNavCacheReset", () => {
+  it("renders button and rebinds on toggle change", async () => {
+    const toggle = document.createElement("input");
+    toggle.id = "feature-nav-cache-reset-button";
+    document.body.appendChild(toggle);
+    vi.mock("../../src/helpers/settings/addNavResetButton.js", () => ({
+      addNavResetButton: vi.fn(() => {
+        const btn = document.createElement("button");
+        btn.id = "nav-cache-reset-button";
+        document.getElementById("feature-flags-container").appendChild(btn);
+      })
+    }));
+    const { renderNavCacheReset } = await import(
+      "../../src/helpers/settings/renderNavCacheReset.js"
+    );
+    renderNavCacheReset();
+    const { addNavResetButton } = await import("../../src/helpers/settings/addNavResetButton.js");
+    expect(addNavResetButton).toHaveBeenCalledTimes(1);
+    expect(document.getElementById("nav-cache-reset-button")).toBeTruthy();
+    toggle.dispatchEvent(new Event("change"));
+    expect(addNavResetButton).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- extract display mode sync, game mode rendering, feature flag rendering, and nav cache reset into dedicated helpers
- simplify settings renderer by calling new helpers
- test each renderer updates DOM independently

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint src/helpers/settingsPage.js src/helpers/settings/renderFeatureFlags.js src/helpers/settings/renderGameModes.js src/helpers/settings/renderNavCacheReset.js src/helpers/settings/syncDisplayMode.js tests/helpers/settingsRenderers.test.js`
- `npx vitest run`
- `npx playwright test` *(fails: browser context dispose error)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b413649d8c832689c3685b80dfb5c8