### PR TITLE
refactor: drop body null check in retro theme toggle

### DIFF
--- a/src/pages/battleCLI.init.js
+++ b/src/pages/battleCLI.init.js
@@ -51,8 +51,8 @@ function focusNextHint() {
 }
 
 function applyRetroTheme(enabled) {
-  const body = document.body;
-  if (body) body.classList.toggle("cli-retro", Boolean(enabled));
+  // document.body is guaranteed to exist in browser environments with a loaded DOM
+  document.body.classList.toggle("cli-retro", Boolean(enabled));
   try {
     localStorage.setItem("battleCLI.retro", enabled ? "1" : "0");
   } catch {}

--- a/tests/pages/battleCLI.pointsToWin.test.js
+++ b/tests/pages/battleCLI.pointsToWin.test.js
@@ -113,34 +113,27 @@ describe("battleCLI points select", () => {
     expect(select.value).toBe("15");
   });
 
-  it.each([5, 15])(
-    "selecting %i updates engine state and header",
-    async (target) => {
-      localStorage.setItem(BATTLE_POINTS_TO_WIN, "10");
-      const mod = await loadBattleCLI();
-      await mod.__test.init();
-      const { setPointsToWin, getPointsToWin } = await import(
-        "../../src/helpers/battleEngineFacade.js"
-      );
-      setPointsToWin.mockClear();
-      vi.spyOn(window, "confirm").mockReturnValue(true);
+  it.each([5, 15])("selecting %i updates engine state and header", async (target) => {
+    localStorage.setItem(BATTLE_POINTS_TO_WIN, "10");
+    const mod = await loadBattleCLI();
+    await mod.__test.init();
+    const { setPointsToWin, getPointsToWin } = await import(
+      "../../src/helpers/battleEngineFacade.js"
+    );
+    setPointsToWin.mockClear();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
 
-      const select = document.getElementById("points-select");
-      select.value = String(target);
-      select.dispatchEvent(new Event("change"));
+    const select = document.getElementById("points-select");
+    select.value = String(target);
+    select.dispatchEvent(new Event("change"));
 
-      await waitFor(() => getPointsToWin() === target);
-      await waitFor(
-        () =>
-          document.getElementById("cli-round").textContent ===
-          `Round 0 of ${target}`
-      );
+    await waitFor(() => getPointsToWin() === target);
+    await waitFor(
+      () => document.getElementById("cli-round").textContent === `Round 0 of ${target}`
+    );
 
-      expect(getPointsToWin()).toBe(target);
-      expect(setPointsToWin).toHaveBeenCalledWith(target);
-      expect(document.getElementById("cli-round").textContent).toBe(
-        `Round 0 of ${target}`
-      );
-    }
-  );
+    expect(getPointsToWin()).toBe(target);
+    expect(setPointsToWin).toHaveBeenCalledWith(target);
+    expect(document.getElementById("cli-round").textContent).toBe(`Round 0 of ${target}`);
+  });
 });


### PR DESCRIPTION
## Summary
- remove unnecessary document.body null check when toggling retro theme
- format battleCLI points-to-win test to satisfy Prettier

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot suite)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b70361636c83269c08fa5a13319313