### PR TITLE
refactor: drop battle debug panel flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ CLI-specific tests live in `playwright/battle-cli.spec.js` and verify the state 
 
 ### Battle Debug Panel
 
-Enable the `battleDebugPanel` feature flag to display a panel above the player and opponent cards with live match data. The panel includes a **Copy** button that copies all text for easy sharing.
+When the `enableTestMode` feature flag is active, a debug panel appears above the player and opponent cards with live match data. The panel includes a **Copy** button that copies all text for easy sharing.
 
 ### Stat Hotkeys
 

--- a/design/codeStandards/settingsPageDesignGuidelines.md
+++ b/design/codeStandards/settingsPageDesignGuidelines.md
@@ -64,17 +64,17 @@ Reuse the following markup for general settings, game modes, and feature flags:
   Example markup:
 
   ```html
-  <label for="feature-battle-debug-panel" class="switch">
+  <label for="feature-enable-test-mode" class="switch">
     <input
       type="checkbox"
-      id="feature-battle-debug-panel"
-      name="battleDebugPanel"
-      data-tooltip-id="settings.battleDebugPanel"
-      data-flag="battleDebugPanel"
-      aria-label="Battle Debug Panel"
+      id="feature-enable-test-mode"
+      name="enableTestMode"
+      data-tooltip-id="settings.enableTestMode"
+      data-flag="enableTestMode"
+      aria-label="Test Mode"
     />
     <div class="slider round"></div>
-    <span>Battle Debug Panel</span>
+    <span>Test Mode</span>
   </label>
   ```
 
@@ -173,8 +173,8 @@ To support AI-assisted testing, variant gameplay modes, and scalable development
   Use predictable `id` and `name` values:
   - ID format: `feature-<kebab-case-feature-name>`
   - Name format: camelCase
-  - Example: `id="feature-battle-debug-panel" name="battleDebugPanel"`
-  - Common example flags include `Battle Debug Panel` and `Card Inspector`
+  - Example: `id="feature-enable-test-mode" name="enableTestMode"`
+  - Common example flags include `Test Mode` and `Card Inspector`
   - Include `data-flag="<camelCaseName>"` on the input element so automation scripts can locate specific toggles
 
 - **ARIA and Accessibility**

--- a/design/productRequirementsDocuments/prdBattleClassic.md
+++ b/design/productRequirementsDocuments/prdBattleClassic.md
@@ -81,7 +81,7 @@ This feedback highlights why Classic Battle is needed now: new players currently
 - Opponent stat selection runs entirely on the client. After the player picks a stat (or the timer auto-chooses), the opponent's choice is revealed after a short artificial delay to mimic turn-taking.
 - During this delay, the Scoreboard displays "Opponent is choosing..." in `#round-message` to reinforce turn flow.
 - The cooldown timer between rounds begins only after round results are shown in the Scoreboard and is displayed using one persistent snackbar that updates its text each second.
-- The debug panel is available when the `battleDebugPanel` feature flag is enabled, appears above the player and opponent cards, and includes a copy button for exporting its text.
+- The debug panel is available when the `enableTestMode` feature flag is enabled, appears above the player and opponent cards, and includes a copy button for exporting its text.
 - A battle state progress list can be enabled via the `battleStateProgress` feature flag to show the sequence of match states beneath the battle area; disabled by default.
 
 ### Round Data Fallback
@@ -225,9 +225,8 @@ This section lists small, implementer-facing contracts to reduce ambiguity betwe
 
   - `autoSelect` — boolean, default: `true`. When enabled, the system auto-selects a random stat on timer expiry.
     When disabled, the timer expires without choosing a stat and the player must pick manually.
-  - `battleDebugPanel` — boolean, default: `false`. When enabled, show debug panel above the cards with copy/export controls.
   - `battleStateProgress` — boolean, default: `false`. When enabled, display a state progress list beneath the battle area.
-  - `testMode` — boolean, default: `false` (test-only). When enabled, allow `battle.testRandomSeed` and fast AI delays for deterministic tests.
+  - `enableTestMode` — boolean, default: `false` (test-only). When enabled, allow `battle.testRandomSeed`, fast AI delays for deterministic tests, and show a debug panel above the cards with copy/export controls.
   - `statHotkeys` — boolean, default: `false`. When enabled, number keys 1–5 map to stat buttons (left→right).
   - `skipRoundCooldown` — boolean, default: `false`. When enabled, bypass inter-round cooldown and begin the next round immediately.
 

--- a/progress.md
+++ b/progress.md
@@ -71,7 +71,7 @@
 
 7. State, Feature Flags, Persistence
 
-- Feature flags: Honor `FF_AUTO_SELECT` (default enabled) and `battleDebugPanel` if present.
+- Feature flags: Honor `FF_AUTO_SELECT` (default enabled) and `enableTestMode` if present.
 - Persist “first visit” help-tooltip dismissal and user-selected points-to-win.
 - Maintain `window.__classicBattleState`/`dataset.battleState` updates for test fixtures if already provided by helpers.
 
@@ -123,7 +123,7 @@
 ## Open Questions
 
 - PRD references URL `battleJudoka.html` but this plan targets `battleClassic.html`. Confirm that `battleClassic.html` is the intended canonical page for Classic Battle.
-- Confirm the feature flag keys and defaults (e.g., `FF_AUTO_SELECT`, `battleDebugPanel`) and their storage location to ensure correct initialization on this page.
+- Confirm the feature flag keys and defaults (e.g., `FF_AUTO_SELECT`, `enableTestMode`) and their storage location to ensure correct initialization on this page.
 - Should the “points to win” choice persist globally across sessions/pages or be per-session on `battleClassic.html` only?
 - Any additional telemetry or analytics events required on match start/end or quit?
 - Should the help tooltip auto-open be gated behind a global “first-run” flag or be specific to Classic Battle only?
@@ -148,7 +148,7 @@
 
 ## Low-Risk, High-Value Extras (plan to include)
 
-- src/config/battleDefaults.js: Centralize defaults (e.g., `pointsToWin: 10`, `featureFlags: { autoSelect: true, battleDebugPanel: false }`) for page bootstrap and tests.
+- src/config/battleDefaults.js: Centralize defaults (e.g., `pointsToWin: 10`, `featureFlags: { autoSelect: true }`) for page bootstrap and tests.
 - Orchestrator testAPI export: Extend existing classic battle exports to expose a small `testAPI` (e.g., `getMachine()`, `waitFor(state)`, `forceSkip()`) for deterministic testing without reaching into internals.
 - seedRandom helper: Add `src/helpers/seedRandom.js` with deterministic PRNG (e.g., mulberry32) and wire under a test flag to produce repeatable draws in tests.
 - Unit test scaffolding: Add vitest scaffolds for timer pause/resume and auto-select paths (expiry → `roundTimeout`, auto-select snackbar/message, AI delay reveal). Keep them minimal and parallel current test patterns.
@@ -196,7 +196,7 @@
 
 ## Notes on Feature Flags
 
-- Canonical keys (camelCase): `autoSelect`, `battleDebugPanel`, `enableTestMode`, `battleStateBadge`, `battleStateProgress`, `statHotkeys`.
+- Canonical keys (camelCase): `autoSelect`, `enableTestMode`, `battleStateBadge`, `battleStateProgress`, `statHotkeys`.
 - Older docs may reference `FF_*` names; prefer the keys above.
 
 ## Observability

--- a/src/config/battleDefaults.js
+++ b/src/config/battleDefaults.js
@@ -22,7 +22,6 @@ export const POINTS_TO_WIN_OPTIONS = [5, 10, 15];
 export const DEFAULT_POINTS_TO_WIN = 10;
 export const FEATURE_FLAGS = {
   autoSelect: { enabled: true },
-  battleDebugPanel: { enabled: false },
   enableTestMode: { enabled: false },
   battleStateBadge: { enabled: false },
   battleStateProgress: { enabled: false },

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -17,10 +17,6 @@
   },
   "gameModes": {},
   "featureFlags": {
-    "battleDebugPanel": {
-      "enabled": false,
-      "tooltipId": "settings.battleDebugPanel"
-    },
     "enableTestMode": {
       "enabled": false,
       "tooltipId": "settings.enableTestMode"

--- a/src/data/tooltips.json
+++ b/src/data/tooltips.json
@@ -66,10 +66,6 @@
       "label": "Tooltips",
       "description": "Show helpful pop-up hints when hovering controls."
     },
-    "battleDebugPanel": {
-      "label": "Battle Debug Panel",
-      "description": "Show a panel with live match data for debugging."
-    },
     "fullNavigationMap": {
       "label": "Full Navigation Map",
       "description": "Display an overlay map linking to every page."

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -597,7 +597,7 @@ function wireNextRoundTimer(controls, btn, cooldownSeconds, scheduler) {
     } catch {}
     controls.timer?.stop();
   });
-  
+
   // Start engine-backed countdown on the next tick.
   scheduler.setTimeout(() => controls.timer.start(cooldownSeconds), 0);
   // Fallback to ensure expiration when the engine isn't running.

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -1350,7 +1350,7 @@ export function applyBattleFeatureFlags(battleArea, banner) {
   setTestMode(isEnabled("enableTestMode"));
   toggleInspectorPanels(isEnabled("enableCardInspector"));
   toggleViewportSimulation(isEnabled("viewportSimulation"));
-  setDebugPanelEnabled(isEnabled("battleDebugPanel") || isEnabled("enableTestMode"));
+  setDebugPanelEnabled(isEnabled("enableTestMode"));
 
   featureFlagsEmitter.addEventListener("change", () => {
     if (battleArea) battleArea.dataset.testMode = String(isEnabled("enableTestMode"));
@@ -1358,7 +1358,7 @@ export function applyBattleFeatureFlags(battleArea, banner) {
     setTestMode(isEnabled("enableTestMode"));
     toggleInspectorPanels(isEnabled("enableCardInspector"));
     toggleViewportSimulation(isEnabled("viewportSimulation"));
-    setDebugPanelEnabled(isEnabled("battleDebugPanel") || isEnabled("enableTestMode"));
+    setDebugPanelEnabled(isEnabled("enableTestMode"));
   });
 }
 
@@ -1399,7 +1399,7 @@ export function initDebugPanel() {
   const debugPanel = document.getElementById("debug-panel");
   if (!debugPanel) return;
   const battleArea = document.getElementById("battle-area");
-  if (isEnabled("battleDebugPanel") && battleArea) {
+  if (isEnabled("enableTestMode") && battleArea) {
     if (debugPanel.tagName !== "DETAILS") {
       const details = document.createElement("details");
       details.id = "debug-panel";

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -14,7 +14,7 @@ describe("classicBattlePage feature flag updates", () => {
     vi.resetModules();
   });
 
-  it("reacts to viewportSimulation and battleDebugPanel flag changes", async () => {
+  it("reacts to viewportSimulation and enableTestMode changes", async () => {
     // Minimal DOM
     const battleArea = document.createElement("div");
     battleArea.id = "battle-area";
@@ -31,7 +31,6 @@ describe("classicBattlePage feature flag updates", () => {
 
     const currentFlags = {
       viewportSimulation: { enabled: false },
-      battleDebugPanel: { enabled: false },
       enableCardInspector: { enabled: false },
       enableTestMode: { enabled: false }
     };
@@ -77,9 +76,9 @@ describe("classicBattlePage feature flag updates", () => {
     const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
     await setupClassicBattlePage();
 
-    // Enable viewportSimulation and battleDebugPanel
+    // Enable viewportSimulation and enableTestMode
     currentFlags.viewportSimulation.enabled = true;
-    currentFlags.battleDebugPanel.enabled = true;
+    currentFlags.enableTestMode.enabled = true;
     featureFlagsEmitter.dispatchEvent(new CustomEvent("change"));
 
     expect(toggleViewportSimulation).toHaveBeenCalledWith(true);
@@ -89,8 +88,8 @@ describe("classicBattlePage feature flag updates", () => {
     expect(panel.parentElement).toBe(battleArea.parentElement);
     expect(panel.nextElementSibling).toBe(battleArea);
 
-    // Disable battleDebugPanel
-    currentFlags.battleDebugPanel.enabled = false;
+    // Disable enableTestMode
+    currentFlags.enableTestMode.enabled = false;
     featureFlagsEmitter.dispatchEvent(new CustomEvent("change"));
     expect(document.getElementById("debug-panel")).toBeFalsy();
   });
@@ -104,7 +103,6 @@ describe("classicBattlePage feature flag updates", () => {
 
     const currentFlags = {
       viewportSimulation: { enabled: false },
-      battleDebugPanel: { enabled: false },
       enableCardInspector: { enabled: false },
       enableTestMode: { enabled: false }
     };
@@ -131,7 +129,7 @@ describe("classicBattlePage feature flag updates", () => {
     const { setupClassicBattlePage } = await import("../../src/helpers/classicBattlePage.js");
     await setupClassicBattlePage();
 
-    currentFlags.battleDebugPanel.enabled = true;
+    currentFlags.enableTestMode.enabled = true;
     featureFlagsEmitter.dispatchEvent(new CustomEvent("change"));
 
     const panel = document.getElementById("debug-panel");

--- a/tests/helpers/randomJudokaPage.drawButton.test.js
+++ b/tests/helpers/randomJudokaPage.drawButton.test.js
@@ -10,7 +10,6 @@ const baseSettings = {
   fullNavigationMap: true,
   gameModes: {},
   featureFlags: {
-    battleDebugPanel: { enabled: false },
     enableTestMode: { enabled: false },
     enableCardInspector: { enabled: false }
   }

--- a/tests/helpers/randomJudokaPage.featureFlags.test.js
+++ b/tests/helpers/randomJudokaPage.featureFlags.test.js
@@ -9,7 +9,6 @@ const baseSettings = {
   fullNavigationMap: true,
   gameModes: {},
   featureFlags: {
-    battleDebugPanel: { enabled: false },
     enableTestMode: { enabled: false },
     enableCardInspector: { enabled: false }
   }

--- a/tests/helpers/randomJudokaPage.historyPanel.test.js
+++ b/tests/helpers/randomJudokaPage.historyPanel.test.js
@@ -9,7 +9,6 @@ const baseSettings = {
   fullNavigationMap: true,
   gameModes: {},
   featureFlags: {
-    battleDebugPanel: { enabled: false },
     enableTestMode: { enabled: false },
     enableCardInspector: { enabled: false }
   }

--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -12,7 +12,6 @@ const baseSettings = {
   fullNavigationMap: true,
   gameModes: {},
   featureFlags: {
-    battleDebugPanel: { enabled: false },
     enableTestMode: { enabled: false },
     enableCardInspector: { enabled: false },
     viewportSimulation: { enabled: false },
@@ -23,8 +22,6 @@ const baseSettings = {
 };
 
 const tooltipMap = {
-  "settings.battleDebugPanel.label": "Battle Debug Panel",
-  "settings.battleDebugPanel.description": "Adds a collapsible debug panel",
   "settings.fullNavigationMap.label": "Full Navigation Map",
   "settings.fullNavigationMap.description": "Expanded map navigation",
   "settings.enableTestMode.label": "Test Mode",
@@ -104,7 +101,7 @@ describe("renderSettingsControls", () => {
     const container = document.getElementById("game-mode-toggle-container");
     const checkboxes = container.querySelectorAll("input[type='checkbox']");
     expect(checkboxes).toHaveLength(3);
-    expect(document.getElementById("feature-battle-debug-panel")).toBeTruthy();
+    expect(document.getElementById("feature-enable-test-mode")).toBeTruthy();
   });
 
   it("updates navigation hidden state when a mode is toggled", async () => {
@@ -155,13 +152,13 @@ describe("renderSettingsControls", () => {
       "../../src/helpers/settingsPage.js"
     );
     renderSettingsControls(baseSettings, [], tooltipMap);
-    const input = document.querySelector("#feature-battle-debug-panel");
+    const input = document.querySelector("#feature-enable-test-mode");
     input.checked = true;
     await handleFeatureFlagChange({
       input,
-      flag: "battleDebugPanel",
-      info: baseSettings.featureFlags.battleDebugPanel,
-      label: "battleDebugPanel",
+      flag: "enableTestMode",
+      info: baseSettings.featureFlags.enableTestMode,
+      label: "enableTestMode",
       getCurrentSettings: () => baseSettings,
       handleUpdate: updateSetting
     });
@@ -169,7 +166,7 @@ describe("renderSettingsControls", () => {
       "featureFlags",
       {
         ...baseSettings.featureFlags,
-        battleDebugPanel: { enabled: true }
+        enableTestMode: { enabled: true }
       },
       expect.any(Function)
     );
@@ -230,19 +227,19 @@ describe("renderSettingsControls", () => {
       ...baseSettings,
       featureFlags: {
         ...baseSettings.featureFlags,
-        battleDebugPanel: { enabled: true }
+        enableTestMode: { enabled: true }
       }
     };
     currentFlags = settingsWithFlag.featureFlags;
     renderSettingsControls(settingsWithFlag, [], tooltipMap);
-    expect(document.getElementById("feature-battle-debug-panel").checked).toBe(true);
+    expect(document.getElementById("feature-enable-test-mode").checked).toBe(true);
     document.getElementById("reset-settings-button").dispatchEvent(new Event("click"));
     document.getElementById("confirm-reset-button").dispatchEvent(new Event("click"));
     await Promise.resolve();
     expect(resetSettings).toHaveBeenCalled();
     expect(initFeatureFlags).toHaveBeenCalled();
     expect(showSnackbar).toHaveBeenCalledWith("Settings restored to defaults");
-    expect(document.getElementById("feature-battle-debug-panel").checked).toBe(false);
+    expect(document.getElementById("feature-enable-test-mode").checked).toBe(false);
   });
 
   it("does not duplicate reset listener on reinit", async () => {

--- a/tests/helpers/settingsUtils.test.js
+++ b/tests/helpers/settingsUtils.test.js
@@ -54,8 +54,8 @@ describe("settings utils", () => {
     );
     const { loadSettings } = await import("../../src/helpers/settingsStorage.js");
     const settings = await loadSettings();
-    expect(settings.featureFlags.battleDebugPanel).toEqual(
-      DEFAULT_SETTINGS.featureFlags.battleDebugPanel
+    expect(settings.featureFlags.enableCardInspector).toEqual(
+      DEFAULT_SETTINGS.featureFlags.enableCardInspector
     );
     expect(settings.featureFlags.enableTestMode.enabled).toBe(true);
   });
@@ -74,7 +74,6 @@ describe("settings utils", () => {
       fullNavigationMap: false,
       gameModes: {},
       featureFlags: {
-        battleDebugPanel: { enabled: false },
         enableTestMode: { enabled: false },
         enableCardInspector: { enabled: false }
       }
@@ -147,7 +146,6 @@ describe("settings utils", () => {
         fullNavigationMap: false,
         gameModes: {},
         featureFlags: {
-          battleDebugPanel: { enabled: false },
           enableTestMode: { enabled: false },
           enableCardInspector: { enabled: false }
         }
@@ -185,7 +183,6 @@ describe("settings utils", () => {
       fullNavigationMap: false,
       gameModes: {},
       featureFlags: {
-        battleDebugPanel: { enabled: false },
         enableTestMode: { enabled: false },
         enableCardInspector: { enabled: false }
       }
@@ -199,7 +196,6 @@ describe("settings utils", () => {
       fullNavigationMap: false,
       gameModes: {},
       featureFlags: {
-        battleDebugPanel: { enabled: false },
         enableTestMode: { enabled: false },
         enableCardInspector: { enabled: false }
       }


### PR DESCRIPTION
## Summary
- remove `battleDebugPanel` feature flag and rely on `enableTestMode` for debug panel
- update defaults, settings, and docs for flag removal
- adjust tests to toggle debug panel with `enableTestMode`

## Testing
- `npm run validate:data`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Classic battle flow and screenshot suite)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b43e2d2ea08326b48e53d09caec024