### PR TITLE
refactor: return outcome codes from battle engine

### DIFF
--- a/src/helpers/BattleEngine.js
+++ b/src/helpers/BattleEngine.js
@@ -12,6 +12,20 @@ import { getStateSnapshot } from "./classicBattle/battleDebug.js";
 
 export const STATS = ["power", "speed", "technique", "kumikata", "newaza"];
 
+export const OUTCOME = {
+  WIN_PLAYER: "winPlayer",
+  WIN_OPPONENT: "winOpponent",
+  DRAW: "draw",
+  MATCH_WIN_PLAYER: "matchWinPlayer",
+  MATCH_WIN_OPPONENT: "matchWinOpponent",
+  MATCH_DRAW: "matchDraw",
+  QUIT: "quit",
+  INTERRUPT_ROUND: "interruptRound",
+  INTERRUPT_MATCH: "interruptMatch",
+  ROUND_MODIFIED: "roundModified",
+  ERROR: "error"
+};
+
 /**
  * Compare two stat values and report the winner.
  *
@@ -39,45 +53,39 @@ export function compareStats(playerVal, opponentVal) {
  *
  * @pseudocode
  * 1. Compute `delta = playerVal - opponentVal`.
- * 2. If `delta > 0` outcome is `"winPlayer"`.
- * 3. Else if `delta < 0` outcome is `"winOpponent"`.
- * 4. Otherwise outcome is `"draw"`.
+ * 2. If `delta > 0` outcome is `OUTCOME.WIN_PLAYER`.
+ * 3. Else if `delta < 0` outcome is `OUTCOME.WIN_OPPONENT`.
+ * 4. Otherwise outcome is `OUTCOME.DRAW`.
  * 5. Return `{ delta, outcome }`.
  *
  * @param {number} playerVal - Player's stat value.
  * @param {number} opponentVal - Opponent's stat value.
- * @returns {{delta: number, outcome: "winPlayer"|"winOpponent"|"draw"}}
+ * @returns {{delta: number, outcome: keyof typeof OUTCOME}}
  */
 export function determineOutcome(playerVal, opponentVal) {
   const delta = playerVal - opponentVal;
-  let outcome = "draw";
-  if (delta > 0) outcome = "winPlayer";
-  else if (delta < 0) outcome = "winOpponent";
+  let outcome = OUTCOME.DRAW;
+  if (delta > 0) outcome = OUTCOME.WIN_PLAYER;
+  else if (delta < 0) outcome = OUTCOME.WIN_OPPONENT;
   return { delta, outcome };
 }
-
-const OUTCOME_MESSAGE = {
-  winPlayer: "You win the round!",
-  winOpponent: "Opponent wins the round!",
-  draw: "Tie – no score!"
-};
 
 /**
  * Apply a round outcome to the engine scores.
  *
  * @pseudocode
- * 1. If `outcome.outcome` is `"winPlayer"`, increment `playerScore`.
- * 2. Else if `outcome.outcome` is `"winOpponent"`, increment `opponentScore`.
+ * 1. If `outcome.outcome` is `OUTCOME.WIN_PLAYER`, increment `playerScore`.
+ * 2. Else if `outcome.outcome` is `OUTCOME.WIN_OPPONENT`, increment `opponentScore`.
  * 3. Otherwise, leave scores unchanged.
  *
  * @param {BattleEngine} engine - Battle engine instance.
- * @param {{outcome: "winPlayer"|"winOpponent"|"draw"}} outcome - Outcome object.
+ * @param {{outcome: keyof typeof OUTCOME}} outcome - Outcome object.
  * @returns {void}
  */
 export function applyOutcome(engine, outcome) {
-  if (outcome.outcome === "winPlayer") {
+  if (outcome.outcome === OUTCOME.WIN_PLAYER) {
     engine.playerScore += 1;
-  } else if (outcome.outcome === "winOpponent") {
+  } else if (outcome.outcome === OUTCOME.WIN_OPPONENT) {
     engine.opponentScore += 1;
   }
 }
@@ -155,14 +163,14 @@ export class BattleEngine {
     ) {
       this.matchEnded = true;
       if (this.playerScore > this.opponentScore) {
-        return "You win the match!";
+        return OUTCOME.MATCH_WIN_PLAYER;
       }
       if (this.playerScore < this.opponentScore) {
-        return "Opponent wins the match!";
+        return OUTCOME.MATCH_WIN_OPPONENT;
       }
-      return "Match ends in a tie!";
+      return OUTCOME.MATCH_DRAW;
     }
-    return "";
+    return null;
   }
 
   /**
@@ -244,19 +252,18 @@ export class BattleEngine {
    * 3. Use `compareStats` to obtain `delta` between values.
    * 4. Look up the outcome by `Math.sign(delta)` and apply its score update.
    * 5. Increment `roundsPlayed`.
-   * 6. Call `#endMatchIfNeeded()` and override the round message if it returns one.
-   * 7. Return the round message, `matchEnded`, and current scores.
+   * 6. Call `#endMatchIfNeeded()` and override the round outcome if it returns one.
+   * 7. Return the outcome code, `matchEnded`, and current scores.
    *
    * @param {number} playerVal - Value selected by the player.
    * @param {number} opponentVal - Value selected by the opponent.
-   * @returns {{message: string, matchEnded: boolean, playerScore: number, opponentScore: number}}
+   * @returns {{delta: number, outcome: keyof typeof OUTCOME, matchEnded: boolean, playerScore: number, opponentScore: number}}
    */
   handleStatSelection(playerVal, opponentVal) {
     if (this.matchEnded) {
       const already = determineOutcome(playerVal, opponentVal);
       return {
         ...already,
-        message: "",
         matchEnded: this.matchEnded,
         playerScore: this.playerScore,
         opponentScore: this.opponentScore
@@ -266,10 +273,10 @@ export class BattleEngine {
     const outcome = determineOutcome(playerVal, opponentVal);
     applyOutcome(this, outcome);
     this.roundsPlayed += 1;
-    const endMsg = this.#endMatchIfNeeded();
+    const matchOutcome = this.#endMatchIfNeeded();
     return {
       ...outcome,
-      message: endMsg || OUTCOME_MESSAGE[outcome.outcome],
+      outcome: matchOutcome || outcome.outcome,
       matchEnded: this.matchEnded,
       playerScore: this.playerScore,
       opponentScore: this.opponentScore
@@ -277,19 +284,20 @@ export class BattleEngine {
   }
 
   /**
-   * End the current match and return the final message.
+   * End the current match and return a quit outcome.
    *
    * @pseudocode
    * 1. Set `matchEnded` to true and stop any running timer.
-   * 2. Return a quit message along with `playerScore` and `opponentScore`.
+   * 2. Return a quit outcome along with `playerScore` and `opponentScore`.
    *
-   * @returns {{message: string, playerScore: number, opponentScore: number}}
+   * @returns {{outcome: keyof typeof OUTCOME, matchEnded: boolean, playerScore: number, opponentScore: number}}
    */
   quitMatch() {
     this.matchEnded = true;
     this.stopTimer();
     return {
-      message: "You quit the match. You lose!",
+      outcome: OUTCOME.QUIT,
+      matchEnded: this.matchEnded,
       playerScore: this.playerScore,
       opponentScore: this.opponentScore
     };
@@ -301,17 +309,18 @@ export class BattleEngine {
    * @pseudocode
    * 1. Stop the timer and set a round interrupted flag.
    * 2. Optionally log or store the reason.
-   * 3. Return an interrupt message and current scores.
+   * 3. Return an interrupt outcome and current scores.
    *
    * @param {string} [reason] - Reason for interruption.
-   * @returns {{message: string, playerScore: number, opponentScore: number}}
+   * @returns {{outcome: keyof typeof OUTCOME, matchEnded: boolean, playerScore: number, opponentScore: number}}
    */
   interruptRound(reason) {
     this.stopTimer();
     this.roundInterrupted = true;
     this.lastInterruptReason = reason || "";
     return {
-      message: `Round interrupted${reason ? ": " + reason : ""}`,
+      outcome: OUTCOME.INTERRUPT_ROUND,
+      matchEnded: this.matchEnded,
       playerScore: this.playerScore,
       opponentScore: this.opponentScore
     };
@@ -323,17 +332,18 @@ export class BattleEngine {
    * @pseudocode
    * 1. Stop the timer and set matchEnded to true.
    * 2. Optionally log or store the reason.
-   * 3. Return an interrupt message and current scores.
+   * 3. Return an interrupt outcome and current scores.
    *
    * @param {string} [reason] - Reason for interruption.
-   * @returns {{message: string, playerScore: number, opponentScore: number}}
+   * @returns {{outcome: keyof typeof OUTCOME, matchEnded: boolean, playerScore: number, opponentScore: number}}
    */
   interruptMatch(reason) {
     this.stopTimer();
     this.matchEnded = true;
     this.lastInterruptReason = reason || "";
     return {
-      message: `Match interrupted${reason ? ": " + reason : ""}`,
+      outcome: OUTCOME.INTERRUPT_MATCH,
+      matchEnded: this.matchEnded,
       playerScore: this.playerScore,
       opponentScore: this.opponentScore
     };
@@ -345,10 +355,10 @@ export class BattleEngine {
    * @pseudocode
    * 1. Accept a modification object and apply changes to round state.
    * 2. Optionally log the modification.
-   * 3. Return a modification message and current scores.
+   * 3. Return a modification outcome and current scores.
    *
    * @param {object} modification - Object describing the round modification.
-   * @returns {{message: string, playerScore: number, opponentScore: number}}
+   * @returns {{outcome: keyof typeof OUTCOME, matchEnded: boolean, playerScore: number, opponentScore: number}}
    */
   roundModification(modification) {
     // Example: allow score override, round reset, etc.
@@ -361,7 +371,8 @@ export class BattleEngine {
     }
     this.lastModification = modification;
     return {
-      message: `Round modified${modification ? ": " + JSON.stringify(modification) : ""}`,
+      outcome: OUTCOME.ROUND_MODIFIED,
+      matchEnded: this.matchEnded,
       playerScore: this.playerScore,
       opponentScore: this.opponentScore
     };
@@ -372,16 +383,17 @@ export class BattleEngine {
    *
    * @pseudocode
    * 1. Stop timer, set error flag, and log error.
-   * 2. Return error message and scores.
+   * 2. Return an error outcome and scores.
    *
    * @param {string} errorMsg - Error message.
-   * @returns {{message: string, playerScore: number, opponentScore: number}}
+   * @returns {{outcome: keyof typeof OUTCOME, matchEnded: boolean, playerScore: number, opponentScore: number}}
    */
   handleError(errorMsg) {
     this.stopTimer();
     this.lastError = errorMsg;
     return {
-      message: `Error: ${errorMsg}`,
+      outcome: OUTCOME.ERROR,
+      matchEnded: this.matchEnded,
       playerScore: this.playerScore,
       opponentScore: this.opponentScore
     };

--- a/src/helpers/api/battleUI.js
+++ b/src/helpers/api/battleUI.js
@@ -1,4 +1,4 @@
-import { STATS, handleStatSelection } from "../battleEngineFacade.js";
+import { STATS, handleStatSelection, OUTCOME } from "../battleEngineFacade.js";
 
 /**
  * Choose an opponent stat based on difficulty and available values.
@@ -33,17 +33,46 @@ export function chooseOpponentStat(values, difficulty = "easy") {
   return STATS[Math.floor(Math.random() * STATS.length)];
 }
 
+const OUTCOME_MESSAGES = {
+  [OUTCOME.WIN_PLAYER]: "You win the round!",
+  [OUTCOME.WIN_OPPONENT]: "Opponent wins the round!",
+  [OUTCOME.DRAW]: "Tie – no score!",
+  [OUTCOME.MATCH_WIN_PLAYER]: "You win the match!",
+  [OUTCOME.MATCH_WIN_OPPONENT]: "Opponent wins the match!",
+  [OUTCOME.MATCH_DRAW]: "Match ends in a tie!",
+  [OUTCOME.QUIT]: "You quit the match. You lose!",
+  [OUTCOME.INTERRUPT_ROUND]: "Round interrupted",
+  [OUTCOME.INTERRUPT_MATCH]: "Match interrupted",
+  [OUTCOME.ROUND_MODIFIED]: "Round modified",
+  [OUTCOME.ERROR]: "Error"
+};
+
 /**
- * Evaluate a round using player and opponent stat values.
+ * Map an outcome code to a localized message.
+ *
+ * @pseudocode
+ * 1. Use a lookup table keyed by outcome codes.
+ * 2. Return the matching message or an empty string.
+ *
+ * @param {keyof typeof OUTCOME} outcome - Outcome code from the engine.
+ * @returns {string} Localized message.
+ */
+export function getOutcomeMessage(outcome) {
+  return OUTCOME_MESSAGES[outcome] || "";
+}
+
+/**
+ * @summary Evaluate a round and map the outcome to a message.
  *
  * @pseudocode
  * 1. Delegate to `handleStatSelection` on the battle engine with the provided values.
- * 2. Return its result.
+ * 2. Map the returned outcome code to a user-facing message.
  *
  * @param {number} playerVal - Player's stat value.
  * @param {number} opponentVal - Opponent's stat value.
- * @returns {{message: string, matchEnded: boolean, playerScore: number, opponentScore: number}}
+ * @returns {{delta: number, outcome: keyof typeof OUTCOME, matchEnded: boolean, playerScore: number, opponentScore: number, message: string}}
  */
 export function evaluateRound(playerVal, opponentVal) {
-  return handleStatSelection(playerVal, opponentVal);
+  const result = handleStatSelection(playerVal, opponentVal);
+  return { ...result, message: getOutcomeMessage(result.outcome) };
 }

--- a/src/helpers/battleEngineFacade.js
+++ b/src/helpers/battleEngineFacade.js
@@ -7,7 +7,7 @@ import { BattleEngine } from "./BattleEngine.js";
  * @pseudocode
  * 1. Import engine implementation from `./BattleEngine.js` and re-export its public API.
  */
-export { BattleEngine, STATS } from "./BattleEngine.js";
+export { BattleEngine, STATS, OUTCOME } from "./BattleEngine.js";
 
 /**
  * Singleton engine instance used by application code and helpers.
@@ -99,7 +99,7 @@ export const resumeTimer = () => battleEngine.resumeTimer();
  * 1. Call `battleEngine.handleStatSelection(...args)` and return its result.
  *
  * @param {...any} args
- * @returns {object}
+ * @returns {{delta: number, outcome: keyof typeof OUTCOME, matchEnded: boolean, playerScore: number, opponentScore: number}}
  */
 export const handleStatSelection = (...args) => battleEngine.handleStatSelection(...args);
 
@@ -109,7 +109,7 @@ export const handleStatSelection = (...args) => battleEngine.handleStatSelection
  * @pseudocode
  * 1. Delegate to `battleEngine.quitMatch()`.
  *
- * @returns {void}
+ * @returns {{outcome: keyof typeof OUTCOME, matchEnded: boolean, playerScore: number, opponentScore: number}}
  */
 export const quitMatch = () => battleEngine.quitMatch();
 
@@ -119,10 +119,10 @@ export const quitMatch = () => battleEngine.quitMatch();
  * @pseudocode
  * 1. Stop the timer and set matchEnded to true.
  * 2. Optionally log or store the reason.
- * 3. Return an interrupt message and current scores.
+ * 3. Return an interrupt outcome and current scores.
  *
  * @param {string} [reason] - Reason for interruption.
- * @returns {{message: string, playerScore: number, opponentScore: number}}
+ * @returns {{outcome: keyof typeof OUTCOME, matchEnded: boolean, playerScore: number, opponentScore: number}}
  */
 export const interruptMatch = (reason) => battleEngine.interruptMatch(reason);
 

--- a/src/helpers/classicBattle/quitModal.js
+++ b/src/helpers/classicBattle/quitModal.js
@@ -2,6 +2,7 @@ import { createModal } from "../../components/Modal.js";
 import { createButton } from "../../components/Button.js";
 import * as battleEngine from "../battleEngineFacade.js";
 import { showResult } from "../battle/index.js";
+import { getOutcomeMessage } from "../api/battleUI.js";
 import { navigateToHome } from "../navUtils.js";
 import { dispatchBattleEvent } from "./orchestrator.js";
 import { getBattleState } from "./eventBus.js";
@@ -84,7 +85,7 @@ export function quitMatch(store, trigger) {
   if (!store.quitModal) {
     store.quitModal = createQuitConfirmation(store, () => {
       const result = battleEngine.quitMatch();
-      showResult(result.message);
+      showResult(getOutcomeMessage(result.outcome));
     });
   }
   const fallback = document.getElementById("quit-match-button");

--- a/tests/helpers/battleEngine/interrupts.test.js
+++ b/tests/helpers/battleEngine/interrupts.test.js
@@ -30,7 +30,7 @@ beforeEach(() => {
 
 describe("BattleEngine interrupts", () => {
   it("interruptRound stops timer and records reason", async () => {
-    const { BattleEngine } = await import("../../../src/helpers/BattleEngine.js");
+    const { BattleEngine, OUTCOME } = await import("../../../src/helpers/BattleEngine.js");
     const engine = new BattleEngine();
     engine._resetForTest();
     await engine.startRound(
@@ -48,14 +48,15 @@ describe("BattleEngine interrupts", () => {
     expect(engine.lastInterruptReason).toBe("referee");
     expect(engine.timer.hasActiveTimer()).toBe(false);
     expect(result).toEqual({
-      message: "Round interrupted: referee",
+      outcome: OUTCOME.INTERRUPT_ROUND,
+      matchEnded: false,
       playerScore: 1,
       opponentScore: 2
     });
   });
 
   it("interruptMatch stops timer and ends match", async () => {
-    const { BattleEngine } = await import("../../../src/helpers/BattleEngine.js");
+    const { BattleEngine, OUTCOME } = await import("../../../src/helpers/BattleEngine.js");
     const engine = new BattleEngine();
     engine._resetForTest();
     await engine.startRound(
@@ -73,14 +74,15 @@ describe("BattleEngine interrupts", () => {
     expect(engine.lastInterruptReason).toBe("injury");
     expect(engine.timer.hasActiveTimer()).toBe(false);
     expect(result).toEqual({
-      message: "Match interrupted: injury",
+      outcome: OUTCOME.INTERRUPT_MATCH,
+      matchEnded: true,
       playerScore: 3,
       opponentScore: 4
     });
   });
 
   it("roundModification applies overrides and resetRound", async () => {
-    const { BattleEngine } = await import("../../../src/helpers/BattleEngine.js");
+    const { BattleEngine, OUTCOME } = await import("../../../src/helpers/BattleEngine.js");
     const engine = new BattleEngine();
     engine._resetForTest();
     await engine.startRound(
@@ -105,7 +107,8 @@ describe("BattleEngine interrupts", () => {
     expect(engine.roundsPlayed).toBe(2);
     expect(engine.roundInterrupted).toBe(false);
     expect(result).toEqual({
-      message: `Round modified: ${JSON.stringify(modification)}`,
+      outcome: OUTCOME.ROUND_MODIFIED,
+      matchEnded: false,
       playerScore: 5,
       opponentScore: 1
     });

--- a/tests/helpers/battleEngine/outcome.test.js
+++ b/tests/helpers/battleEngine/outcome.test.js
@@ -1,17 +1,22 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { BattleEngine, determineOutcome, applyOutcome } from "../../../src/helpers/BattleEngine.js";
+import {
+  BattleEngine,
+  determineOutcome,
+  applyOutcome,
+  OUTCOME
+} from "../../../src/helpers/BattleEngine.js";
 
 describe("determineOutcome", () => {
   it("returns player win when player value higher", () => {
-    expect(determineOutcome(5, 3)).toEqual({ delta: 2, outcome: "winPlayer" });
+    expect(determineOutcome(5, 3)).toEqual({ delta: 2, outcome: OUTCOME.WIN_PLAYER });
   });
 
   it("returns opponent win when opponent value higher", () => {
-    expect(determineOutcome(3, 5)).toEqual({ delta: -2, outcome: "winOpponent" });
+    expect(determineOutcome(3, 5)).toEqual({ delta: -2, outcome: OUTCOME.WIN_OPPONENT });
   });
 
   it("returns draw when values equal", () => {
-    expect(determineOutcome(4, 4)).toEqual({ delta: 0, outcome: "draw" });
+    expect(determineOutcome(4, 4)).toEqual({ delta: 0, outcome: OUTCOME.DRAW });
   });
 });
 
@@ -23,19 +28,19 @@ describe("applyOutcome", () => {
   });
 
   it("increments player score on player win", () => {
-    applyOutcome(engine, { outcome: "winPlayer" });
+    applyOutcome(engine, { outcome: OUTCOME.WIN_PLAYER });
     expect(engine.playerScore).toBe(1);
     expect(engine.opponentScore).toBe(0);
   });
 
   it("increments opponent score on opponent win", () => {
-    applyOutcome(engine, { outcome: "winOpponent" });
+    applyOutcome(engine, { outcome: OUTCOME.WIN_OPPONENT });
     expect(engine.playerScore).toBe(0);
     expect(engine.opponentScore).toBe(1);
   });
 
   it("leaves scores unchanged on draw", () => {
-    applyOutcome(engine, { outcome: "draw" });
+    applyOutcome(engine, { outcome: OUTCOME.DRAW });
     expect(engine.playerScore).toBe(0);
     expect(engine.opponentScore).toBe(0);
   });
@@ -51,7 +56,7 @@ describe("BattleEngine handleStatSelection", () => {
   it("handles player win", () => {
     const res = engine.handleStatSelection(5, 3);
     expect(res).toMatchObject({
-      outcome: "winPlayer",
+      outcome: OUTCOME.WIN_PLAYER,
       delta: 2,
       matchEnded: false,
       playerScore: 1,
@@ -62,7 +67,7 @@ describe("BattleEngine handleStatSelection", () => {
   it("handles opponent win", () => {
     const res = engine.handleStatSelection(3, 5);
     expect(res).toMatchObject({
-      outcome: "winOpponent",
+      outcome: OUTCOME.WIN_OPPONENT,
       delta: -2,
       playerScore: 0,
       opponentScore: 1
@@ -72,7 +77,7 @@ describe("BattleEngine handleStatSelection", () => {
   it("handles tie", () => {
     const res = engine.handleStatSelection(4, 4);
     expect(res).toMatchObject({
-      outcome: "draw",
+      outcome: OUTCOME.DRAW,
       delta: 0,
       playerScore: 0,
       opponentScore: 0
@@ -83,6 +88,6 @@ describe("BattleEngine handleStatSelection", () => {
     engine.setPointsToWin(1);
     const res = engine.handleStatSelection(5, 3);
     expect(res.matchEnded).toBe(true);
-    expect(res.message).toMatch(/win the match/i);
+    expect(res.outcome).toBe(OUTCOME.MATCH_WIN_PLAYER);
   });
 });

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -67,13 +67,14 @@ beforeEach(() => {
   }));
 
   vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
-    handleStatSelection: vi.fn().mockReturnValue({ message: "", matchEnded: false }),
+    handleStatSelection: vi.fn().mockReturnValue({ outcome: "", matchEnded: false }),
     quitMatch: vi.fn(),
     pauseTimer: vi.fn(),
     stopTimer: vi.fn(),
     getScores: vi.fn().mockReturnValue({ playerScore: 0, opponentScore: 0 }),
     _resetForTest: vi.fn(),
-    STATS: ["power"]
+    STATS: ["power"],
+    OUTCOME: {}
   }));
 });
 

--- a/tests/helpers/classicBattle/quitModal.test.js
+++ b/tests/helpers/classicBattle/quitModal.test.js
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi } from "vitest";
 
 vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
-  quitMatch: vi.fn(() => ({ message: "Bye" }))
+  quitMatch: vi.fn(() => ({
+    outcome: "QUIT",
+    matchEnded: true,
+    playerScore: 0,
+    opponentScore: 0
+  }))
 }));
 vi.mock("../../../src/helpers/battle/index.js", () => ({
   showResult: vi.fn()
+}));
+vi.mock("../../../src/helpers/api/battleUI.js", () => ({
+  getOutcomeMessage: () => "Bye"
 }));
 vi.mock("../../../src/components/Modal.js", () => ({
   createModal: (content) => {


### PR DESCRIPTION
## Summary
- refactor BattleEngine to emit outcome codes instead of messages
- map outcome codes to UI text in battleUI
- adjust tests for battle engine to expect codes

## Testing
- `npm run check:jsdoc` (fails: Functions missing or with incomplete JSDoc blocks)
- `npx prettier . --check` (fails: Code style issues found in 5 files)
- `npx eslint .`
- `npx vitest run` (fails: tests failing)
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b72f917c84832683448f28f2eebc28