### PR TITLE
refactor: modularize round decision flow

### DIFF
--- a/progress.md
+++ b/progress.md
@@ -240,3 +240,8 @@
 ## Milestone 12 — Stat Hotkeys Toggle
 
 - Surfaced `statHotkeys` in Advanced Settings with tooltip coverage and keyboard shortcut tests.
+
+## Milestone 13 — Round Decision Helper Extraction
+
+- Simplified `roundDecisionEnter` by composing `recordEntry`, `guardSelectionResolution`, `awaitPlayerChoice`, and `schedulePostResolveWatchdog`.
+- Added unit tests covering each helper in isolation.

--- a/tests/helpers/orchestratorHandlers.helpers.test.js
+++ b/tests/helpers/orchestratorHandlers.helpers.test.js
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+  document.body.innerHTML = '<div id="player-card"></div><div id="opponent-card"></div>';
+});
+
+describe("recordEntry", () => {
+  it("stamps window and emits debug update", async () => {
+    const emitBattleEvent = vi.fn();
+    vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+      emitBattleEvent,
+      onBattleEvent: vi.fn(),
+      offBattleEvent: vi.fn()
+    }));
+    const mod = await import("../../src/helpers/classicBattle/orchestratorHandlers.js");
+    delete window.__roundDecisionEnter;
+    mod.recordEntry();
+    expect(typeof window.__roundDecisionEnter).toBe("number");
+    expect(emitBattleEvent).toHaveBeenCalledWith("debugPanelUpdate");
+  });
+});
+
+describe("guardSelectionResolution", () => {
+  it("cancels scheduled outcome when invoked", async () => {
+    vi.useFakeTimers();
+    const mod = await import("../../src/helpers/classicBattle/orchestratorHandlers.js");
+    const outcomeSpy = vi.spyOn(mod, "computeAndDispatchOutcome").mockResolvedValue(undefined);
+    const cancel = mod.guardSelectionResolution({}, {});
+    expect(typeof window.__roundDecisionGuard).toBe("function");
+    cancel();
+    await vi.runAllTimersAsync();
+    expect(outcomeSpy).not.toHaveBeenCalled();
+    expect(window.__roundDecisionGuard).toBeNull();
+    vi.useRealTimers();
+  });
+});
+
+describe("awaitPlayerChoice", () => {
+  it("resolves immediately when choice exists", async () => {
+    const store = { playerChoice: "power" };
+    const mod = await import("../../src/helpers/classicBattle/orchestratorHandlers.js");
+    await expect(mod.awaitPlayerChoice(store)).resolves.toBeUndefined();
+  });
+});
+
+describe("schedulePostResolveWatchdog", () => {
+  it("interrupts if state remains roundDecision", async () => {
+    vi.useFakeTimers();
+    const mod = await import("../../src/helpers/classicBattle/orchestratorHandlers.js");
+    const machine = {
+      getState: vi.fn(() => "roundDecision"),
+      dispatch: vi.fn()
+    };
+    mod.schedulePostResolveWatchdog(machine);
+    await vi.runAllTimersAsync();
+    expect(machine.dispatch).toHaveBeenCalledWith("interrupt", {
+      reason: "postResolveWatchdog"
+    });
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- break `roundDecisionEnter` into focused helpers and compose them
- document helper flow and update progress notes
- add unit tests for new helpers

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED, timeouts)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b4bccf8d048326b7cda937e68f8e5c