### PR TITLE
fix: use trailing separator for ONNX wasm paths

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -630,7 +630,7 @@ async function loadModel() {
       );
       await stat(workerPath);
       const ortDir = path.dirname(workerPath);
-      env.backends.onnx.wasm.wasmPaths = path.join(ortDir, path.sep);
+      env.backends.onnx.wasm.wasmPaths = ortDir + path.sep;
       env.backends.onnx.wasm.worker = workerPath;
     } catch {
       // Worker script not found: ONNX backend will use its default worker and WASM paths.


### PR DESCRIPTION
## Summary
- adjust ONNX wasmPaths to append the platform path separator directly

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .` *(warnings: 9 warnings)*
- `npx vitest run`
- `npx playwright test` *(fails: 1 interrupted, 54 did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b6c9d887c483269a9d500189b2c764