### PR TITLE
refactor classic battle transition listeners

### DIFF
--- a/design/testing/classicBattleTesting.md
+++ b/design/testing/classicBattleTesting.md
@@ -41,6 +41,16 @@ This note explains how Classic Battle bindings and promises are set up for tests
 
 - In Vitest, Classic Battle adds small test-mode fallbacks to avoid flaky races:
   - `startRound()` applies UI immediately and emits `roundPrompt`.
-  - `selectionHandler` clears transient text and surfaces the opponent-delay snackbar during selection.
+- `selectionHandler` clears transient text and surfaces the opponent-delay snackbar during selection.
   - `handleStatSelectionTimeout()` only shows the stall message at timeout (not earlier).
   - `__triggerStallPromptNow(store)` surfaces a stall prompt immediately for tests.
+
+## State Transition Listeners
+
+- `battleStateChange` events now drive side effects such as DOM mirroring, debug logging, and resolving waiters.
+- Tests should emit `battleStateChange` instead of mutating `document.body.dataset` or `window` globals.
+- `src/helpers/classicBattle/stateTransitionListeners.js` exports:
+  - `domStateListener` – mirrors state to `document.body.dataset` and dispatches a legacy `battle:state` event.
+  - `createDebugLogListener(machine)` – updates debug globals and emits `debugPanelUpdate`.
+  - `createWaiterResolver(stateWaiters)` – settles promises awaiting specific states.
+- Register these listeners with `onBattleEvent('battleStateChange', ...)` after the state machine is created (see orchestrator init).

--- a/src/helpers/classicBattle/stateTransitionListeners.js
+++ b/src/helpers/classicBattle/stateTransitionListeners.js
@@ -1,0 +1,123 @@
+/**
+ * Handlers responding to `battleStateChange` events.
+ *
+ * @module stateTransitionListeners
+ */
+import { emitBattleEvent } from "./battleEvents.js";
+
+/**
+ * Mirror the current battle state to the DOM and dispatch the legacy
+ * `battle:state` event.
+ *
+ * @param {CustomEvent<{from:string|null,to:string,event:string|null}>} e
+ *   State transition detail.
+ * @summary Sync battle state to DOM.
+ * @pseudocode
+ * 1. Extract `from`, `to`, and `event` from `e.detail`.
+ * 2. If `document` is available:
+ *    a. Update `document.body.dataset.battleState` to `to`.
+ *    b. Set `prevBattleState` when `from` exists, otherwise remove it.
+ *    c. Dispatch a `battle:state` event with the same detail.
+ */
+export function domStateListener(e) {
+  const { from, to, event } = e.detail || {};
+  if (typeof document === "undefined") return;
+  try {
+    const ds = document.body?.dataset;
+    if (ds) {
+      ds.battleState = to;
+      if (from) ds.prevBattleState = from;
+      else delete ds.prevBattleState;
+    }
+    document.dispatchEvent(new CustomEvent("battle:state", { detail: { from, to, event } }));
+  } catch {}
+}
+
+/**
+ * Create a listener that logs state transitions on `window` and updates
+ * timer diagnostics.
+ *
+ * @param {import("./stateMachine.js").BattleStateMachine|null} machine
+ *   Active battle machine.
+ * @returns {(e: CustomEvent<{from:string|null,to:string,event:string|null}>) => void}
+ *   Registered listener.
+ * @summary Create debug listener for state transitions.
+ * @pseudocode
+ * 1. Return a function handling the `battleStateChange` event.
+ * 2. Inside the handler:
+ *    a. Update `window.__classicBattleState`, `__classicBattlePrevState`,
+ *       `__classicBattleLastEvent`, and append to `__classicBattleStateLog`.
+ *    b. Read timer state from the machine and mirror it on
+ *       `window.__classicBattleTimerState`.
+ *    c. Emit `debugPanelUpdate` for UI consumers.
+ */
+export function createDebugLogListener(machine) {
+  return function debugLogListener(e) {
+    const { from, to, event } = e.detail || {};
+    if (typeof window !== "undefined") {
+      try {
+        window.__classicBattleState = to;
+        if (from) window.__classicBattlePrevState = from;
+        if (event) window.__classicBattleLastEvent = event;
+        const log = Array.isArray(window.__classicBattleStateLog)
+          ? window.__classicBattleStateLog
+          : [];
+        log.push({ from, to, event, ts: Date.now() });
+        while (log.length > 20) log.shift();
+        window.__classicBattleStateLog = log;
+      } catch {}
+    }
+    try {
+      if (machine) {
+        const timerState = machine.context?.engine?.getTimerState?.();
+        if (timerState && typeof window !== "undefined") {
+          window.__classicBattleTimerState = timerState;
+        }
+      }
+    } catch {}
+    emitBattleEvent("debugPanelUpdate");
+  };
+}
+
+/**
+ * Create a listener that resolves state transition waiters.
+ *
+ * @param {Map<string, {resolve:Function,timer?:ReturnType<typeof setTimeout>,__id?:string}[]>} stateWaiters
+ *   Waiters keyed by target state.
+ * @returns {(e: CustomEvent<{to:string}>) => void}
+ *   Registered listener.
+ * @summary Resolve promises waiting on a state.
+ * @pseudocode
+ * 1. Read the `to` state from `e.detail`.
+ * 2. Resolve and clear any global waiters stored on `window.__stateWaiters[to]`.
+ * 3. Resolve and clear waiters stored in the provided `stateWaiters` map.
+ */
+export function createWaiterResolver(stateWaiters) {
+  return function waiterResolver(e) {
+    const { to } = e.detail || {};
+    if (typeof window !== "undefined") {
+      try {
+        const winWaiters = (window.__stateWaiters && window.__stateWaiters[to]) || [];
+        if (Array.isArray(winWaiters) && winWaiters.length) {
+          window.__stateWaiters[to] = [];
+          for (const w of winWaiters) {
+            try {
+              if (w.timer) clearTimeout(w.timer);
+              w.resolve(true);
+            } catch {}
+          }
+        }
+      } catch {}
+    }
+    const waiters = stateWaiters.get(to);
+    if (waiters) {
+      stateWaiters.delete(to);
+      for (const w of waiters) {
+        try {
+          if (w.timer) clearTimeout(w.timer);
+          w.resolve(true);
+        } catch {}
+      }
+    }
+  };
+}

--- a/tests/helpers/classicBattle/debugPanel.test.js
+++ b/tests/helpers/classicBattle/debugPanel.test.js
@@ -46,7 +46,6 @@ vi.mock("../../../src/helpers/cardUtils.js", () => ({ toggleInspectorPanels: vi.
 vi.mock("../../../src/components/Modal.js", () => ({ createModal: vi.fn() }));
 vi.mock("../../../src/components/Button.js", () => ({ createButton: vi.fn() }));
 vi.mock("../../../src/helpers/classicBattle/uiService.js", () => ({ syncScoreDisplay: vi.fn() }));
-vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({ onBattleEvent: vi.fn() }));
 
 import { updateDebugPanel } from "../../../src/helpers/classicBattle/uiHelpers.js";
 
@@ -76,8 +75,16 @@ describe("updateDebugPanel", () => {
     expect(output.machineTriggers).toBeUndefined();
   });
 
-  it("includes machine diagnostics when available", () => {
-    window.__classicBattleState = "idle";
+  it("includes machine diagnostics when available", async () => {
+    const { onBattleEvent, emitBattleEvent, __resetBattleEventTarget } = await import(
+      "../../../src/helpers/classicBattle/battleEvents.js"
+    );
+    const { createDebugLogListener } = await import(
+      "../../../src/helpers/classicBattle/stateTransitionListeners.js"
+    );
+    __resetBattleEventTarget();
+    onBattleEvent("battleStateChange", createDebugLogListener(null));
+    emitBattleEvent("battleStateChange", { from: null, to: "idle", event: null });
     window.__getClassicBattleMachine = () => ({
       getState: () => "idle",
       statesByName: new Map([["idle", { triggers: [{ on: "start" }, { on: "quit" }] }]])

--- a/tests/helpers/classicBattle/nextButton.cooldown.fallback.test.js
+++ b/tests/helpers/classicBattle/nextButton.cooldown.fallback.test.js
@@ -1,9 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 describe("Next button cooldown fallback", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     document.body.innerHTML = `<button id="next-button">Next</button>`;
-    window.__classicBattleState = "cooldown";
+    const { onBattleEvent, emitBattleEvent, __resetBattleEventTarget } = await import(
+      "../../../src/helpers/classicBattle/battleEvents.js"
+    );
+    const { createDebugLogListener } = await import(
+      "../../../src/helpers/classicBattle/stateTransitionListeners.js"
+    );
+    __resetBattleEventTarget();
+    onBattleEvent("battleStateChange", createDebugLogListener(null));
+    emitBattleEvent("battleStateChange", { from: null, to: "cooldown", event: null });
   });
   afterEach(() => {
     vi.restoreAllMocks();

--- a/tests/helpers/classicBattle/race.statSelected.startup.test.js
+++ b/tests/helpers/classicBattle/race.statSelected.startup.test.js
@@ -23,12 +23,6 @@ vi.mock("../../../src/helpers/battleEngineFacade.js", async () => {
   };
 });
 
-vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
-  emitBattleEvent: vi.fn(),
-  onBattleEvent: vi.fn(),
-  offBattleEvent: vi.fn()
-}));
-
 // Capture dispatched machine events and simulate no machine at click time
 vi.mock("../../../src/helpers/classicBattle/eventDispatcher.js", () => {
   const events = [];
@@ -62,8 +56,15 @@ describe("race: statSelected before setMachine does not stall round", () => {
     </ul>`;
     document.body.append(playerCard, opponentCard, header);
 
-    // Make selectionHandler believe the machine is active, while event dispatcher isn't wired yet
-    document.body.dataset.battleState = "waitingForPlayerAction";
+    const { onBattleEvent, emitBattleEvent, __resetBattleEventTarget } = await import(
+      "../../../src/helpers/classicBattle/battleEvents.js"
+    );
+    const { domStateListener } = await import(
+      "../../../src/helpers/classicBattle/stateTransitionListeners.js"
+    );
+    __resetBattleEventTarget();
+    onBattleEvent("battleStateChange", domStateListener);
+    emitBattleEvent("battleStateChange", { from: null, to: "waitingForPlayerAction", event: null });
 
     const selectionMod = await import("../../../src/helpers/classicBattle/selectionHandler.js");
     const { handleStatSelection, getPlayerAndOpponentValues } = selectionMod;

--- a/tests/helpers/classicBattle/roundDecisionGuard.test.js
+++ b/tests/helpers/classicBattle/roundDecisionGuard.test.js
@@ -8,11 +8,21 @@ describe("scheduleRoundDecisionGuard", () => {
   beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    document.body.dataset.battleState = "roundDecision";
     window.__roundDebug = {};
     timerSpy = vi.useFakeTimers();
     store = { playerChoice: null };
     machine = { dispatch: vi.fn().mockResolvedValue(undefined) };
+    return (async () => {
+      const { onBattleEvent, emitBattleEvent, __resetBattleEventTarget } = await import(
+        "../../../src/helpers/classicBattle/battleEvents.js"
+      );
+      const { domStateListener } = await import(
+        "../../../src/helpers/classicBattle/stateTransitionListeners.js"
+      );
+      __resetBattleEventTarget();
+      onBattleEvent("battleStateChange", domStateListener);
+      emitBattleEvent("battleStateChange", { from: null, to: "roundDecision", event: null });
+    })();
   });
   afterEach(() => {
     timerSpy.clearAllTimers();

--- a/tests/helpers/classicBattle/roundResolverOnce.test.js
+++ b/tests/helpers/classicBattle/roundResolverOnce.test.js
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
-  emitBattleEvent: vi.fn(),
-  onBattleEvent: vi.fn()
-}));
 vi.mock("../../../src/helpers/classicBattle/eventDispatcher.js", () => ({
   dispatchBattleEvent: vi.fn().mockResolvedValue()
 }));
@@ -44,7 +40,15 @@ describe.sequential("classicBattle round resolver once", () => {
       <div id="opponent-card"><ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul></div>
       <div id="stat-buttons"><button data-stat="power"></button></div>
     `;
-    document.body.dataset.battleState = "roundDecision";
+    const { onBattleEvent, emitBattleEvent, __resetBattleEventTarget } = await import(
+      "../../../src/helpers/classicBattle/battleEvents.js"
+    );
+    const { domStateListener } = await import(
+      "../../../src/helpers/classicBattle/stateTransitionListeners.js"
+    );
+    __resetBattleEventTarget();
+    onBattleEvent("battleStateChange", domStateListener);
+    emitBattleEvent("battleStateChange", { from: null, to: "roundDecision", event: null });
     ({ handleStatSelection, createBattleStore, _resetForTest, getCardStatValue } = await import(
       "../../../src/helpers/classicBattle.js"
     ));

--- a/tests/helpers/classicBattle/stateTransitions.test.js
+++ b/tests/helpers/classicBattle/stateTransitions.test.js
@@ -42,21 +42,17 @@ describe("classic battle state table transitions", () => {
     if (!Array.isArray(state.triggers)) continue;
     for (const trigger of state.triggers) {
       it(`${state.name} --${trigger.on}--> ${trigger.target}`, async () => {
-        document.body.dataset.battleState = "";
-        document.body.dataset.prevBattleState = "";
         const spy = vi.fn();
-        const onTransition = ({ from, to }) => {
-          document.body.dataset.prevBattleState = from || "";
-          document.body.dataset.battleState = to;
-          emitBattleEvent("debugPanelUpdate");
+        const onTransition = ({ from, to, event }) => {
+          emitBattleEvent("battleStateChange", { from, to, event });
         };
-        onBattleEvent("debugPanelUpdate", spy);
+        onBattleEvent("battleStateChange", spy);
         const machine = createMachineForTransition(state, trigger, onTransition);
         await machine.dispatch(trigger.on);
         expect(machine.getState()).toBe(trigger.target);
         expect(spy).toHaveBeenCalled();
         expect(isStateTransition(state.name, trigger.target)).toBe(true);
-        offBattleEvent("debugPanelUpdate", spy);
+        offBattleEvent("battleStateChange", spy);
       });
     }
   }


### PR DESCRIPTION
## Summary
- centralize battle state DOM, debug, and waiter resolution logic in stateTransitionListeners
- emit only battleStateChange events in orchestrator and register new listeners
- update classic battle tests to use events and document listener pattern

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-cli and battle-orientation specs)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b45e320c3083268789ea5a47884528