### PR TITLE
chore: use grep counts for doc sync

### DIFF
--- a/.github/workflows/syncAgentDocs.yml
+++ b/.github/workflows/syncAgentDocs.yml
@@ -131,8 +131,8 @@ jobs:
           set -euo pipefail
           DIFF=$(git diff --unified=0 -- AGENTS.md || true)
 
-          ADDED=$(printf "%s" "$DIFF" | grep -E '^\+' | grep -vE '^\+\+\+' | wc -l | tr -d ' ' || echo 0)
-          REMOVED=$(printf "%s" "$DIFF" | grep -E '^\-' | grep -vE '^\-\-\-' | wc -l | tr -d ' ' || echo 0)
+          ADDED=$(printf "%s" "$DIFF" | grep -cE '^\+[^+]')
+          REMOVED=$(printf "%s" "$DIFF" | grep -cE '^-[^-]')
           TOTAL=$((ADDED + REMOVED))
 
           if   [ "$TOTAL" -lt 20 ];  then MOOD="Tiny tune-up 🎻"


### PR DESCRIPTION
## Summary
- use `grep -c` for added/removed line counts in agent docs workflow

## Testing
- `npx prettier .github/workflows/syncAgentDocs.yml --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: playwright/prd-reader.spec.js sidebar-tab-traversal)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b772e797988326882198270fa65b1a