### PR TITLE
feat(cli): improve focus visibility

### DIFF
--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -31,29 +31,29 @@
         border-bottom: 1px solid #3a3a3a;
         display: flex;
         justify-content: space-between;
-          min-width: 18ch; /* reserve width for longest state (prevents wrap/jump) */
+        min-width: 18ch; /* reserve width for longest state (prevents wrap/jump) */
         box-sizing: border-box; /* include padding in fixed height */
         height: 56px; /* hard cap header height for consistency */
       }
       .cli-title {
         font-weight: 700;
       }
-        /* Reserve visible space for countdown even when empty */
-        #cli-countdown {
-          min-height: 1.2em;
-        }
+      /* Reserve visible space for countdown even when empty */
+      #cli-countdown {
+        min-height: 1.2em;
+      }
       .state-badge {
         font-size: 12px;
         opacity: 0.8;
         margin-left: 8px;
-          /* Reserve vertical space for stat rows to avoid layout shift when populated */
-          min-height: 8rem;
-        }
-        .cli-stat {
-          padding: 4px 6px;
-          background: #121212;
-          border: 1px solid #3a3a3a;
-          min-height: 2.4em;
+        /* Reserve vertical space for stat rows to avoid layout shift when populated */
+        min-height: 8rem;
+      }
+      .cli-stat {
+        padding: 4px 6px;
+        background: #121212;
+        border: 1px solid #3a3a3a;
+        min-height: 2.4em;
         display: flex;
         align-items: center;
         gap: 8px;
@@ -62,8 +62,8 @@
       .cli-main {
         flex: 1;
         display: flex;
-          max-width: 980px;
-          margin: 0 auto;
+        max-width: 980px;
+        margin: 0 auto;
         flex-direction: column;
         padding: 12px;
         gap: 12px;
@@ -73,8 +73,12 @@
         background: #000 !important;
         color: #8cff6b !important;
       }
-      .cli-retro a { color: #8cff6b; }
-      .cli-retro .cli-stat.selected { border-color: #8cff6b; }
+      .cli-retro a {
+        color: #8cff6b;
+      }
+      .cli-retro .cli-stat.selected {
+        border-color: #8cff6b;
+      }
       .cli-block {
         padding: 8px 10px;
         border: 1px solid #2a2a2a;
@@ -107,6 +111,14 @@
       .cli-stat.selected {
         border-color: #9ad1ff;
         background: #1a1a1a;
+      }
+      #cli-stats:focus {
+        outline: 3px solid #9ad1ff;
+        outline-offset: 2px;
+      }
+      .cli-stat:focus {
+        background: #000;
+        box-shadow: 0 0 0 2px #9ad1ff;
       }
       .cli-status {
         text-align: right;
@@ -199,7 +211,7 @@
   </head>
   <body>
     <a href="#cli-main" class="skip-link">Skip to main content</a>
-  <div id="cli-root" class="cli-root" data-round="0" data-test="cli-root">
+    <div id="cli-root" class="cli-root" data-round="0" data-test="cli-root">
       <header id="cli-header" class="cli-header" role="banner">
         <div class="cli-title">
           <a href="../../index.html" data-testid="home-link" aria-label="Return to home">Home</a>
@@ -242,7 +254,9 @@
         </div>
         <div class="cli-status" aria-live="polite" aria-atomic="true">
           <div id="cli-round">Round 0 of 0</div>
-          <div id="cli-score" data-score-player="0" data-score-opponent="0" data-test="cli-score">You: 0 Opponent: 0</div>
+          <div id="cli-score" data-score-player="0" data-score-opponent="0" data-test="cli-score">
+            You: 0 Opponent: 0
+          </div>
         </div>
       </header>
 
@@ -313,8 +327,8 @@
       <div id="player-card" style="display: none"></div>
       <div id="opponent-card" style="display: none"></div>
       <div id="modal-container"></div>
-  <script type="module" src="../pages/battleCLI.init.js"></script>
-  <script type="module" src="../pages/battleCLI.js"></script>
+      <script type="module" src="../pages/battleCLI.init.js"></script>
+      <script type="module" src="../pages/battleCLI.js"></script>
     </div>
   </body>
 </html>

--- a/tests/styles/battleCLIFocusContrast.test.js
+++ b/tests/styles/battleCLIFocusContrast.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { hex } from "wcag-contrast";
+
+describe("battleCLI focus contrast", () => {
+  it(".cli-stat:focus background contrasts with text", () => {
+    const html = readFileSync("src/pages/battleCLI.html", "utf8");
+    const bgMatch = html.match(/\.cli-stat:focus[^}]*background:\s*([^;]+);/);
+    const textMatch = html.match(/body[^}]*color:\s*([^;]+);/);
+    expect(bgMatch).toBeTruthy();
+    expect(textMatch).toBeTruthy();
+    const contrast = hex(bgMatch[1].trim(), textMatch[1].trim());
+    expect(contrast).toBeGreaterThanOrEqual(4.5);
+  });
+});


### PR DESCRIPTION
## Summary
- enhance CLI stat focus visibility with outlined stat list and high-contrast box-shadow
- add test verifying CLI stat focus color contrast

## Testing
- `npm run check:jsdoc`
- `npx prettier src/pages/battleCLI.html tests/styles/battleCLIFocusContrast.test.js --check`
- `npx eslint src/pages/battleCLI.html tests/styles/battleCLIFocusContrast.test.js`
- `npx vitest run` *(fails: tests/pages/battleClassic.roundStart.dom.test.js > populates player and opponent card containers on round start)*
- `npm run test:style`
- `npx playwright test` *(fails: network errors, screenshot diffs)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68b60694ff088326be64b5c2b32e9c7a