### PR TITLE
fix: guard grep counts in doc sync

### DIFF
--- a/.github/workflows/syncAgentDocs.yml
+++ b/.github/workflows/syncAgentDocs.yml
@@ -131,8 +131,10 @@ jobs:
           set -euo pipefail
           DIFF=$(git diff --unified=0 -- AGENTS.md || true)
 
-          ADDED=$(printf "%s" "$DIFF" | grep -cE '^\+[^+]' || echo 0)
-          REMOVED=$(printf "%s" "$DIFF" | grep -cE '^-[^-]' || echo 0)
+          ADDED=$(printf "%s" "$DIFF" | grep -cE '^\+[^+]' || true)
+          REMOVED=$(printf "%s" "$DIFF" | grep -cE '^-[^-]' || true)
+          ADDED=${ADDED:-0}
+          REMOVED=${REMOVED:-0}
           TOTAL=$((ADDED + REMOVED))
 
           if   [ "$TOTAL" -lt 20 ];  then MOOD="Tiny tune-up 🎻"


### PR DESCRIPTION
## Summary
- ignore non-zero grep exit status and default line counts to 0 so doc sync summary handles empty diffs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 171 missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": [".github/workflows/syncAgentDocs.yml"],
  "outputs": [".github/workflows/syncAgentDocs.yml"],
  "success": [
    "prettier: PASS",
    "eslint: PASS",
    "jsdoc: FAIL",
    "vitest: PASS",
    "playwright: PASS",
    "contrast: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `.github/workflows/syncAgentDocs.yml`: handle zero-match grep counts without duplicating output

## Verification
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 171 missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Risk
- Low: updates shell logic in CI workflow

## Follow-Up
- Investigate repository-wide JSDoc warnings

------
https://chatgpt.com/codex/tasks/task_e_68b7e20979ec8326bb12350817beca33