### PR TITLE
Add manual start and in-page reset for CLI battles

### DIFF
--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -116,6 +116,7 @@ test.describe("Classic Battle CLI", () => {
     expect(Number(secondPlayer) + Number(secondOpponent)).toBeGreaterThanOrEqual(
       Number(firstPlayer) + Number(firstOpponent)
     );
+  });
 
   test("returns to lobby after quitting", async ({ page }) => {
     await page.goto("/src/pages/battleCLI.html");

--- a/tests/pages/battleCLI.a11y.focus.test.js
+++ b/tests/pages/battleCLI.a11y.focus.test.js
@@ -11,7 +11,8 @@ async function loadBattleCLI() {
   }));
   vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
     createBattleStore: vi.fn(() => ({})),
-    startRound: vi.fn()
+    startRound: vi.fn(),
+    resetGame: vi.fn()
   }));
   vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
     initClassicBattleOrchestrator: vi.fn()
@@ -23,7 +24,8 @@ async function loadBattleCLI() {
   vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: ["speed"] }));
   vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
     setPointsToWin: vi.fn(),
-    getPointsToWin: vi.fn(() => 10)
+    getPointsToWin: vi.fn(() => 10),
+    getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 }))
   }));
   vi.doMock("../../src/helpers/dataUtils.js", () => ({
     fetchJson: vi.fn().mockResolvedValue([{ statIndex: 1, name: "Speed" }])

--- a/tests/pages/battleCLI.cliShortcutsFlag.test.js
+++ b/tests/pages/battleCLI.cliShortcutsFlag.test.js
@@ -12,7 +12,8 @@ async function loadBattleCLI(flagEnabled) {
   }));
   vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
     createBattleStore: vi.fn(() => ({})),
-    startRound: vi.fn()
+    startRound: vi.fn(),
+    resetGame: vi.fn()
   }));
   vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
     initClassicBattleOrchestrator: vi.fn()
@@ -22,7 +23,11 @@ async function loadBattleCLI(flagEnabled) {
     emitBattleEvent: vi.fn()
   }));
   vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: [] }));
-  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({ setPointsToWin: vi.fn() }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    setPointsToWin: vi.fn(),
+    getPointsToWin: vi.fn(() => 5),
+    getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 }))
+  }));
   vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson: vi.fn().mockResolvedValue([]) }));
   vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
   const mod = await import("../../src/pages/battleCLI.js");

--- a/tests/pages/battleCLI.countdown.test.js
+++ b/tests/pages/battleCLI.countdown.test.js
@@ -13,7 +13,8 @@ async function loadBattleCLI(autoSelect = true, withSkip = false) {
   }));
   vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
     createBattleStore: vi.fn(() => ({})),
-    startRound: vi.fn()
+    startRound: vi.fn(),
+    resetGame: vi.fn()
   }));
   vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
     initClassicBattleOrchestrator: vi.fn()
@@ -23,7 +24,11 @@ async function loadBattleCLI(autoSelect = true, withSkip = false) {
     emitBattleEvent
   }));
   vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: ["speed"] }));
-  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({ setPointsToWin: vi.fn() }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    setPointsToWin: vi.fn(),
+    getPointsToWin: vi.fn(() => 5),
+    getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 }))
+  }));
   vi.doMock("../../src/helpers/dataUtils.js", () => ({
     fetchJson: vi.fn().mockResolvedValue([{ statIndex: 1, name: "Speed" }])
   }));

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -20,7 +20,8 @@ async function loadHandlers({ autoSelect = false, skipCooldown = false } = {}) {
   }));
   vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
     createBattleStore: vi.fn(() => ({})),
-    startRound: vi.fn()
+    startRound: vi.fn(),
+    resetGame: vi.fn()
   }));
   vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
     initClassicBattleOrchestrator: vi.fn()
@@ -129,19 +130,17 @@ describe("battleCLI event handlers", () => {
   });
 
   it("clears verbose log when play again clicked", async () => {
-    const { handlers } = await loadHandlers();
+    const { handlers, emitBattleEvent } = await loadHandlers();
     document.body.innerHTML = '<main id="cli-main"></main><pre id="cli-verbose-log">old</pre>';
-    const reload = vi.fn();
-    const originalLocation = window.location;
-    // @ts-ignore
-    delete window.location;
-    // Provide minimal reload stub
-    window.location = { reload };
     handlers.handleMatchOver();
-    document.getElementById("play-again-button").click();
+    const btn = document.getElementById("play-again-button");
+    const { resetGame } = await import("../../src/helpers/classicBattle/roundManager.js");
+    btn.click();
+    await Promise.resolve();
+    await Promise.resolve();
     expect(document.getElementById("cli-verbose-log").textContent).toBe("");
-    expect(reload).toHaveBeenCalled();
-    window.location = originalLocation;
+    expect(resetGame).toHaveBeenCalled();
+    expect(emitBattleEvent).toHaveBeenCalledWith("startClicked");
   });
 
   it("handles battle state transitions", async () => {

--- a/tests/pages/battleCLI.pointsToWin.test.js
+++ b/tests/pages/battleCLI.pointsToWin.test.js
@@ -13,7 +13,8 @@ async function loadBattleCLI() {
   }));
   vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
     createBattleStore: vi.fn(() => ({})),
-    startRound: vi.fn()
+    startRound: vi.fn(),
+    resetGame: vi.fn()
   }));
   vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
     initClassicBattleOrchestrator: vi.fn()
@@ -23,7 +24,11 @@ async function loadBattleCLI() {
     emitBattleEvent: vi.fn()
   }));
   vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: [] }));
-  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({ setPointsToWin: vi.fn() }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    setPointsToWin: vi.fn(),
+    getPointsToWin: vi.fn(() => 5),
+    getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 }))
+  }));
   vi.doMock("../../src/helpers/dataUtils.js", () => ({
     fetchJson: vi.fn().mockResolvedValue([{ statIndex: 1, name: "Speed" }])
   }));
@@ -36,6 +41,7 @@ describe("battleCLI points select", () => {
   beforeEach(() => {
     window.__TEST__ = true;
     document.body.innerHTML = `
+      <main id="cli-main"></main>
       <div id="cli-stats"></div>
       <div id="cli-help"></div>
       <select id="points-select">
@@ -79,7 +85,7 @@ describe("battleCLI points select", () => {
     setPointsToWin.mockClear();
 
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    const reloadSpy = vi.spyOn(window.location, "reload").mockImplementation(() => {});
+    const { emitBattleEvent } = await import("../../src/helpers/classicBattle/battleEvents.js");
 
     const select = document.getElementById("points-select");
     select.value = "15";
@@ -87,7 +93,7 @@ describe("battleCLI points select", () => {
 
     expect(confirmSpy).toHaveBeenCalled();
     expect(setPointsToWin).toHaveBeenCalledWith(15);
-    expect(reloadSpy).toHaveBeenCalled();
+    expect(emitBattleEvent).not.toHaveBeenCalledWith("startClicked");
     expect(localStorage.getItem(BATTLE_POINTS_TO_WIN)).toBe("15");
 
     setPointsToWin.mockClear();

--- a/tests/pages/battleCLI.roundHeader.test.js
+++ b/tests/pages/battleCLI.roundHeader.test.js
@@ -11,7 +11,8 @@ async function loadBattleCLI() {
   }));
   vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
     createBattleStore: vi.fn(),
-    startRound: vi.fn().mockResolvedValue({ playerJudoka: null, roundNumber: 2 })
+    startRound: vi.fn().mockResolvedValue({ playerJudoka: null, roundNumber: 2 }),
+    resetGame: vi.fn()
   }));
   vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
     initClassicBattleOrchestrator: vi.fn()
@@ -23,7 +24,8 @@ async function loadBattleCLI() {
   vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: [] }));
   vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
     setPointsToWin: vi.fn(),
-    getPointsToWin: vi.fn().mockReturnValue(10)
+    getPointsToWin: vi.fn().mockReturnValue(10),
+    getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 }))
   }));
   vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson: vi.fn().mockResolvedValue([]) }));
   vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));

--- a/tests/pages/battleCLI.scoreboard.test.js
+++ b/tests/pages/battleCLI.scoreboard.test.js
@@ -18,7 +18,8 @@ async function loadHandlers(scores) {
   }));
   vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
     createBattleStore: vi.fn(() => ({})),
-    startRound: vi.fn()
+    startRound: vi.fn(),
+    resetGame: vi.fn()
   }));
   vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
     initClassicBattleOrchestrator: vi.fn()

--- a/tests/pages/battleCLI.selectedStat.test.js
+++ b/tests/pages/battleCLI.selectedStat.test.js
@@ -10,7 +10,8 @@ async function loadBattleCLI() {
   }));
   vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
     createBattleStore: vi.fn(),
-    startRound: vi.fn()
+    startRound: vi.fn(),
+    resetGame: vi.fn()
   }));
   vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
     initClassicBattleOrchestrator: vi.fn()
@@ -22,7 +23,8 @@ async function loadBattleCLI() {
   vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: ["speed", "strength"] }));
   vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
     setPointsToWin: vi.fn(),
-    getPointsToWin: vi.fn()
+    getPointsToWin: vi.fn(),
+    getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 }))
   }));
   vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson: vi.fn().mockResolvedValue([]) }));
   vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));

--- a/tests/pages/battleCLI.verboseFlag.test.js
+++ b/tests/pages/battleCLI.verboseFlag.test.js
@@ -12,7 +12,8 @@ async function loadBattleCLI(flagEnabled) {
   }));
   vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
     createBattleStore: vi.fn(() => ({})),
-    startRound: vi.fn()
+    startRound: vi.fn(),
+    resetGame: vi.fn()
   }));
   vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
     initClassicBattleOrchestrator: vi.fn()
@@ -22,7 +23,11 @@ async function loadBattleCLI(flagEnabled) {
     emitBattleEvent: vi.fn()
   }));
   vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: [] }));
-  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({ setPointsToWin: vi.fn() }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    setPointsToWin: vi.fn(),
+    getPointsToWin: vi.fn(() => 10),
+    getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 }))
+  }));
   vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson: vi.fn().mockResolvedValue([]) }));
   vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
   const mod = await import("../../src/pages/battleCLI.js");


### PR DESCRIPTION
## Summary
- Replace automatic battle start with a Start match button and Play again reset
- Reset match state in-page when win target changes
- Test that matches start only on button press and settings changes don't auto-start

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 17 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b45361bf508326b4bcb13ac5054296