### PR TITLE
feat(cli): add controls hint

### DIFF
--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -97,6 +97,16 @@
         margin-top: auto;
         border-top: 1px solid #3a3a3a;
       }
+      #cli-controls-hint {
+        position: relative;
+        z-index: 2;
+        padding: 4px 12px;
+        font-size: 12px;
+        text-align: center;
+        background: #0b0c0c;
+        color: #e6e6e6;
+        opacity: 0.8;
+      }
       /* Terminal-style snackbar line at the bottom */
       #snackbar-container {
         padding: 8px 12px;
@@ -263,6 +273,9 @@
       </main>
 
       <footer class="cli-footer" role="contentinfo">
+        <div id="cli-controls-hint" aria-hidden="true">
+          [1–5] Stats · [Enter/Space] Next · [H] Help · [Q] Quit
+        </div>
         <!-- Terminal-style snackbar container anchored at the bottom -->
         <div id="snackbar-container">
           <!-- snackbar.js will populate .snackbar elements here; in CLI this renders as a single bottom line. -->

--- a/tests/pages/battleCLI.a11y.controlsHint.test.js
+++ b/tests/pages/battleCLI.a11y.controlsHint.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+
+describe("battleCLI controls hint", () => {
+  it("includes static controls hint near footer", () => {
+    const html = readFileSync("src/pages/battleCLI.html", "utf8");
+    document.documentElement.innerHTML = html;
+    const hint = document.getElementById("cli-controls-hint");
+    expect(hint).toBeTruthy();
+    expect(hint?.getAttribute("aria-hidden")).toBe("true");
+    expect(hint?.textContent?.trim()).toBe(
+      "[1–5] Stats · [Enter/Space] Next · [H] Help · [Q] Quit"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add persistent CLI controls hint at bottom of battleCLI
- test for controls hint accessibility

## Testing
- `npm run check:jsdoc` *(fails: 215 missing JSDoc entries)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Element is not visible; screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b5e559e60c83268959c304c96eecac