### PR TITLE
chore: prevent battle CLI horizontal scroll

### DIFF
--- a/playwright/cli-scroll.spec.js
+++ b/playwright/cli-scroll.spec.js
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test";
+
+test("CLI layout has no horizontal scrollbar when content fits", async ({ page }) => {
+  await page.goto("/src/pages/battleCLI.html");
+  const hasHorizontalScroll = await page.evaluate(() => {
+    const el = document.documentElement;
+    return el.scrollWidth > el.clientWidth;
+  });
+  expect(hasHorizontalScroll).toBe(false);
+});

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -25,6 +25,10 @@
         min-height: 100vh;
         display: flex;
         flex-direction: column;
+        overflow-x: hidden;
+      }
+      .cli-root > * {
+        max-width: 100%;
       }
       .cli-header {
         padding: 8px 12px;
@@ -65,11 +69,14 @@
         flex: 1;
         display: flex;
         width: 100%;
-        max-width: none;
+        max-width: 100%;
         margin: 0;
         flex-direction: column;
         padding: 12px 16px;
         gap: 12px;
+      }
+      .cli-main > * {
+        max-width: 100%;
       }
       /* Retro theme: green-on-black optional class and global retro theme */
       body.cli-retro,


### PR DESCRIPTION
## Summary
- hide horizontal overflow in the battle CLI layout and cap child elements at the container width
- add Playwright test to ensure the battle CLI has no horizontal scrollbar when content fits

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: Code style issues found in .github/workflows/buildOfflineRAG.yml and progressRetro.md)*
- `npx eslint .` *(fails: 3 errors in .github/workflows/buildOfflineRAG.yml)*
- `npx vitest run`
- `npx playwright test` *(fails: 4 screenshot.spec.js tests)*
- `npx playwright test playwright/cli-scroll.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b70e2cffc48326a05b8a2f2d78d358