### PR TITLE
Refactor timer utilities to use JS data module

### DIFF
--- a/src/helpers/timerUtils.js
+++ b/src/helpers/timerUtils.js
@@ -9,14 +9,14 @@ import {
  * Retrieve the default timer value for a category.
  *
  * @param {string} category Timer category to search.
- * @returns {Promise<number|undefined>} Resolved default timer value.
+ * @returns {number|undefined} Resolved default timer value.
  *
  * @summary Find the default timer for a given category.
  * @pseudocode
  * 1. Locate the timer entry whose category matches and is marked as default.
  * 2. Return its value or `undefined` if none found.
  */
-export async function getDefaultTimer(category) {
+export function getDefaultTimer(category) {
   const entry = gameTimers.find((t) => t.category === category && t.default);
   return entry ? entry.value : undefined;
 }


### PR DESCRIPTION
## Summary
- make getDefaultTimer synchronous

## Testing
- `npm run check:jsdoc` *(fails: 189 missing or incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: missing OUTCOME export in battleEngineFacade mocks; assertion errors)*
- `npx playwright test` *(fails: 13 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b7411d6d888326b2cadcce7d72e82b