### PR TITLE
docs: add terminal safety note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ Before submitting or completing a task, verify that your work:
 
 ## 🧯 Runtime Safeguards
 
-### 🚫 Avoid Output Errors in Terminal
+### Terminal Safety
 
 To prevent session crashes in the terminal:
 
@@ -133,13 +133,13 @@ To prevent session crashes in the terminal:
 #### ✅ Use safe search patterns:
 
 ```bash
-grep "kumi-kata" . --exclude=client_embeddings.json
+grep "kumi-kata" . --exclude=client_embeddings.json --exclude=offline_rag_metadata.json
 ```
 
 Or recursively:
 
 ```bash
-grep -r "kumi-kata" . --exclude-dir=node_modules --exclude=client_embeddings.json
+grep -r "kumi-kata" . --exclude-dir=node_modules --exclude=client_embeddings.json --exclude=offline_rag_metadata.json
 ```
 
 🔍 Why it matters

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,10 @@ It consolidates the instructions from `AGENTS.md` and the design documents so co
 
 The project ships directly as static ES modules without a build step.
 
+### Terminal Safety
+
+When running terminal searches like `grep` or `find`, exclude `client_embeddings.json` and `offline_rag_metadata.json` to prevent output overflow. See [AGENTS.md](./AGENTS.md#terminal-safety) for details.
+
 ---
 
 ## ✅ Required Programmatic Checks

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Whether you're a developer, designer, tester, writer—or an AI agent—we welco
 
 For full contribution guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
+### Terminal Safety
+
+When running terminal searches like `grep` or `find`, exclude `client_embeddings.json` and `offline_rag_metadata.json` to prevent output overflow. See [AGENTS.md](./AGENTS.md#terminal-safety) for details.
+
 ---
 
 ## 🤖 AI Agent Compatibility


### PR DESCRIPTION
## Summary
- add Terminal Safety note to README and CONTRIBUTING
- document safe grep patterns in AGENTS

## Testing
- `npm run check:jsdoc` (fails: Total missing: 188)
- `npx prettier . --check`
- `npx eslint .` (warns: 1 warning)
- `npx vitest run` (fails: battleCLI scoreboard tests)
- `npx playwright test` (fails: 2 interrupted)
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68b7478ba5e88326954ee0e64b25b233