### PR TITLE
refactor: centralize classic battle debug hooks

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -305,19 +305,17 @@ export function disableNextRoundButton() {
  */
 
 /**
- * Extract machine state and diagnostics from a window object.
+ * Extract machine state and diagnostics.
  *
  * @pseudocode
- * 1. Exit with `{}` if `win` lacks machine globals.
- * 2. Copy current, previous, last event, and state log values.
- * 3. Append round decision and guard diagnostics when present.
- * 4. Merge machine readiness and triggers via `addMachineDiagnostics`.
- * 5. Return accumulated machine info.
+ * 1. Copy current, previous, last event, and state log values.
+ * 2. Append round decision and guard diagnostics when present.
+ * 3. Merge machine readiness and triggers via `addMachineDiagnostics`.
+ * 4. Return accumulated machine info.
  *
- * @param {Window | null} win Source window.
  * @returns {object}
  */
-export function getMachineDebugState(win) {
+export function getMachineDebugState() {
   const state = {};
   try {
     const snap = getStateSnapshot();
@@ -331,7 +329,7 @@ export function getMachineDebugState(win) {
     if (gfa) state.guardFiredAt = gfa;
     const goe = readDebugState("guardOutcomeEvent");
     if (goe) state.guardOutcomeEvent = goe;
-    addMachineDiagnostics(win, state);
+    addMachineDiagnostics(state);
   } catch {}
   return state;
 }
@@ -427,15 +425,15 @@ export function collectDebugState() {
   const win = typeof window !== "undefined" ? window : null;
   return {
     ...base,
-    ...getMachineDebugState(win),
+    ...getMachineDebugState(),
     ...getStoreSnapshot(win),
     ...getBuildInfo(win)
   };
 }
 
-function addMachineDiagnostics(win, state) {
+function addMachineDiagnostics(state) {
   try {
-    const getMachine = win.__getClassicBattleMachine;
+    const getMachine = readDebugState("getClassicBattleMachine");
     const machine = typeof getMachine === "function" ? getMachine() : null;
     if (!machine || typeof machine.getState !== "function") return;
     state.machineReady = true;

--- a/tests/helpers/classicBattle/debugPanel.test.js
+++ b/tests/helpers/classicBattle/debugPanel.test.js
@@ -47,6 +47,7 @@ vi.mock("../../../src/components/Button.js", () => ({ createButton: vi.fn() }));
 vi.mock("../../../src/helpers/classicBattle/uiService.js", () => ({ syncScoreDisplay: vi.fn() }));
 
 import { updateDebugPanel } from "../../../src/helpers/classicBattle/uiHelpers.js";
+import * as debugHooks from "../../../src/helpers/classicBattle/debugHooks.js";
 
 describe("updateDebugPanel", () => {
   let pre;
@@ -56,7 +57,7 @@ describe("updateDebugPanel", () => {
   });
 
   afterEach(() => {
-    delete window.__getClassicBattleMachine;
+    debugHooks.exposeDebugState("getClassicBattleMachine", undefined);
     vi.restoreAllMocks();
   });
 
@@ -83,10 +84,10 @@ describe("updateDebugPanel", () => {
     __resetBattleEventTarget();
     onBattleEvent("battleStateChange", createDebugLogListener(null));
     emitBattleEvent("battleStateChange", { from: null, to: "idle", event: null });
-    window.__getClassicBattleMachine = () => ({
+    debugHooks.exposeDebugState("getClassicBattleMachine", () => ({
       getState: () => "idle",
       statesByName: new Map([["idle", { triggers: [{ on: "start" }, { on: "quit" }] }]])
-    });
+    }));
     updateDebugPanel();
     const output = JSON.parse(pre.textContent);
     expect(output.machineReady).toBe(true);

--- a/tests/helpers/uiHelpers.collectDebugState.test.js
+++ b/tests/helpers/uiHelpers.collectDebugState.test.js
@@ -36,11 +36,11 @@ describe("collectDebugState", () => {
     debugHooks.exposeDebugState("guardFiredAt", 456);
     debugHooks.exposeDebugState("guardOutcomeEvent", "guard");
     debugHooks.exposeDebugState("roundDebug", 7);
+    debugHooks.exposeDebugState("getClassicBattleMachine", () => ({
+      getState: () => "idle",
+      statesByName: new Map([["idle", { triggers: [{ on: "start" }] }]])
+    }));
     Object.assign(window, {
-      __getClassicBattleMachine: () => ({
-        getState: () => "idle",
-        statesByName: new Map([["idle", { triggers: [{ on: "start" }] }]])
-      }),
       battleStore: { selectionMade: true, playerChoice: "power" },
       __buildTag: "v1",
       __eventDebug: ["x"]
@@ -51,7 +51,7 @@ describe("collectDebugState", () => {
     document.body.innerHTML = "";
     __setStateSnapshot({ state: null, prev: null, event: null, log: [] });
     vi.restoreAllMocks();
-    delete window.__getClassicBattleMachine;
+    debugHooks.exposeDebugState("getClassicBattleMachine", undefined);
     delete window.battleStore;
     delete window.__buildTag;
     delete window.__eventDebug;


### PR DESCRIPTION
## Summary
- fetch Classic Battle machine via `readDebugState` in debug helpers
- update debug panel tests to use new hook instead of window global

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: dispatch-related expectations)*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b4ca4ba59083268965ef4bceceb1f2