### PR TITLE
Await CLI verbose flag updates and test runtime toggle

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -1192,7 +1192,7 @@ async function init() {
     const params = new URLSearchParams(location.search);
     if (params.has("verbose")) {
       const v = params.get("verbose");
-      setFlag("cliVerbose", v === "1" || v === "true");
+      await setFlag("cliVerbose", v === "1" || v === "true");
     }
     if (params.has("skipRoundCooldown")) {
       const skip = params.get("skipRoundCooldown") === "1";
@@ -1217,8 +1217,9 @@ async function init() {
     const sec = byId("cli-shortcuts");
     if (sec) sec.hidden = true;
   });
-  checkbox?.addEventListener("change", () => {
-    setFlag("cliVerbose", !!checkbox.checked);
+  checkbox?.addEventListener("change", async () => {
+    await setFlag("cliVerbose", !!checkbox.checked);
+    updateVerbose();
   });
   featureFlagsEmitter.addEventListener("change", (e) => {
     const flag = e.detail?.flag;

--- a/tests/pages/battleCLI.verboseToggle.test.js
+++ b/tests/pages/battleCLI.verboseToggle.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+async function loadBattleCLI() {
+  const emitter = new EventTarget();
+  const handlers = {};
+  const emitBattleEvent = vi.fn((type, detail) => {
+    (handlers[type] || []).forEach((h) => h({ detail }));
+  });
+  const onBattleEvent = vi.fn((type, handler) => {
+    handlers[type] = handlers[type] || [];
+    handlers[type].push(handler);
+  });
+  let flag = false;
+  const isEnabled = vi.fn(() => flag);
+  const setFlag = vi.fn(async (_, value) => {
+    flag = value;
+  });
+  vi.doMock("../../src/helpers/featureFlags.js", () => ({
+    initFeatureFlags: vi.fn(),
+    isEnabled,
+    setFlag,
+    featureFlagsEmitter: emitter
+  }));
+  vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+    createBattleStore: vi.fn(() => ({})),
+    startRound: vi.fn(),
+    resetGame: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    onBattleEvent,
+    emitBattleEvent
+  }));
+  vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: [] }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    setPointsToWin: vi.fn(),
+    getPointsToWin: vi.fn(() => 10),
+    getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 }))
+  }));
+  vi.doMock("../../src/helpers/dataUtils.js", () => ({ fetchJson: vi.fn().mockResolvedValue([]) }));
+  vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+  const mod = await import("../../src/pages/battleCLI.js");
+  return { mod, emitBattleEvent };
+}
+
+describe("battleCLI verbose toggle", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.__TEST__;
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doUnmock("../../src/helpers/featureFlags.js");
+    vi.doUnmock("../../src/helpers/classicBattle/roundManager.js");
+    vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+    vi.doUnmock("../../src/helpers/classicBattle/battleEvents.js");
+    vi.doUnmock("../../src/helpers/BattleEngine.js");
+    vi.doUnmock("../../src/helpers/battleEngineFacade.js");
+    vi.doUnmock("../../src/helpers/dataUtils.js");
+    vi.doUnmock("../../src/helpers/constants.js");
+  });
+
+  it("shows verbose section and logs after enabling mid-match", async () => {
+    window.__TEST__ = true;
+    document.body.innerHTML = `
+      <section id="cli-verbose-section" hidden>
+        <pre id="cli-verbose-log"></pre>
+      </section>
+      <input id="verbose-toggle" type="checkbox" />
+    `;
+    const { mod, emitBattleEvent } = await loadBattleCLI();
+    await mod.__test.init();
+    const section = document.getElementById("cli-verbose-section");
+    const pre = document.getElementById("cli-verbose-log");
+    emitBattleEvent("battleStateChange", { from: "a", to: "b" });
+    expect(section.hidden).toBe(true);
+    expect(pre.textContent).toBe("");
+    const checkbox = document.getElementById("verbose-toggle");
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event("change"));
+    await Promise.resolve();
+    emitBattleEvent("battleStateChange", { from: "c", to: "d" });
+    expect(section.hidden).toBe(false);
+    expect(pre.textContent).toMatch(/c -> d/);
+  });
+});


### PR DESCRIPTION
## Summary
- await cliVerbose flag updates before refreshing the verbose UI
- test that toggling verbose mid-match reveals log section and records events

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: navigation links navigate to expected pages, PRD Reader page forward and back navigation)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b5e51e20cc8326bdf3501253461aa6