### PR TITLE
Navigate to lobby after CLI quit

### DIFF
--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -95,4 +95,15 @@ test.describe("Classic Battle CLI", () => {
     await expect(score).toHaveText(afterRoundScore || "");
     expect(cardAfter).not.toBe(cardBefore);
   });
+
+  test("returns to lobby after quitting", async ({ page }) => {
+    await page.goto("/src/pages/battleCLI.html");
+    await waitForBattleState(page, "waitingForPlayerAction", 15000);
+    await page.keyboard.press("q");
+    const confirm = page.locator("#confirm-quit-button");
+    await expect(confirm).toBeVisible();
+    await confirm.click();
+    await page.waitForURL("**/index.html");
+    await expect(page.locator(".home-screen")).toBeVisible();
+  });
 });

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -280,6 +280,7 @@ function resumeTimers() {
  *   listen for modal 'close' to resume timers when not quitting
  *   cancel closes modal
  *   quit sets quitting flag, dispatches interrupt and clears bottom line
+ *   after interrupt resolves: navigate to lobby
  *   append modal to container
  * open modal
  */
@@ -311,13 +312,16 @@ function showQuitModal() {
     cancel.addEventListener("click", () => {
       quitModal.close();
     });
-    quit.addEventListener("click", () => {
+    quit.addEventListener("click", async () => {
       isQuitting = true;
       quitModal.close();
       clearBottomLine();
       try {
         const machine = window.__getClassicBattleMachine?.();
-        if (machine) machine.dispatch("interrupt", { reason: "quit" });
+        if (machine) await machine.dispatch("interrupt", { reason: "quit" });
+      } catch {}
+      try {
+        window.location.href = "/index.html";
       } catch {}
     });
     ensureModalContainer().appendChild(quitModal.element);


### PR DESCRIPTION
## Summary
- Navigate back to the home lobby after the battle CLI confirms a quit
- Add end-to-end test ensuring the quit flow returns to the lobby

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 10 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b449b71ea883269f38dd1e313dd01b