### PR TITLE
refactor PRD reader sidebar setup

### DIFF
--- a/tests/helpers/prdReaderPage.js
+++ b/tests/helpers/prdReaderPage.js
@@ -1,0 +1,8 @@
+/** Sample PRD documents used for unit tests. */
+export const mockDocsMap = {
+  "b.md": "# Second doc",
+  "a.md": "# First doc"
+};
+
+/** Basic parser that wraps markdown headings in an `<h1>` tag. */
+export const basicParser = (md) => `<h1>${md}</h1>`;

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
+import { mockDocsMap, basicParser } from "./prdReaderPage.js";
 
 describe("prdReaderPage", () => {
   afterEach(() => {
@@ -14,6 +15,22 @@ describe("prdReaderPage", () => {
     });
     expect(files).toEqual(["a.md", "b.md"]);
     expect(baseNames).toEqual(["a", "b"]);
+  });
+  it("seeds history state from doc map", async () => {
+    history.replaceState(null, "", "/?doc=b");
+    document.body.innerHTML = `
+      <div id="prd-title"></div>
+      <div id="task-summary"></div>
+      <ul id="prd-list"></ul>
+      <div id="prd-content" tabindex="-1"></div>
+      <button data-nav="prev">Prev</button>
+      <button data-nav="next">Next</button>
+    `;
+    globalThis.SKIP_PRD_AUTO_INIT = true;
+    const { setupPrdReaderPage } = await import("../../src/helpers/prdReaderPage.js");
+    await setupPrdReaderPage(mockDocsMap, basicParser);
+    expect(history.state.index).toBe(1);
+    expect(new URL(window.location).search).toBe("?doc=b");
   });
   it("navigates documents with wrap-around", async () => {
     const docs = {


### PR DESCRIPTION
## Summary
- split PRD reader data loading into `loadPrdDocs` and UI wiring into `setupSidebarUI`
- add lightweight `SidebarState` class for navigation state
- test PRD reader history seeding with mocked docs

## Testing
- `npm run check:jsdoc`
- `npx prettier src/helpers/prdReaderPage.js tests/helpers/prdReaderPage.js tests/helpers/prdReaderPage.test.js --check`
- `npx eslint src/helpers/prdReaderPage.js tests/helpers/prdReaderPage.js tests/helpers/prdReaderPage.test.js && echo 'ESLint passed'`
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b4136ac5948326a16aeeb0360b70d6