### PR TITLE
Use local MiniLM in Node and add offline evaluation test

### DIFF
--- a/scripts/evaluation/evaluateRAG.js
+++ b/scripts/evaluation/evaluateRAG.js
@@ -163,7 +163,11 @@ function createSparseVector(text) {
 }
 
 async function loadModel() {
-  return pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", { quantized: true });
+  const modelPath =
+    typeof process !== "undefined" && process.versions?.node
+      ? path.join(rootDir, "models/minilm")
+      : "Xenova/all-MiniLM-L6-v2";
+  return pipeline("feature-extraction", modelPath, { quantized: true });
 }
 
 export async function evaluate() {

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -606,7 +606,11 @@ async function getFiles() {
  */
 async function loadModel() {
   // Reduce memory footprint by loading the quantized model
-  return pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", { quantized: true });
+  const modelPath =
+    typeof process !== "undefined" && process.versions?.node
+      ? path.join(rootDir, "models/minilm")
+      : "Xenova/all-MiniLM-L6-v2";
+  return pipeline("feature-extraction", modelPath, { quantized: true });
 }
 
 function determineTags(relativePath, ext, isTest) {


### PR DESCRIPTION
## Summary
- load MiniLM from local `models/minilm` directory when running on Node
- test `evaluate()` to confirm no network requests are made with fetch blocked

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: playwright/cli.spec.mjs, progress2.md, src/pages/battleCLI.html, tests/pages/battleClassic.roundStart.dom.test.js)*
- `npx eslint .`
- `npx vitest run` *(fails: tests/pages/battleClassic.roundStart.dom.test.js)*
- `npx playwright test` *(fails: 2 interrupted, 79 did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b6073996b08326a4a07ef984a40d39