### PR TITLE
feat: add classic battle auto-continue toggle

### DIFF
--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -12,6 +12,21 @@ import { debugLog } from "../debug.js";
 // Removed unused import for enableNextRoundButton
 
 /**
+ * Whether the orchestrator should automatically dispatch "continue" after an
+ * outcome. Consumers like the CLI can toggle this for readability.
+ * @type {boolean}
+ */
+export let autoContinue = true;
+
+/**
+ * Update the `autoContinue` behavior.
+ * @param {boolean} val
+ */
+export function setAutoContinue(val) {
+  autoContinue = val !== false;
+}
+
+/**
  * Handle round-related errors in a consistent manner.
  *
  * @param {object} machine
@@ -576,7 +591,7 @@ async function dispatchOutcome(outcomeEvent, machine) {
       const run = async () => {
         try {
           await machine.dispatch(outcomeEvent);
-          await machine.dispatch("continue");
+          if (autoContinue) await machine.dispatch("continue");
         } catch {}
       };
       if (typeof queueMicrotask === "function") queueMicrotask(run);
@@ -584,7 +599,7 @@ async function dispatchOutcome(outcomeEvent, machine) {
     } catch {
       try {
         await machine.dispatch(outcomeEvent);
-        await machine.dispatch("continue");
+        if (autoContinue) await machine.dispatch("continue");
       } catch {}
     }
   } else {

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -32,6 +32,7 @@ import { BATTLE_POINTS_TO_WIN } from "../config/storageKeys.js";
 import { POINTS_TO_WIN_OPTIONS } from "../config/battleDefaults.js";
 import * as debugHooks from "../helpers/classicBattle/debugHooks.js";
 import { dispatchBattleEvent } from "../helpers/classicBattle/orchestrator.js";
+import { setAutoContinue, autoContinue } from "../helpers/classicBattle/orchestratorHandlers.js";
 
 /**
  * Minimal DOM utils for the CLI page
@@ -1140,7 +1141,7 @@ function handleBattleState(ev) {
   } else {
     stopSelectionCountdown();
   }
-  if (to === "roundOver") {
+  if (to === "roundOver" && !autoContinue) {
     showBottomLine("Press Enter to continue");
     byId("snackbar-container")?.querySelector(".snackbar")?.focus();
   }
@@ -1204,6 +1205,7 @@ async function init() {
   try {
     await initFeatureFlags();
   } catch {}
+  setAutoContinue(true);
   try {
     const params = new URLSearchParams(location.search);
     if (params.has("verbose")) {
@@ -1213,6 +1215,10 @@ async function init() {
     if (params.has("skipRoundCooldown")) {
       const skip = params.get("skipRoundCooldown") === "1";
       setFlag("skipRoundCooldown", skip);
+    }
+    if (params.has("autoContinue")) {
+      const v = params.get("autoContinue");
+      setAutoContinue(!(v === "0" || v === "false"));
     }
   } catch {}
   updateVerbose();

--- a/tests/helpers/orchestratorHandlers.computeOutcome.test.js
+++ b/tests/helpers/orchestratorHandlers.computeOutcome.test.js
@@ -49,6 +49,38 @@ describe("computeAndDispatchOutcome", () => {
     vi.useRealTimers();
   });
 
+  it("waits for user input when autoContinue is disabled", async () => {
+    vi.useFakeTimers();
+    vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+      emitBattleEvent: vi.fn(),
+      onBattleEvent: vi.fn(),
+      offBattleEvent: vi.fn()
+    }));
+    vi.doMock("../../src/helpers/classicBattle/cardSelection.js", () => ({
+      getOpponentJudoka: vi.fn(() => ({ stats: { strength: 3 } }))
+    }));
+    vi.doMock("../../src/helpers/battle/index.js", () => ({
+      getStatValue: vi.fn((el) => (el?.id === "player-card" ? 5 : 3))
+    }));
+
+    const mod = await import("../../src/helpers/classicBattle/orchestratorHandlers.js");
+    mod.setAutoContinue(false);
+
+    document.body.innerHTML = '<div id="player-card"></div><div id="opponent-card"></div>';
+    document.body.dataset.battleState = "roundDecision";
+    debugHooks.exposeDebugState("roundDebug", {});
+
+    const store = { playerChoice: "strength" };
+    const machine = { dispatch: vi.fn().mockResolvedValue(undefined) };
+
+    await mod.computeAndDispatchOutcome(store, machine);
+    await vi.runAllTimersAsync();
+
+    expect(machine.dispatch).toHaveBeenCalledWith("outcome=winPlayer");
+    expect(machine.dispatch).not.toHaveBeenCalledWith("continue");
+    vi.useRealTimers();
+  });
+
   it("dispatches interrupt when no outcome is produced", async () => {
     vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
       emitBattleEvent: vi.fn(),

--- a/tests/pages/battleCLI.a11y.focus.test.js
+++ b/tests/pages/battleCLI.a11y.focus.test.js
@@ -101,6 +101,10 @@ describe("battleCLI accessibility", () => {
       const { emitBattleEvent } = await loadBattleCLI();
       emitBattleEvent("battleStateChange", { to: "waitingForPlayerAction" });
       expect(document.activeElement?.id).toBe("cli-stats");
+      const { setAutoContinue } = await import(
+        "../../src/helpers/classicBattle/orchestratorHandlers.js"
+      );
+      setAutoContinue(false);
       emitBattleEvent("battleStateChange", { to: "roundOver" });
       const bar = document.querySelector("#snackbar-container .snackbar");
       expect(bar?.textContent).toBe("Press Enter to continue");

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -146,6 +146,10 @@ describe("battleCLI event handlers", () => {
   it("handles battle state transitions", async () => {
     const { handlers, updateBattleStateBadge } = await loadHandlers();
     document.body.innerHTML = '<div id="snackbar-container"></div>';
+    const { setAutoContinue } = await import(
+      "../../src/helpers/classicBattle/orchestratorHandlers.js"
+    );
+    setAutoContinue(false);
     handlers.handleBattleState({ detail: { from: "a", to: "roundOver" } });
     expect(updateBattleStateBadge).toHaveBeenCalledWith("roundOver");
     expect(document.querySelector(".snackbar").textContent).toBe("Press Enter to continue");


### PR DESCRIPTION
## Summary
- add `autoContinue` flag to orchestrator handlers
- expose `setAutoContinue` and hook into CLI via query param
- add tests for manual continue flow

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: navigation links navigate to expected pages, PRD Reader page forward/back navigation; 2 interrupted, 10 skipped)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b5e0c31ba88326a91244a7b33bc8ef