### PR TITLE
Handle Escape key in Battle CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ npm run check:jsdoc && npx prettier . --check && npx eslint . && npx vitest run 
 ### Classic Battle CLI (text-first)
 
 - Page: `src/pages/battleCLI.html` – terminal-style UI that reuses the Classic Battle engine/state machine.
-- Controls: number keys [1–5] select stats, Enter/Space advances, Q quits, H toggles a help panel (also closable via button). Stats can also be selected by clicking or tapping, and rounds can be advanced with a click. Closing the help panel with its button ignores the next background click to avoid accidental advancement.
+- Controls: number keys [1–5] select stats, Enter/Space advances, Q quits, H toggles a help panel, and Esc closes help or quit dialogs. Stats can also be selected by clicking or tapping, and rounds can be advanced with a click. Closing the help panel with its button ignores the next background click to avoid accidental advancement.
 - State badge: `#battle-state-badge` reflects the current machine state.
 - Bottom line: snackbars render as a single status line using `#snackbar-container`.
 - Win target: choose 5/10/15 from the header; persisted in localStorage under `battleCLI.pointsToWin`.

--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -79,21 +79,21 @@ The animated Classic Battle UI can be heavy for low-spec devices and noisy for p
 
 ## Functional Requirements (Prioritized)
 
-| Prio   | Feature                 | Requirement                                                                                                                                                       |
-| ------ | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **P1** | **Engine Parity**       | Reuse the Classic Battle engine/state table verbatim; no logic forks.                                                                                             |
-| **P1** | **Text Renderer**       | Render prompts, countdown, stat list (with numeric hotkeys), outcome, and score in a monospace pane. No images/animations.                                        |
-| **P1** | **Keyboard Controls**   | `1–5` select stat; `Enter`/`Space` advance; `H` help; `Q` quit/confirm; keys are debounced per state. Stat selection can be overwritten before timeout.           |
-| **P1** | **Pointer/Touch**       | Click/tap on stat rows to select (≥44px tall targets); a visible **Next** control appears post-round.                                                             |
-| **P1** | **Timer Display**       | 1 Hz textual countdown for selection window; expiry behavior mirrors engine (see Feature Flags).                                                                  |
-| **P1** | **Outcome & Score**     | Print Win/Loss/Draw and show both compared values; update score immediately.                                                                                      |
-| **P1** | **Accessibility Hooks** | Announce prompts/timers/outcomes via `aria-live="polite"` / `role="status"`, logical focus order, visible focus ring.                                             |
-| **P1** | **Test Hooks**          | Provide stable selectors: `#cli-root`, `#cli-header`, `#cli-countdown`, `#cli-stats`, `#round-message`, `#cli-score`; expose `data-round`, `data-remaining-time`. |
-| **P2** | **Settings (Minimal)**  | Win target selector (5/10/15). Changing value offers to reset match; persist choice locally via `localStorage`. Invalid values reset to defaults.                 |
-| **P2** | **Deterministic Seed**  | Input and `?seed=` param; store last seed; seed drives PRNG used by engine/selection tie-breakers. Invalid seeds revert to default.                               |
-| **P2** | **Round Context**       | Header shows “Round X” and win target; optional state badge mirrors engine state.                                                                                 |
-| **P2** | **Observability Mode**  | Feature-flagged verbose log view echoing state transitions and key events.                                                                                        |
-| **P2** | **Interrupt Handling**  | Quit confirmation pauses timers; cancel resumes; confirm ends/rolls back per engine rules.                                                                        |
+| Prio   | Feature                 | Requirement                                                                                                                                                                  |
+| ------ | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **P1** | **Engine Parity**       | Reuse the Classic Battle engine/state table verbatim; no logic forks.                                                                                                        |
+| **P1** | **Text Renderer**       | Render prompts, countdown, stat list (with numeric hotkeys), outcome, and score in a monospace pane. No images/animations.                                                   |
+| **P1** | **Keyboard Controls**   | `1–5` select stat; `Enter`/`Space` advance; `H` help; `Q` quit/confirm; `Esc` close dialogs; keys are debounced per state. Stat selection can be overwritten before timeout. |
+| **P1** | **Pointer/Touch**       | Click/tap on stat rows to select (≥44px tall targets); a visible **Next** control appears post-round.                                                                        |
+| **P1** | **Timer Display**       | 1 Hz textual countdown for selection window; expiry behavior mirrors engine (see Feature Flags).                                                                             |
+| **P1** | **Outcome & Score**     | Print Win/Loss/Draw and show both compared values; update score immediately.                                                                                                 |
+| **P1** | **Accessibility Hooks** | Announce prompts/timers/outcomes via `aria-live="polite"` / `role="status"`, logical focus order, visible focus ring.                                                        |
+| **P1** | **Test Hooks**          | Provide stable selectors: `#cli-root`, `#cli-header`, `#cli-countdown`, `#cli-stats`, `#round-message`, `#cli-score`; expose `data-round`, `data-remaining-time`.            |
+| **P2** | **Settings (Minimal)**  | Win target selector (5/10/15). Changing value offers to reset match; persist choice locally via `localStorage`. Invalid values reset to defaults.                            |
+| **P2** | **Deterministic Seed**  | Input and `?seed=` param; store last seed; seed drives PRNG used by engine/selection tie-breakers. Invalid seeds revert to default.                                          |
+| **P2** | **Round Context**       | Header shows “Round X” and win target; optional state badge mirrors engine state.                                                                                            |
+| **P2** | **Observability Mode**  | Feature-flagged verbose log view echoing state transitions and key events.                                                                                                   |
+| **P2** | **Interrupt Handling**  | Quit confirmation pauses timers; cancel resumes; confirm ends/rolls back per engine rules.                                                                                   |
 
 ### Feature Flags (Configurable)
 
@@ -110,7 +110,7 @@ The animated Classic Battle UI can be heavy for low-spec devices and noisy for p
 ### Layout (single column, desktop & mobile)
 
 +––––––––––––––––––––––––––+
-| Classic Battle — CLI Round 2 Target: 5   |
+| Classic Battle — CLI Round 2 Target: 5 |
 | [State: waitingForPlayerAction] [Score: 1–1] |
 +––––––––––––––––––––––––––+
 
@@ -125,7 +125,7 @@ Choose a stat:
 Last round: You WON (Technique 9 vs 7)  
 Match Outcome: You WON (9 vs 7)
 
-Shortcuts: [1–5] Select [Enter]/[Space] Next [H] Help [Q] Quit
+Shortcuts: [1–5] Select [Enter]/[Space] Next [H] Help [Q] Quit [Esc] Back
 
 **Sections**
 
@@ -133,12 +133,12 @@ Shortcuts: [1–5] Select [Enter]/[Space] Next [H] Help [Q] Quit
 - **Prompt Area:** timer + instruction.
 - **Stat List:** numbered rows; whole row is focusable/clickable; shows value; each row ≥44px tall for tap targets.
 - **Round Message:** outcome and compared values.
-- **Shortcuts/Help:** inline hints; help panel toggled with `H`.
+- **Shortcuts/Help:** inline hints; help panel toggled with `H` and closed with `Esc`.
 - **Settings (collapsible):** win target, seed, verbose toggle (remembered).
 
 **Focus & Navigation**
 
-- On stat selection phase: focus moves to the **stat list container**; arrow keys cycle rows; `1–9` selects. 
+- On stat selection phase: focus moves to the **stat list container**; arrow keys cycle rows; `1–9` selects.
 - Opening Help/Settings moves focus inside; closing restores prior focus.
 
 **Styling**
@@ -194,8 +194,8 @@ Shortcuts: [1–5] Select [Enter]/[Space] Next [H] Help [Q] Quit
 
 - **Given** stat selection, **when** the user presses `1–5` for a visible stat, **then** that stat is selected once and input is debounced until next state.
 - **Given** round resolved, **when** `Enter` or `Space` is pressed, **then** next phase begins (or next round if in cooldown).
-- **Given** active match, **when** `Q` is pressed, **then** a quit confirmation appears; **confirm** ends/rolls back per rules; **cancel** resumes timers.
-- **Given** help is hidden, **when** `H` is pressed, **then** help opens and is closable via `H` or Close.
+- **Given** active match, **when** `Q` is pressed, **then** a quit confirmation appears; **confirm** ends/rolls back per rules; **cancel** or `Esc` resumes timers.
+- **Given** help is hidden, **when** `H` is pressed, **then** help opens and is closable via `H`, `Esc`, or Close.
 
 ### Timer
 

--- a/tests/pages/battleCLI.escape.test.js
+++ b/tests/pages/battleCLI.escape.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { __resetBattleEventTarget } from "../../src/helpers/classicBattle/battleEvents.js";
+import * as debugHooks from "../../src/helpers/classicBattle/debugHooks.js";
+
+describe("battleCLI Escape key", () => {
+  let store, mod;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    __resetBattleEventTarget();
+    window.__TEST__ = true;
+    store = {};
+    vi.spyOn(debugHooks, "exposeDebugState").mockImplementation((k, v) => {
+      store[k] = v;
+    });
+    vi.spyOn(debugHooks, "readDebugState").mockImplementation((k) => store[k]);
+    vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+      dispatchBattleEvent: vi.fn()
+    }));
+    vi.doMock("../../src/components/Button.js", () => ({
+      createButton: (label, opts = {}) => {
+        const btn = document.createElement("button");
+        if (opts.id) btn.id = opts.id;
+        if (opts.className) btn.className = opts.className;
+        btn.textContent = label;
+        return btn;
+      }
+    }));
+    mod = await import("../../src/pages/battleCLI.js");
+    document.body.innerHTML = `
+      <div id="cli-root">
+        <div id="cli-main"><button id="focus-me"></button></div>
+      </div>
+      <div id="cli-shortcuts" hidden>
+        <button id="cli-shortcuts-close"></button>
+      </div>
+      <div id="cli-countdown" aria-live="polite"></div>
+      <div id="snackbar-container"></div>
+      <div id="modal-container"></div>
+    `;
+    document.body.className = "";
+    document.body.dataset.battleState = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    document.body.className = "";
+    delete document.body.dataset.battleState;
+    debugHooks.exposeDebugState("getClassicBattleMachine", undefined);
+    delete window.__TEST__;
+    vi.resetModules();
+    vi.doUnmock("../../src/components/Button.js");
+    vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+    vi.restoreAllMocks();
+  });
+
+  it("closes shortcuts with Escape and restores focus", () => {
+    const focusBtn = document.getElementById("focus-me");
+    focusBtn.focus();
+    mod.onKeyDown(new KeyboardEvent("keydown", { key: "h" }));
+    const sec = document.getElementById("cli-shortcuts");
+    expect(sec.hidden).toBe(false);
+    mod.onKeyDown(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(sec.hidden).toBe(true);
+    expect(document.activeElement).toBe(focusBtn);
+  });
+
+  it("closes quit modal with Escape", () => {
+    mod.onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
+    const confirm = document.getElementById("confirm-quit-button");
+    expect(confirm).toBeTruthy();
+    mod.onKeyDown(new KeyboardEvent("keydown", { key: "Escape" }));
+    const backdrop = confirm.closest(".modal-backdrop");
+    expect(backdrop?.hasAttribute("hidden")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Escape handling to global CLI key handler to close help panel or quit dialog and restore focus
- Cover Escape behavior for help and quit flows with new tests
- Document Escape shortcut in README and Battle CLI design spec

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b7f07a55c88326892e7409cd25680a