### PR TITLE
fix: share battle debug wait helpers

### DIFF
--- a/src/helpers/classicBattle/battleDebug.js
+++ b/src/helpers/classicBattle/battleDebug.js
@@ -126,3 +126,9 @@ export function __setStateSnapshot(next) {
   lastEvent = next.event || null;
   stateLog = Array.isArray(next.log) ? next.log.slice() : [];
 }
+
+// Expose helpers for in-page consumers like Playwright fixtures.
+if (typeof window !== "undefined") {
+  window.waitForState = waitForState;
+  window.getStateSnapshot = getStateSnapshot;
+}


### PR DESCRIPTION
## Summary
- expose waitForState and getStateSnapshot on window for browser-side reuse
- rely on window helpers in Playwright waitForBattleState instead of dynamic imports

## Testing
- `npm run check:jsdoc` (fails: Functions missing or with incomplete JSDoc blocks)
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: waitForState timeout for waitingForPlayerAction and other failures)
- `npx playwright test` (fails: Test timeout of 30000ms exceeded)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b48a0e224c8326a32a994268ef5d1b