### PR TITLE
test: expand BattleEngine configuration and event coverage

### DIFF
--- a/tests/helpers/battleEngine/config.test.js
+++ b/tests/helpers/battleEngine/config.test.js
@@ -32,4 +32,17 @@ describe("BattleEngine configuration", () => {
     const content = fs.readFileSync(file, "utf8");
     expect(content).not.toMatch(/classicBattle\/battleDebug/);
   });
+
+  it("supports per-instance overrides without cross-talk", () => {
+    const engineA = new BattleEngine({ pointsToWin: 1, stats: ["x"] });
+    const engineB = new BattleEngine({ pointsToWin: 2, stats: ["y", "z"] });
+
+    engineA.handleStatSelection(10, 5);
+    engineB.handleStatSelection(10, 5);
+
+    expect(engineA.matchEnded).toBe(true);
+    expect(engineB.matchEnded).toBe(false);
+    expect(engineA.stats).toEqual(["x"]);
+    expect(engineB.stats).toEqual(["y", "z"]);
+  });
 });

--- a/tests/helpers/battleEngine/interrupts.test.js
+++ b/tests/helpers/battleEngine/interrupts.test.js
@@ -124,4 +124,32 @@ describe("BattleEngine interrupts", () => {
     expect(engine.lastInterruptReason).toBe("");
     expect(engine.lastError).toBe("");
   });
+
+  it("interruptMatch emits matchEnded", async () => {
+    const { BattleEngine } = await import("../../../src/helpers/BattleEngine.js");
+    const engine = new BattleEngine();
+    const end = vi.fn();
+    engine.on("matchEnded", end);
+    await engine.startRound(
+      () => {},
+      () => {},
+      5
+    );
+    engine.interruptMatch("injury");
+    expect(end).toHaveBeenCalled();
+  });
+
+  it("interruptRound does not emit matchEnded", async () => {
+    const { BattleEngine } = await import("../../../src/helpers/BattleEngine.js");
+    const engine = new BattleEngine();
+    const end = vi.fn();
+    engine.on("matchEnded", end);
+    await engine.startRound(
+      () => {},
+      () => {},
+      5
+    );
+    engine.interruptRound("pause");
+    expect(end).not.toHaveBeenCalled();
+  });
 });

--- a/tests/helpers/battleEngine/multipleInstances.test.js
+++ b/tests/helpers/battleEngine/multipleInstances.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+import { BattleEngine } from "../../../src/helpers/BattleEngine.js";
+
+describe("BattleEngine multiple instances", () => {
+  it("operate independently", () => {
+    const engineA = new BattleEngine({ pointsToWin: 1, stats: ["a"] });
+    const engineB = new BattleEngine({ pointsToWin: 2, stats: ["b"] });
+    const aEnd = vi.fn();
+    const bEnd = vi.fn();
+    engineA.on("matchEnded", aEnd);
+    engineB.on("matchEnded", bEnd);
+
+    engineA.handleStatSelection(10, 5);
+    expect(engineA.matchEnded).toBe(true);
+    expect(engineB.matchEnded).toBe(false);
+    expect(aEnd).toHaveBeenCalled();
+    expect(bEnd).not.toHaveBeenCalled();
+    expect(engineB.playerScore).toBe(0);
+
+    engineB.handleStatSelection(10, 5);
+    expect(engineB.matchEnded).toBe(false);
+    engineB.handleStatSelection(8, 4);
+    expect(engineB.matchEnded).toBe(true);
+    expect(bEnd).toHaveBeenCalledTimes(1);
+    expect(aEnd).toHaveBeenCalledTimes(1);
+    expect(engineA.stats).toEqual(["a"]);
+    expect(engineB.stats).toEqual(["b"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add per-instance override tests for BattleEngine configuration
- verify event sequences for normal and interrupted rounds
- ensure multiple BattleEngine instances operate independently

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/helpers/battleEngine/config.test.js tests/helpers/battleEngine/events.test.js tests/helpers/battleEngine/interrupts.test.js tests/helpers/battleEngine/multipleInstances.test.js`
- `npx vitest run` *(fails: No "createBattleEngine" export defined on mock)*
- `npx playwright test` *(fails: locator.click timeout)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b74d3c809083269074b6a8a9c541b8