### PR TITLE
feat: statically import next round cooldown

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -11,6 +11,7 @@ import { isEnabled } from "../featureFlags.js";
 import { realScheduler } from "../scheduler.js";
 import { dispatchBattleEvent } from "./orchestrator.js";
 import { createRoundTimer } from "../timers/createRoundTimer.js";
+import { computeNextRoundCooldown } from "../timers/computeNextRoundCooldown.js";
 import { getStateSnapshot } from "./battleDebug.js";
 const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
 import { getNextRoundControls } from "./roundManager.js";


### PR DESCRIPTION
## Summary
- statically import computeNextRoundCooldown in timerService

## Testing
- `node - <<'NODE'
import { handleStatSelectionTimeout } from './src/helpers/classicBattle/timerService.js';

// stub global objects
globalThis.document = {
  getElementById: () => null,
  createElement: () => ({
    appendChild(){},
    setAttribute(){},
    append(){},
    classList:{ add(){}, remove(){} },
    remove(){},
    style:{},
    dataset: {}
  }),
  body: { appendChild(){} },
  querySelector: () => null
};

globalThis.window = {};

globalThis.requestAnimationFrame = (fn) => { fn(); };

globalThis.setTimeout = (fn) => { fn(); return 0; };
globalThis.clearTimeout = () => {};

handleStatSelectionTimeout(
  { selectionMade: false },
  () => {},
  0,
  { setTimeout: (fn) => { fn(); return 0; } }
);
console.log('handleStatSelectionTimeout executed');
NODE`
- `npm run check:jsdoc` (fails: Functions missing or with incomplete JSDoc blocks)
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` (fails: 4 failed tests)
- `npx playwright test` (fails: 11 failed tests)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b558fa1c9c83269126462319ad0565