### PR TITLE
Mirror cooldown state for key handling

### DIFF
--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -145,6 +145,20 @@ test.describe("Classic Battle CLI", () => {
     expect(cardAfter).not.toBe(cardBefore);
   });
 
+  test("skips cooldown with Space key", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__NEXT_ROUND_COOLDOWN_MS = 3000;
+    });
+    await page.reload();
+    await page.locator("#start-match-button").click();
+    await waitForBattleState(page, "waitingForPlayerAction", 15000);
+
+    await page.keyboard.press("1");
+    await waitForBattleState(page, "cooldown", 10000);
+    await page.keyboard.press("Space");
+    await waitForBattleState(page, "waitingForPlayerAction", 10000);
+  });
+
   test("scoreboard updates after each round", async ({ page }) => {
     await page.goto("/src/pages/battleCLI.html?seed=1");
     await page.locator("#start-match-button").click();

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -1051,6 +1051,10 @@ function handleStatSelectionStalled() {
 
 function handleCountdownStart(e) {
   if (skipRoundCooldownIfEnabled()) return;
+  try {
+    const ds = document.body?.dataset;
+    if (ds) ds.battleState = "cooldown";
+  } catch {}
   const duration = Number(e.detail?.duration) || 0;
   try {
     if (cooldownTimer) clearTimeout(cooldownTimer);

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -164,10 +164,13 @@ describe("battleCLI onKeyDown", () => {
     expect(dispatchSpy).toHaveBeenCalledWith("continue");
   });
 
-  it("dispatches ready in cooldown state", () => {
+  it("dispatches ready in cooldown state for Enter and Space", () => {
     document.body.dataset.battleState = "cooldown";
-    onKeyDown(new KeyboardEvent("keydown", { key: "Enter" }));
-    expect(dispatchSpy).toHaveBeenCalledWith("ready");
+    for (const key of ["Enter", " "]) {
+      dispatchSpy.mockClear();
+      onKeyDown(new KeyboardEvent("keydown", { key }));
+      expect(dispatchSpy).toHaveBeenCalledWith("ready");
+    }
   });
 
   it("allows quitting with Q when cliShortcuts flag is disabled", async () => {


### PR DESCRIPTION
## Summary
- Mirror `cooldown` state to `document.body.dataset.battleState` before countdown timers start
- Test that Enter and Space dispatch `ready` during cooldown
- Cover skipping cooldown with Space in Playwright

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: navigation links, PRD Reader navigation, battleJudoka-narrow screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b5db8c58cc8326949346be14518b83