### PR TITLE
test: share classic battle mocks

### DIFF
--- a/tests/helpers/classicBattle/battleStateBadge.test.js
+++ b/tests/helpers/classicBattle/battleStateBadge.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "./commonMocks.js";
 import {
-  mockScheduler,
   mockFeatureFlags,
   mockDataUtils,
   mockStats,
@@ -16,7 +16,6 @@ import { CLASSIC_BATTLE_STATES } from "../../../src/helpers/classicBattle/stateT
 import { waitForState } from "../../waitForState.js";
 
 // Apply all the necessary mocks
-mockScheduler();
 mockFeatureFlags({ battleStateProgress: { enabled: true } });
 mockDataUtils();
 mockStats();

--- a/tests/helpers/classicBattle/battleStateProgress.test.js
+++ b/tests/helpers/classicBattle/battleStateProgress.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { emitBattleEvent } from "../../../src/helpers/classicBattle/battleEvents.js";
 import { waitForState } from "../../waitForState.js";
+import "./commonMocks.js";
 import {
-  mockScheduler,
   mockFeatureFlags,
   mockDataUtils,
   mockStats,
@@ -96,7 +96,6 @@ describe("battle-state-progress stays in sync across transitions", () => {
   });
 
   it("tracks waitingForPlayerAction \u2192 roundDecision", async () => {
-    mockScheduler();
     mockFeatureFlags({ battleStateProgress: { enabled: true } });
     mockDataUtils();
     mockStats();


### PR DESCRIPTION
## Summary
- reuse shared Classic Battle mocks for scheduler/motionUtils in battle state tests

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 14 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b58a2854588326b1f85f713aad8731