### PR TITLE
docs(agent): add engine usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,32 @@ For debugging or automated tests, append `?autostart=1` to `battleJudoka.html` t
 Note on Next button behavior:
 - The `Next` button advances only during the inter-round cooldown. It remains disabled while choosing a stat to avoid skipping the cooldown logic accidentally. The cooldown enables `Next` (or auto-advances in test mode); do not expect `Next` to be ready during stat selection.
 
+## 🔌 Engine API
+
+```js
+import BattleEngine from "./src/helpers/BattleEngine.js";
+import { renderMessage } from "./src/ui/renderMessage.js";
+
+const engine = new BattleEngine({ pointsToWin: 3 });
+
+const messages = {
+  roundStarted: ({ round }) => `Round ${round} begins`,
+  matchEnded: ({ outcome }) => `Match ${outcome}`,
+};
+
+engine.on("roundStarted", (data) => {
+  renderMessage("#status", messages.roundStarted(data));
+});
+
+engine.on("matchEnded", (data) => {
+  renderMessage("#status", messages.matchEnded(data));
+});
+
+engine.start();
+```
+
+`BattleEngine` contains only match logic. A mode subscribes to events and maps them to UI helpers like `renderMessage`, keeping presentation separate from engine code.
+
 ---
 
 ## 🚧 Development Status

--- a/design/productRequirementsDocuments/prdBattleEngine.md
+++ b/design/productRequirementsDocuments/prdBattleEngine.md
@@ -70,6 +70,42 @@ subscribe with `on(event, handler)`:
 | `matchEnded`   | Same payload as `roundEnded`                                 |
 | `error`        | `{ message: string }`                                        |
 
+### Example Integration
+
+```js
+import BattleEngine from "../../src/helpers/BattleEngine.js";
+import { renderMessage } from "../../src/ui/renderMessage.js";
+
+const engine = new BattleEngine({ pointsToWin: 3 });
+
+// map engine events to UI messages
+const messages = {
+  roundStarted: ({ round }) => ({
+    surface: "#status",
+    text: `Round ${round} begins`
+  }),
+  matchEnded: ({ outcome }) => ({
+    surface: "#status",
+    text: `Match ${outcome}`
+  })
+};
+
+// subscribe without coupling engine to the DOM
+engine.on("roundStarted", (payload) => {
+  const { surface, text } = messages.roundStarted(payload);
+  renderMessage(surface, text);
+});
+
+engine.on("matchEnded", (payload) => {
+  const { surface, text } = messages.matchEnded(payload);
+  renderMessage(surface, text);
+});
+
+engine.start();
+```
+
+The engine runs purely on logic; UI helpers receive events and decide how to render them.
+
 ---
 
 ## User Stories

--- a/design/productRequirementsDocuments/prdGameModes.md
+++ b/design/productRequirementsDocuments/prdGameModes.md
@@ -56,6 +56,42 @@ Improving session variety directly supports retention and encourages more person
 - Mode entry and exit flows should be clear to prevent disorientation.
 - Mode exit returns to the map with confirmation ("Are you sure?").
 
+### Engine Integration Example
+
+```js
+import BattleEngine from "../../src/helpers/BattleEngine.js";
+import { renderMessage } from "../../src/ui/renderMessage.js";
+
+export function startTrainingMode() {
+  const engine = new BattleEngine({ pointsToWin: 1 });
+
+  const messages = {
+    roundStarted: ({ round }) => ({
+      surface: "#status",
+      text: `Round ${round}`
+    }),
+    matchEnded: ({ outcome }) => ({
+      surface: "#status",
+      text: `Match ${outcome}`
+    })
+  };
+
+  engine.on("roundStarted", (payload) => {
+    const { surface, text } = messages.roundStarted(payload);
+    renderMessage(surface, text);
+  });
+
+  engine.on("matchEnded", (payload) => {
+    const { surface, text } = messages.matchEnded(payload);
+    renderMessage(surface, text);
+  });
+
+  engine.start();
+}
+```
+
+The engine contains no UI code. Game modes translate events into messages and decide how to present them.
+
 ---
 
 ## Prioritized Functional Requirements


### PR DESCRIPTION
## Summary
- document how to instantiate the battle engine and map events to UI messages
- show new game mode engine example in the game modes PRD
- add Engine API snippet to README for quick integration reference

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .` *(warn: defaultSettings is defined but never used)*
- `npx vitest run` *(fails: No "createBattleEngine" export defined on mock)*
- `npx playwright test` *(fails: locator.click timeout on #round-select-1)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b74d375cb08326abd4c846685ad3d9