### PR TITLE
Show stat values and handle clicks (fix reviewer comments)

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -711,11 +711,10 @@ export async function renderStatList(judoka) {
           list.appendChild(div);
         });
       const onClick = handleStatListClick;
-      const STAT_LIST_BOUND_TARGETS_KEY = "data-battle-cli-stat-list-bound-targets";
-      const set = (globalThis[STAT_LIST_BOUND_TARGETS_KEY] ||= new WeakSet());
-      if (!set.has(list)) {
+      const boundTargets = (globalThis.__battleCLIStatListBoundTargets ||= new WeakSet());
+      if (!boundTargets.has(list)) {
         list.addEventListener("click", onClick);
-        set.add(list);
+        boundTargets.add(list);
       }
       try {
         window.__battleCLIinit?.clearSkeletonStats?.();


### PR DESCRIPTION
## Summary
- clarify global tracker for battle CLI stat list bindings

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b70983d22483268abbb601ad228911