### PR TITLE
Show stat values and handle clicks

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -711,8 +711,11 @@ export async function renderStatList(judoka) {
           list.appendChild(div);
         });
       const onClick = handleStatListClick;
-      list.removeEventListener("click", onClick);
-      list.addEventListener("click", onClick);
+      const KEY = "__battleCLIStatListBound";
+      if (!list[KEY]) {
+        list.addEventListener("click", onClick);
+        list[KEY] = true;
+      }
       try {
         window.__battleCLIinit?.clearSkeletonStats?.();
       } catch {}
@@ -1072,12 +1075,13 @@ function handleStatListClick(event) {
   const list = byId("cli-stats");
   const statDiv = event.target?.closest?.(".cli-stat");
   if (statDiv && list?.contains(statDiv)) {
-    handleStatClick.call(statDiv, event);
+    handleStatClick(statDiv, event);
   }
 }
 
-function handleStatClick(event) {
-  const idx = this?.dataset?.statIndex;
+function handleStatClick(statDiv, event) {
+  event?.preventDefault?.();
+  const idx = statDiv?.dataset?.statIndex;
   if (!idx) return;
   const state = document.body?.dataset?.battleState || "";
   if (state !== "waitingForPlayerAction") return;


### PR DESCRIPTION
## Summary
- bind stat list clicks idempotently to avoid duplicate listeners
- refactor stat click handler to accept target element instead of relying on `this`

## Testing
- `npm run check:jsdoc src/pages` *(fails: src/pages/index.js:8 -> battleCLI)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED; 1 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b6e757b88483268481d9646f373ce4