### PR TITLE
feat: sync CLI scoreboard

### DIFF
--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -95,4 +95,26 @@ test.describe("Classic Battle CLI", () => {
     await expect(score).toHaveText(afterRoundScore || "");
     expect(cardAfter).not.toBe(cardBefore);
   });
+
+  test("scoreboard updates after each round", async ({ page }) => {
+    await page.goto("/src/pages/battleCLI.html?seed=1");
+    await waitForBattleState(page, "waitingForPlayerAction", 15000);
+    const score = page.locator("#cli-score");
+    await page.keyboard.press("1");
+    await waitForBattleState(page, "roundOver", 10000);
+    const firstPlayer = await score.getAttribute("data-score-player");
+    const firstOpponent = await score.getAttribute("data-score-opponent");
+    await expect(score).toHaveText(`You: ${firstPlayer} Opponent: ${firstOpponent}`);
+
+    await page.keyboard.press("Enter");
+    await waitForBattleState(page, "waitingForPlayerAction", 10000);
+    await page.keyboard.press("1");
+    await waitForBattleState(page, "roundOver", 10000);
+    const secondPlayer = await score.getAttribute("data-score-player");
+    const secondOpponent = await score.getAttribute("data-score-opponent");
+    await expect(score).toHaveText(`You: ${secondPlayer} Opponent: ${secondOpponent}`);
+    expect(Number(secondPlayer) + Number(secondOpponent)).toBeGreaterThanOrEqual(
+      Number(firstPlayer) + Number(firstOpponent)
+    );
+  });
 });

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -168,7 +168,7 @@
         </div>
         <div class="cli-status" aria-live="polite" aria-atomic="true">
           <div id="cli-round">Round 0 of 0</div>
-          <div id="cli-score">You: 0 Opponent: 0</div>
+          <div id="cli-score" data-score-player="0" data-score-opponent="0">You: 0 Opponent: 0</div>
         </div>
       </header>
 

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -8,7 +8,7 @@ import {
 import { initClassicBattleOrchestrator } from "../helpers/classicBattle/orchestrator.js";
 import { onBattleEvent, emitBattleEvent } from "../helpers/classicBattle/battleEvents.js";
 import { STATS } from "../helpers/BattleEngine.js";
-import { setPointsToWin, getPointsToWin } from "../helpers/battleEngineFacade.js";
+import { setPointsToWin, getPointsToWin, getScores } from "../helpers/battleEngineFacade.js";
 import { fetchJson } from "../helpers/dataUtils.js";
 import { DATA_DIR } from "../helpers/constants.js";
 import { createModal } from "../components/Modal.js";
@@ -99,9 +99,14 @@ function setRoundMessage(text) {
   if (el) el.textContent = text || "";
 }
 
-function updateScoreLine(player, opponent) {
+function updateScoreLine() {
+  const { playerScore, opponentScore } = getScores();
   const el = byId("cli-score");
-  if (el) el.textContent = `You: ${player} Opponent: ${opponent}`;
+  if (el) {
+    el.textContent = `You: ${playerScore} Opponent: ${opponentScore}`;
+    el.dataset.scorePlayer = String(playerScore);
+    el.dataset.scoreOpponent = String(opponentScore);
+  }
 }
 
 function initSeed() {
@@ -941,7 +946,7 @@ function handleRoundResolved(e) {
     setRoundMessage(
       `${result.message} (${String(stat || "").toUpperCase()} – You: ${playerVal} Opponent: ${opponentVal})`
     );
-    updateScoreLine(result.playerScore ?? 0, result.opponentScore ?? 0);
+    updateScoreLine();
   }
 }
 

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -28,7 +28,8 @@ async function loadHandlers({ autoSelect = false, skipCooldown = false } = {}) {
   vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: ["speed"] }));
   vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
     setPointsToWin: vi.fn(),
-    getPointsToWin: vi.fn()
+    getPointsToWin: vi.fn(),
+    getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 }))
   }));
   vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson: vi.fn().mockResolvedValue([]) }));
   vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));

--- a/tests/pages/battleCLI.scoreboard.test.js
+++ b/tests/pages/battleCLI.scoreboard.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+async function loadHandlers(scores) {
+  const emitter = new EventTarget();
+  vi.doMock("../../src/helpers/featureFlags.js", () => ({
+    initFeatureFlags: vi.fn(),
+    isEnabled: vi.fn(() => false),
+    setFlag: vi.fn(),
+    featureFlagsEmitter: emitter
+  }));
+  vi.doMock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
+    skipRoundCooldownIfEnabled: vi.fn(),
+    updateBattleStateBadge: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    onBattleEvent: vi.fn(),
+    emitBattleEvent: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+    createBattleStore: vi.fn(() => ({})),
+    startRound: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: ["speed"] }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    setPointsToWin: vi.fn(),
+    getPointsToWin: vi.fn(),
+    getScores: vi.fn(() => scores)
+  }));
+  vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson: vi.fn().mockResolvedValue([]) }));
+  vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+  vi.doMock("../../src/helpers/classicBattle/autoSelectStat.js", () => ({
+    autoSelectStat: vi.fn()
+  }));
+  window.__TEST__ = true;
+  const { battleCLI } = await import("../../src/pages/index.js");
+  return battleCLI;
+}
+
+describe("battleCLI scoreboard", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.__TEST__;
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doUnmock("../../src/helpers/featureFlags.js");
+    vi.doUnmock("../../src/helpers/classicBattle/uiHelpers.js");
+    vi.doUnmock("../../src/helpers/classicBattle/battleEvents.js");
+    vi.doUnmock("../../src/helpers/classicBattle/roundManager.js");
+    vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+    vi.doUnmock("../../src/helpers/BattleEngine.js");
+    vi.doUnmock("../../src/helpers/battleEngineFacade.js");
+    vi.doUnmock("../../src/helpers/dataUtils.js");
+    vi.doUnmock("../../src/helpers/constants.js");
+    vi.doUnmock("../../src/helpers/classicBattle/autoSelectStat.js");
+  });
+
+  it("updates after player win", async () => {
+    const handlers = await loadHandlers({ playerScore: 1, opponentScore: 0 });
+    document.body.innerHTML =
+      '<div id="round-message"></div><div id="cli-score" data-score-player="0" data-score-opponent="0">You: 0 Opponent: 0</div>';
+    handlers.handleRoundResolved({ detail: { result: { message: "Win" } } });
+    const el = document.getElementById("cli-score");
+    expect(el.textContent).toBe("You: 1 Opponent: 0");
+    expect(el.dataset.scorePlayer).toBe("1");
+    expect(el.dataset.scoreOpponent).toBe("0");
+  });
+
+  it("updates after player loss", async () => {
+    const handlers = await loadHandlers({ playerScore: 0, opponentScore: 1 });
+    document.body.innerHTML =
+      '<div id="round-message"></div><div id="cli-score" data-score-player="2" data-score-opponent="2">You: 2 Opponent: 2</div>';
+    handlers.handleRoundResolved({ detail: { result: { message: "Loss" } } });
+    const el = document.getElementById("cli-score");
+    expect(el.textContent).toBe("You: 0 Opponent: 1");
+    expect(el.dataset.scorePlayer).toBe("0");
+    expect(el.dataset.scoreOpponent).toBe("1");
+  });
+
+  it("updates after draw", async () => {
+    const handlers = await loadHandlers({ playerScore: 0, opponentScore: 0 });
+    document.body.innerHTML =
+      '<div id="round-message"></div><div id="cli-score" data-score-player="5" data-score-opponent="6">You: 5 Opponent: 6</div>';
+    handlers.handleRoundResolved({ detail: { result: { message: "Draw" } } });
+    const el = document.getElementById("cli-score");
+    expect(el.textContent).toBe("You: 0 Opponent: 0");
+    expect(el.dataset.scorePlayer).toBe("0");
+    expect(el.dataset.scoreOpponent).toBe("0");
+  });
+});


### PR DESCRIPTION
## Summary
- read score from battle engine to update CLI score display
- expose score data attributes and verify updates in tests

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot and CLI tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b449adeef08326988b8601d5efbb60