### PR TITLE
feat(cli): add toggleable help panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ npm run check:jsdoc
 ### Classic Battle CLI (text-first)
 
 - Page: `src/pages/battleCLI.html` – terminal-style UI that reuses the Classic Battle engine/state machine.
-- Controls: number keys [1–5] select stats, Enter/Space advances, Q quits, H toggles help. Stats can also be selected by clicking or tapping, and rounds can be advanced with a click.
+- Controls: number keys [1–5] select stats, Enter/Space advances, Q quits, H toggles a help panel (also closable via button). Stats can also be selected by clicking or tapping, and rounds can be advanced with a click.
 - State badge: `#battle-state-badge` reflects the current machine state.
 - Bottom line: snackbars render as a single status line using `#snackbar-container`.
 - Win target: choose 5/10/15 from the header; persisted in localStorage under `battleCLI.pointsToWin`.

--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -68,7 +68,7 @@ A terminal-style Classic Battle ensures **fast load, consistent behavior, and im
 |---|---|---|
 | **P1** | Engine Integration | Use the same Classic Battle engine and state machine as battleJudoka; static import for core gameplay modules. |
 | **P1** | Textual Renderer | Render all state changes (countdown, prompts, outcomes, score) as text within a monospace pane; no images/animations. |
-| **P1** | Keyboard Controls | Shortcut keys for stat selection (1–9), Next/Continue (Enter/Space), Quit (Q), Help (H). Display a multi-line help list. |
+| **P1** | Keyboard Controls | Shortcut keys for stat selection (1–9), Next/Continue (Enter/Space), Quit (Q), Help (H). Help opens a floating panel with a close button and is hidden by default. |
 | **P1** | Pointer Controls | Stats and Next prompts are clickable/tappable for mouse and touch users. |
 | **P1** | Timer Display | Show a 1 Hz textual countdown for stat selection; on expiry, auto-select per `FF_AUTO_SELECT`. |
 | **P1** | Outcome/Score | After decision, print outcome (Win/Loss/Draw), selected stat/value pairs, and updated score. |
@@ -102,11 +102,12 @@ Notes:
 1. Engine Parity  
    - Given a match is running, when any state transition occurs, then the new state matches `src/helpers/classicBattle/stateTable.js` exactly.  
 
-2. Keyboard Controls  
-   - Given the player is in stat selection, when pressing keys 1–9 mapped to visible stats, then the corresponding stat is selected and input is debounced until the next state.  
-   - Given a round has completed, when pressing Enter/Space, then the flow advances to cooldown/next round.  
-   - Given an inter-round cooldown is running, when pressing Enter/Space, then the countdown is skipped and the next round begins immediately.  
+2. Keyboard Controls
+   - Given the player is in stat selection, when pressing keys 1–9 mapped to visible stats, then the corresponding stat is selected and input is debounced until the next state.
+   - Given a round has completed, when pressing Enter/Space, then the flow advances to cooldown/next round.
+   - Given an inter-round cooldown is running, when pressing Enter/Space, then the countdown is skipped and the next round begins immediately.
   - Given an active match, when pressing Q, then a quit confirmation modal appears; confirming ends or rolls back per engine rules, cancelling resumes any paused timers.
+  - Given the help panel is hidden, when pressing H, then the help panel appears and can be dismissed with H or its close button.
 
 3. Timer Behavior  
   - Given `waitingForPlayerAction`, when the timer ticks, then `#cli-countdown` updates once per second with remaining time and exposes the value via `data-remaining-time`.

--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -72,6 +72,17 @@ test.describe("Classic Battle CLI", () => {
     await expect(page.locator("#cli-verbose-section")).toBeHidden();
   });
 
+  test("help panel toggles via keyboard and close button", async ({ page }) => {
+    await page.goto("/src/pages/battleCLI.html");
+    await waitForBattleState(page, "waitingForPlayerAction", 15000);
+    const panel = page.locator("#cli-shortcuts");
+    await expect(panel).toBeHidden();
+    await page.keyboard.press("h");
+    await expect(panel).toBeVisible();
+    await page.locator("#cli-shortcuts-close").click();
+    await expect(panel).toBeHidden();
+  });
+
   test("plays a full round and skips cooldown", async ({ page }) => {
     await page.addInitScript(() => {
       window.__NEXT_ROUND_COOLDOWN_MS = 3000;
@@ -116,6 +127,7 @@ test.describe("Classic Battle CLI", () => {
     expect(Number(secondPlayer) + Number(secondOpponent)).toBeGreaterThanOrEqual(
       Number(firstPlayer) + Number(firstOpponent)
     );
+  });
 
   test("returns to lobby after quitting", async ({ page }) => {
     await page.goto("/src/pages/battleCLI.html");

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -106,6 +106,23 @@
       #snackbar-container .snackbar {
         display: block;
       }
+      /* Floating help panel */
+      #cli-shortcuts {
+        position: fixed;
+        top: 56px;
+        right: 12px;
+        background: #0b0c0c;
+        z-index: 1;
+        max-width: 260px;
+      }
+      #cli-shortcuts-close {
+        float: right;
+        background: none;
+        border: 0;
+        color: #f2f2f2;
+        cursor: pointer;
+        font-size: 16px;
+      }
       /* Ensure good contrast for links if any appear */
       a {
         color: #9ad1ff;
@@ -194,8 +211,10 @@
           id="cli-shortcuts"
           class="cli-block"
           data-flag="cliShortcuts"
+          hidden
         >
-          <ul id="cli-help">
+          <button id="cli-shortcuts-close" aria-label="Close help">×</button>
+          <ul id="cli-help" style="clear: both">
             <li>[1–5] Select Stat</li>
             <li>[Enter]/[Space] Next</li>
             <li>[Q] Quit</li>

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -171,7 +171,14 @@ function updateStateBadgeVisibility() {
  */
 function updateCliShortcutsVisibility() {
   const section = byId("cli-shortcuts");
-  if (section) section.hidden = !isEnabled("cliShortcuts");
+  if (!section) return;
+  if (!isEnabled("cliShortcuts")) {
+    section.hidden = true;
+    section.style.display = "none";
+  } else {
+    section.style.display = "";
+    section.hidden = true;
+  }
 }
 
 function showBottomLine(text) {
@@ -1074,6 +1081,11 @@ async function init() {
   updateStateBadgeVisibility();
   updateBattleStateBadge(window.__classicBattleState || null);
   updateCliShortcutsVisibility();
+  const close = byId("cli-shortcuts-close");
+  close?.addEventListener("click", () => {
+    const sec = byId("cli-shortcuts");
+    if (sec) sec.hidden = true;
+  });
   checkbox?.addEventListener("change", () => {
     setFlag("cliVerbose", !!checkbox.checked);
   });

--- a/tests/pages/battleCLI.cliShortcutsFlag.test.js
+++ b/tests/pages/battleCLI.cliShortcutsFlag.test.js
@@ -40,7 +40,7 @@ describe("battleCLI cliShortcuts flag", () => {
         <pre id="cli-verbose-log"></pre>
       </section>
       <input id="verbose-toggle" type="checkbox" />
-      <section id="cli-shortcuts"></section>
+      <section id="cli-shortcuts" hidden><button id="cli-shortcuts-close"></button></section>
     `;
   });
 
@@ -59,15 +59,21 @@ describe("battleCLI cliShortcuts flag", () => {
     vi.doUnmock("../../src/helpers/constants.js");
   });
 
-  it("hides shortcuts section when cliShortcuts is disabled", async () => {
+  it("does not toggle when cliShortcuts is disabled", async () => {
     const mod = await loadBattleCLI(false);
     await mod.__test.init();
-    expect(document.getElementById("cli-shortcuts").hidden).toBe(true);
+    const sec = document.getElementById("cli-shortcuts");
+    expect(sec.hidden).toBe(true);
+    mod.onKeyDown(new KeyboardEvent("keydown", { key: "h" }));
+    expect(sec.hidden).toBe(true);
   });
 
-  it("shows shortcuts section when cliShortcuts is enabled", async () => {
+  it("toggles when cliShortcuts is enabled", async () => {
     const mod = await loadBattleCLI(true);
     await mod.__test.init();
-    expect(document.getElementById("cli-shortcuts").hidden).toBe(false);
+    const sec = document.getElementById("cli-shortcuts");
+    expect(sec.hidden).toBe(true);
+    mod.onKeyDown(new KeyboardEvent("keydown", { key: "h" }));
+    expect(sec.hidden).toBe(false);
   });
 });

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -24,7 +24,7 @@ describe("battleCLI onKeyDown", () => {
       <div id="cli-root">
         <div id="cli-main"></div>
       </div>
-      <div id="cli-shortcuts" hidden></div>
+      <div id="cli-shortcuts" hidden><button id="cli-shortcuts-close"></button></div>
       <div id="cli-countdown" aria-live="polite"></div>
       <div id="snackbar-container"></div>
       <div id="modal-container"></div>
@@ -46,8 +46,12 @@ describe("battleCLI onKeyDown", () => {
 
   it("toggles shortcuts with H key", () => {
     onKeyDown(new KeyboardEvent("keydown", { key: "h" }));
-    expect(document.getElementById("cli-shortcuts").hidden).toBe(false);
+    const sec = document.getElementById("cli-shortcuts");
+    expect(sec.hidden).toBe(false);
+    onKeyDown(new KeyboardEvent("keydown", { key: "h" }));
+    expect(sec.hidden).toBe(true);
   });
+
 
   // Retro mode was removed; no longer handles 'R'.
 


### PR DESCRIPTION
## Summary
- make CLI help a floating panel with close button
- document CLI help panel behavior
- cover help panel toggling in tests

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/pages/battleCLI.onKeyDown.test.js tests/pages/battleCLI.cliShortcutsFlag.test.js`
- `npx playwright test playwright/battle-cli.spec.js` *(fails: timed out)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b4535bec048326881f9170ac4fc941