### PR TITLE
feat(cli): hint invalid stat keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ When the `enableTestMode` feature flag is active, a debug panel appears above th
 ### Stat Hotkeys
 
 Enable the `statHotkeys` feature flag to map number keys 1–5 to stat buttons for quicker selection. Disabled by default.
+Invalid numeric keys now trigger a hint: "Use 1-5, press H for help".
 
 
 Screenshot suites store their baseline images in `playwright/*-snapshots/`. To skip running these comparison tests locally, set the `SKIP_SCREENSHOTS` environment variable:

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -31,6 +31,7 @@ import { BATTLE_POINTS_TO_WIN } from "../config/storageKeys.js";
 import { POINTS_TO_WIN_OPTIONS } from "../config/battleDefaults.js";
 import * as debugHooks from "../helpers/classicBattle/debugHooks.js";
 import { setAutoContinue, autoContinue } from "../helpers/classicBattle/orchestratorHandlers.js";
+import { SNACKBAR_REMOVE_MS } from "../helpers/constants.js";
 
 // Initialize engine and subscribe to engine events when available.
 try {
@@ -382,6 +383,28 @@ function showBottomLine(text) {
       } catch {}
     }
   } catch {}
+}
+
+/**
+ * Display a short-lived snackbar hint without clearing the countdown.
+ *
+ * @pseudocode
+ * container = document.getElementById("snackbar-container")
+ * if container missing: return
+ * create div.snackbar.show with message
+ * append to container
+ * after SNACKBAR_REMOVE_MS milliseconds remove div
+ *
+ * @param {string} text - Hint text to display.
+ */
+function showHint(text) {
+  const container = byId("snackbar-container");
+  if (!container) return;
+  const bar = document.createElement("div");
+  bar.className = "snackbar show";
+  bar.textContent = text;
+  container.appendChild(bar);
+  setTimeout(() => bar.remove(), SNACKBAR_REMOVE_MS);
 }
 
 /**
@@ -1014,17 +1037,22 @@ export function handleGlobalKey(key) {
  * @param {string} key - Normalized single-character key value (e.g., '1').
  * @returns {boolean} True when the key was handled and resulted in a selection.
  * @pseudocode
- * if key is between '1' and '9':
- *   lookup stat by index
- *   if stat missing: return false
+ * if key is a digit:
+ *   stat = getStatByIndex(key)
+ *   if stat missing:
+ *     showHint("Use 1-5, press H for help")
+ *     return false
  *   selectStat(stat)
  *   return true
  * return false
  */
 export function handleWaitingForPlayerActionKey(key) {
-  if (key >= "1" && key <= "9") {
+  if (key >= "0" && key <= "9") {
     const stat = getStatByIndex(key);
-    if (!stat) return false;
+    if (!stat) {
+      showHint("Use 1-5, press H for help");
+      return false;
+    }
     selectStat(stat);
     return true;
   }

--- a/tests/pages/battleCLI.invalidNumber.test.js
+++ b/tests/pages/battleCLI.invalidNumber.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+async function loadBattleCLI() {
+  const emitter = new EventTarget();
+  const startRound = vi.fn();
+  vi.doMock("../../src/helpers/featureFlags.js", () => ({
+    initFeatureFlags: vi.fn(),
+    isEnabled: vi.fn().mockReturnValue(false),
+    setFlag: vi.fn(),
+    featureFlagsEmitter: emitter
+  }));
+  vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+    createBattleStore: vi.fn(),
+    startRound,
+    resetGame: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    onBattleEvent: vi.fn(),
+    emitBattleEvent: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: ["speed", "strength"] }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    setPointsToWin: vi.fn(),
+    getPointsToWin: vi.fn(),
+    getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 }))
+  }));
+  vi.doMock("../../src/helpers/dataUtils.js", () => ({
+    fetchJson: vi.fn().mockResolvedValue([
+      { statIndex: 1, name: "Speed" },
+      { statIndex: 2, name: "Strength" }
+    ])
+  }));
+  vi.doMock("../../src/helpers/constants.js", () => ({
+    DATA_DIR: "",
+    SNACKBAR_REMOVE_MS: 3000
+  }));
+  const mod = await import("../../src/pages/battleCLI.js");
+  return { mod };
+}
+
+describe("battleCLI invalid number hint", () => {
+  beforeEach(() => {
+    window.__TEST__ = true;
+    document.body.innerHTML = `
+      <div id="cli-stats"></div>
+      <ul id="cli-help"></ul>
+      <div id="snackbar-container"></div>
+      <div id="player-card"></div>
+    `;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.__TEST__;
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doUnmock("../../src/helpers/featureFlags.js");
+    vi.doUnmock("../../src/helpers/classicBattle/roundManager.js");
+    vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+    vi.doUnmock("../../src/helpers/classicBattle/battleEvents.js");
+    vi.doUnmock("../../src/helpers/BattleEngine.js");
+    vi.doUnmock("../../src/helpers/battleEngineFacade.js");
+    vi.doUnmock("../../src/helpers/dataUtils.js");
+    vi.doUnmock("../../src/helpers/constants.js");
+  });
+
+  it("shows hint for digits without stats", async () => {
+    const { mod } = await loadBattleCLI();
+    const keys = ["0", "6"];
+    for (const key of keys) {
+      document.getElementById("snackbar-container").innerHTML = "";
+      mod.handleWaitingForPlayerActionKey(key);
+      expect(document.querySelector("#snackbar-container .snackbar")?.textContent).toBe(
+        "Use 1-5, press H for help"
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Task Contract
- inputs: ["src/pages/battleCLI.js", "README.md", "tests/pages/battleCLI.invalidNumber.test.js"]
- outputs: ["src/pages/battleCLI.js", "README.md", "tests/pages/battleCLI.invalidNumber.test.js"]
- success: ["prettier: pass", "eslint: pass (3 warnings)", "jsdoc: 171 missing", "vitest: pass", "playwright: pass", "contrast: pass"]
- errorMode: "continue on jsdoc warnings"

## Summary
- handle numeric keys without stats by showing a hint and leaving countdown intact
- add transient `showHint` snackbar helper and test for invalid digits
- document hint feedback for invalid stat hotkeys

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Risk & Follow-Up
- Low: DOM hint injection is isolated but further JSDoc coverage remains outstanding.


------
https://chatgpt.com/codex/tasks/task_e_68b7fd3173c48326be04145cad3c8eed