### PR TITLE
feat: expose match restart controls

### DIFF
--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -212,4 +212,15 @@ test.describe("Classic Battle CLI", () => {
     await page.waitForURL("**/index.html");
     await expect(page.locator(".home-screen")).toBeVisible();
   });
+
+  test("shows restart control after match completes", async ({ page }) => {
+    await page.goto("/src/pages/battleCLI.html?seed=1");
+    await page.locator("#start-match-button").click();
+    await waitForBattleState(page, "waitingForPlayerAction", 15000);
+    await page.locator("#cli-stats .cli-stat").first().click();
+    await page.evaluate(() => {
+      globalThis.__classicBattleEventTarget?.dispatchEvent(new CustomEvent("matchOver"));
+    });
+    await expect(page.locator("#play-again-button")).toBeVisible();
+  });
 });

--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -884,11 +884,14 @@ export async function roundOverEnter(machine) {
 export async function matchDecisionEnter() {}
 
 /**
- * @summary TODO: Add summary
+ * onEnter handler for the `matchOver` state.
+ *
  * @pseudocode
- * 1. TODO: Add pseudocode
+ * 1. Emit a `matchOver` battle event so consumers can show restart controls.
  */
-export async function matchOverEnter() {}
+export async function matchOverEnter() {
+  emitBattleEvent("matchOver");
+}
 
 /**
  * @summary TODO: Add summary

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -1161,6 +1161,15 @@ function handleRoundResolved(e) {
   }
 }
 
+/**
+ * Show restart controls when a match concludes.
+ *
+ * @pseudocode
+ * 1. Locate `#cli-main`; abort if missing or already rendered.
+ * 2. Build a "Play again" button that resets the match and restarts on click.
+ * 3. If a home link exists, append a "Return to lobby" anchor using its href.
+ * 4. Append the controls section to the main container.
+ */
 function handleMatchOver() {
   const main = byId("cli-main");
   if (!main || byId("play-again-button")) return;
@@ -1176,6 +1185,16 @@ function handleMatchOver() {
     emitBattleEvent("startClicked");
   });
   section.append(btn);
+  try {
+    const homeHref = document.querySelector("[data-testid='home-link']")?.getAttribute("href");
+    if (homeHref) {
+      const link = document.createElement("a");
+      link.id = "return-to-lobby-link";
+      link.href = homeHref;
+      link.textContent = "Return to lobby";
+      section.append(" ", link);
+    }
+  } catch {}
   main.append(section);
 }
 

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -156,10 +156,15 @@ describe("battleCLI event handlers", () => {
     expect(document.getElementById("round-message").textContent).toContain(kumikataName);
   });
 
-  it("adds play again button on match over", async () => {
+  it("adds play again button and lobby link on match over", async () => {
     const { handlers } = await setupHandlers();
+    const home = document.createElement("a");
+    home.dataset.testid = "home-link";
+    home.href = "/index.html";
+    document.body.appendChild(home);
     handlers.handleMatchOver();
     expect(document.getElementById("play-again-button")).toBeTruthy();
+    expect(document.getElementById("return-to-lobby-link")).toBeTruthy();
   });
 
   it("clears verbose log on new match start", async () => {


### PR DESCRIPTION
## Summary
- emit `matchOver` battle event when the state reaches match end
- surface "Play again" and optional "Return to lobby" controls in CLI
- test that match completion reveals restart controls

## Testing
- `npm run check:jsdoc`
- `npx prettier playwright/battle-cli.spec.js src/pages/battleCLI.js src/helpers/classicBattle/orchestratorHandlers.js tests/pages/battleCLI.handlers.test.js --check`
- `npx eslint src/helpers/classicBattle/orchestratorHandlers.js src/pages/battleCLI.js tests/pages/battleCLI.handlers.test.js playwright/battle-cli.spec.js`
- `npx vitest run tests/pages/battleCLI.handlers.test.js`
- `npx playwright test playwright/battle-cli.spec.js -g "shows restart control after match completes"`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b6e0f441248326a9da04032a28f358