### PR TITLE
fix orchestrator initial state mirroring

### DIFF
--- a/tests/helpers/orchestrator.stateChange.test.js
+++ b/tests/helpers/orchestrator.stateChange.test.js
@@ -12,7 +12,7 @@ describe("initClassicBattleOrchestrator state change hooks", () => {
       BattleStateMachine: {
         create: vi.fn(async (_onEnter, _context, onTransition) => {
           await onTransition({ from: "a", to: "b", event: "go" });
-          return { context: {} };
+          return { context: {}, getState: () => "b" };
         })
       }
     }));


### PR DESCRIPTION
## Summary
- ensure classic battle orchestrator mirrors initial state after listener registration
- update orchestrator state change test to mock `getState`

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: battle-cli.spec.js, battleRoundCompletion.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b4640ac60883269a2aa9c765fdae17