### PR TITLE
test: centralize classic battle mocks

### DIFF
--- a/tests/helpers/classicBattle/autoSelect.test.js
+++ b/tests/helpers/classicBattle/autoSelect.test.js
@@ -1,26 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./commonMocks.js";
 import { setupClassicBattleDom } from "./utils.js";
 import { applyMockSetup } from "./mockSetup.js";
-
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
-vi.mock("../../../src/utils/scheduler.js", () => ({
-  onFrame: (cb) => {
-    const id = setTimeout(() => cb(performance.now()), 16);
-    return id;
-  },
-  onSecondTick: (cb) => {
-    const id = setInterval(() => cb(performance.now()), 1000);
-    return id;
-  },
-  cancel: (id) => {
-    clearTimeout(id);
-    clearInterval(id);
-  },
-  start: vi.fn(),
-  stop: vi.fn()
-}));
 
 let timerSpy;
 let fetchJsonMock;

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./commonMocks.js";
 import { createBattleHeader, createBattleCardContainers, resetDom } from "../../utils/testUtils.js";
 import { applyMockSetup, mocks } from "./mockSetup.js";
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
 
 let fetchJsonMock;
 let generateRandomCardMock;

--- a/tests/helpers/classicBattle/commonMocks.js
+++ b/tests/helpers/classicBattle/commonMocks.js
@@ -1,0 +1,22 @@
+import { vi } from "vitest";
+
+vi.mock("../../../src/helpers/motionUtils.js", () => ({
+  shouldReduceMotionSync: () => true
+}));
+
+vi.mock("../../../src/utils/scheduler.js", () => ({
+  onFrame: (cb) => {
+    const id = setTimeout(() => cb(performance.now()), 16);
+    return id;
+  },
+  onSecondTick: (cb) => {
+    const id = setInterval(() => cb(performance.now()), 1000);
+    return id;
+  },
+  cancel: vi.fn((id) => {
+    clearTimeout(id);
+    clearInterval(id);
+  }),
+  start: vi.fn(),
+  stop: vi.fn()
+}));

--- a/tests/helpers/classicBattle/countdownReset.test.js
+++ b/tests/helpers/classicBattle/countdownReset.test.js
@@ -1,26 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import "./commonMocks.js";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
 import { createRoundMessage, createSnackbarContainer, createTimerNodes } from "./domUtils.js";
-vi.mock("../../../src/utils/scheduler.js", () => ({
-  onFrame: (cb) => {
-    const id = setTimeout(() => cb(performance.now()), 16);
-    return id;
-  },
-  onSecondTick: (cb) => {
-    const id = setInterval(() => cb(performance.now()), 1000);
-    return id;
-  },
-  cancel: (id) => {
-    clearTimeout(id);
-    clearInterval(id);
-  },
-  start: vi.fn(),
-  stop: vi.fn()
-}));
-
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
 
 vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", async () => {
   const actual = await vi.importActual("../../../src/helpers/classicBattle/uiHelpers.js");

--- a/tests/helpers/classicBattle/debugPanel.test.js
+++ b/tests/helpers/classicBattle/debugPanel.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./commonMocks.js";
 
 vi.mock("../../../src/helpers/classicBattle/opponentController.js", () => ({
   getOpponentCardData: vi.fn()
@@ -30,8 +31,6 @@ vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   updateTimer: vi.fn()
 }));
 vi.mock("../../../src/helpers/battle/index.js", () => ({ showResult: vi.fn() }));
-vi.mock("../../../src/helpers/motionUtils.js", () => ({ shouldReduceMotionSync: () => true }));
-vi.mock("../../../src/utils/scheduler.js", () => ({ onFrame: vi.fn(), cancel: vi.fn() }));
 vi.mock("../../../src/helpers/classicBattle/selectionHandler.js", () => ({
   handleStatSelection: vi.fn()
 }));

--- a/tests/helpers/classicBattle/difficulty.test.js
+++ b/tests/helpers/classicBattle/difficulty.test.js
@@ -1,8 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "./commonMocks.js";
 import { STATS } from "../../../src/helpers/battleEngineFacade.js";
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
 
 describe("simulateOpponentStat difficulty", () => {
   let simulateOpponentStat;

--- a/tests/helpers/classicBattle/interruptHandlers.test.js
+++ b/tests/helpers/classicBattle/interruptHandlers.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./commonMocks.js";
 
 let modalOpenMock;
 let modalElement;
@@ -13,10 +14,6 @@ vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   showMessage: vi.fn(),
   clearTimer: vi.fn(),
   updateTimer: vi.fn()
-}));
-vi.mock("../../../src/utils/scheduler.js", () => ({
-  stop: vi.fn(),
-  cancel: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/skipHandler.js", () => ({
   resetSkipState: vi.fn()

--- a/tests/helpers/classicBattle/matchEnd.test.js
+++ b/tests/helpers/classicBattle/matchEnd.test.js
@@ -1,27 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./commonMocks.js";
 import { setupClassicBattleDom } from "./utils.js";
 import { CLASSIC_BATTLE_POINTS_TO_WIN } from "../../../src/helpers/constants.js";
 import { applyMockSetup } from "./mockSetup.js";
-
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
-vi.mock("../../../src/utils/scheduler.js", () => ({
-  onFrame: (cb) => {
-    const id = setTimeout(() => cb(performance.now()), 16);
-    return id;
-  },
-  onSecondTick: (cb) => {
-    const id = setInterval(() => cb(performance.now()), 1000);
-    return id;
-  },
-  cancel: (id) => {
-    clearTimeout(id);
-    clearInterval(id);
-  },
-  start: vi.fn(),
-  stop: vi.fn()
-}));
 
 vi.mock("../../../src/components/Modal.js", () => ({
   createModal: (content) => {

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -1,8 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
+import "./commonMocks.js";
 
 let showMessage;
 let clearMessage;

--- a/tests/helpers/classicBattle/outcomeVsComparison.test.js
+++ b/tests/helpers/classicBattle/outcomeVsComparison.test.js
@@ -1,9 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import "./commonMocks.js";
 
 // Force synchronous stat comparison (no animation)
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
 
 describe("Classic Battle — outcome vs comparison surfaces", () => {
   let ui;

--- a/tests/helpers/classicBattle/pauseTimer.test.js
+++ b/tests/helpers/classicBattle/pauseTimer.test.js
@@ -1,11 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./commonMocks.js";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
 import { createRoundMessage } from "./domUtils.js";
 import { applyMockSetup } from "./mockSetup.js";
-
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
 
 let fetchJsonMock;
 let generateRandomCardMock;

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -1,28 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./commonMocks.js";
 import { setupClassicBattleDom } from "./utils.js";
 import { createTimerNodes } from "./domUtils.js";
 import { applyMockSetup } from "./mockSetup.js";
 import { waitForState } from "../../../src/helpers/classicBattle/battleDebug.js";
-
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
-vi.mock("../../../src/utils/scheduler.js", () => ({
-  onFrame: (cb) => {
-    const id = setTimeout(() => cb(performance.now()), 16);
-    return id;
-  },
-  onSecondTick: (cb) => {
-    const id = setInterval(() => cb(performance.now()), 1000);
-    return id;
-  },
-  cancel: (id) => {
-    clearTimeout(id);
-    clearInterval(id);
-  },
-  start: vi.fn(),
-  stop: vi.fn()
-}));
 
 let timerSpy;
 let fetchJsonMock;

--- a/tests/helpers/classicBattle/selectionPrompt.test.js
+++ b/tests/helpers/classicBattle/selectionPrompt.test.js
@@ -1,26 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./commonMocks.js";
 import { setupClassicBattleDom } from "./utils.js";
 import { applyMockSetup } from "./mockSetup.js";
-
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
-vi.mock("../../../src/utils/scheduler.js", () => ({
-  onFrame: (cb) => {
-    const id = setTimeout(() => cb(performance.now()), 16);
-    return id;
-  },
-  onSecondTick: (cb) => {
-    const id = setInterval(() => cb(performance.now()), 1000);
-    return id;
-  },
-  cancel: (id) => {
-    clearTimeout(id);
-    clearInterval(id);
-  },
-  start: vi.fn(),
-  stop: vi.fn()
-}));
 
 let timerSpy;
 let fetchJsonMock;

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./commonMocks.js";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
 import { applyMockSetup } from "./mockSetup.js";
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
 
 vi.mock("../../../src/helpers/classicBattle/timerService.js", async () => {
   const actual = await vi.importActual("../../../src/helpers/classicBattle/timerService.js");

--- a/tests/helpers/classicBattle/statButtons.state.test.js
+++ b/tests/helpers/classicBattle/statButtons.state.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import "./commonMocks.js";
 import { createStateManager } from "../../../src/helpers/classicBattle/stateManager.js";
 import {
   waitingForPlayerActionEnter,
@@ -35,13 +36,6 @@ vi.mock("../../../src/helpers/battleStateProgress.js", () => ({
   initBattleStateProgress: vi.fn().mockResolvedValue(null)
 }));
 vi.mock("../../../src/helpers/tooltip.js", () => ({ initTooltips: vi.fn().mockResolvedValue() }));
-vi.mock("../../../src/utils/scheduler.js", () => ({
-  onFrame: vi.fn(),
-  onSecondTick: vi.fn(),
-  cancel: vi.fn(),
-  start: vi.fn(),
-  stop: vi.fn()
-}));
 vi.mock("../../../src/helpers/setupBottomNavbar.js", () => ({}));
 vi.mock("../../../src/helpers/setupDisplaySettings.js", () => ({}));
 vi.mock("../../../src/helpers/setupSvgFallback.js", () => ({}));

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -1,25 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./commonMocks.js";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
 import { applyMockSetup } from "./mockSetup.js";
-vi.mock("../../../src/helpers/motionUtils.js", () => ({
-  shouldReduceMotionSync: () => true
-}));
-vi.mock("../../../src/utils/scheduler.js", () => ({
-  onFrame: (cb) => {
-    const id = setTimeout(() => cb(performance.now()), 16);
-    return id;
-  },
-  onSecondTick: (cb) => {
-    const id = setInterval(() => cb(performance.now()), 1000);
-    return id;
-  },
-  cancel: (id) => {
-    clearTimeout(id);
-    clearInterval(id);
-  },
-  start: vi.fn(),
-  stop: vi.fn()
-}));
 
 let fetchJsonMock;
 let generateRandomCardMock;

--- a/tests/helpers/classicBattle/view.initHelpers.test.js
+++ b/tests/helpers/classicBattle/view.initHelpers.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import "./commonMocks.js";
 import createClassicBattleDebugAPI from "../../../src/helpers/classicBattle/setupTestHelpers.js";
 import setupScheduler from "../../../src/helpers/classicBattle/setupScheduler.js";
 import setupUIBindings from "../../../src/helpers/classicBattle/setupUIBindings.js";
@@ -9,13 +10,6 @@ vi.mock("../../../src/helpers/battle/index.js", () => ({
 }));
 vi.mock("../../../src/helpers/classicBattle/skipHandler.js", () => ({
   skipCurrentPhase: vi.fn()
-}));
-vi.mock("../../../src/utils/scheduler.js", () => ({
-  onFrame: vi.fn(),
-  onSecondTick: vi.fn(),
-  cancel: vi.fn(),
-  start: vi.fn(),
-  stop: vi.fn()
 }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   setupScoreboard: vi.fn()


### PR DESCRIPTION
## Summary
- add shared commonMocks for Classic Battle tests
- use shared mocks in tests instead of repeated motionUtils/scheduler stubs

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b497ce2fcc8326be6d4098e71bc320