### PR TITLE
Reset skipRoundCooldown flag and clear CLI verbose log

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -104,6 +104,19 @@ function updateScoreLine(player, opponent) {
   if (el) el.textContent = `You: ${player} Opponent: ${opponent}`;
 }
 
+/**
+ * Clear the verbose log output.
+ *
+ * @pseudocode
+ * el = document.getElementById("cli-verbose-log")
+ * if el exists:
+ *   set textContent to ""
+ */
+function clearVerboseLog() {
+  const el = byId("cli-verbose-log");
+  if (el) el.textContent = "";
+}
+
 function initSeed() {
   const input = byId("seed-input");
   let seed = null;
@@ -956,6 +969,9 @@ function handleMatchOver() {
   });
   btn.addEventListener("click", () => {
     try {
+      clearVerboseLog();
+    } catch {}
+    try {
       location.reload();
     } catch {}
   });
@@ -966,6 +982,9 @@ function handleMatchOver() {
 function handleBattleState(ev) {
   const { from, to } = ev.detail || {};
   updateBattleStateBadge(to);
+  if (to === "matchStart") {
+    clearVerboseLog();
+  }
   if (to === "waitingForPlayerAction") {
     startSelectionCountdown(30);
     byId("cli-stats")?.focus();
@@ -1036,8 +1055,9 @@ async function init() {
     await initFeatureFlags();
   } catch {}
   try {
-    const skip = new URLSearchParams(location.search).get("skipRoundCooldown");
-    if (skip === "1") setFlag("skipRoundCooldown", true);
+    const params = new URLSearchParams(location.search);
+    const skip = params.get("skipRoundCooldown") === "1";
+    setFlag("skipRoundCooldown", skip);
   } catch {}
   updateVerbose();
   updateStateBadgeVisibility();

--- a/tests/pages/battleCLI.countdown.test.js
+++ b/tests/pages/battleCLI.countdown.test.js
@@ -105,4 +105,9 @@ describe("battleCLI countdown", () => {
     const { setFlag } = await loadBattleCLI(true, true);
     expect(setFlag).toHaveBeenCalledWith("skipRoundCooldown", true);
   });
+
+  it("resets skipRoundCooldown flag when query param missing", async () => {
+    const { setFlag } = await loadBattleCLI(true, false);
+    expect(setFlag).toHaveBeenCalledWith("skipRoundCooldown", false);
+  });
 });

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -120,6 +120,29 @@ describe("battleCLI event handlers", () => {
     expect(document.getElementById("play-again-button")).toBeTruthy();
   });
 
+  it("clears verbose log on new match start", async () => {
+    const { handlers } = await loadHandlers();
+    document.body.innerHTML = '<pre id="cli-verbose-log">old</pre>';
+    handlers.handleBattleState({ detail: { from: "roundOver", to: "matchStart" } });
+    expect(document.getElementById("cli-verbose-log").textContent).toBe("");
+  });
+
+  it("clears verbose log when play again clicked", async () => {
+    const { handlers } = await loadHandlers();
+    document.body.innerHTML = '<main id="cli-main"></main><pre id="cli-verbose-log">old</pre>';
+    const reload = vi.fn();
+    const originalLocation = window.location;
+    // @ts-ignore
+    delete window.location;
+    // Provide minimal reload stub
+    window.location = { reload };
+    handlers.handleMatchOver();
+    document.getElementById("play-again-button").click();
+    expect(document.getElementById("cli-verbose-log").textContent).toBe("");
+    expect(reload).toHaveBeenCalled();
+    window.location = originalLocation;
+  });
+
   it("handles battle state transitions", async () => {
     const { handlers, updateBattleStateBadge } = await loadHandlers();
     document.body.innerHTML = '<div id="snackbar-container"></div>';


### PR DESCRIPTION
## Summary
- reset `skipRoundCooldown` feature flag on Battle CLI load when URL param absent
- clear `#cli-verbose-log` at match start and when "Play again" is clicked
- add tests for flag reset and verbose log clearing

## Testing
- `npx vitest run tests/pages/battleCLI.countdown.test.js tests/pages/battleCLI.handlers.test.js`
- `npx playwright test` *(fails: classicBattleFlow countdown and battle round completion)*
- `npm run check:jsdoc`
- `npx prettier src/pages/battleCLI.js tests/pages/battleCLI.countdown.test.js tests/pages/battleCLI.handlers.test.js --check`
- `npx eslint src/pages/battleCLI.js tests/pages/battleCLI.countdown.test.js tests/pages/battleCLI.handlers.test.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b449b38e4c832684552b90605f43bd