### PR TITLE
feat: label country filter panel

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -32,7 +32,10 @@ test.describe("Browse Judoka screen", () => {
 
   test("filter panel toggles", async ({ page }) => {
     const toggle = page.getByTestId(COUNTRY_TOGGLE_LOCATOR);
-    const panel = page.getByRole("region");
+    const panel = page.getByRole("region", {
+      name: /country filter panel/i,
+      hidden: true
+    });
 
     await expect(panel).toBeHidden();
     await toggle.click();

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -84,7 +84,13 @@
         <div id="carousel-container" data-testid="carousel-container"></div>
       </main>
 
-      <aside id="country-panel" class="country-panel" role="region">
+      <aside
+        id="country-panel"
+        class="country-panel"
+        role="region"
+        hidden
+        aria-label="Country filter panel"
+      >
         <div class="country-flag-slider">
           <div class="country-flag-slide-track" id="country-list">
             <!-- Country names will be dynamically inserted here -->


### PR DESCRIPTION
## Summary
- hide country panel by default and label it for assistive tech
- reference hidden panel by accessible name in browse-judoka test

## Testing
- `npm run check:jsdoc` *(fails: 213 missing or incomplete JSDoc blocks)*
- `npx prettier . --check` *(fails: code style issues in src/helpers/classicBattle/controller.js)*
- `npx eslint .` *(fails: Parsing error and prettier violations)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b57b6cb1b0832691aeef6944d834b5