### PR TITLE
docs: record retro theme contrast ratios

### DIFF
--- a/design/retroThemeContrast.md
+++ b/design/retroThemeContrast.md
@@ -1,0 +1,25 @@
+# Retro Theme Contrast
+
+This retro palette provides a terminal-like green-on-black style.
+
+## Colour Tokens
+
+| Token                 | Value     |
+| --------------------- | --------- |
+| `--color-background`  | `#000000` |
+| `--color-text`        | `#8cff6b` |
+| `--color-primary`     | `#8cff6b` |
+| `--color-secondary`   | `#8cff6b` |
+| `--button-bg`         | `#8cff6b` |
+| `--button-text-color` | `#000000` |
+
+## Contrast Ratios
+
+Calculated with the `wcag-contrast` package.
+
+| Foreground | Background | Ratio   |
+| ---------- | ---------- | ------- |
+| `#8cff6b`  | `#000000`  | 16.63:1 |
+| `#000000`  | `#8cff6b`  | 16.63:1 |
+
+Running `npm run check:contrast` reports **No issues found**, confirming all ratios meet or exceed the WCAG AA threshold of 4.5:1.


### PR DESCRIPTION
## Summary
- document retro palette color tokens and wcag contrast ratios

## Testing
- `npm run check:jsdoc` *(fails: 217 missing JSDoc blocks)*
- `npx prettier . --check` *(fails: .github/workflows/buildOfflineRAG.yml, progressRetro.md)*
- `npx eslint .` *(fails: 3 errors, 9 warnings)
- `npx vitest run`
- `npx playwright test` *(fails: 4 screenshot mismatches)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68b70e3352588326b6a871248b1820c5