### PR TITLE
fix: load local MiniLM tokenizer config

### DIFF
--- a/models/minilm/tokenizer_config.json
+++ b/models/minilm/tokenizer_config.json
@@ -1,0 +1,17 @@
+{
+  "do_lower_case": true,
+  "tokenizer_class": "BertTokenizer",
+  "model_max_length": 512,
+  "special_tokens_map_file": null,
+  "padding_side": "right",
+  "truncation_side": "right",
+  "clean_text": true,
+  "handle_chinese_chars": true,
+  "strip_accents": null,
+  "unk_token": "[UNK]",
+  "sep_token": "[SEP]",
+  "pad_token": "[PAD]",
+  "cls_token": "[CLS]",
+  "mask_token": "[MASK]",
+  "tokenizer_file": null
+}

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -36,7 +36,7 @@
 import { readFile, writeFile, stat } from "node:fs/promises";
 import { createWriteStream } from "node:fs";
 import path from "path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { glob } from "glob";
 import * as acorn from "acorn";
 import { walk } from "estree-walker";
@@ -609,9 +609,15 @@ async function loadModel() {
   if (typeof process !== "undefined" && process.versions?.node) {
     const { pipeline, env } = await import("@xenova/transformers");
     env.allowLocalModels = true;
-    const modelDir = path.join(rootDir, "models/minilm");
-    const modelUrl = pathToFileURL(modelDir).href;
-    return pipeline("feature-extraction", modelUrl, { quantized: true });
+    env.localModelPath = rootDir;
+    env.backends.onnx.wasm.wasmPaths = path.join(rootDir, "node_modules/onnxruntime-web/dist/");
+    env.backends.onnx.wasm.worker = path.join(
+      rootDir,
+      "node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.worker.js"
+    );
+    env.backends.onnx.wasm.proxy = false;
+    const modelDir = path.join("models", "minilm");
+    return pipeline("feature-extraction", modelDir, { quantized: true });
   }
   const { pipeline } = await import("@xenova/transformers");
   return pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", {


### PR DESCRIPTION
## Summary
- add MiniLM tokenizer configuration for offline embeddings
- load embeddings model via filesystem path and configure ONNX runtime for local usage

## Testing
- `npm run validate:data`
- `npm run check:jsdoc` *(fails: 216 missing pseudocode)*
- `npx prettier scripts/generateEmbeddings.js models/minilm/tokenizer_config.json --check`
- `npx eslint scripts/generateEmbeddings.js models/minilm/tokenizer_config.json`
- `npx vitest run`
- `npx playwright test` *(fails: 3 failed, 2 interrupted)*
- `npm run check:contrast`
- `npm run generate:embeddings` *(fails: Failed to load model because protobuf parsing failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b69cdeac008326a9c515b1e4c8b0fb