### PR TITLE
fix: validate tokenizer files for local MiniLM loading

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -649,8 +649,10 @@ async function loadModel() {
     const modelDir = path.join("models", "minilm");
     const configPath = path.join(rootDir, modelDir, "config.json");
     const onnxPath = path.join(rootDir, modelDir, "onnx", "model_quantized.onnx");
+    const tokenizerPath = path.join(rootDir, modelDir, "tokenizer.json");
+    const tokenizerConfigPath = path.join(rootDir, modelDir, "tokenizer_config.json");
     let useLocal = true;
-    for (const file of [configPath, onnxPath]) {
+    for (const file of [configPath, onnxPath, tokenizerPath, tokenizerConfigPath]) {
       try {
         const stats = await stat(file);
         if (stats.size === 0) throw new Error("empty");


### PR DESCRIPTION
## Summary
- verify tokenizer files before using local quantized MiniLM model

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 2 interrupted, 74 did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b6dd035054832681660ec4beea1f0b