### PR TITLE
Reset before updating points-to-win

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -789,14 +789,16 @@ export function restorePointsToWin() {
       setPointsToWin(saved);
       select.value = String(saved);
     }
+    updateRoundHeader(0, getPointsToWin());
     let current = Number(select.value);
-    select.addEventListener("change", () => {
+    select.addEventListener("change", async () => {
       const val = Number(select.value);
       if (!POINTS_TO_WIN_OPTIONS.includes(val)) return;
       if (window.confirm("Changing win target resets scores. Start a new match?")) {
         storage.set(val);
+        await resetMatch();
         setPointsToWin(val);
-        resetMatch();
+        updateRoundHeader(0, val);
         renderStartButton();
         current = val;
       } else {


### PR DESCRIPTION
## Summary
- ensure match reset finishes before changing points-to-win
- initialize round header with stored points target
- test points-to-win selections update engine state and header

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: ERR_TUNNEL_CONNECTION_FAILED; 2 interrupted, 69 did not run, 29 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b6ede022e0832685600c6c1661848a