### PR TITLE
fix: address review feedback on battle engine events

### DIFF
--- a/tests/helpers/classicBattle/rebindEngineEvents.test.js
+++ b/tests/helpers/classicBattle/rebindEngineEvents.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Ensure engine events are rebound when resetting the game.
+describe("_resetForTest", () => {
+  it("rebinds engine events after engine recreation", async () => {
+    const on = vi.fn();
+    vi.doMock("../../../src/helpers/battleEngineFacade.js", () => ({
+      createBattleEngine: vi.fn(),
+      on
+    }));
+    const { initClassicBattleTest } = await import("../initClassicBattleTest.js");
+    await initClassicBattleTest({ afterMock: true });
+    const { _resetForTest } = await import("../../../src/helpers/classicBattle/roundManager.js");
+    on.mockClear();
+    _resetForTest({});
+    expect(on).toHaveBeenCalledWith("roundEnded", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("matchEnded", expect.any(Function));
+  });
+});


### PR DESCRIPTION
## Summary
- correct battle engine PRD event table
- log errors from event handlers
- bridge classic battle events after engine creation
- rebind engine events on replay and test resets

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Test Files 40 failed | 179 passed)*
- `npx playwright test` *(fails: 12 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b752fcb1208326b66eb24c7d35f391