### PR TITLE
Refactor CLI tests and stat name reset

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -63,7 +63,7 @@ let pausedSelectionRemaining = null;
 let pausedCooldownRemaining = null;
 let ignoreNextAdvanceClick = false;
 let roundResolving = false;
-const statDisplayNames = {};
+let statDisplayNames = {};
 
 // Test hooks to access internal timer state
 export const __test = {
@@ -606,7 +606,7 @@ export async function renderStatList() {
     const list = byId("cli-stats");
     if (list && Array.isArray(stats)) {
       list.innerHTML = "";
-      for (const key of Object.keys(statDisplayNames)) delete statDisplayNames[key];
+      statDisplayNames = {};
       stats
         .sort((a, b) => (a.statIndex || 0) - (b.statIndex || 0))
         .forEach((s) => {


### PR DESCRIPTION
## Summary
- reset `statDisplayNames` by reassigning to a fresh object
- consolidate battleCLI test DOM setup with a shared `beforeEach`

## Testing
- `npm run check:jsdoc` *(fails: missing JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: navigation links and screenshot tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b5fe0b2d8483269776af06653cb406