### PR TITLE
Allow tab navigation in battle CLI

### DIFF
--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -116,6 +116,27 @@ test.describe("Classic Battle CLI", () => {
     expect(Number(secondPlayer) + Number(secondOpponent)).toBeGreaterThanOrEqual(
       Number(firstPlayer) + Number(firstOpponent)
     );
+  });
+
+  test("allows tab navigation without invalid key messages", async ({ page }) => {
+    await page.goto("/src/pages/battleCLI.html");
+    await waitForBattleState(page, "waitingForPlayerAction", 15000);
+    const countdown = page.locator("#cli-countdown");
+
+    const steps = ["Tab", "Tab", "Tab", "Shift+Tab", "Tab", "Tab", "Tab", "Tab", "Tab"];
+    for (const step of steps) {
+      await page.keyboard.press(step);
+      await expect(countdown).not.toContainText("Invalid key");
+    }
+
+    await page.keyboard.press("q");
+    const confirm = page.locator("#confirm-quit-button");
+    await expect(confirm).toBeVisible();
+    await page.keyboard.press("Tab");
+    await expect(countdown).not.toContainText("Invalid key");
+    await page.keyboard.press("Shift+Tab");
+    await expect(countdown).not.toContainText("Invalid key");
+  });
 
   test("returns to lobby after quitting", async ({ page }) => {
     await page.goto("/src/pages/battleCLI.html");

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -111,6 +111,9 @@
         color: #9ad1ff;
       }
       a:focus,
+      button:focus,
+      input:focus,
+      select:focus,
       [tabindex]:focus {
         outline: 2px solid #9ad1ff;
         outline-offset: 2px;

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -837,6 +837,7 @@ export function handleCooldownKey(key) {
  * table = { waitingForPlayerAction: handleWaitingForPlayerActionKey,
  *           roundOver: handleRoundOverKey,
  *           cooldown: handleCooldownKey }
+ * if key == "tab": return
  * handler = table[state]
  * handled = handleGlobalKey(key) OR (handler ? handler(key) : false)
  * countdown = element '#cli-countdown'
@@ -847,6 +848,7 @@ export function handleCooldownKey(key) {
  */
 export function onKeyDown(e) {
   const key = e.key.toLowerCase();
+  if (key === "tab") return;
   if (!isEnabled("cliShortcuts") && key !== "q") return;
   const state = document.body?.dataset?.battleState || "";
   const table = {

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -59,6 +59,14 @@ describe("battleCLI onKeyDown", () => {
     expect(countdown.textContent).toBe("");
   });
 
+  it("ignores tab navigation", () => {
+    const countdown = document.getElementById("cli-countdown");
+    onKeyDown(new KeyboardEvent("keydown", { key: "Tab" }));
+    expect(countdown.textContent).toBe("");
+    onKeyDown(new KeyboardEvent("keydown", { key: "Tab", shiftKey: true }));
+    expect(countdown.textContent).toBe("");
+  });
+
   it("confirms quit via modal", () => {
     const dispatch = vi.fn();
     window.__getClassicBattleMachine = () => ({ dispatch });


### PR DESCRIPTION
## Summary
- Ignore Tab in battleCLI key handler so browser handles focus
- Ensure focus outlines on links, inputs, selects, and buttons
- Test tabbing through CLI controls doesn't trigger invalid key message

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 8 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b45357c74483268e9c094214986d00