### PR TITLE
fix: avoid double round resolution after stat selection

### DIFF
--- a/tests/helpers/classicBattle/selectionHandler.resolve.test.js
+++ b/tests/helpers/classicBattle/selectionHandler.resolve.test.js
@@ -60,4 +60,20 @@ describe("handleStatSelection resolution", () => {
     expect(result).toBe("direct");
     expect(store.playerChoice).toBeNull();
   });
+
+  it("skips direct resolution when machine handles round", async () => {
+    dispatchMock.mockImplementation(async (event) => {
+      if (event === "statSelected") {
+        store.playerChoice = null;
+      }
+    });
+    const result = await handleStatSelection(store, "power", {
+      playerVal: 1,
+      opponentVal: 2
+    });
+    expect(resolveMock).not.toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalledWith("roundResolved");
+    expect(result).toBeUndefined();
+    expect(store.playerChoice).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- stop `handleStatSelection` from resolving the round twice by checking if the battle machine already cleared `playerChoice`
- add test ensuring manual resolution is skipped when state machine handles the round

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b4b068a82083268ff176c36e8dc574