### PR TITLE
Show stat values and handle clicks

### DIFF
--- a/tests/pages/battleCLI.selectedStat.test.js
+++ b/tests/pages/battleCLI.selectedStat.test.js
@@ -45,6 +45,7 @@ describe("battleCLI stat interactions", () => {
       <div id="cli-stats"></div>
       <ul id="cli-help"></ul>
       <div id="snackbar-container"></div>
+      <div id="player-card"></div>
     `;
   });
 
@@ -83,6 +84,8 @@ describe("battleCLI stat interactions", () => {
     document.body.dataset.battleState = "waitingForPlayerAction";
     const statEl = document.querySelector('[data-stat-index="1"]');
     expect(statEl.textContent).toBe("[1] Speed: 5");
+    const hiddenVal = document.querySelector("#player-card li.stat span")?.textContent;
+    expect(hiddenVal).toBe("5");
     statEl.click();
     expect(statEl.classList.contains("selected")).toBe(true);
   });


### PR DESCRIPTION
## Summary
- reuse event delegation for stat clicks
- restore hidden player card population for accurate stat lookups
- test hidden player card values alongside click behavior

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b6e0a5cbd88326b948a21a5dbe9dfa