### PR TITLE
feat: configurize battle engine

### DIFF
--- a/design/productRequirementsDocuments/prdBattleEngine.md
+++ b/design/productRequirementsDocuments/prdBattleEngine.md
@@ -46,6 +46,15 @@ A well-defined engine will enable consistent gameplay, predictable UI updates th
 
 > **Note:** Feature flags use camelCase keys.
 
+### Constructor Options
+
+The `BattleEngine` constructor accepts a config object allowing modes to override classic behavior:
+
+- `pointsToWin` – win threshold, defaults to classic value
+- `maxRounds` – round cap before declaring a draw
+- `stats` – list of stat keys used in comparisons
+- `debugHooks` – optional callbacks (e.g., `getStateSnapshot` for tests)
+
 ---
 
 ## User Stories

--- a/src/helpers/battleEngineFacade.js
+++ b/src/helpers/battleEngineFacade.js
@@ -1,4 +1,6 @@
-import { BattleEngine } from "./BattleEngine.js";
+import { BattleEngine, STATS } from "./BattleEngine.js";
+import { CLASSIC_BATTLE_POINTS_TO_WIN, CLASSIC_BATTLE_MAX_ROUNDS } from "./constants.js";
+import { getStateSnapshot } from "./classicBattle/battleDebug.js";
 
 /**
  * Core battle engine and useful constants exported from the engine module.
@@ -17,7 +19,12 @@ export { BattleEngine, STATS, OUTCOME } from "./BattleEngine.js";
  * 1. Construct a new `BattleEngine` and export it so modules can delegate calls.
  * @type {BattleEngine}
  */
-export const battleEngine = new BattleEngine();
+export const battleEngine = new BattleEngine({
+  pointsToWin: CLASSIC_BATTLE_POINTS_TO_WIN,
+  maxRounds: CLASSIC_BATTLE_MAX_ROUNDS,
+  stats: STATS,
+  debugHooks: { getStateSnapshot }
+});
 
 /**
  * Set the number of points required to win a match.

--- a/tests/helpers/battleEngine/config.test.js
+++ b/tests/helpers/battleEngine/config.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { BattleEngine } from "../../../src/helpers/BattleEngine.js";
+
+describe("BattleEngine configuration", () => {
+  it("accepts custom config values", () => {
+    const customStats = ["a", "b"];
+    const getStateSnapshot = vi.fn().mockReturnValue({ log: ["x"] });
+    const engine = new BattleEngine({
+      pointsToWin: 2,
+      maxRounds: 3,
+      stats: customStats,
+      debugHooks: { getStateSnapshot }
+    });
+    const snap = engine.getTimerStateSnapshot();
+    expect(engine.pointsToWin).toBe(2);
+    expect(engine.maxRounds).toBe(3);
+    expect(engine.stats).toBe(customStats);
+    expect(getStateSnapshot).toHaveBeenCalled();
+    expect(snap.transitions).toEqual(["x"]);
+  });
+
+  it("uses provided maxRounds to end match", () => {
+    const engine = new BattleEngine({ maxRounds: 1 });
+    const res = engine.handleStatSelection(1, 1);
+    expect(res.matchEnded).toBe(true);
+  });
+
+  it("does not import classic debug module", () => {
+    const file = path.resolve(__dirname, "../../../src/helpers/BattleEngine.js");
+    const content = fs.readFileSync(file, "utf8");
+    expect(content).not.toMatch(/classicBattle\/battleDebug/);
+  });
+});


### PR DESCRIPTION
## Summary
- allow BattleEngine to take configuration for points, rounds, stats, and debug hooks
- inject classic configuration from battleEngineFacade instead of hardcoding
- test custom engine setup and ensure debug module is not imported

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier src/helpers/BattleEngine.js src/helpers/battleEngineFacade.js tests/helpers/battleEngine/config.test.js design/productRequirementsDocuments/prdBattleEngine.md --check`
- `npx eslint src/helpers/BattleEngine.js src/helpers/battleEngineFacade.js tests/helpers/battleEngine/config.test.js`
- `npx vitest run` *(fails: Scoreboard integration without explicit init, battleCLI accessibility focus management)*
- `npx playwright test` *(fails: network errors and interrupted tests)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68b735cb03dc83268bd86cf4cc19d6d9