### PR TITLE
Refactor settings rendering helpers

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -160,7 +160,7 @@ function makeRenderSwitches(controls, getCurrentSettings, handleUpdate) {
     const next = syncDisplayMode(current, handleUpdate);
     applyInitialControlValues(controls, next, tooltipMap);
     renderGameModes(gameModes, getCurrentSettings, handleUpdate);
-    renderFeatureFlags(next, getCurrentSettings, handleUpdate, tooltipMap);
+    renderFeatureFlags(current, getCurrentSettings, handleUpdate, tooltipMap);
     renderNavCacheReset();
     initTooltips().then((fn) => {
       cleanupTooltips = fn;


### PR DESCRIPTION
## Summary
- pass live settings object to feature flag renderer so defaults merge into persistent state

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: browser context dispose error)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b43de64b488326a379593079cb06f8