### PR TITLE
refactor classic battle test setup

### DIFF
--- a/tests/helpers/classicBattle/selectionPrompt.test.js
+++ b/tests/helpers/classicBattle/selectionPrompt.test.js
@@ -1,44 +1,19 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import "./commonMocks.js";
-import { setupClassicBattleDom } from "./utils.js";
-import { applyMockSetup } from "./mockSetup.js";
-
-let timerSpy;
-let fetchJsonMock;
-let generateRandomCardMock;
-let getRandomJudokaMock;
-let renderMock;
-let currentFlags;
-
-beforeEach(() => {
-  try {
-    if (typeof window !== "undefined" && window.__disableSnackbars)
-      delete window.__disableSnackbars;
-  } catch {}
-  ({
-    timerSpy,
-    fetchJsonMock,
-    generateRandomCardMock,
-    getRandomJudokaMock,
-    renderMock,
-    currentFlags
-  } = setupClassicBattleDom());
-  applyMockSetup({
-    fetchJsonMock,
-    generateRandomCardMock,
-    getRandomJudokaMock,
-    renderMock,
-    currentFlags
-  });
-});
-
-afterEach(() => {
-  timerSpy.clearAllTimers();
-  vi.restoreAllMocks();
-});
+import { setupClassicBattleHooks } from "./setupTestEnv.js";
 
 describe("classicBattle selection prompt", () => {
+  const getEnv = setupClassicBattleHooks();
+
+  beforeEach(() => {
+    try {
+      if (typeof window !== "undefined" && window.__disableSnackbars)
+        delete window.__disableSnackbars;
+    } catch {}
+  });
+
   it("shows selection prompt until a stat is chosen", async () => {
+    const { timerSpy } = getEnv();
     const { initClassicBattleTest } = await import("./initClassicBattle.js");
     const battleMod = await initClassicBattleTest({ afterMock: true });
     const store = battleMod.createBattleStore();
@@ -62,7 +37,7 @@ describe("classicBattle selection prompt", () => {
         playerVal,
         opponentVal
       });
-      await vi.runAllTimersAsync();
+      await timerSpy.runAllTimersAsync();
       await p;
     }
     expect(document.querySelector(".snackbar")?.textContent).not.toBe("Select your move");

--- a/tests/helpers/classicBattle/setupTestEnv.js
+++ b/tests/helpers/classicBattle/setupTestEnv.js
@@ -1,0 +1,16 @@
+import { beforeEach, afterEach, vi } from "vitest";
+import { setupClassicBattleDom } from "./utils.js";
+import { applyMockSetup } from "./mockSetup.js";
+
+export function setupClassicBattleHooks() {
+  let env = {};
+  beforeEach(() => {
+    env = setupClassicBattleDom();
+    applyMockSetup(env);
+  });
+  afterEach(() => {
+    env.timerSpy?.clearAllTimers();
+    vi.restoreAllMocks();
+  });
+  return () => env;
+}


### PR DESCRIPTION
## Summary
- add reusable setupClassicBattleHooks for classic battle tests
- simplify autoSelect and selectionPrompt tests to use new hooks

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b4a0b0de648326982659c42c9ad42d