### PR TITLE
test: cleanup classic battle flags timers

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ src/data/client_embeddings.meta.json
 src/data/client_embeddings.shard.*.json
 src/data/client_embeddings.manifest.json
 src/data/offline_rag_metadata.json
+eslint-dry.json

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { _resetForTest } from "../../src/helpers/classicBattle/roundManager.js";
 
 vi.mock("../../src/utils/scheduler.js", () => ({
   start: vi.fn(),
@@ -12,6 +13,14 @@ describe("classicBattlePage feature flag updates", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
     vi.resetModules();
+  });
+
+  afterEach(() => {
+    _resetForTest();
+    try {
+      vi.runOnlyPendingTimers();
+      vi.clearAllTimers();
+    } catch {}
   });
 
   it("reacts to viewportSimulation and enableTestMode changes", async () => {


### PR DESCRIPTION
## Summary
- reset round manager and clear timers after each classicBattleFlags test
- ignore generated eslint-dry.json in Prettier checks

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b778a393e08326b5ecd47f79969fea