### PR TITLE
Show stat values and handle clicks

### DIFF
--- a/src/pages/battleCLI.README.md
+++ b/src/pages/battleCLI.README.md
@@ -16,3 +16,7 @@ await page.evaluate(() => window.__battleCLIinit.setSettingsCollapsed(true));
 ```
 
 These helpers are intentionally small and synchronous to keep tests deterministic.
+
+## Stat list interaction
+
+When a round begins, each stat row in `#cli-stats` shows the current player's value in the format `(index) Name: value`. Clicking a row triggers the same selection logic as using the numeric keyboard shortcut.


### PR DESCRIPTION
## Summary
- show stat values in CLI stat list
- allow clicking a stat to select it
- test stat rows for value display and pointer clicks

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b6d9aa5a2c8326879f4f09c41f19a3