### PR TITLE
test: centralize nav link coverage

### DIFF
--- a/playwright/browse-judoka.spec.js
+++ b/playwright/browse-judoka.spec.js
@@ -31,11 +31,6 @@ test.describe("Browse Judoka screen", () => {
     await expect(right).toBeVisible();
   });
 
-  test("classic battle link navigates", async ({ page }) => {
-    await page.getByTestId(NAV_CLASSIC_BATTLE).click();
-    await expect(page).toHaveURL(/battleJudoka\.html/);
-  });
-
   test("filter panel toggles", async ({ page }) => {
     const toggle = page.getByTestId(COUNTRY_TOGGLE_LOCATOR);
     const panel = page.getByRole("region", {

--- a/playwright/fixtures/navigationChecks.js
+++ b/playwright/fixtures/navigationChecks.js
@@ -3,6 +3,9 @@ import { expect } from "@playwright/test";
 export const NAV_RANDOM_JUDOKA = "nav-12";
 export const NAV_CLASSIC_BATTLE = "nav-1";
 export const NAV_UPDATE_JUDOKA = "nav-9";
+export const NAV_BROWSE_JUDOKA = "nav-7";
+export const NAV_MEDITATION = "nav-11";
+export const NAV_SETTINGS = "nav-13";
 
 /**
  * Verify common page elements like title, navigation bar and logo.

--- a/playwright/navigation.spec.js
+++ b/playwright/navigation.spec.js
@@ -1,0 +1,26 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+import {
+  NAV_CLASSIC_BATTLE,
+  NAV_BROWSE_JUDOKA,
+  NAV_UPDATE_JUDOKA,
+  NAV_MEDITATION,
+  NAV_RANDOM_JUDOKA,
+  NAV_SETTINGS
+} from "./fixtures/navigationChecks.js";
+
+const links = [
+  { id: NAV_CLASSIC_BATTLE, url: "/src/pages/battleJudoka.html" },
+  { id: NAV_BROWSE_JUDOKA, url: "/src/pages/browseJudoka.html" },
+  { id: NAV_UPDATE_JUDOKA, url: "/src/pages/updateJudoka.html" },
+  { id: NAV_MEDITATION, url: "/src/pages/meditation.html" },
+  { id: NAV_RANDOM_JUDOKA, url: "/src/pages/randomJudoka.html" },
+  { id: NAV_SETTINGS, url: "/src/pages/settings.html" }
+];
+
+test("navigation links navigate to expected pages", async ({ page }) => {
+  for (const { id, url } of links) {
+    await page.goto("/");
+    await page.locator(`[data-testid="${id}"]`).evaluate((el) => el.click());
+    await expect(page).toHaveURL(new RegExp(`${url.replace(/\./g, "\\.")}$`));
+  }
+});

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -12,11 +12,6 @@ test.describe("View Judoka screen", () => {
     await expect(page.getByTestId("draw-button")).toBeVisible();
   });
 
-  test("classic battle link navigates", async ({ page }) => {
-    await page.getByTestId(NAV_CLASSIC_BATTLE).click();
-    await expect(page).toHaveURL(/battleJudoka\.html/);
-  });
-
   test("draw button accessible name constant", async ({ page }) => {
     const btn = page.getByTestId("draw-button");
     await expect(btn).toHaveText(/draw card/i);


### PR DESCRIPTION
## Summary
- add constants for all nav link IDs
- add navigation spec verifying each nav link
- remove redundant classic battle nav tests from browse-judoka and random-judoka specs

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .` *(fails: Cannot find package 'eslint-plugin-yml')*
- `npx vitest run`
- `npx playwright test` *(fails: screenshot.spec.js snapshot mismatch; navigation.spec.js passes when run alone)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b5c2f49b5083268167a13a831d7a0e