### PR TITLE
fix: clarify battle engine config pseudocode and guard debug hooks

### DIFF
--- a/src/helpers/BattleEngine.js
+++ b/src/helpers/BattleEngine.js
@@ -94,9 +94,9 @@ export class BattleEngine {
    * Initializes a new instance of the BattleEngine.
    *
    * @pseudocode
-   * 1. Merge `config` with classic defaults (`pointsToWin`, `maxRounds`, `stats`).
+   * 1. Extract configuration values using destructuring with classic defaults as fallbacks (`pointsToWin`, `maxRounds`, `stats`).
    * 2. Initialize scores, timer, and status flags.
-   * 3. Store the merged config for test resets.
+   * 3. Store the extracted config values for test resets.
    *
    * @param {object} [config]
    * @param {number} [config.pointsToWin] - Points required to win the match.
@@ -457,7 +457,7 @@ export class BattleEngine {
   getTimerStateSnapshot() {
     const timer = this.getTimerState();
     let transitions = [];
-    const snap = this.debugHooks.getStateSnapshot?.();
+    const snap = this.debugHooks?.getStateSnapshot?.();
     if (Array.isArray(snap?.log)) {
       transitions = snap.log.slice();
     }


### PR DESCRIPTION
## Summary
- document configuration destructuring and fallback logic in BattleEngine pseudocode
- safely access debug hook snapshot via optional chaining

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check` *(fails: Code style issues found in 3 files)*
- `npx eslint .`
- `npx vitest run` *(fails: multiple test suites due to missing OUTCOME export and focus assertions)*
- `npx playwright test` *(fails: network errors loading external resources; tests still passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b739a84918832694ed03e51b5fc219