### PR TITLE
fix: dispatch statSelected before round resolution

### DIFF
--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -122,33 +122,14 @@ function applySelectionToStore(store, stat, playerVal, opponentVal) {
 }
 
 /**
- * Stop timers and clear pending timeouts tied to stat selection.
+ * @summary Stop timers and clear pending timeouts tied to stat selection.
  *
  * @pseudocode
  * 1. Call `stopTimer()` to halt the countdown.
  * 2. Clear `store.statTimeoutId` and `store.autoSelectId`.
  *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
+ * @returns {void}
  */
 export function cleanupTimers(store) {
   stopTimer();
@@ -194,39 +175,21 @@ async function emitSelectionEvent(store, stat, playerVal, opponentVal) {
 }
 
 /**
- * Handles the player's stat selection.
+ * @summary Handles the player's stat selection.
  *
  * @pseudocode
  * 1. Abort unless `validateSelectionState` allows the selection.
  * 2. Mark the selection and coerce stat values via `applySelectionToStore`.
  * 3. Halt timers with `cleanupTimers`.
  * 4. Emit the `statSelected` event via `emitSelectionEvent`.
- * 5. Resolve the round via `resolveRoundDirect`.
- * 6. Dispatch `roundResolved` to advance the battle state machine.
+ * 5. Dispatch `statSelected` to advance the battle state machine.
+ * 6. Resolve the round via `resolveRoundDirect`.
+ * 7. Dispatch `roundResolved` to finalize the round.
  *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
  * @param {string} stat - Chosen stat key.
  * @param {{playerVal: number, opponentVal: number}} values - Precomputed stat values.
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
+ * @returns {Promise<ReturnType<typeof resolveRound>>}
  */
 export async function handleStatSelection(store, stat, { playerVal, opponentVal, ...opts } = {}) {
   if (!validateSelectionState(store)) {
@@ -236,6 +199,9 @@ export async function handleStatSelection(store, stat, { playerVal, opponentVal,
   ({ playerVal, opponentVal } = applySelectionToStore(store, stat, playerVal, opponentVal));
   cleanupTimers(store);
   await emitSelectionEvent(store, stat, playerVal, opponentVal);
+  try {
+    await dispatchBattleEvent("statSelected");
+  } catch {}
   const result = await resolveRoundDirect(store, stat, playerVal, opponentVal, opts);
   try {
     await dispatchBattleEvent("roundResolved");

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -166,11 +166,17 @@ describe("classicBattle stat selection", () => {
     document.getElementById("opponent-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     await selectStat("power");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "evaluate");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "outcome=winPlayer");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(3, "continue");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "statSelected");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "evaluate");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(3, "outcome=winPlayer");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(4, "continue");
     const stateLog = eventDispatcher.__getStateLog();
-    expect(stateLog.slice(0, 3)).toEqual(["processingRound", "roundOver", "cooldown"]);
+    expect(stateLog.slice(0, 4)).toEqual([
+      "roundDecision",
+      "processingRound",
+      "roundOver",
+      "cooldown"
+    ]);
   });
 
   it("dispatches matchPointReached when match ends", async () => {
@@ -184,10 +190,12 @@ describe("classicBattle stat selection", () => {
       `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
     await selectStat("power");
     await selectStat("power");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "evaluate");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "outcome=winPlayer");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(3, "matchPointReached");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "statSelected");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "evaluate");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(3, "outcome=winPlayer");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(4, "matchPointReached");
     expect(eventDispatcher.__getStateLog()).toEqual([
+      "roundDecision",
       "processingRound",
       "roundOver",
       "matchDecision"


### PR DESCRIPTION
## Summary
- dispatch `statSelected` before resolving the round so the battle state machine transitions correctly
- update classic battle stat selection tests for new dispatch order

## Testing
- `npm run check:jsdoc`
- `npx prettier src/helpers/classicBattle/selectionHandler.js tests/helpers/classicBattle/statSelection.test.js --check`
- `npx eslint src/helpers/classicBattle/selectionHandler.js tests/helpers/classicBattle/statSelection.test.js`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b4a9fe40dc8326a0f448185092c8c1