### PR TITLE
Use feature flag for PRD prefetch

### DIFF
--- a/src/helpers/prdReaderPage.js
+++ b/src/helpers/prdReaderPage.js
@@ -5,6 +5,7 @@ import { SidebarList } from "../components/SidebarList.js";
 import { getPrdTaskStats } from "./prdTaskStats.js";
 import { getSanitizer } from "./sanitizeHtml.js";
 import { createSpinner } from "../components/Spinner.js";
+import { getFeatureFlag } from "../helpers/settingsCache.js";
 
 export class SidebarState {
   /**
@@ -356,7 +357,7 @@ export function initNavigationHandlers(sidebar, _files) {
  * @pseudocode
  * 1. Load document metadata with `loadPrdDocs`.
  * 2. Build sidebar UI and bind navigation handlers.
- * 3. Seed history, render the start document, then prefetch remaining docs.
+ * 3. Seed history, render the start document, then prefetch remaining docs unless test mode is enabled.
  *
  * @param {Record<string, string>} [docsMap]
  * @param {Function} [parserFn=markdownToHtml]
@@ -378,11 +379,8 @@ export async function setupPrdReaderPage(docsMap, parserFn = markdownToHtml) {
   sidebar.container.focus();
   sidebar.spinner.remove();
 
-  // Preload remaining docs during idle. Skip in test to reduce overhead.
-  const isTest =
-    typeof process !== "undefined" &&
-    process?.env &&
-    (process.env.VITEST || process.env.NODE_ENV === "test");
+  // Preload remaining docs during idle. Skip when test mode flag is enabled.
+  const isTest = getFeatureFlag("enableTestMode");
   if (!isTest) {
     Promise.resolve().then(() => {
       for (let i = 0; i < sidebar.files.length; i++) {


### PR DESCRIPTION
## Summary
- Guard PRD document prefetching behind `enableTestMode` feature flag
- Add test ensuring prefetch is skipped when the test mode flag is active

## Testing
- `npm run check:jsdoc` *(fails: Total missing 213)*
- `npx prettier src/helpers/prdReaderPage.js tests/helpers/prdReaderPage.test.js --check`
- `npx eslint .`
- `npx vitest run tests/helpers/prdReaderPage.test.js`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b5c86ede3483269fb08ddf93aba33c