### PR TITLE
refactor: remove DOM battle events

### DIFF
--- a/tests/helpers/classicBattle/battleStateBadge.test.js
+++ b/tests/helpers/classicBattle/battleStateBadge.test.js
@@ -13,25 +13,7 @@ import {
   mockRoundSelectModal
 } from "./mocks.js";
 import { CLASSIC_BATTLE_STATES } from "../../../src/helpers/classicBattle/stateTable.js";
-import { onBattleEvent, offBattleEvent } from "../../../src/helpers/classicBattle/battleEvents.js";
-import { getStateSnapshot } from "../../../src/helpers/classicBattle/battleDebug.js";
-
-function waitForState(target, timeout = 10000) {
-  return new Promise((resolve, reject) => {
-    if (getStateSnapshot().state === target) return resolve();
-    const handler = (e) => {
-      if (e.detail?.to === target) {
-        offBattleEvent("battleStateChange", handler);
-        resolve();
-      }
-    };
-    onBattleEvent("battleStateChange", handler);
-    setTimeout(() => {
-      offBattleEvent("battleStateChange", handler);
-      reject(new Error(`timeout for ${target}`));
-    }, timeout);
-  });
-}
+import { waitForState } from "../../waitForState.js";
 
 // Apply all the necessary mocks
 mockScheduler();

--- a/tests/helpers/classicBattle/battleStateProgress.test.js
+++ b/tests/helpers/classicBattle/battleStateProgress.test.js
@@ -1,27 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  emitBattleEvent,
-  onBattleEvent,
-  offBattleEvent
-} from "../../../src/helpers/classicBattle/battleEvents.js";
-import { getStateSnapshot } from "../../../src/helpers/classicBattle/battleDebug.js";
-
-function waitForState(target, timeout = 4000) {
-  return new Promise((resolve, reject) => {
-    if (getStateSnapshot().state === target) return resolve();
-    const handler = (e) => {
-      if (e.detail?.to === target) {
-        offBattleEvent("battleStateChange", handler);
-        resolve();
-      }
-    };
-    onBattleEvent("battleStateChange", handler);
-    setTimeout(() => {
-      offBattleEvent("battleStateChange", handler);
-      reject(new Error(`timeout for ${target}`));
-    }, timeout);
-  });
-}
+import { emitBattleEvent } from "../../../src/helpers/classicBattle/battleEvents.js";
+import { waitForState } from "../../waitForState.js";
 import {
   mockScheduler,
   mockFeatureFlags,

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -3,29 +3,8 @@ import "./commonMocks.js";
 import { setupClassicBattleDom } from "./utils.js";
 import { createTimerNodes } from "./domUtils.js";
 import { applyMockSetup } from "./mockSetup.js";
-import {
-  onBattleEvent,
-  offBattleEvent,
-  emitBattleEvent
-} from "../../../src/helpers/classicBattle/battleEvents.js";
-import { getStateSnapshot } from "../../../src/helpers/classicBattle/battleDebug.js";
-
-function waitForState(target, timeout = 10000) {
-  return new Promise((resolve, reject) => {
-    if (getStateSnapshot().state === target) return resolve();
-    const handler = (e) => {
-      if (e.detail?.to === target) {
-        offBattleEvent("battleStateChange", handler);
-        resolve();
-      }
-    };
-    onBattleEvent("battleStateChange", handler);
-    setTimeout(() => {
-      offBattleEvent("battleStateChange", handler);
-      reject(new Error(`timeout for ${target}`));
-    }, timeout);
-  });
-}
+import { emitBattleEvent } from "../../../src/helpers/classicBattle/battleEvents.js";
+import { waitForState } from "../../waitForState.js";
 
 vi.mock("../../../src/helpers/CooldownRenderer.js", () => ({
   attachCooldownRenderer: vi.fn()

--- a/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
+++ b/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getStateSnapshot } from "../../../src/helpers/classicBattle/battleDebug.js";
-import { onBattleEvent, offBattleEvent } from "../../../src/helpers/classicBattle/battleEvents.js";
+import { waitForState } from "../../waitForState.js";
 
 vi.mock("../../../src/helpers/classicBattle/roundSelectModal.js", () => ({
   initRoundSelectModal: vi.fn(async (cb) => {
@@ -52,20 +52,3 @@ describe("timeout → interruptRound → cooldown auto-advance", () => {
     expect(["roundStart", "waitingForPlayerAction"]).toContain(snapshot?.state);
   });
 });
-
-function waitForState(target, timeout = 5000) {
-  return new Promise((resolve, reject) => {
-    if (getStateSnapshot().state === target) return resolve();
-    const handler = (e) => {
-      if (e.detail?.to === target) {
-        offBattleEvent("battleStateChange", handler);
-        resolve();
-      }
-    };
-    onBattleEvent("battleStateChange", handler);
-    setTimeout(() => {
-      offBattleEvent("battleStateChange", handler);
-      reject(new Error(`timeout for ${target}`));
-    }, timeout);
-  });
-}

--- a/tests/waitForState.js
+++ b/tests/waitForState.js
@@ -1,0 +1,32 @@
+import { onBattleEvent, offBattleEvent } from "../src/helpers/classicBattle/battleEvents.js";
+import { getStateSnapshot } from "../src/helpers/classicBattle/battleDebug.js";
+
+/**
+ * Wait for the classic battle state machine to reach a specific state.
+ *
+ * @pseudocode
+ * if current state matches target, resolve
+ * register listener for battleStateChange
+ * on match, remove listener and resolve
+ * on timeout, remove listener and reject
+ *
+ * @param {string} target - Expected state name.
+ * @param {number} [timeout=10000] - Time in ms before rejecting.
+ * @returns {Promise<void>} Resolves when the state is reached.
+ */
+export function waitForState(target, timeout = 10000) {
+  return new Promise((resolve, reject) => {
+    if (getStateSnapshot().state === target) return resolve();
+    const handler = (e) => {
+      if (e.detail?.to === target) {
+        offBattleEvent("battleStateChange", handler);
+        resolve();
+      }
+    };
+    onBattleEvent("battleStateChange", handler);
+    setTimeout(() => {
+      offBattleEvent("battleStateChange", handler);
+      reject(new Error(`timeout for ${target}`));
+    }, timeout);
+  });
+}


### PR DESCRIPTION
## Summary
- route classic battle events through internal EventTarget only
- replace DOM listeners and waiter utilities with onBattleEvent
- document event bus usage in architecture guide
- extract shared `waitForState` helper for classic battle tests

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: expect(page).toHaveScreenshot expected vs received)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b5498df86883268639627ed289f7cb