### PR TITLE
test: consolidate mocks and reset helper import

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -12,6 +12,7 @@ import { realScheduler } from "../scheduler.js";
 import { dispatchBattleEvent } from "./orchestrator.js";
 import { createRoundTimer } from "../timers/createRoundTimer.js";
 import { getStateSnapshot } from "./battleDebug.js";
+import { computeNextRoundCooldown } from "../timers/computeNextRoundCooldown.js";
 const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
 import { getNextRoundControls } from "./roundManager.js";
 export { getNextRoundControls } from "./roundManager.js";

--- a/tests/helpers/classicBattle/roundResolved.statButton.test.js
+++ b/tests/helpers/classicBattle/roundResolved.statButton.test.js
@@ -14,9 +14,6 @@ vi.mock("../../../src/helpers/classicBattle/uiService.js", () => ({
   showMatchSummaryModal: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
-  handleReplay: vi.fn()
-}));
-vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
   handleReplay: vi.fn(),
   startCooldown: vi.fn(),
   setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -5,6 +5,7 @@ import { createTimerNodes } from "./domUtils.js";
 import { applyMockSetup } from "./mockSetup.js";
 import { emitBattleEvent } from "../../../src/helpers/classicBattle/battleEvents.js";
 import { waitForState } from "../../waitForState.js";
+import { _resetForTest } from "../../../src/helpers/classicBattle/roundManager.js";
 
 vi.mock("../../../src/helpers/CooldownRenderer.js", () => ({
   attachCooldownRenderer: vi.fn()
@@ -81,7 +82,7 @@ describe("classicBattle startCooldown", () => {
     const dispatchSpy = vi.spyOn(orchestrator, "dispatchBattleEvent");
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const store = battleMod.createBattleStore();
-    battleMod._resetForTest(store);
+    _resetForTest(store);
     const startRoundWrapper = vi.fn(async () => {
       await battleMod.startRound(store);
     });
@@ -124,7 +125,7 @@ describe("classicBattle startCooldown", () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const orchestrator = await import("../../../src/helpers/classicBattle/orchestrator.js");
     const store = battleMod.createBattleStore();
-    battleMod._resetForTest(store);
+    _resetForTest(store);
     const startRoundWrapper = vi.fn(async () => {
       await battleMod.startRound(store);
     });
@@ -189,7 +190,7 @@ describe("classicBattle startCooldown", () => {
     const { setTestMode } = await import("../../../src/helpers/testModeUtils.js");
     setTestMode(true);
     const store = battleMod.createBattleStore();
-    battleMod._resetForTest(store);
+    _resetForTest(store);
     const controls = battleMod.startCooldown(store);
     emitBattleEvent("battleStateChange", { to: "cooldown" });
     expect(nextButton.dataset.nextReady).toBeUndefined();


### PR DESCRIPTION
## Summary
- merge duplicate `roundManager` mocks in `roundResolved.statButton` test
- import `_resetForTest` from `roundManager` for `scheduleNextRound` tests
- add missing `computeNextRoundCooldown` import to `timerService`

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: various classicBattle tests)*
- `npx playwright test` *(fails: battle CLI, browse, screenshot, skip cooldown)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b558c7d6c88326a6396ea102295c6f