### PR TITLE
chore: clean orchestrator logging and clarify test dispatch mock

### DIFF
--- a/src/helpers/classicBattle/orchestrator.js
+++ b/src/helpers/classicBattle/orchestrator.js
@@ -24,7 +24,6 @@ import { getStateSnapshot } from "./battleDebug.js";
 import { exposeDebugState } from "./debugHooks.js";
 
 let machine = null;
-const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
 
 /**
  * Dispatch an event to the active battle machine.
@@ -41,40 +40,13 @@ const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
  * @returns {Promise<any>|void} Result of the dispatch when available.
  */
 export async function dispatchBattleEvent(eventName, payload) {
-  if (!machine) {
-    try {
-      if (!IS_VITEST) {
-        console.log("DEBUG: orchestrator has no machine for", eventName);
-      }
-    } catch {}
-    return;
-  }
+  if (!machine) return;
   try {
-    if (!IS_VITEST) {
-      console.log("DEBUG: orchestrator dispatch", {
-        state: machine?.getState?.(),
-        eventName,
-        payload
-      });
-    }
-  } catch {}
-  try {
-    const res = await machine.dispatch(eventName, payload);
-    try {
-      if (!IS_VITEST) {
-        console.log("DEBUG: orchestrator dispatched", {
-          newState: machine?.getState?.(),
-          eventName
-        });
-      }
-    } catch {}
-    return res;
+    return await machine.dispatch(eventName, payload);
   } catch {
     try {
       emitBattleEvent("debugPanelUpdate");
-    } catch (innerError) {
-      if (!IS_VITEST) console.error("Failed to emit debugPanelUpdate event:", innerError);
-    }
+    } catch {}
   }
 }
 
@@ -211,7 +183,6 @@ export async function initClassicBattleOrchestrator(store, startRoundWrapper, op
       };
     }
   } catch {}
-  console.log("initClassicBattleOrchestrator completed");
   return machine;
 }
 

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -6,7 +6,7 @@ import {
 import * as debugHooks from "../../src/helpers/classicBattle/debugHooks.js";
 
 describe("battleCLI onKeyDown", () => {
-  let onKeyDown, __test, store, dispatch;
+  let onKeyDown, __test, store, dispatchSpy;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -17,9 +17,9 @@ describe("battleCLI onKeyDown", () => {
       store[k] = v;
     });
     vi.spyOn(debugHooks, "readDebugState").mockImplementation((k) => store[k]);
-    dispatch = vi.fn();
+    dispatchSpy = vi.fn();
     vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
-      dispatchBattleEvent: dispatch
+      dispatchBattleEvent: dispatchSpy
     }));
     vi.doMock("../../src/components/Button.js", () => ({
       createButton: (label, opts = {}) => {
@@ -85,9 +85,9 @@ describe("battleCLI onKeyDown", () => {
     onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
     const confirm = document.getElementById("confirm-quit-button");
     expect(confirm).toBeTruthy();
-    expect(dispatch).not.toHaveBeenCalled();
+    expect(dispatchSpy).not.toHaveBeenCalled();
     confirm.click();
-    expect(dispatch).toHaveBeenCalledWith("interrupt", { reason: "quit" });
+    expect(dispatchSpy).toHaveBeenCalledWith("interrupt", { reason: "quit" });
   });
 
   it("resumes timers when quit is canceled", () => {
@@ -155,19 +155,19 @@ describe("battleCLI onKeyDown", () => {
   it("dispatches statSelected in waitingForPlayerAction state", () => {
     document.body.dataset.battleState = "waitingForPlayerAction";
     onKeyDown(new KeyboardEvent("keydown", { key: "1" }));
-    expect(dispatch).toHaveBeenCalledWith("statSelected");
+    expect(dispatchSpy).toHaveBeenCalledWith("statSelected");
   });
 
   it("dispatches continue in roundOver state", () => {
     document.body.dataset.battleState = "roundOver";
     onKeyDown(new KeyboardEvent("keydown", { key: "Enter" }));
-    expect(dispatch).toHaveBeenCalledWith("continue");
+    expect(dispatchSpy).toHaveBeenCalledWith("continue");
   });
 
   it("dispatches ready in cooldown state", () => {
     document.body.dataset.battleState = "cooldown";
     onKeyDown(new KeyboardEvent("keydown", { key: "Enter" }));
-    expect(dispatch).toHaveBeenCalledWith("ready");
+    expect(dispatchSpy).toHaveBeenCalledWith("ready");
   });
 
   it("allows quitting with Q when cliShortcuts flag is disabled", async () => {
@@ -175,7 +175,7 @@ describe("battleCLI onKeyDown", () => {
     vi.spyOn(featureFlags, "isEnabled").mockImplementation((flag) =>
       flag === "cliShortcuts" ? false : featureFlags.isEnabled(flag)
     );
-    dispatch.mockReset();
+    dispatchSpy.mockReset();
     onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
     expect(document.getElementById("confirm-quit-button")).toBeTruthy();
   });


### PR DESCRIPTION
## Summary
- rename `dispatch` mock to `dispatchSpy` in battleCLI tests
- remove stray console logging from classicBattle orchestrator

## Testing
- `npm run check:jsdoc` *(fails: functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(terminated after partial run)*
- `npx playwright test` *(fails: Classic Battle CLI closing help panel does not advance state, Browse Judoka screen country filter, etc.)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b53fcb9f1c8326acb814ef38f676f7