### PR TITLE
feat: add offline RAG builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "update:codes": "node updateCodes.mjs",
     "check:jsdoc": "node scripts/run-check-jsdoc.mjs",
     "sync:agents": "node scripts/syncAgentDocs.mjs",
-    "rag:query": "node scripts/queryRagCli.mjs"
+    "rag:query": "node scripts/queryRagCli.mjs",
+    "build:offline-rag": "node scripts/buildOfflineRag.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,15 @@
+# Scripts
+
+## buildOfflineRag.mjs
+
+Converts `client_embeddings.json` into compact assets for offline vector search.
+
+### Usage
+
+```bash
+npm run build:offline-rag
+```
+
+This writes:
+- `src/data/offline_rag_vectors.bin` – binary Int8 vectors
+- `src/data/offline_rag_metadata.json` – JSON metadata matching vector order

--- a/scripts/buildOfflineRag.mjs
+++ b/scripts/buildOfflineRag.mjs
@@ -1,0 +1,72 @@
+/**
+ * Build offline RAG assets from client embeddings.
+ *
+ * @pseudocode
+ * 1. Load `src/data/client_embeddings.json` entries.
+ * 2. For each item:
+ *    - Quantize the embedding to an Int8Array.
+ *    - Create metadata without the embedding field.
+ *    - Generate a sparse vector using `createSparseVector`.
+ * 3. Write all vectors to `src/data/offline_rag_vectors.bin`.
+ * 4. Write metadata and summary info to `src/data/offline_rag_metadata.json`.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createSparseVector } from "./generateEmbeddings.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+
+/**
+ * Convert a float embedding array to an Int8Array.
+ *
+ * @param {number[]} embedding - Float embedding values in the range [-1, 1].
+ * @returns {Int8Array} Quantized vector.
+ */
+function toInt8(embedding) {
+  return Int8Array.from(embedding, (v) => Math.max(-128, Math.min(127, Math.round(v * 127))));
+}
+
+/**
+ * Generate offline RAG vectors and metadata.
+ */
+export async function buildOfflineRag() {
+  const inputPath = path.join(rootDir, "src/data/client_embeddings.json");
+  const raw = await readFile(inputPath, "utf8");
+  const entries = JSON.parse(raw);
+
+  const vectors = [];
+  const metaItems = [];
+
+  for (const { embedding, text, qaContext, source, tags, metadata, id } of entries) {
+    vectors.push(toInt8(embedding));
+    metaItems.push({
+      id,
+      text,
+      qaContext,
+      source,
+      tags,
+      metadata,
+      sparseVector: createSparseVector(text)
+    });
+  }
+
+  const vectorLength = vectors[0]?.length || 0;
+  const buffer = Buffer.concat(vectors.map((v) => Buffer.from(v.buffer)));
+
+  await writeFile(path.join(rootDir, "src/data/offline_rag_vectors.bin"), buffer);
+  await writeFile(
+    path.join(rootDir, "src/data/offline_rag_metadata.json"),
+    JSON.stringify({ vectorLength, count: metaItems.length, items: metaItems }, null, 2)
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await buildOfflineRag();
+  } catch (err) {
+    console.error("Offline RAG build failed:", err);
+    process.exit(1);
+  }
+}

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -887,7 +887,8 @@ export {
   BOILERPLATE_STRINGS,
   normalizeText,
   normalizeAndFilter,
-  extractAllowedValues
+  extractAllowedValues,
+  createSparseVector
 };
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## Summary
- add buildOfflineRag.mjs to package binary Int8 vectors and metadata
- expose createSparseVector helper
- document and wire npm run build:offline-rag

## Testing
- `npm run check:jsdoc`
- `npx prettier scripts/buildOfflineRag.mjs scripts/README.md package.json scripts/generateEmbeddings.js --check`
- `npx eslint scripts/buildOfflineRag.mjs scripts/README.md package.json scripts/generateEmbeddings.js`
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b5e50550488326b636f13a15178ef1