### PR TITLE
Show stat values and handle clicks (fix reviewer comments)

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -711,10 +711,11 @@ export async function renderStatList(judoka) {
           list.appendChild(div);
         });
       const onClick = handleStatListClick;
-      const KEY = "__battleCLIStatListBound";
-      if (!list[KEY]) {
+      const KEY = "__battleCLIStatListBoundTargets";
+      const set = (globalThis[KEY] ||= new WeakSet());
+      if (!set.has(list)) {
         list.addEventListener("click", onClick);
-        list[KEY] = true;
+        set.add(list);
       }
       try {
         window.__battleCLIinit?.clearSkeletonStats?.();
@@ -1080,7 +1081,7 @@ function handleStatListClick(event) {
 }
 
 function handleStatClick(statDiv, event) {
-  event?.preventDefault?.();
+  event.preventDefault();
   const idx = statDiv?.dataset?.statIndex;
   if (!idx) return;
   const state = document.body?.dataset?.battleState || "";


### PR DESCRIPTION
## Summary
- track battle CLI stat list bindings via global WeakSet to ensure idempotency
- drop optional chaining from `event.preventDefault()` in stat click handler

## Testing
- `npm run check:jsdoc` *(fails: Total missing: 217)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: playwright/screenshot.spec.js:38:5, playwright/screenshot.spec.js:66:3)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b6ef397cd08326b63f0ef459cc322c