### PR TITLE
test: cleanup classic battle flags timers

### DIFF
--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { _resetForTest } from "../../src/helpers/classicBattle/roundManager.js";
 
 vi.mock("../../src/utils/scheduler.js", () => ({
   start: vi.fn(),
@@ -15,7 +14,10 @@ describe("classicBattlePage feature flag updates", () => {
     vi.resetModules();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    const { _resetForTest } = await vi.importActual(
+      "../../src/helpers/classicBattle/roundManager.js"
+    );
     _resetForTest();
     try {
       vi.runOnlyPendingTimers();


### PR DESCRIPTION
## Summary
- reset round manager and clear timers after each classicBattleFlags test
- ignore generated eslint-dry.json in Prettier checks
- dynamically import roundManager reset hook so mocks stay in place

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run` (fails: No "importJsonModule" export defined in dataUtils mock)
- `npx playwright test` (1 test interrupted, 75 skipped)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b7e18438648326aba7c7ff871c2bbf