### PR TITLE
refactor: embed navigation items

### DIFF
--- a/tests/helpers/classicBattlePage.startRoundWrapper.test.js
+++ b/tests/helpers/classicBattlePage.startRoundWrapper.test.js
@@ -64,7 +64,7 @@ describe("startRoundWrapper failures", () => {
       pauseTimer: vi.fn(),
       resumeTimer: vi.fn(),
       STATS: [],
-      OUTCOME: {},
+      OUTCOME: {}, // mock enum to satisfy consumers expecting battleEngineFacade.OUTCOME
       setPointsToWin: vi.fn()
     }));
     vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
@@ -174,7 +174,7 @@ describe("startRoundWrapper failures", () => {
       pauseTimer: vi.fn(),
       resumeTimer: vi.fn(),
       STATS: [],
-      OUTCOME: {},
+      OUTCOME: {}, // mock enum to satisfy consumers expecting battleEngineFacade.OUTCOME
       setPointsToWin: vi.fn()
     }));
     vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
@@ -285,7 +285,7 @@ describe("startRoundWrapper success", () => {
       pauseTimer: vi.fn(),
       resumeTimer: vi.fn(),
       STATS: [],
-      OUTCOME: {},
+      OUTCOME: {}, // mock enum to satisfy consumers expecting battleEngineFacade.OUTCOME
       setPointsToWin: vi.fn()
     }));
     vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({


### PR DESCRIPTION
## Summary
- clarify why OUTCOME mock is needed in startRoundWrapper tests

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 36 failed | 180 passed)*
- `npx playwright test` *(fails: 5 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b74704002083269865e24c7046502f