### PR TITLE
docs(agent): centralize import policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,9 @@ Even if you’re not directly searching client_embeddings.json or offline_rag_me
 
 ## 🔧 Module Loading Policy for Agents
 
+> This section is the canonical source for JU-DO-KON!'s static vs dynamic import rules.
+> Update this section when import policy changes; other docs link here.
+
 > JU-DO-KON! runs unbundled on GitHub Pages, relying on native ES modules.
 
 When reviewing or modifying imports, agents must apply the JU-DO-KON! static vs dynamic policy to ensure gameplay remains smooth and errors surface early.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,31 +131,9 @@ To keep CI and local runs readable, **no test should emit unsilenced `console.wa
 
 ---
 
-## 🧭 Static vs Dynamic Import Checklist
+## 🧭 Module Loading Policy
 
-When contributing code, especially in gameplay or input-related areas, follow these rules for module loading:
-
-### ✅ Use Static Imports When:
-
-- Code runs on a **hot path**:
-  - Stat selection handlers
-  - Round decision logic
-  - Event dispatchers / orchestrators
-  - Per-frame animation or rendering in battle
-- Code is **always required** in a normal play session.
-- Breakage should be detected at build/startup (fail fast).
-
-### ✅ Use Dynamic Imports (with Preload) When:
-
-- The module is **optional** or **infrequently used** (e.g., Settings, Tooltip Viewer, Credits).
-- The module is **heavy** or behind a **feature flag** (e.g., canvas/WebGL renderer, debug panels, markdown/HL libs).
-- You can **preload** it during idle/cooldown to hide latency.
-
-### 🚫 Anti-Patterns to Avoid:
-
-- ❌ `await import()` inside click/input handlers for core gameplay.
-- ❌ Removing feature flag checks during refactor.
-- ❌ Adding heavy optional modules to the initial bundle without justification.
+Use static imports for hot paths and always-required modules; use dynamic imports with preload for optional or heavy features. See the canonical [Module Loading Policy for Agents](./AGENTS.md#module-loading-policy-for-agents) for the full policy.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -238,24 +238,9 @@ It reads `scripts/evaluation/queries.json` and reports **MRR@5**, **Recall@3**, 
    ```
 
    The browser path continues to load embeddings via the manifest + shard loader, so no changes are required there.
-## ⚡ Module Loading Policy: Static vs Dynamic Imports
+## ⚡ Module Loading Policy
 
-JU-DO-KON! favors **deterministic gameplay and snappy input handling**. Use **static imports** for core gameplay; reserve **dynamic imports** (`import('…')`) for optional screens and heavy tools.
-
-**Use static imports when the code:**
-- Runs on a **hot path** (stat selection, round decision, event dispatch, per-frame animation).
-- Is **always required** in a typical play session.
-- Should **fail at build/startup** if broken (orchestrators, rules, event bus).
-
-**Use dynamic imports (with preload) when the code:**
-- Powers **optional** or **infrequent** screens (Settings, Tooltip Viewer, Credits, docs).
-- Is **heavy** or behind a **feature flag** (canvas/WebGL renderer, debug panels, markdown/HL libs).
-- Can be **preloaded** during idle/cooldown to hide latency.
-
-**Hot path (for this project) =**
-- Stat selection handlers → round outcome
-- Rules engine / orchestrators / event dispatchers
-- Animation tick or per-frame rendering used during battle
+Use static imports for hot paths and always-required modules; use dynamic imports with preload for optional or heavy features. See the canonical [Module Loading Policy for Agents](./AGENTS.md#module-loading-policy-for-agents) for the full policy.
 
 ## 🧪 Testing
 


### PR DESCRIPTION
## Summary
- designate `AGENTS.md` as the canonical import policy
- link `README.md` and `CONTRIBUTING.md` to the canonical policy instead of duplicating details

## Testing
- `npm run check:jsdoc` *(fails: missing JSDoc for 187 functions, non-blocking)*
- `npx prettier . --check`
- `npx eslint .` *(warns: tests/helpers/settingsPage.test.js no-unused-vars)*
- `npx vitest run` *(fails: missing createBattleEngine mock exports)*
- `npx playwright test` *(fails: timeout in battle-orientation.spec.js, others interrupted)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68b74d0650348326a1c71899ba8734b0