### PR TITLE
test: import roundManager after CooldownRenderer mock

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -13,8 +13,9 @@ import { dispatchBattleEvent } from "./orchestrator.js";
 import { createRoundTimer } from "../timers/createRoundTimer.js";
 import { getStateSnapshot } from "./battleDebug.js";
 import { computeNextRoundCooldown } from "../timers/computeNextRoundCooldown.js";
-const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
 import { getNextRoundControls } from "./roundManager.js";
+
+const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
 export { getNextRoundControls } from "./roundManager.js";
 
 // Skip handler utilities moved to skipHandler.js

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -5,11 +5,15 @@ import { createTimerNodes } from "./domUtils.js";
 import { applyMockSetup } from "./mockSetup.js";
 import { emitBattleEvent } from "../../../src/helpers/classicBattle/battleEvents.js";
 import { waitForState } from "../../waitForState.js";
-import { _resetForTest } from "../../../src/helpers/classicBattle/roundManager.js";
 
 vi.mock("../../../src/helpers/CooldownRenderer.js", () => ({
   attachCooldownRenderer: vi.fn()
 }));
+
+async function resetRoundManager(store) {
+  const { _resetForTest } = await import("../../../src/helpers/classicBattle/roundManager.js");
+  _resetForTest(store);
+}
 
 let timerSpy;
 let fetchJsonMock;
@@ -82,7 +86,7 @@ describe("classicBattle startCooldown", () => {
     const dispatchSpy = vi.spyOn(orchestrator, "dispatchBattleEvent");
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const store = battleMod.createBattleStore();
-    _resetForTest(store);
+    await resetRoundManager(store);
     const startRoundWrapper = vi.fn(async () => {
       await battleMod.startRound(store);
     });
@@ -125,7 +129,7 @@ describe("classicBattle startCooldown", () => {
     const battleMod = await import("../../../src/helpers/classicBattle.js");
     const orchestrator = await import("../../../src/helpers/classicBattle/orchestrator.js");
     const store = battleMod.createBattleStore();
-    _resetForTest(store);
+    await resetRoundManager(store);
     const startRoundWrapper = vi.fn(async () => {
       await battleMod.startRound(store);
     });
@@ -190,7 +194,7 @@ describe("classicBattle startCooldown", () => {
     const { setTestMode } = await import("../../../src/helpers/testModeUtils.js");
     setTestMode(true);
     const store = battleMod.createBattleStore();
-    _resetForTest(store);
+    await resetRoundManager(store);
     const controls = battleMod.startCooldown(store);
     emitBattleEvent("battleStateChange", { to: "cooldown" });
     expect(nextButton.dataset.nextReady).toBeUndefined();


### PR DESCRIPTION
## Summary
- import classicBattle `roundManager` dynamically so `CooldownRenderer` mock is applied
- group `timerService` imports above `IS_VITEST` constant

## Testing
- `npm run check:jsdoc` *(fails: 213 missing or incomplete blocks)*
- `npx prettier . --check`
- `npx eslint .` *(warnings: 9, e.g., unused vars)*
- `npx vitest run` *(failures: startRoundWrapper success, battleStateProgress, battleStateBadge)*
- `npx playwright test` *(failures: battle CLI help panel, browse judoka spinner; 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b55f9f94ac8326b1694e08b26985a8