### PR TITLE
refactor: centralize classic battle debug hooks

### DIFF
--- a/design/testing/classicBattleTesting.md
+++ b/design/testing/classicBattleTesting.md
@@ -54,3 +54,16 @@ This note explains how Classic Battle bindings and promises are set up for tests
   - `createDebugLogListener(machine)` – updates debug globals and emits `debugPanelUpdate`.
   - `createWaiterResolver(stateWaiters)` – settles promises awaiting specific states.
 - Register these listeners with `onBattleEvent('battleStateChange', ...)` after the state machine is created (see orchestrator init).
+
+## Debug Hooks
+
+Classic Battle exposes internal state for tests through `exposeDebugState(key, value)` and `readDebugState(key)`. Tests may monkey‑patch these helpers to inspect values without touching `window` globals.
+
+```js
+import * as debugHooks from "../../src/helpers/classicBattle/debugHooks.js";
+const store = {};
+vi.spyOn(debugHooks, "exposeDebugState").mockImplementation((k, v) => {
+  store[k] = v;
+});
+vi.spyOn(debugHooks, "readDebugState").mockImplementation((k) => store[k]);
+```

--- a/src/helpers/classicBattle/debugHooks.js
+++ b/src/helpers/classicBattle/debugHooks.js
@@ -1,0 +1,23 @@
+const debugState = {};
+
+/**
+ * Store a debug value for tests or diagnostics.
+ *
+ * @param {string} key
+ * @param {*} value
+ */
+export function exposeDebugState(key, value) {
+  debugState[key] = value;
+}
+
+/**
+ * Read a debug value previously stored via `exposeDebugState`.
+ *
+ * @param {string} key
+ * @returns {*}
+ */
+export function readDebugState(key) {
+  return debugState[key];
+}
+
+export default { exposeDebugState, readDebugState };

--- a/src/helpers/classicBattle/orchestrator.js
+++ b/src/helpers/classicBattle/orchestrator.js
@@ -23,6 +23,7 @@ import {
   createWaiterResolver
 } from "./stateTransitionListeners.js";
 import { getStateSnapshot } from "./battleDebug.js";
+import { exposeDebugState } from "./debugHooks.js";
 
 let machine = null;
 
@@ -32,7 +33,7 @@ let machine = null;
  * @pseudocode
  * 1. Return early when not in a browser or when no engine is present.
  * 2. Read timer state from the machine's engine.
- * 3. Mirror the timer state on `window.__classicBattleTimerState`.
+ * 3. Mirror the timer state via `exposeDebugState('classicBattleTimerState')`.
  *
  * @param {import("./stateManager.js").ClassicBattleStateManager|null} machineRef - Current battle machine.
  * @returns {void}
@@ -115,9 +116,7 @@ export async function initClassicBattleOrchestrator(store, startRoundWrapper, op
   // Expose a safe getter for the running machine to avoid import cycles
   // in hot-path modules (e.g., selection handling).
   try {
-    if (typeof window !== "undefined") {
-      window.__getClassicBattleMachine = () => machine;
-    }
+    exposeDebugState("getClassicBattleMachine", () => machine);
   } catch {}
 
   if (typeof document !== "undefined") {

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -4,6 +4,7 @@ import * as battleEngine from "../battleEngineFacade.js";
 import { cancel as cancelFrame, stop as stopScheduler } from "../../utils/scheduler.js";
 import { resetSkipState } from "./skipHandler.js";
 import { emitBattleEvent } from "./battleEvents.js";
+import { readDebugState } from "./debugHooks.js";
 
 /**
  * Create a new battle state store.
@@ -27,10 +28,8 @@ export function createBattleStore() {
 }
 
 function getStartRound(store) {
-  if (typeof window !== "undefined") {
-    const api = window.__classicBattleDebugAPI;
-    if (api?.startRoundOverride) return api.startRoundOverride;
-  }
+  const api = readDebugState("classicBattleDebugAPI");
+  if (api?.startRoundOverride) return api.startRoundOverride;
   return () => startRound(store);
 }
 
@@ -153,7 +152,7 @@ export function _resetForTest(store) {
   battleEngine._resetForTest();
   stopScheduler();
   if (typeof window !== "undefined") {
-    const api = window.__classicBattleDebugAPI;
+    const api = readDebugState("classicBattleDebugAPI");
     if (api) delete api.startRoundOverride;
     else delete window.startRoundOverride;
   }

--- a/src/helpers/classicBattle/stateTransitionListeners.js
+++ b/src/helpers/classicBattle/stateTransitionListeners.js
@@ -5,6 +5,7 @@
  */
 import { emitBattleEvent } from "./battleEvents.js";
 import { logStateTransition, resolveStateWaiters } from "./battleDebug.js";
+import { exposeDebugState } from "./debugHooks.js";
 
 /**
  * Mirror the current battle state to the DOM and dispatch the legacy
@@ -47,8 +48,7 @@ export function domStateListener(e) {
  * 1. Return a function handling the `battleStateChange` event.
  * 2. Inside the handler:
  *    a. Record the transition via `logStateTransition`.
- *    b. Read timer state from the machine and mirror it on
- *       `window.__classicBattleTimerState`.
+ *    b. Read timer state from the machine and expose it via `exposeDebugState`.
  *    c. Emit `debugPanelUpdate` for UI consumers.
  */
 export function createDebugLogListener(machine) {
@@ -58,9 +58,7 @@ export function createDebugLogListener(machine) {
     try {
       if (machine) {
         const timerState = machine.context?.engine?.getTimerState?.();
-        if (timerState && typeof window !== "undefined") {
-          window.__classicBattleTimerState = timerState;
-        }
+        if (timerState) exposeDebugState("classicBattleTimerState", timerState);
       }
     } catch {}
     emitBattleEvent("debugPanelUpdate");

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -16,6 +16,7 @@ import { attachCooldownRenderer } from "../CooldownRenderer.js";
 import { awaitCooldownState } from "./awaitCooldownState.js";
 import { getStateSnapshot } from "./battleDebug.js";
 const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
+import { exposeDebugState, readDebugState } from "./debugHooks.js";
 
 /**
  * Store controls for the pending next round. Updated by `scheduleNextRound`
@@ -549,13 +550,12 @@ export function scheduleNextRound(result, scheduler = realScheduler) {
 function logScheduleNextRound(result) {
   try {
     const { state: s } = getStateSnapshot();
-    if (typeof window !== "undefined") {
-      window.__scheduleNextRoundCount = (window.__scheduleNextRoundCount || 0) + 1;
-      if (!IS_VITEST)
-        console.warn(
-          `[test] scheduleNextRound call#${window.__scheduleNextRoundCount}: state=${s} matchEnded=${!!result?.matchEnded}`
-        );
-    }
+    const count = (readDebugState("scheduleNextRoundCount") || 0) + 1;
+    exposeDebugState("scheduleNextRoundCount", count);
+    if (!IS_VITEST)
+      console.warn(
+        `[test] scheduleNextRound call#${count}: state=${s} matchEnded=${!!result?.matchEnded}`
+      );
   } catch {}
 }
 

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -28,6 +28,7 @@ import {
   createStatHotkeyHandler
 } from "./statButtons.js";
 import { guard } from "./guard.js";
+import { readDebugState } from "./debugHooks.js";
 
 /**
  * Skip the inter-round cooldown when the corresponding feature flag is enabled.
@@ -324,9 +325,12 @@ export function getMachineDebugState(win) {
     if (snap.prev) state.machinePrevState = snap.prev;
     if (snap.event) state.machineLastEvent = snap.event;
     if (Array.isArray(snap.log)) state.machineLog = snap.log.slice();
-    if (win?.__roundDecisionEnter) state.roundDecisionEnter = win.__roundDecisionEnter;
-    if (win?.__guardFiredAt) state.guardFiredAt = win.__guardFiredAt;
-    if (win?.__guardOutcomeEvent) state.guardOutcomeEvent = win.__guardOutcomeEvent;
+    const rde = readDebugState("roundDecisionEnter");
+    if (rde) state.roundDecisionEnter = rde;
+    const gfa = readDebugState("guardFiredAt");
+    if (gfa) state.guardFiredAt = gfa;
+    const goe = readDebugState("guardOutcomeEvent");
+    if (goe) state.guardOutcomeEvent = goe;
     addMachineDiagnostics(win, state);
   } catch {}
   return state;
@@ -373,7 +377,8 @@ export function getBuildInfo(win) {
   const info = {};
   try {
     if (win?.__buildTag) info.buildTag = win.__buildTag;
-    if (win?.__roundDebug) info.round = win.__roundDebug;
+    const rd = readDebugState("roundDebug");
+    if (rd !== undefined) info.round = rd;
     if (Array.isArray(win?.__eventDebug)) info.eventDebug = win.__eventDebug.slice();
     const opp = win?.document?.getElementById("opponent-card");
     if (opp) {

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -30,6 +30,7 @@ import { setTestMode } from "../helpers/testModeUtils.js";
 import { wrap } from "../helpers/storage.js";
 import { BATTLE_POINTS_TO_WIN } from "../config/storageKeys.js";
 import { POINTS_TO_WIN_OPTIONS } from "../config/battleDefaults.js";
+import { readDebugState } from "../helpers/classicBattle/debugHooks.js";
 
 /**
  * Minimal DOM utils for the CLI page
@@ -375,7 +376,7 @@ function showQuitModal() {
       quitModal.close();
       clearBottomLine();
       try {
-        const machine = window.__getClassicBattleMachine?.();
+        const machine = readDebugState("getClassicBattleMachine")?.();
         if (machine) await machine.dispatch("interrupt", { reason: "quit" });
       } catch {}
       try {
@@ -443,7 +444,7 @@ function selectStat(stat) {
   } catch {}
   showBottomLine(`You Picked: ${stat.charAt(0).toUpperCase()}${stat.slice(1)}`);
   try {
-    const machine = window.__getClassicBattleMachine?.();
+    const machine = readDebugState("getClassicBattleMachine")?.();
     if (machine) machine.dispatch("statSelected");
   } catch {}
 }
@@ -511,7 +512,7 @@ export function autostartBattle() {
   try {
     const autostart = new URLSearchParams(location.search).get("autostart");
     if (autostart === "1") {
-      const machine = window.__getClassicBattleMachine?.();
+      const machine = readDebugState("getClassicBattleMachine")?.();
       if (machine) machine.dispatch("startClicked");
     }
   } catch {}
@@ -790,7 +791,7 @@ export function handleWaitingForPlayerActionKey(key) {
 export function handleRoundOverKey(key) {
   if (key === "enter" || key === " ") {
     try {
-      const machine = window.__getClassicBattleMachine?.();
+      const machine = readDebugState("getClassicBattleMachine")?.();
       if (machine) machine.dispatch("continue");
     } catch {}
     return true;
@@ -855,7 +856,7 @@ export function handleCooldownKey(key) {
     cooldownInterval = null;
     clearBottomLine();
     try {
-      const machine = window.__getClassicBattleMachine?.();
+      const machine = readDebugState("getClassicBattleMachine")?.();
       if (machine) machine.dispatch("ready");
     } catch {}
     return true;
@@ -932,7 +933,7 @@ function onClickAdvance(event) {
   if (event.target?.closest?.("#cli-shortcuts")) return;
   if (state === "roundOver") {
     try {
-      const machine = window.__getClassicBattleMachine?.();
+      const machine = readDebugState("getClassicBattleMachine")?.();
       if (machine) machine.dispatch("continue");
     } catch {}
   } else if (state === "cooldown") {
@@ -946,7 +947,7 @@ function onClickAdvance(event) {
     cooldownInterval = null;
     clearBottomLine();
     try {
-      const machine = window.__getClassicBattleMachine?.();
+      const machine = readDebugState("getClassicBattleMachine")?.();
       if (machine) machine.dispatch("ready");
     } catch {}
   }

--- a/tests/helpers/battleTestUtils.js
+++ b/tests/helpers/battleTestUtils.js
@@ -9,11 +9,11 @@
  *   1. Set the next round timer to a short value.
  *   2. Populate player and opponent cards with equal Power stats to force a tie.
  */
+import { readDebugState } from "../../src/helpers/classicBattle/debugHooks.js";
 export async function _resetForTest() {
   const mod = await import(new URL("/src/helpers/classicBattle.js", window.location.href));
-  const store = window.__classicBattleDebugAPI
-    ? window.__classicBattleDebugAPI.battleStore
-    : window.battleStore;
+  const api = readDebugState("classicBattleDebugAPI");
+  const store = api ? api.battleStore : window.battleStore;
   mod._resetForTest(store);
 }
 

--- a/tests/helpers/orchestratorHandlers.computeOutcome.test.js
+++ b/tests/helpers/orchestratorHandlers.computeOutcome.test.js
@@ -1,8 +1,20 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+let debugHooks;
 
-beforeEach(() => {
+let store;
+beforeEach(async () => {
   vi.resetModules();
+  debugHooks = await import("../../src/helpers/classicBattle/debugHooks.js");
+  store = {};
+  vi.spyOn(debugHooks, "exposeDebugState").mockImplementation((k, v) => {
+    store[k] = v;
+  });
+  vi.spyOn(debugHooks, "readDebugState").mockImplementation((k) => store[k]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("computeAndDispatchOutcome", () => {
@@ -24,7 +36,7 @@ describe("computeAndDispatchOutcome", () => {
 
     document.body.innerHTML = '<div id="player-card"></div><div id="opponent-card"></div>';
     document.body.dataset.battleState = "roundDecision";
-    window.__roundDebug = {};
+    debugHooks.exposeDebugState("roundDebug", {});
 
     const store = { playerChoice: "strength" };
     const machine = { dispatch: vi.fn().mockResolvedValue(undefined) };
@@ -54,7 +66,7 @@ describe("computeAndDispatchOutcome", () => {
 
     document.body.innerHTML = '<div id="player-card"></div><div id="opponent-card"></div>';
     document.body.dataset.battleState = "roundDecision";
-    window.__roundDebug = {};
+    debugHooks.exposeDebugState("roundDebug", {});
 
     const store = { playerChoice: "strength" };
     const machine = { dispatch: vi.fn().mockResolvedValue(undefined) };

--- a/tests/pages/battleCLI.a11y.focus.test.js
+++ b/tests/pages/battleCLI.a11y.focus.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { readFileSync } from "fs";
+import * as debugHooks from "../../src/helpers/classicBattle/debugHooks.js";
 
 async function loadBattleCLI() {
   const emitter = new EventTarget();
@@ -65,14 +66,17 @@ describe("battleCLI accessibility", () => {
         <div id="snackbar-container"></div>
       `;
       const machine = { dispatch: vi.fn() };
-      window.__getClassicBattleMachine = vi.fn(() => machine);
+      debugHooks.exposeDebugState(
+        "getClassicBattleMachine",
+        vi.fn(() => machine)
+      );
     });
 
     afterEach(() => {
       vi.useRealTimers();
       document.body.innerHTML = "";
       delete window.__TEST__;
-      delete window.__getClassicBattleMachine;
+      debugHooks.exposeDebugState("getClassicBattleMachine", undefined);
       vi.resetModules();
       vi.clearAllMocks();
       vi.doUnmock("../../src/helpers/featureFlags.js");

--- a/tests/pages/battleCLI.countdown.test.js
+++ b/tests/pages/battleCLI.countdown.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as debugHooks from "../../src/helpers/classicBattle/debugHooks.js";
 
 async function loadBattleCLI(autoSelect = true, withSkip = false) {
   const emitter = new EventTarget();
@@ -62,14 +63,17 @@ describe("battleCLI countdown", () => {
       <div id="snackbar-container"></div>
     `;
     const machine = { dispatch: vi.fn() };
-    window.__getClassicBattleMachine = vi.fn(() => machine);
+    debugHooks.exposeDebugState(
+      "getClassicBattleMachine",
+      vi.fn(() => machine)
+    );
   });
 
   afterEach(() => {
     vi.useRealTimers();
     document.body.innerHTML = "";
     delete window.__TEST__;
-    delete window.__getClassicBattleMachine;
+    debugHooks.exposeDebugState("getClassicBattleMachine", undefined);
     vi.resetModules();
     vi.clearAllMocks();
     vi.doUnmock("../../src/helpers/featureFlags.js");

--- a/tests/pages/battleCLI.init.test.js
+++ b/tests/pages/battleCLI.init.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as debugHooks from "../../src/helpers/classicBattle/debugHooks.js";
 import { BATTLE_POINTS_TO_WIN } from "../../src/config/storageKeys.js";
 
 async function loadBattleCLI() {
@@ -51,7 +52,10 @@ describe("battleCLI init helpers", () => {
       <input id="verbose-toggle" type="checkbox" />
     `;
     const machine = { dispatch: vi.fn() };
-    window.__getClassicBattleMachine = vi.fn(() => machine);
+    debugHooks.exposeDebugState(
+      "getClassicBattleMachine",
+      vi.fn(() => machine)
+    );
     window.__TEST_MACHINE__ = machine;
     localStorage.setItem(BATTLE_POINTS_TO_WIN, "5");
   });
@@ -59,7 +63,7 @@ describe("battleCLI init helpers", () => {
   afterEach(() => {
     document.body.innerHTML = "";
     delete window.__TEST__;
-    delete window.__getClassicBattleMachine;
+    debugHooks.exposeDebugState("getClassicBattleMachine", undefined);
     delete window.__TEST_MACHINE__;
     vi.resetModules();
     vi.clearAllMocks();

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -3,13 +3,19 @@ import {
   emitBattleEvent,
   __resetBattleEventTarget
 } from "../../src/helpers/classicBattle/battleEvents.js";
+import * as debugHooks from "../../src/helpers/classicBattle/debugHooks.js";
 
 describe("battleCLI onKeyDown", () => {
-  let onKeyDown, __test;
+  let onKeyDown, __test, store;
 
   beforeEach(async () => {
     __resetBattleEventTarget();
     window.__TEST__ = true;
+    store = {};
+    vi.spyOn(debugHooks, "exposeDebugState").mockImplementation((k, v) => {
+      store[k] = v;
+    });
+    vi.spyOn(debugHooks, "readDebugState").mockImplementation((k) => store[k]);
     vi.doMock("../../src/components/Button.js", () => ({
       createButton: (label, opts = {}) => {
         const btn = document.createElement("button");
@@ -37,7 +43,7 @@ describe("battleCLI onKeyDown", () => {
     document.body.innerHTML = "";
     document.body.className = "";
     delete document.body.dataset.battleState;
-    delete window.__getClassicBattleMachine;
+    debugHooks.exposeDebugState("getClassicBattleMachine", undefined);
     delete window.__TEST__;
     vi.resetModules();
     vi.doUnmock("../../src/components/Button.js");
@@ -72,7 +78,7 @@ describe("battleCLI onKeyDown", () => {
 
   it("confirms quit via modal", () => {
     const dispatch = vi.fn();
-    window.__getClassicBattleMachine = () => ({ dispatch });
+    debugHooks.exposeDebugState("getClassicBattleMachine", () => ({ dispatch }));
     onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
     const confirm = document.getElementById("confirm-quit-button");
     expect(confirm).toBeTruthy();
@@ -83,7 +89,7 @@ describe("battleCLI onKeyDown", () => {
 
   it("resumes timers when quit is canceled", () => {
     const dispatch = vi.fn();
-    window.__getClassicBattleMachine = () => ({ dispatch });
+    debugHooks.exposeDebugState("getClassicBattleMachine", () => ({ dispatch }));
     document.body.dataset.battleState = "waitingForPlayerAction";
     const selT = setTimeout(() => {}, 1000);
     const selI = setInterval(() => {}, 1000);
@@ -97,7 +103,7 @@ describe("battleCLI onKeyDown", () => {
 
   it("resumes timers when quit modal dismissed with Escape", () => {
     const dispatch = vi.fn();
-    window.__getClassicBattleMachine = () => ({ dispatch });
+    debugHooks.exposeDebugState("getClassicBattleMachine", () => ({ dispatch }));
     document.body.dataset.battleState = "waitingForPlayerAction";
     const selT = setTimeout(() => {}, 1000);
     const selI = setInterval(() => {}, 1000);
@@ -111,7 +117,7 @@ describe("battleCLI onKeyDown", () => {
 
   it("resumes timers when backdrop is clicked", () => {
     const dispatch = vi.fn();
-    window.__getClassicBattleMachine = () => ({ dispatch });
+    debugHooks.exposeDebugState("getClassicBattleMachine", () => ({ dispatch }));
     document.body.dataset.battleState = "waitingForPlayerAction";
     const selT = setTimeout(() => {}, 1000);
     const selI = setInterval(() => {}, 1000);
@@ -125,7 +131,7 @@ describe("battleCLI onKeyDown", () => {
 
   it("clears timers when confirming quit", () => {
     const dispatch = vi.fn();
-    window.__getClassicBattleMachine = () => ({ dispatch });
+    debugHooks.exposeDebugState("getClassicBattleMachine", () => ({ dispatch }));
     const cooldownT = setTimeout(() => {}, 1000);
     const cooldownI = setInterval(() => {}, 1000);
     const selT = setTimeout(() => {}, 1000);
@@ -153,7 +159,7 @@ describe("battleCLI onKeyDown", () => {
 
   it("dispatches statSelected in waitingForPlayerAction state", () => {
     const dispatch = vi.fn();
-    window.__getClassicBattleMachine = () => ({ dispatch });
+    debugHooks.exposeDebugState("getClassicBattleMachine", () => ({ dispatch }));
     document.body.dataset.battleState = "waitingForPlayerAction";
     onKeyDown(new KeyboardEvent("keydown", { key: "1" }));
     expect(dispatch).toHaveBeenCalledWith("statSelected");
@@ -161,7 +167,7 @@ describe("battleCLI onKeyDown", () => {
 
   it("dispatches continue in roundOver state", () => {
     const dispatch = vi.fn();
-    window.__getClassicBattleMachine = () => ({ dispatch });
+    debugHooks.exposeDebugState("getClassicBattleMachine", () => ({ dispatch }));
     document.body.dataset.battleState = "roundOver";
     onKeyDown(new KeyboardEvent("keydown", { key: "Enter" }));
     expect(dispatch).toHaveBeenCalledWith("continue");
@@ -169,7 +175,7 @@ describe("battleCLI onKeyDown", () => {
 
   it("dispatches ready in cooldown state", () => {
     const dispatch = vi.fn();
-    window.__getClassicBattleMachine = () => ({ dispatch });
+    debugHooks.exposeDebugState("getClassicBattleMachine", () => ({ dispatch }));
     document.body.dataset.battleState = "cooldown";
     onKeyDown(new KeyboardEvent("keydown", { key: "Enter" }));
     expect(dispatch).toHaveBeenCalledWith("ready");
@@ -181,7 +187,7 @@ describe("battleCLI onKeyDown", () => {
       flag === "cliShortcuts" ? false : featureFlags.isEnabled(flag)
     );
     const dispatch = vi.fn();
-    window.__getClassicBattleMachine = () => ({ dispatch });
+    debugHooks.exposeDebugState("getClassicBattleMachine", () => ({ dispatch }));
     onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
     expect(document.getElementById("confirm-quit-button")).toBeTruthy();
   });

--- a/tests/pages/battleCLI.pointsToWin.test.js
+++ b/tests/pages/battleCLI.pointsToWin.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { BATTLE_POINTS_TO_WIN } from "../../src/config/storageKeys.js";
+import * as debugHooks from "../../src/helpers/classicBattle/debugHooks.js";
 
 async function loadBattleCLI() {
   const emitter = new EventTarget();
@@ -55,7 +56,10 @@ describe("battleCLI points select", () => {
       <input id="verbose-toggle" type="checkbox" />
     `;
     const machine = { dispatch: vi.fn() };
-    window.__getClassicBattleMachine = vi.fn(() => machine);
+    debugHooks.exposeDebugState(
+      "getClassicBattleMachine",
+      vi.fn(() => machine)
+    );
     window.__TEST_MACHINE__ = machine;
     localStorage.setItem(BATTLE_POINTS_TO_WIN, "5");
   });
@@ -63,7 +67,7 @@ describe("battleCLI points select", () => {
   afterEach(() => {
     document.body.innerHTML = "";
     delete window.__TEST__;
-    delete window.__getClassicBattleMachine;
+    debugHooks.exposeDebugState("getClassicBattleMachine", undefined);
     delete window.__TEST_MACHINE__;
     vi.resetModules();
     vi.clearAllMocks();

--- a/tests/pages/battleCLI.seed.test.js
+++ b/tests/pages/battleCLI.seed.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as debugHooks from "../../src/helpers/classicBattle/debugHooks.js";
 import { BATTLE_POINTS_TO_WIN } from "../../src/config/storageKeys.js";
 
 async function loadBattleCLI(seed) {
@@ -53,7 +54,10 @@ describe("battleCLI deterministic seed", () => {
       <input id="seed-input" type="number" />
     `;
     const machine = { dispatch: vi.fn() };
-    window.__getClassicBattleMachine = vi.fn(() => machine);
+    debugHooks.exposeDebugState(
+      "getClassicBattleMachine",
+      vi.fn(() => machine)
+    );
     window.__TEST_MACHINE__ = machine;
     localStorage.setItem(BATTLE_POINTS_TO_WIN, "5");
   });
@@ -61,7 +65,7 @@ describe("battleCLI deterministic seed", () => {
   afterEach(() => {
     document.body.innerHTML = "";
     delete window.__TEST__;
-    delete window.__getClassicBattleMachine;
+    debugHooks.exposeDebugState("getClassicBattleMachine", undefined);
     delete window.__TEST_MACHINE__;
     vi.resetModules();
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary
- add `exposeDebugState`/`readDebugState` utilities
- replace `window.__*` debugging variables with hook calls
- document new debugging hook for Classic Battle tests

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Classic Battle CLI tests interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b4c260bb70832681333a17977012f7