### PR TITLE
refactor: move round cooldown to roundManager

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -189,6 +189,17 @@ The manager exposes `getState()` and `dispatch(event)` and invokes
 `onEnter` handlers for each state. Transition hooks emit the
 `battleStateChange` event for listeners.
 
+#### Round lifecycle
+
+- `roundManager.startRound(store)` draws cards and initializes round UI.
+- After a round resolves, `roundManager.startCooldown(store)` computes the
+  cooldown and schedules the Next button enablement.
+- When the cooldown expires or the player clicks Next, the orchestrator
+  dispatches `ready` to begin the following round.
+
+`roundManager` owns all cooldown logic, exposing `startCooldown` and
+`getNextRoundControls` for helpers like the Next button handler.
+
 Modules outside the orchestrator interact with the machine only through
 `dispatchBattleEvent` exported by `orchestrator.js`. The machine instance
 itself remains private to the orchestrator, with a getter available for

--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -70,7 +70,7 @@ export { getCardStatValue } from "./classicBattle/cardStatUtils.js";
  * @pseudocode
  * 1. TODO: Add pseudocode
  */
-export { scheduleNextRound } from "./classicBattle/timerService.js";
+export { startCooldown } from "./classicBattle/roundManager.js";
 /**
  * @summary TODO: Add summary
  * @pseudocode

--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -1,5 +1,5 @@
 import { getDefaultTimer } from "../timerUtils.js";
-import { getNextRoundControls, setupFallbackTimer } from "./timerService.js";
+import { getNextRoundControls, setupFallbackTimer } from "./roundManager.js";
 import { computeNextRoundCooldown } from "../timers/computeNextRoundCooldown.js";
 import { isTestModeEnabled } from "../testModeUtils.js";
 import { getOpponentJudoka } from "./cardSelection.js";
@@ -402,11 +402,11 @@ export async function waitingForPlayerActionEnter(machine) {
   emitBattleEvent("statButtons:enable");
   // Do NOT mark the Next button as ready here. The Next button is reserved
   // for advancing after cooldown between rounds. Enabling it during stat
-  // selection can cause `scheduleNextRound` to short-circuit, skipping the
-  // cooldown timer and preventing the state machine from progressing — seen
-  // as a "hang" on the classic battle page. The CLI page never enables Next
-  // during selection and does not suffer this issue. Keep Next controlled by
-  // `scheduleNextRound` only.
+  // selection can cause the cooldown scheduler to short-circuit, skipping the
+  // timer and preventing the state machine from progressing — seen as a "hang"
+  // on the classic battle page. The CLI page never enables Next during
+  // selection and does not suffer this issue. Keep Next controlled by the
+  // cooldown scheduler only.
   const store = machine?.context?.store;
   if (store?.playerChoice) {
     await machine.dispatch("statSelected");

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -1,7 +1,8 @@
 import { showSelectionPrompt, updateDebugPanel } from "./uiHelpers.js";
 import { resetStatButtons } from "../battle/index.js";
 import { syncScoreDisplay } from "./uiService.js";
-import { startTimer, handleStatSelectionTimeout, scheduleNextRound } from "./timerService.js";
+import { startTimer, handleStatSelectionTimeout } from "./timerService.js";
+import { startCooldown } from "./roundManager.js";
 import * as scoreboard from "../setupScoreboard.js";
 import { handleStatSelection } from "./selectionHandler.js";
 import { showMatchSummaryModal } from "./uiService.js";
@@ -176,7 +177,7 @@ export function bindRoundUIEventHandlers() {
       // validates live state before dispatching 'ready', so scheduling here is
       // safe and ensures the snackbar countdown appears without waiting for a
       // separate state change event that may be mocked out in tests.
-      scheduleNextRound(result);
+      startCooldown(store);
       // Proactively surface the countdown text in the snackbar so tests can
       // observe it even if timer wiring races with other snackbar messages.
       try {
@@ -319,9 +320,9 @@ export function bindRoundUIEventHandlersDynamic() {
         emitBattleEvent("matchOver");
       } catch {}
     } else {
-      const { scheduleNextRound } = await import("./timerService.js");
+      const { startCooldown } = await import("./roundManager.js");
       // Schedule immediately to surface the countdown in tests and runtime.
-      scheduleNextRound(result);
+      startCooldown(store);
       // Failsafe for dynamic path as well
       try {
         const outcomeEvent =

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -11,54 +11,10 @@ import { isEnabled } from "../featureFlags.js";
 import { realScheduler } from "../scheduler.js";
 import { dispatchBattleEvent } from "./orchestrator.js";
 import { createRoundTimer } from "../timers/createRoundTimer.js";
-import { computeNextRoundCooldown } from "../timers/computeNextRoundCooldown.js";
-import { attachCooldownRenderer } from "../CooldownRenderer.js";
 import { getStateSnapshot } from "./battleDebug.js";
 const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
-import { exposeDebugState, readDebugState } from "./debugHooks.js";
-
-/**
- * Store controls for the pending next round. Updated by `scheduleNextRound`
- * and consumed by `onNextButtonClick` when invoked via the Next button.
- * @type {{timer: ReturnType<typeof createRoundTimer>|null, resolveReady: (()=>void)|null, ready: Promise<void>|null}|null}
- */
-let currentNextRound = null;
-
-/**
- * Schedule a fallback timeout and return its id.
- *
- * @pseudocode
- * 1. Attempt to call `setTimeout(cb, ms)`.
- * 2. Return the timer id or `null` on failure.
- *
- * @param {number} ms
- * @param {Function} cb
- * @returns {ReturnType<typeof setTimeout>|null}
- */
-export function setupFallbackTimer(ms, cb) {
-  try {
-    return setTimeout(cb, ms);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Mark the Next button as ready and enable it.
- *
- * @pseudocode
- * 1. If `btn` exists:
- * 2.   - Set `data-next-ready` to "true".
- * 3.   - Enable the button.
- *
- * @param {HTMLButtonElement | null} btn - Next button element.
- */
-export function markNextReady(btn) {
-  if (btn) {
-    btn.dataset.nextReady = "true";
-    btn.disabled = false;
-  }
-}
+import { getNextRoundControls } from "./roundManager.js";
+export { getNextRoundControls } from "./roundManager.js";
 
 // Skip handler utilities moved to skipHandler.js
 
@@ -172,8 +128,8 @@ export async function cancelTimerOrAdvance(_btn, timer, resolveReady) {
  * Handle clicks on the Next button by delegating to helper functions.
  *
  * @param {MouseEvent} _evt - Click event.
- * @param {{timer: {stop: () => void} | null, resolveReady: (() => void) | null}} [controls=currentNextRound]
- * - Timer controls returned from `scheduleNextRound`.
+ * @param {{timer: {stop: () => void} | null, resolveReady: (() => void) | null}} [controls=getNextRoundControls()]
+ * - Timer controls returned from `startCooldown`.
  * @example
  * const controls = { timer, resolveReady };
  * await onNextButtonClick(new MouseEvent("click"), controls);
@@ -198,7 +154,8 @@ export async function cancelTimerOrAdvance(_btn, timer, resolveReady) {
  * @pseudocode
  * 1. TODO: Add pseudocode
  */
-export async function onNextButtonClick(_evt, { timer, resolveReady } = currentNextRound ?? {}) {
+export async function onNextButtonClick(_evt, controls = getNextRoundControls()) {
+  const { timer = null, resolveReady = null } = controls || {};
   const btn = document.getElementById("next-button");
   if (!btn) return;
   if (btn.dataset.nextReady === "true") {
@@ -208,34 +165,7 @@ export async function onNextButtonClick(_evt, { timer, resolveReady } = currentN
   await cancelTimerOrAdvance(btn, timer, resolveReady);
 }
 
-/**
- * Expose current next-round controls for helpers like `setupNextButton`.
- *
- * @returns {{timer: ReturnType<typeof createRoundTimer>|null, resolveReady: (()=>void)|null, ready: Promise<void>|null}|null}
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-export function getNextRoundControls() {
-  return currentNextRound;
-}
+// `getNextRoundControls` re-exported from roundManager.js
 
 /**
  * Helper to force auto-select and dispatch outcome on timer error or drift.
@@ -438,216 +368,4 @@ export function handleStatSelectionTimeout(
       }
     }
   }, timeoutMs);
-}
-
-/**
- * Handle expiration of the next-round cooldown.
- *
- * @pseudocode
- * 1. Clear the skip handler and scoreboard timer.
- * 2. Enable the Next button and mark it as ready.
- * 3. Wait for the battle state to reach "cooldown".
- * 4. Dispatch "ready" and wait for handlers to complete.
- * 5. Mark the button as ready again, update the debug panel, and resolve the ready promise.
- *
- * @param {{resolveReady: (() => void) | null}} controls - Timer controls.
- * @param {HTMLButtonElement | null} btn - Next button element.
- * @returns {Promise<void>}
- */
-export async function handleNextRoundExpiration(controls, btn) {
-  setSkipHandler(null);
-  scoreboard.clearTimer();
-  markNextReady(btn);
-  await new Promise((resolve) => {
-    try {
-      const state = getStateSnapshot().state;
-      if (!state || state === "cooldown") {
-        resolve();
-        return;
-      }
-    } catch {}
-    const handler = (e) => {
-      try {
-        if (e.detail?.to === "cooldown") {
-          offBattleEvent("battleStateChange", handler);
-          resolve();
-        }
-      } catch {}
-    };
-    onBattleEvent("battleStateChange", handler);
-  });
-  try {
-    try {
-      const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
-      if (!IS_VITEST) {
-        console.log("DEBUG: handleNextRoundExpiration dispatching 'ready'");
-      }
-    } catch {}
-    await dispatchBattleEvent("ready");
-  } catch {}
-  markNextReady(btn);
-  try {
-    const { updateDebugPanel } = await import("./uiHelpers.js");
-    updateDebugPanel();
-  } catch {}
-  if (typeof controls.resolveReady === "function") {
-    controls.resolveReady();
-  }
-}
-
-/**
- * Create an expiration handler for the next-round cooldown timer.
- *
- * @pseudocode
- * 1. Ignore subsequent calls after the first invocation.
- * 2. Delegate to `handleNextRoundExpiration(controls, btn)`.
- *
- * @param {{resolveReady: (() => void) | null}} controls - Timer controls.
- * @param {HTMLButtonElement | null} btn - Next button element.
- * @returns {() => Promise<void>} Expiration handler.
- */
-function createNextRoundOnExpired(controls, btn) {
-  let expired = false;
-  return () => {
-    if (expired) return;
-    expired = true;
-    return handleNextRoundExpiration(controls, btn);
-  };
-}
-
-/**
- * Prepare and return the cooldown timer for the next round.
- *
- * @pseudocode
- * 1. Create a round timer and attach `CooldownRenderer`.
- * 2. Register the provided expiration handler.
- * 3. Forward drift events to a fallback message.
- * 4. Register a skip handler that stops the timer.
- *
- * @param {{timer: ReturnType<typeof createRoundTimer>|null}} controls - Timer controls.
- * @param {HTMLButtonElement | null} btn - Next button element.
- * @param {number} cooldownSeconds - Cooldown duration in seconds.
- * @param {() => Promise<void>} onExpired - Expiration handler.
- * @returns {ReturnType<typeof createRoundTimer>} Prepared timer instance.
- */
-function prepareNextRoundTimer(controls, btn, cooldownSeconds, onExpired) {
-  const timer = createRoundTimer();
-  attachCooldownRenderer(timer, cooldownSeconds);
-  timer.on("expired", onExpired);
-  timer.on("drift", () => {
-    const msgEl = document.getElementById("round-message");
-    if (msgEl && msgEl.textContent) {
-      showSnackbar("Waiting…");
-    } else {
-      scoreboard.showMessage("Waiting…");
-    }
-  });
-  controls.timer = timer;
-  setSkipHandler(() => {
-    try {
-      console.warn("[test] skip: stop nextRoundTimer");
-    } catch {}
-    controls.timer?.stop();
-  });
-  return timer;
-}
-
-/**
- * Enable the Next Round button after a cooldown period.
- *
- * @pseudocode
- * 1. If the match ended, resolve immediately.
- * 2. Determine cooldown seconds via `computeNextRoundCooldown` (minimum 1s).
- * 3. Locate `#next-button` and reset the button state.
- * 4. Attach `CooldownRenderer` and wire expiration callbacks via helpers.
- * 5. Register a skip handler that logs the skip (for tests) and stops the timer.
- * 6. Start the timer and schedule a fallback with `setupFallbackTimer`.
- *
- * @param {{matchEnded: boolean}} result - Result from a completed round.
- * @returns {{
- *   ready: Promise<void>,
- *   timer: ReturnType<typeof createRoundTimer> | null,
- *   resolveReady: (() => void) | null
- * }} Controls for the scheduled next round.
- */
-export function scheduleNextRound(result, scheduler = realScheduler) {
-  logScheduleNextRound(result);
-  const controls = createNextRoundControls();
-  if (result.matchEnded) {
-    setSkipHandler(null);
-    if (controls.resolveReady) controls.resolveReady();
-    currentNextRound = controls;
-    return controls;
-  }
-  const btn = document.getElementById("next-button");
-  if (btn) {
-    btn.disabled = false;
-    delete btn.dataset.nextReady;
-  }
-  const cooldownSeconds = computeNextRoundCooldown();
-  wireNextRoundTimer(controls, btn, cooldownSeconds, scheduler);
-  currentNextRound = controls;
-  return controls;
-}
-
-function logScheduleNextRound(result) {
-  try {
-    const { state: s } = getStateSnapshot();
-    const count = (readDebugState("scheduleNextRoundCount") || 0) + 1;
-    exposeDebugState("scheduleNextRoundCount", count);
-    if (!IS_VITEST)
-      console.warn(
-        `[test] scheduleNextRound call#${count}: state=${s} matchEnded=${!!result?.matchEnded}`
-      );
-  } catch {}
-}
-
-function createNextRoundControls() {
-  const controls = { timer: null, resolveReady: null, ready: null };
-  controls.ready = new Promise((resolve) => {
-    controls.resolveReady = () => {
-      emitBattleEvent("nextRoundTimerReady");
-      resolve();
-      controls.resolveReady = null;
-    };
-  });
-  return controls;
-}
-
-function wireNextRoundTimer(controls, btn, cooldownSeconds, scheduler) {
-  // Do not skip scheduling based on current state; roundResolved may fire
-  // while the machine is still transitioning. Scheduling early is safe — the
-  // expiration handler checks the live state before dispatching 'ready'.
-  const timer = createRoundTimer();
-  attachCooldownRenderer(timer, cooldownSeconds);
-  let expired = false;
-  const onExpired = () => {
-    if (expired) return;
-    expired = true;
-    return handleNextRoundExpiration(controls, btn);
-  };
-  timer.on("expired", onExpired);
-  timer.on("drift", () => {
-    const msgEl = document.getElementById("round-message");
-    if (msgEl && msgEl.textContent) {
-      showSnackbar("Waiting…");
-    } else {
-      scoreboard.showMessage("Waiting…");
-    }
-  });
-  controls.timer = timer;
-  setSkipHandler(() => {
-    try {
-      console.warn("[test] skip: stop nextRoundTimer");
-    } catch {}
-    controls.timer?.stop();
-  });
-
-  // Start engine-backed countdown on the next tick.
-  scheduler.setTimeout(() => controls.timer.start(cooldownSeconds), 0);
-  // Fallback to ensure expiration when the engine isn't running.
-  try {
-    const ms = Math.max(0, Number(cooldownSeconds) * 1000) + 10;
-    setupFallbackTimer(ms, onExpired);
-  } catch {}
 }

--- a/src/helpers/timers/computeNextRoundCooldown.js
+++ b/src/helpers/timers/computeNextRoundCooldown.js
@@ -30,11 +30,11 @@ export function computeNextRoundCooldown(utils = { isTestModeEnabled }) {
   if (!IS_VITEST) {
     if (isTestModeEnabled()) {
       try {
-        console.warn(`[test] scheduleNextRound: testMode=true cooldown=${cooldownSeconds}`);
+        console.warn(`[test] startCooldown: testMode=true cooldown=${cooldownSeconds}`);
       } catch {}
     } else {
       try {
-        console.warn(`[test] scheduleNextRound: testMode=false cooldown=${cooldownSeconds}`);
+        console.warn(`[test] startCooldown: testMode=false cooldown=${cooldownSeconds}`);
       } catch {}
     }
   }

--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -30,7 +30,7 @@ This directory contains unit tests for Classic Battle helpers.
 - One behavior per test.
 - Prefer shared helpers in `domUtils.js`, `utils/testUtils.js`, `commonMocks.js`, and `setupTestEnv.js`.
 - Do not commit `it.skip`; use `test.todo` or remove obsolete tests instead.
-- Timer drift, state exposure, and Next button behavior belong in `timerService` tests; `scheduleNextRound` tests cover cooldown scheduling and ready dispatch.
+- Timer drift, state exposure, and Next button behavior belong in `timerService` tests; cooldown tests cover scheduling and ready dispatch.
 - Avoid duplicating coverage across suites. Interrupt behavior triggered by browser events (such as `pagehide`, global `error`, or `unhandledrejection`) is covered exclusively in `interruptHandlers.test.js`.
 
 ### Usage

--- a/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
+++ b/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
+vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
   getNextRoundControls: vi.fn(() => null),
   setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
 }));

--- a/tests/helpers/classicBattle/cooldownEnter.zeroDuration.test.js
+++ b/tests/helpers/classicBattle/cooldownEnter.zeroDuration.test.js
@@ -10,7 +10,7 @@ vi.mock("../../../src/helpers/timerUtils.js", () => ({
   getDefaultTimer: vi.fn(async () => 0)
 }));
 
-vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
+vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
   getNextRoundControls: vi.fn(() => ({ timer: true })),
   setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
 }));

--- a/tests/helpers/classicBattle/debugPanel.test.js
+++ b/tests/helpers/classicBattle/debugPanel.test.js
@@ -34,10 +34,14 @@ vi.mock("../../../src/helpers/battle/index.js", () => ({ showResult: vi.fn() }))
 vi.mock("../../../src/helpers/classicBattle/selectionHandler.js", () => ({
   handleStatSelection: vi.fn()
 }));
-vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
-  onNextButtonClick: vi.fn(),
+vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
   getNextRoundControls: vi.fn(),
-  setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
+  setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms)),
+  startCooldown: vi.fn(),
+  handleReplay: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
+  onNextButtonClick: vi.fn()
 }));
 vi.mock("../../../src/helpers/stats.js", () => ({ loadStatNames: vi.fn() }));
 vi.mock("../../../src/helpers/viewportDebug.js", () => ({ toggleViewportSimulation: vi.fn() }));

--- a/tests/helpers/classicBattle/drawNextRound.test.js
+++ b/tests/helpers/classicBattle/drawNextRound.test.js
@@ -59,7 +59,7 @@ describe("classicBattle draw next round", () => {
     battleMod._resetForTest(store);
 
     const result = await playRound(battleMod, store, 5, 5);
-    battleMod.scheduleNextRound(result);
+    battleMod.startCooldown(store);
     await vi.runAllTimersAsync();
     const nextBtn = document.getElementById("next-button");
     expect(nextBtn.disabled).toBe(false);

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -6,7 +6,7 @@ let showMessage;
 let clearMessage;
 let clearTimer;
 let showSnackbar;
-let scheduleNextRound;
+let startCooldown;
 let renderOpponentCard;
 let resetStatButtons;
 let updateDebugPanel;
@@ -17,7 +17,7 @@ beforeEach(() => {
   showMessage = vi.fn();
   clearMessage = vi.fn();
   clearTimer = vi.fn();
-  scheduleNextRound = vi.fn();
+  startCooldown = vi.fn();
   renderOpponentCard = vi.fn();
   resetStatButtons = vi.fn();
   updateDebugPanel = vi.fn();
@@ -51,10 +51,13 @@ beforeEach(() => {
     getOpponentCardData: vi.fn().mockResolvedValue(null)
   }));
 
+  vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+    startCooldown,
+    setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms)),
+    createBattleStore: () => ({})
+  }));
   vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
-    scheduleNextRound,
-    startTimer: vi.fn(),
-    setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
+    startTimer: vi.fn()
   }));
 
   vi.mock("../../../src/helpers/battle/index.js", () => ({

--- a/tests/helpers/classicBattle/roundResolved.statButton.test.js
+++ b/tests/helpers/classicBattle/roundResolved.statButton.test.js
@@ -16,11 +16,14 @@ vi.mock("../../../src/helpers/classicBattle/uiService.js", () => ({
 vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
   handleReplay: vi.fn()
 }));
+vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+  handleReplay: vi.fn(),
+  startCooldown: vi.fn(),
+  setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
+}));
 vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
   startTimer: vi.fn(),
-  handleStatSelectionTimeout: vi.fn(),
-  scheduleNextRound: vi.fn(),
-  setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
+  handleStatSelectionTimeout: vi.fn()
 }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   clearRoundCounter: vi.fn(),

--- a/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createTimerNodes } from "./domUtils.js";
 import { createMockScheduler } from "../mockScheduler.js";
 
-describe("scheduleNextRound fallback timer", () => {
+describe("startCooldown fallback timer", () => {
   let scheduler;
   beforeEach(() => {
     vi.useFakeTimers();
@@ -57,12 +57,10 @@ describe("scheduleNextRound fallback timer", () => {
   });
 
   it("resolves ready after fallback timer and enables button", async () => {
-    const { scheduleNextRound } = await import(
-      "../../../src/helpers/classicBattle/timerService.js"
-    );
+    const { startCooldown } = await import("../../../src/helpers/classicBattle/roundManager.js");
     const btn = document.getElementById("next-button");
     btn.disabled = true;
-    const controls = scheduleNextRound({ matchEnded: false }, scheduler);
+    const controls = startCooldown({}, scheduler);
     let resolved = false;
     controls.ready.then(() => {
       resolved = true;

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -61,7 +61,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("classicBattle scheduleNextRound", () => {
+describe("classicBattle startCooldown", () => {
   function mockBattleData() {
     // Provide a minimal machine table directly via the test-only override so
     // the embedded state table uses this deterministic set.
@@ -115,7 +115,7 @@ describe("classicBattle scheduleNextRound", () => {
     await orchestrator.dispatchBattleEvent("continue");
     expect(machine.getState()).toBe("cooldown");
 
-    const controls = battleMod.scheduleNextRound({ matchEnded: false });
+    const controls = battleMod.startCooldown(store);
 
     timerSpy.advanceTimersByTime(1000);
     await vi.runAllTimersAsync();
@@ -159,7 +159,7 @@ describe("classicBattle scheduleNextRound", () => {
     await orchestrator.dispatchBattleEvent("continue");
     expect(machine.getState()).toBe("cooldown");
 
-    const controls = battleMod.scheduleNextRound({ matchEnded: false });
+    const controls = battleMod.startCooldown(store);
     document.getElementById("next-button").click();
     await controls.ready;
     // Ensure state progressed before assertions
@@ -209,8 +209,9 @@ describe("classicBattle scheduleNextRound", () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const { setTestMode } = await import("../../../src/helpers/testModeUtils.js");
     setTestMode(true);
-
-    const controls = battleMod.scheduleNextRound({ matchEnded: false });
+    const store = battleMod.createBattleStore();
+    battleMod._resetForTest(store);
+    const controls = battleMod.startCooldown(store);
     emitBattleEvent("battleStateChange", { to: "cooldown" });
     expect(nextButton.dataset.nextReady).toBeUndefined();
     timerSpy.advanceTimersByTime(1000);

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -7,10 +7,13 @@ vi.mock("../../../src/helpers/classicBattle/timerService.js", async () => {
   const actual = await vi.importActual("../../../src/helpers/classicBattle/timerService.js");
   return {
     ...actual,
-    startTimer: vi.fn().mockResolvedValue(undefined),
-    scheduleNextRound: vi.fn()
+    startTimer: vi.fn().mockResolvedValue(undefined)
   };
 });
+vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+  startCooldown: vi.fn(),
+  createBattleStore: () => ({})
+}));
 
 let fetchJsonMock;
 let generateRandomCardMock;

--- a/tests/helpers/classicBattle/statDoubleClick.test.js
+++ b/tests/helpers/classicBattle/statDoubleClick.test.js
@@ -63,7 +63,7 @@ describe("classicBattle stat double-click", () => {
     expect(result1.playerScore).toBe(1);
     expect(result1.matchEnded).toBe(false);
 
-    battleMod.scheduleNextRound(result1);
+    battleMod.startCooldown(store);
     await vi.runAllTimersAsync();
     const { onNextButtonClick } = await import(
       "../../../src/helpers/classicBattle/timerService.js"

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -34,7 +34,7 @@ describe("timerService drift handling", () => {
     expect(startRound).toHaveBeenCalledTimes(2);
   });
 
-  it("scheduleNextRound shows fallback on drift", async () => {
+  it("startCooldown shows fallback on drift", async () => {
     vi.resetModules();
     vi.doMock("../../../src/helpers/classicBattle/orchestrator.js", () => ({
       dispatchBattleEvent: vi.fn()
@@ -58,10 +58,10 @@ describe("timerService drift handling", () => {
       const actual = await vi.importActual("../../../src/helpers/battleEngineFacade.js");
       return { ...actual, startCoolDown };
     });
-    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const mod = await import("../../../src/helpers/classicBattle/roundManager.js");
     const scheduler = createMockScheduler();
     createTimerNodes();
-    mod.scheduleNextRound({ matchEnded: false }, scheduler);
+    mod.startCooldown({}, scheduler);
     scheduler.tick(0);
     cool.triggerDrift(1);
     // Cooldown drift displays a non-intrusive fallback; may use snackbar

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -44,10 +44,11 @@ describe("timerService next round handling", () => {
   });
 
   it("clicking Next during cooldown skips current phase", async () => {
-    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const timerMod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const roundMod = await import("../../../src/helpers/classicBattle/roundManager.js");
     const { nextButton } = createTimerNodes();
-    const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
-    nextButton.addEventListener("click", (e) => mod.onNextButtonClick(e, controls));
+    const controls = roundMod.startCooldown({}, scheduler);
+    nextButton.addEventListener("click", (e) => timerMod.onNextButtonClick(e, controls));
     scheduler.tick(100);
     nextButton.click();
     await controls.ready;
@@ -61,9 +62,10 @@ describe("timerService next round handling", () => {
     startCoolDown.mockImplementation((_t, onExpired) => {
       onExpired();
     });
-    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const timerMod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const roundMod = await import("../../../src/helpers/classicBattle/roundManager.js");
     createTimerNodes();
-    const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
+    const controls = roundMod.startCooldown({}, scheduler);
     scheduler.tick(1100);
     await controls.ready;
     expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
@@ -71,12 +73,13 @@ describe("timerService next round handling", () => {
   });
 
   it("clears stale nextReady before starting a new cooldown", async () => {
-    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const timerMod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const roundMod = await import("../../../src/helpers/classicBattle/roundManager.js");
     const { nextButton } = createTimerNodes();
     nextButton.dataset.nextReady = "true";
     nextButton.disabled = false;
     window.__NEXT_ROUND_COOLDOWN_MS = 1000;
-    const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
+    const controls = roundMod.startCooldown({}, scheduler);
     expect(nextButton.dataset.nextReady).toBeUndefined();
     expect(nextButton.disabled).toBe(false);
     scheduler.tick(1100);
@@ -116,12 +119,13 @@ describe("timerService next round handling", () => {
   });
 
   it("resolves ready after minimum cooldown in test mode", async () => {
-    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const timerMod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const roundMod = await import("../../../src/helpers/classicBattle/roundManager.js");
     const { nextButton } = createTimerNodes();
     const { setTestMode } = await import("../../../src/helpers/testModeUtils.js");
     setTestMode(true);
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    const controls = mod.scheduleNextRound({ matchEnded: false }, scheduler);
+    const controls = roundMod.startCooldown({}, scheduler);
     scheduler.tick(1100);
     await controls.ready;
     expect(nextButton.dataset.nextReady).toBe("true");

--- a/tests/helpers/classicBattlePage.startRoundWrapper.test.js
+++ b/tests/helpers/classicBattlePage.startRoundWrapper.test.js
@@ -66,10 +66,15 @@ describe("startRoundWrapper failures", () => {
       STATS: [],
       setPointsToWin: vi.fn()
     }));
-    vi.doMock("../../src/helpers/classicBattle/timerService.js", () => ({
-      onNextButtonClick: vi.fn(),
+    vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
       getNextRoundControls: vi.fn(),
-      setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
+      setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms)),
+      startCooldown: vi.fn(),
+      handleReplay: vi.fn(),
+      createBattleStore: () => ({})
+    }));
+    vi.doMock("../../src/helpers/classicBattle/timerService.js", () => ({
+      onNextButtonClick: vi.fn()
     }));
     vi.doMock("../../src/helpers/classicBattle/skipHandler.js", () => ({
       skipCurrentPhase: vi.fn()
@@ -168,10 +173,15 @@ describe("startRoundWrapper failures", () => {
       STATS: [],
       setPointsToWin: vi.fn()
     }));
-    vi.doMock("../../src/helpers/classicBattle/timerService.js", () => ({
-      onNextButtonClick: vi.fn(),
+    vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
       getNextRoundControls: vi.fn(),
-      setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
+      setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms)),
+      startCooldown: vi.fn(),
+      handleReplay: vi.fn(),
+      createBattleStore: () => ({})
+    }));
+    vi.doMock("../../src/helpers/classicBattle/timerService.js", () => ({
+      onNextButtonClick: vi.fn()
     }));
     vi.doMock("../../src/helpers/classicBattle/skipHandler.js", () => ({
       skipCurrentPhase: vi.fn()
@@ -272,10 +282,15 @@ describe("startRoundWrapper success", () => {
       STATS: [],
       setPointsToWin: vi.fn()
     }));
-    vi.doMock("../../src/helpers/classicBattle/timerService.js", () => ({
-      onNextButtonClick: vi.fn(),
+    vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
       getNextRoundControls: vi.fn(),
-      setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
+      setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms)),
+      startCooldown: vi.fn(),
+      handleReplay: vi.fn(),
+      createBattleStore: () => ({})
+    }));
+    vi.doMock("../../src/helpers/classicBattle/timerService.js", () => ({
+      onNextButtonClick: vi.fn()
     }));
     vi.doMock("../../src/helpers/classicBattle/skipHandler.js", () => ({
       skipCurrentPhase: vi.fn()

--- a/tests/helpers/timerService.test.js
+++ b/tests/helpers/timerService.test.js
@@ -99,8 +99,8 @@ describe("timerService", () => {
     const skip = await import("../../src/helpers/classicBattle/skipHandler.js");
     skip.skipCurrentPhase();
 
-    const { scheduleNextRound } = await import("../../src/helpers/classicBattle/timerService.js");
-    const controls = scheduleNextRound({ matchEnded: false }, scheduler);
+    const { startCooldown } = await import("../../src/helpers/classicBattle/roundManager.js");
+    const controls = startCooldown({}, scheduler);
     scheduler.tick(0);
     await controls.ready;
 

--- a/tests/helpers/uiHelpers.resetBattleUI.test.js
+++ b/tests/helpers/uiHelpers.resetBattleUI.test.js
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("../../src/helpers/classicBattle/timerService.js", () => ({
-  onNextButtonClick: vi.fn(),
-  setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
+  onNextButtonClick: vi.fn()
 }));
 
 vi.mock("../../src/helpers/setupScoreboard.js", () => ({


### PR DESCRIPTION
## Summary
- expose `roundManager.startCooldown` to own next-round cooldown logic
- route UI and handlers through `startCooldown` and remove obsolete helpers from `timerService`
- document round lifecycle and roundManager's cooldown ownership

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: expected spy to not be called; battleStateBadge timeout; battleStateProgress timeout; _resetForTest undefined)*
- `npx playwright test` *(fails: battle-state-progress spec; interrupted tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b54c3201588326970c84bfad9a9689