### PR TITLE
fix: ignore CLI help panel clicks

### DIFF
--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -83,6 +83,32 @@ test.describe("Classic Battle CLI", () => {
     await expect(panel).toBeHidden();
   });
 
+  test("closing help panel does not advance state", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__NEXT_ROUND_COOLDOWN_MS = 10000;
+    });
+    await page.goto("/src/pages/battleCLI.html");
+    await waitForBattleState(page, "waitingForPlayerAction", 15000);
+
+    // Play first round to reach roundOver
+    await page.keyboard.press("1");
+    await waitForBattleState(page, "roundOver", 10000);
+
+    // Open and close shortcuts panel, ensure state unchanged
+    await page.keyboard.press("h");
+    await page.locator("#cli-shortcuts-close").click();
+    await expect(page.locator("#cli-shortcuts")).toBeHidden();
+    await expect(page.locator("body")).toHaveAttribute("data-battle-state", "roundOver");
+
+    // Advance to cooldown and repeat
+    await page.keyboard.press("Enter");
+    await waitForBattleState(page, "cooldown", 10000);
+    await page.keyboard.press("h");
+    await page.locator("#cli-shortcuts-close").click();
+    await expect(page.locator("#cli-shortcuts")).toBeHidden();
+    await expect(page.locator("body")).toHaveAttribute("data-battle-state", "cooldown");
+  });
+
   test("plays a full round and skips cooldown", async ({ page }) => {
     await page.addInitScript(() => {
       window.__NEXT_ROUND_COOLDOWN_MS = 3000;

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -914,9 +914,21 @@ function handleStatClick(event) {
   selectStat(stat);
 }
 
+/**
+ * Advance battle state when clicking outside interactive areas.
+ *
+ * @pseudocode
+ * state = body.dataset.battleState
+ * if click inside .cli-stat or #cli-shortcuts -> return
+ * if state == "roundOver" -> dispatch "continue"
+ * else if state == "cooldown" -> clear timers, dispatch "ready"
+ *
+ * @param {MouseEvent} event - Click event.
+ */
 function onClickAdvance(event) {
   const state = document.body?.dataset?.battleState || "";
   if (event.target?.closest?.(".cli-stat")) return;
+  if (event.target?.closest?.("#cli-shortcuts")) return;
   if (state === "roundOver") {
     try {
       const machine = window.__getClassicBattleMachine?.();
@@ -1114,7 +1126,8 @@ async function init() {
   updateBattleStateBadge(window.__classicBattleState || null);
   updateCliShortcutsVisibility();
   const close = byId("cli-shortcuts-close");
-  close?.addEventListener("click", () => {
+  close?.addEventListener("click", (event) => {
+    event.stopPropagation();
     const sec = byId("cli-shortcuts");
     if (sec) sec.hidden = true;
   });


### PR DESCRIPTION
## Summary
- ignore clicks inside CLI shortcuts panel
- stop click propagation when closing CLI help panel
- test that closing help panel doesn't advance battle state

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b45e2376048326941171ae0a1880a1