### PR TITLE
refactor: centralize round error handling

### DIFF
--- a/tests/helpers/classicBattle/roundStartError.test.js
+++ b/tests/helpers/classicBattle/roundStartError.test.js
@@ -32,10 +32,15 @@ describe("round start error recovery", () => {
       undefined,
       states
     );
+    const spy = vi.spyOn(machine, "dispatch");
 
     await roundStartEnter(machine);
 
     expect(machine.getState()).toBe("interruptRound");
+    expect(spy).toHaveBeenCalledWith("interrupt", {
+      reason: "roundStartError",
+      error: "no cards"
+    });
   });
 
   it("dispatches interrupt when startRoundWrapper throws", async () => {
@@ -64,9 +69,14 @@ describe("round start error recovery", () => {
       undefined,
       states
     );
+    const spy = vi.spyOn(machine, "dispatch");
 
     await roundStartEnter(machine);
 
     expect(machine.getState()).toBe("interruptRound");
+    expect(spy).toHaveBeenCalledWith("interrupt", {
+      reason: "roundStartError",
+      error: "sync fail"
+    });
   });
 });

--- a/tests/helpers/orchestratorHandlers.roundDecisionEnter.test.js
+++ b/tests/helpers/orchestratorHandlers.roundDecisionEnter.test.js
@@ -24,9 +24,10 @@ describe("roundDecisionEnter", () => {
     };
 
     const p = mod.roundDecisionEnter(machine);
+    expect(typeof window.__roundDecisionGuard).toBe("function");
     await vi.runAllTimersAsync();
     await p;
-    expect(typeof window.__roundDecisionGuard).toBe("function");
+    expect(window.__roundDecisionGuard).toBeNull();
     vi.useRealTimers();
   });
 
@@ -120,7 +121,10 @@ describe("roundDecisionEnter", () => {
       "scoreboardShowMessage",
       "Round error. Recovering…"
     );
-    expect(machine.dispatch).toHaveBeenCalledWith("interrupt", { reason: "roundResolutionError" });
+    expect(machine.dispatch).toHaveBeenCalledWith("interrupt", {
+      reason: "roundResolutionError",
+      error: "boom"
+    });
     expect(window.__roundDecisionGuard).toBeNull();
     await vi.runAllTimersAsync();
     vi.useRealTimers();


### PR DESCRIPTION
## Summary
- add `handleRoundError` helper to unify round error messaging and interrupt payloads
- simplify `roundStartEnter` and `roundDecisionEnter` with single try/catch blocks
- assert error messages in round-start and round-decision tests

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b4b5c320388326b699061baec53dac