### PR TITLE
fix: dispatch correct match outcome events

### DIFF
--- a/src/helpers/classicBattle/roundResolver.js
+++ b/src/helpers/classicBattle/roundResolver.js
@@ -132,9 +132,9 @@ export async function computeRoundResult(store, stat, playerVal, opponentVal) {
     debugLog("DEBUG: evaluateRound result", result);
   } catch {}
   const outcomeEvent =
-    result.outcome === "winPlayer"
+    result.outcome === "winPlayer" || result.outcome === "matchWinPlayer"
       ? "outcome=winPlayer"
-      : result.outcome === "winOpponent"
+      : result.outcome === "winOpponent" || result.outcome === "matchWinOpponent"
         ? "outcome=winOpponent"
         : "outcome=draw";
   // Fire-and-forget dispatch to avoid re-entrancy deadlocks when called from

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -188,6 +188,28 @@ describe("classicBattle stat selection", () => {
     ]);
   });
 
+  it("dispatches opponent win outcome when opponent wins match", async () => {
+    const { setPointsToWin } = await import("../../../src/helpers/battleEngineFacade.js");
+    const eventDispatcher = await import("../../../src/helpers/classicBattle/orchestrator.js");
+    setPointsToWin(1);
+    eventDispatcher.__reset();
+    document.getElementById("player-card").innerHTML =
+      `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
+    document.getElementById("opponent-card").innerHTML =
+      `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
+    await selectStat("power");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "statSelected");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "evaluate");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(3, "outcome=winOpponent");
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(4, "matchPointReached");
+    expect(eventDispatcher.__getStateLog()).toEqual([
+      "roundDecision",
+      "processingRound",
+      "roundOver",
+      "matchDecision"
+    ]);
+  });
+
   it("simulateOpponentStat returns a valid stat", async () => {
     const { STATS } = await import("../../../src/helpers/battleEngineFacade.js");
     const stat = simulateOpponentStat({ power: 1, speed: 1, technique: 1, kumikata: 1, newaza: 1 });


### PR DESCRIPTION
## Summary
- handle match-level outcomes in `computeRoundResult` so win events map correctly
- add test verifying opponent match win maps to `outcome=winOpponent`

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check` *(fails: Code style issues found in 3 files)*
- `npx eslint .`
- `npx vitest run` *(fails: No "OUTCOME" export defined in mocked battleEngineFacade)*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b7357324b483269003eb54015cf9bf