### PR TITLE
fix: guard grep counts in doc sync

### DIFF
--- a/.github/workflows/syncAgentDocs.yml
+++ b/.github/workflows/syncAgentDocs.yml
@@ -131,8 +131,8 @@ jobs:
           set -euo pipefail
           DIFF=$(git diff --unified=0 -- AGENTS.md || true)
 
-          ADDED=$(printf "%s" "$DIFF" | grep -cE '^\+[^+]')
-          REMOVED=$(printf "%s" "$DIFF" | grep -cE '^-[^-]')
+          ADDED=$(printf "%s" "$DIFF" | grep -cE '^\+[^+]' || echo 0)
+          REMOVED=$(printf "%s" "$DIFF" | grep -cE '^-[^-]' || echo 0)
           TOTAL=$((ADDED + REMOVED))
 
           if   [ "$TOTAL" -lt 20 ];  then MOOD="Tiny tune-up 🎻"


### PR DESCRIPTION
## Summary
- add `|| echo 0` fallback when counting added/removed lines in syncAgentDocs workflow

## Testing
- `npx prettier . --check` *(fails: eslint-dry.json code style issues)*
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 171 missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": [".github/workflows/syncAgentDocs.yml"],
  "outputs": [".github/workflows/syncAgentDocs.yml"],
  "success": [
    "prettier: FAIL",
    "eslint: PASS",
    "jsdoc: FAIL",
    "vitest: PASS",
    "playwright: PASS",
    "contrast: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `.github/workflows/syncAgentDocs.yml`: guard grep counts against zero matches to avoid failing the workflow

## Verification
- `npx prettier . --check` *(fails: eslint-dry.json code style issues)*
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 171 missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Risk
- Low: adjusts shell script in CI workflow

## Follow-Up
- Investigate repository-wide Prettier and JSDoc warnings

------
https://chatgpt.com/codex/tasks/task_e_68b7779a8a5883269c33ca8da28a7276