### PR TITLE
feat: emit battle engine events

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ accessing `settings.featureFlags` directly.
 
 > `navigationItems.js` and `gameModes.json` must be present on the server; otherwise, the game loads built-in fallback data.
 
+## Battle Engine Events API
+
+The battle engine exposes a lightweight event emitter. Subscribe via
+`on(event, handler)` from `src/helpers/battleEngineFacade.js`:
+
+- `roundStarted` → `{ round }`
+- `roundEnded` → `{ delta, outcome, matchEnded, playerScore, opponentScore }`
+- `timerTick` → `{ remaining, phase: 'round' | 'cooldown' }`
+- `matchEnded` → same payload as `roundEnded`
+- `error` → `{ message }`
+
 ## 🔎 Using the Vector RAG System
 
 Before scanning the repo for answers, call [`queryRag`](./src/helpers/queryRag.js)

--- a/design/productRequirementsDocuments/prdBattleEngine.md
+++ b/design/productRequirementsDocuments/prdBattleEngine.md
@@ -55,6 +55,21 @@ The `BattleEngine` constructor accepts a config object allowing modes to overrid
 - `stats` – list of stat keys used in comparisons
 - `debugHooks` – optional callbacks (e.g., `getStateSnapshot` for tests)
 
+- `emitter` – optional `{ on, off, emit }` object to override the internal event emitter
+
+### Events
+
+The engine emits updates through a small event emitter. Listeners may
+subscribe with `on(event, handler)`:
+
+| Event          | Payload                                                      |
+| -------------- | ------------------------------------------------------------ | ------------- |
+| `roundStarted` | `{ round: number }`                                          |
+| `roundEnded`   | `{ delta, outcome, matchEnded, playerScore, opponentScore }` |
+| `timerTick`    | `{ remaining: number, phase: 'round'                         | 'cooldown' }` |
+| `matchEnded`   | Same payload as `roundEnded`                                 |
+| `error`        | `{ message: string }`                                        |
+
 ---
 
 ## User Stories

--- a/src/helpers/battleEngineFacade.js
+++ b/src/helpers/battleEngineFacade.js
@@ -202,6 +202,30 @@ export const isMatchEnded = () => battleEngine.isMatchEnded();
  */
 export const getTimerState = () => battleEngine.getTimerState();
 
+/**
+ * Subscribe to battle engine events.
+ *
+ * @pseudocode
+ * 1. Delegate to `battleEngine.on(type, handler)`.
+ *
+ * @param {string} type - Event name.
+ * @param {(payload: any) => void} handler - Callback for the event.
+ * @returns {void}
+ */
+export const on = (type, handler) => battleEngine?.on?.(type, handler);
+
+/**
+ * Unsubscribe from battle engine events.
+ *
+ * @pseudocode
+ * 1. Delegate to `battleEngine.off(type, handler)`.
+ *
+ * @param {string} type - Event name.
+ * @param {(payload: any) => void} handler - Callback for the event.
+ * @returns {void}
+ */
+export const off = (type, handler) => battleEngine?.off?.(type, handler);
+
 // Internal test helper removed; tests should instantiate engines via `createBattleEngine()`.
 
 /**

--- a/src/helpers/classicBattle/roundResolver.js
+++ b/src/helpers/classicBattle/roundResolver.js
@@ -1,9 +1,20 @@
 import { evaluateRound as evaluateRoundApi } from "../api/battleUI.js";
 import { dispatchBattleEvent } from "./orchestrator.js";
 import { emitBattleEvent } from "./battleEvents.js";
+import { on as onEngine } from "../battleEngineFacade.js";
 import { resetStatButtons } from "../battle/battleUI.js";
 import { exposeDebugState, readDebugState } from "./debugHooks.js";
 import { debugLog } from "../debug.js";
+
+if (typeof onEngine === "function") {
+  onEngine("roundEnded", (detail) => {
+    emitBattleEvent("roundResolved", detail);
+  });
+
+  onEngine("matchEnded", (detail) => {
+    emitBattleEvent("matchOver", detail);
+  });
+}
 
 /**
  * Round resolution helpers and orchestrator for Classic Battle.

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -13,7 +13,8 @@ import {
   createBattleEngine,
   setPointsToWin,
   getPointsToWin,
-  getScores
+  getScores,
+  on as onEngine
 } from "../helpers/battleEngineFacade.js";
 import statNamesData from "../data/statNames.js";
 import { createModal } from "../components/Modal.js";
@@ -38,6 +39,19 @@ import * as debugHooks from "../helpers/classicBattle/debugHooks.js";
 import { setAutoContinue, autoContinue } from "../helpers/classicBattle/orchestratorHandlers.js";
 
 createBattleEngine();
+
+if (typeof onEngine === "function") {
+  onEngine("timerTick", ({ remaining, phase }) => {
+    if (phase === "round") {
+      const el = byId("cli-timer");
+      if (el) el.textContent = String(remaining);
+    }
+  });
+
+  onEngine("matchEnded", ({ outcome }) => {
+    setRoundMessage(`Match over: ${outcome}`);
+  });
+}
 
 function disposeClassicBattleOrchestrator() {
   try {

--- a/tests/helpers/battleEngine/events.test.js
+++ b/tests/helpers/battleEngine/events.test.js
@@ -1,0 +1,38 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+import { BattleEngine } from "../../../src/helpers/BattleEngine.js";
+
+describe("BattleEngine events", () => {
+  it("emits roundStarted and timerTick", async () => {
+    const engine = new BattleEngine();
+    engine.timer.startRound = vi.fn(async (onTick) => {
+      onTick(3);
+    });
+    const started = vi.fn();
+    const tick = vi.fn();
+    engine.on("roundStarted", started);
+    engine.on("timerTick", tick);
+    await engine.startRound();
+    expect(started).toHaveBeenCalledWith({ round: 1 });
+    expect(tick).toHaveBeenCalledWith({ remaining: 3, phase: "round" });
+  });
+
+  it("emits roundEnded and matchEnded", () => {
+    const engine = new BattleEngine({ pointsToWin: 1 });
+    const roundEnd = vi.fn();
+    const matchEnd = vi.fn();
+    engine.on("roundEnded", roundEnd);
+    engine.on("matchEnded", matchEnd);
+    const result = engine.handleStatSelection(10, 5);
+    expect(roundEnd).toHaveBeenCalledWith(result);
+    expect(matchEnd).toHaveBeenCalledWith(result);
+  });
+
+  it("emits error", () => {
+    const engine = new BattleEngine();
+    const err = vi.fn();
+    engine.on("error", err);
+    engine.handleError("fail");
+    expect(err).toHaveBeenCalledWith({ message: "fail" });
+  });
+});


### PR DESCRIPTION
## Summary
- emit core battle engine events and expose a tiny emitter API
- bridge engine events to classic battle and CLI layers
- document and test new battle engine event hooks

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: No "createBattleEngine" export defined in mocks)*
- `npx playwright test` *(fails: Timed out waiting for battle state "waitingForPlayerAction")*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b747c173048326b0ca96496aa00cd6