### PR TITLE
fix: address review feedback on battle engine events

### DIFF
--- a/design/productRequirementsDocuments/prdBattleEngine.md
+++ b/design/productRequirementsDocuments/prdBattleEngine.md
@@ -63,10 +63,10 @@ The engine emits updates through a small event emitter. Listeners may
 subscribe with `on(event, handler)`:
 
 | Event          | Payload                                                      |
-| -------------- | ------------------------------------------------------------ | ------------- |
+| -------------- | ------------------------------------------------------------ |
 | `roundStarted` | `{ round: number }`                                          |
 | `roundEnded`   | `{ delta, outcome, matchEnded, playerScore, opponentScore }` |
-| `timerTick`    | `{ remaining: number, phase: 'round'                         | 'cooldown' }` |
+| `timerTick`    | `{ remaining: number, phase: 'round' \| 'cooldown' }`        |
 | `matchEnded`   | Same payload as `roundEnded`                                 |
 | `error`        | `{ message: string }`                                        |
 

--- a/src/helpers/BattleEngine.js
+++ b/src/helpers/BattleEngine.js
@@ -44,7 +44,9 @@ class SimpleEmitter {
     for (const h of handlers) {
       try {
         h(detail);
-      } catch {}
+      } catch (err) {
+        console.error("Error in event handler for type '" + type + "':", err);
+      }
     }
   }
 }

--- a/src/helpers/classicBattle/bootstrap.js
+++ b/src/helpers/classicBattle/bootstrap.js
@@ -10,6 +10,7 @@ import createClassicBattleDebugAPI from "./setupTestHelpers.js";
 import { onDomReady } from "../domReady.js";
 import { initRoundSelectModal } from "./roundSelectModal.js";
 import { createBattleEngine } from "../battleEngineFacade.js";
+import { bridgeEngineEvents } from "./roundResolver.js";
 
 /**
  * Bootstrap Classic Battle page by wiring controller and view.
@@ -26,6 +27,7 @@ import { createBattleEngine } from "../battleEngineFacade.js";
  */
 export async function setupClassicBattlePage() {
   createBattleEngine();
+  bridgeEngineEvents();
   let debugApi;
   let resolveStart;
   let rejectStart;

--- a/src/helpers/classicBattle/roundResolver.js
+++ b/src/helpers/classicBattle/roundResolver.js
@@ -6,11 +6,11 @@ import { resetStatButtons } from "../battle/battleUI.js";
 import { exposeDebugState, readDebugState } from "./debugHooks.js";
 import { debugLog } from "../debug.js";
 
-if (typeof onEngine === "function") {
+export function bridgeEngineEvents() {
+  if (typeof onEngine !== "function") return;
   onEngine("roundEnded", (detail) => {
     emitBattleEvent("roundResolved", detail);
   });
-
   onEngine("matchEnded", (detail) => {
     emitBattleEvent("matchOver", detail);
   });


### PR DESCRIPTION
## Summary
- correct battle engine PRD event table
- log errors from event handlers
- bridge classic battle events after engine creation

## Testing
- `npm run check:jsdoc`
- `npx prettier design/productRequirementsDocuments/prdBattleEngine.md src/helpers/BattleEngine.js src/helpers/classicBattle/bootstrap.js src/helpers/classicBattle/roundResolver.js --check`
- `npx eslint .`
- `npx vitest run` *(fails: No "OUTCOME" export is defined...)*
- `npx playwright test` *(fails: 12 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b74cf97eec83269da50aee3cf553df