### PR TITLE
Enable local MiniLM loading for offline scripts

### DIFF
--- a/scripts/evaluation/evaluateRAG.js
+++ b/scripts/evaluation/evaluateRAG.js
@@ -1,8 +1,8 @@
 /* eslint-env node */
 import { readFile } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { pipeline } from "@xenova/transformers";
+import path from "path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { pipeline, env } from "@xenova/transformers";
 import vectorSearch from "../../src/helpers/vectorSearch/index.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -163,11 +163,15 @@ function createSparseVector(text) {
 }
 
 async function loadModel() {
-  const modelPath =
-    typeof process !== "undefined" && process.versions?.node
-      ? path.join(rootDir, "models/minilm")
-      : "Xenova/all-MiniLM-L6-v2";
-  return pipeline("feature-extraction", modelPath, { quantized: true });
+  if (typeof process !== "undefined" && process.versions?.node) {
+    env.allowLocalModels = true;
+    const modelDir = path.join(rootDir, "models/minilm");
+    const modelUrl = pathToFileURL(modelDir).href;
+    return pipeline("feature-extraction", modelUrl, { quantized: true });
+  }
+  return pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", {
+    quantized: true
+  });
 }
 
 export async function evaluate() {

--- a/tests/scripts/evaluateRAG.test.js
+++ b/tests/scripts/evaluateRAG.test.js
@@ -1,10 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 
 vi.mock("@xenova/transformers", () => ({
-  pipeline: vi.fn(async (task, model) => {
-    if (!model.includes("models/minilm")) {
-      await fetch("https://example.com/model");
-    }
+  pipeline: vi.fn(async () => {
+    // Simulate model loading without any network calls
     return async () => ({ data: new Float32Array([0, 0, 0]) });
   })
 }));


### PR DESCRIPTION
## Summary
- allow evaluation and embedding scripts to load MiniLM from local directory when running in Node
- stop evaluateRAG test's pipeline mock from performing network fetches

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: progress2.md, src/pages/battleCLI.html)*
- `npx eslint .`
- `npx vitest run` *(exited without summary; repeated missing mock errors)*
- `npx playwright test` *(1 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b60f6e83e4832681780a3654636326