### PR TITLE
Ensure skip-cooldown flow exposes snackbar

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -5,6 +5,12 @@
 | `homepage.spec.js` | Verifies footer navigation link visibility, ordering, and other interactive elements. |
 | `homepage-layout.spec.js` | Focuses on responsive layout of the homepage grid and footer without testing navigation behavior. |
 
+# Battle tests
+
+| Spec file | Responsibilities |
+|-----------|------------------|
+| `skip-cooldown.spec.js` | Ensures the **Next** button can skip an active cooldown and re-enable stat buttons. |
+
 # Playwright Tests
 
 ## Settings tests

--- a/playwright/fixtures/commonSetup.js
+++ b/playwright/fixtures/commonSetup.js
@@ -54,6 +54,10 @@ export const test = base.extend({
 
     await page.addInitScript(() => {
       localStorage.clear();
+      // Reset snackbar override between tests so snackbar-based assertions remain deterministic
+      try {
+        delete window.__disableSnackbars;
+      } catch {}
       localStorage.setItem(
         "settings",
         JSON.stringify({ featureFlags: { enableTestMode: { enabled: true } } })

--- a/playwright/skip-cooldown.spec.js
+++ b/playwright/skip-cooldown.spec.js
@@ -6,6 +6,8 @@ test.describe("Skip cooldown flow", () => {
     await page.addInitScript(() => {
       // Make cooldowns long so we can reliably test skipping them
       window.__NEXT_ROUND_COOLDOWN_MS = 15000;
+      // Ensure snackbars remain enabled regardless of prior runs
+      window.__disableSnackbars = false;
       localStorage.setItem(
         "settings",
         JSON.stringify({ featureFlags: { enableTestMode: { enabled: false } } })
@@ -27,7 +29,6 @@ test.describe("Skip cooldown flow", () => {
 
     // Check that the snackbar shows a long cooldown
     await page.waitForTimeout(1000);
-    await page.waitForSelector(".snackbar");
     const snackbar = page.locator(".snackbar");
     await expect(snackbar).toHaveText(/Next round in: 1\\d+s/);
 


### PR DESCRIPTION
## Summary
- reset snackbar override in Playwright fixture to keep snackbar assertions reliable
- document battle Playwright specs
- ensure skip-cooldown test enables snackbars and waits on snackbar text

## Testing
- `npm run check:jsdoc` *(fails: Total missing: 213)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(partial log due to early termination)*
- `npx playwright test playwright/skip-cooldown.spec.js -g "Skip cooldown flow" --reporter=list` *(network error: GET https://esm.sh/dompurify@3.2.6 net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b54fd56428832687d8aaf39627f2e6