### PR TITLE
feat: toggle retro theme via body class

### DIFF
--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -72,14 +72,21 @@
         gap: 12px;
       }
       /* Retro theme: green-on-black optional class */
-      .cli-retro {
+      body.cli-retro {
         background: #000 !important;
         color: #8cff6b !important;
       }
-      .cli-retro a {
+      body.cli-retro a {
         color: #8cff6b;
       }
-      .cli-retro .cli-stat.selected {
+      body.cli-retro .cli-stat,
+      body.cli-retro .cli-block {
+        background: #000;
+        color: #8cff6b;
+        border-color: #8cff6b;
+      }
+      body.cli-retro .cli-stat.selected {
+        background: #001900;
         border-color: #8cff6b;
       }
       .cli-block {

--- a/src/pages/battleCLI.init.js
+++ b/src/pages/battleCLI.init.js
@@ -51,12 +51,8 @@ function focusNextHint() {
 }
 
 function applyRetroTheme(enabled) {
-  const root = document.documentElement;
-  if (enabled) {
-    root.classList.add("cli-retro");
-  } else {
-    root.classList.remove("cli-retro");
-  }
+  const body = document.body;
+  if (body) body.classList.toggle("cli-retro", Boolean(enabled));
   try {
     localStorage.setItem("battleCLI.retro", enabled ? "1" : "0");
   } catch {}

--- a/tests/pages/battleCLI.retroTheme.test.js
+++ b/tests/pages/battleCLI.retroTheme.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { applyRetroTheme } from "../../src/pages/battleCLI.init.js";
+
+describe("applyRetroTheme", () => {
+  beforeEach(() => {
+    document.body.className = "";
+    localStorage.clear();
+  });
+
+  it("toggles cli-retro class on body and persists state", () => {
+    applyRetroTheme(true);
+    expect(document.body.classList.contains("cli-retro")).toBe(true);
+    expect(localStorage.getItem("battleCLI.retro")).toBe("1");
+    applyRetroTheme(false);
+    expect(document.body.classList.contains("cli-retro")).toBe(false);
+    expect(localStorage.getItem("battleCLI.retro")).toBe("0");
+  });
+});


### PR DESCRIPTION
## Summary
- toggle `cli-retro` on `document.body`
- scope retro CSS to `body.cli-retro` and apply green-on-black palette to stats and blocks
- test retro theme toggling and persistence

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot suite)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b6edd20e888326bf5af1ec8e69fd74