### PR TITLE
Reset state machine before start

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -6,7 +6,7 @@ import {
   startRound as startRoundCore,
   resetGame
 } from "../helpers/classicBattle/roundManager.js";
-import { initClassicBattleOrchestrator } from "../helpers/classicBattle/orchestrator.js";
+import * as battleOrchestrator from "../helpers/classicBattle/orchestrator.js";
 import { onBattleEvent, emitBattleEvent } from "../helpers/classicBattle/battleEvents.js";
 import { STATS } from "../helpers/BattleEngine.js";
 import { setPointsToWin, getPointsToWin, getScores } from "../helpers/battleEngineFacade.js";
@@ -31,8 +31,11 @@ import { wrap } from "../helpers/storage.js";
 import { BATTLE_POINTS_TO_WIN } from "../config/storageKeys.js";
 import { POINTS_TO_WIN_OPTIONS } from "../config/battleDefaults.js";
 import * as debugHooks from "../helpers/classicBattle/debugHooks.js";
-import { dispatchBattleEvent } from "../helpers/classicBattle/orchestrator.js";
 import { setAutoContinue, autoContinue } from "../helpers/classicBattle/orchestratorHandlers.js";
+
+const { initClassicBattleOrchestrator, dispatchBattleEvent } = battleOrchestrator;
+const disposeClassicBattleOrchestrator =
+  battleOrchestrator.disposeClassicBattleOrchestrator ?? (() => {});
 
 /**
  * Minimal DOM utils for the CLI page
@@ -151,6 +154,7 @@ function clearVerboseLog() {
  * clearVerboseLog()
  * remove play-again/start buttons
  * resetPromise = async () => {
+ *   disposeClassicBattleOrchestrator()
  *   await resetGame(store)
  *   updateRoundHeader(0, getPointsToWin())
  *   updateScoreLine()
@@ -170,6 +174,7 @@ async function resetMatch() {
     document.getElementById("start-match-button")?.remove();
   } catch {}
   const next = (async () => {
+    disposeClassicBattleOrchestrator();
     await resetGame(store);
     updateRoundHeader(0, getPointsToWin());
     updateScoreLine();

--- a/tests/pages/battleCLI.pointsToWin.startOnce.test.js
+++ b/tests/pages/battleCLI.pointsToWin.startOnce.test.js
@@ -112,11 +112,18 @@ describe("battleCLI points to win start", () => {
     const select = document.getElementById("points-select");
     select.value = "10";
     select.dispatchEvent(new Event("change"));
-    let btn = document.getElementById("start-match-button");
-    for (let i = 0; i < 5 && !btn; i++) {
-      await new Promise((r) => setTimeout(r, 0));
-      btn = document.getElementById("start-match-button");
-    }
+    const btn = await new Promise((resolve) => {
+      const existing = document.getElementById("start-match-button");
+      if (existing) return resolve(existing);
+      const observer = new MutationObserver(() => {
+        const el = document.getElementById("start-match-button");
+        if (el) {
+          observer.disconnect();
+          resolve(el);
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    });
     expect(btn).toBeTruthy();
     btn.click();
     expect(emitBattleEvent).toHaveBeenCalledWith("battleStateChange", {


### PR DESCRIPTION
## Summary
- reset match disposes previous classic battle orchestrator instance before reinit
- await orchestrator reset before rendering Start button
- use MutationObserver instead of polling for Start button in points-to-win test

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: progress2.md, battleCLI.html)*
- `npx eslint .`
- `npx vitest run` *(fails: missing mocked exports and timeouts)*
- `npx playwright test` *(fails: screenshot mismatch, other tests interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b60db12ba483269a2c2e76ec0a0d8e