### PR TITLE
feat: show target in CLI round header

### DIFF
--- a/src/pages/battleCLI.README.md
+++ b/src/pages/battleCLI.README.md
@@ -17,6 +17,11 @@ await page.evaluate(() => window.__battleCLIinit.setSettingsCollapsed(true));
 
 These helpers are intentionally small and synchronous to keep tests deterministic.
 
+## Round header
+
+The header displays the current round and win target as `Round X Target: Y 🏆`.
+The `#cli-root` element mirrors these values via `data-round` and `data-target`.
+
 ## Stat list interaction
 
 When a round begins, each stat row in `#cli-stats` shows the current player's value in the format `(index) Name: value`. Clicking a row triggers the same selection logic as using the numeric keyboard shortcut.

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -358,7 +358,7 @@
   </head>
   <body>
     <a href="#cli-main" class="skip-link">Skip to main content</a>
-    <div id="cli-root" class="cli-root" data-round="0" data-test="cli-root">
+    <div id="cli-root" class="cli-root" data-round="0" data-target="0" data-test="cli-root">
       <header id="cli-header" class="cli-header" role="banner">
         <div class="cli-title">
           <a href="../../index.html" data-testid="home-link" aria-label="Return to home">Home</a>

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -147,14 +147,18 @@ export const __test = {
  *
  * @pseudocode
  * if round element exists:
- *   set text to `Round ${round} of ${target}`
- * set `data-round` on root element
+ *   set text to `Round ${round} Target: ${target} 🏆`
+ * if root exists:
+ *   set `data-round` and `data-target`
  */
 function updateRoundHeader(round, target) {
   const el = byId("cli-round");
-  if (el) el.textContent = `Round ${round} of ${target}`;
+  if (el) el.textContent = `Round ${round} Target: ${target} 🏆`;
   const root = byId("cli-root");
-  if (root) root.dataset.round = String(round);
+  if (root) {
+    root.dataset.round = String(round);
+    root.dataset.target = String(target);
+  }
 }
 
 function setRoundMessage(text) {
@@ -884,7 +888,8 @@ export function restorePointsToWin() {
       engineFacade.setPointsToWin?.(saved);
       select.value = String(saved);
     }
-    updateRoundHeader(0, engineFacade.getPointsToWin?.());
+    const round = Number(byId("cli-root")?.dataset.round || 0);
+    updateRoundHeader(round, engineFacade.getPointsToWin?.());
     let current = Number(select.value);
     select.addEventListener("change", async () => {
       const val = Number(select.value);
@@ -1479,6 +1484,8 @@ async function init() {
         if (pre) pre.scrollTop = pre.scrollHeight;
       } catch {}
     }
+    const round = Number(byId("cli-root")?.dataset.round || 0);
+    updateRoundHeader(round, engineFacade.getPointsToWin?.());
   };
   try {
     await initFeatureFlags();

--- a/tests/pages/battleCLI.pointsToWin.test.js
+++ b/tests/pages/battleCLI.pointsToWin.test.js
@@ -129,11 +129,39 @@ describe("battleCLI points select", () => {
 
     await waitFor(() => getPointsToWin() === target);
     await waitFor(
-      () => document.getElementById("cli-round").textContent === `Round 0 of ${target}`
+      () => document.getElementById("cli-round").textContent === `Round 0 Target: ${target} 🏆`
     );
 
     expect(getPointsToWin()).toBe(target);
     expect(setPointsToWin).toHaveBeenCalledWith(target);
-    expect(document.getElementById("cli-round").textContent).toBe(`Round 0 of ${target}`);
+    expect(document.getElementById("cli-round").textContent).toBe(`Round 0 Target: ${target} 🏆`);
+  });
+
+  it("keeps target after toggling verbose", async () => {
+    localStorage.setItem(BATTLE_POINTS_TO_WIN, "10");
+    const mod = await loadBattleCLI();
+    await mod.__test.init();
+    const select = document.getElementById("points-select");
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    select.value = "15";
+    select.dispatchEvent(new Event("change"));
+    await waitFor(
+      () => document.getElementById("cli-round").textContent === "Round 0 Target: 15 🏆"
+    );
+
+    const checkbox = document.getElementById("verbose-toggle");
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event("change"));
+    await waitFor(
+      () => document.getElementById("cli-round").textContent === "Round 0 Target: 15 🏆"
+    );
+
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event("change"));
+    await waitFor(
+      () => document.getElementById("cli-round").textContent === "Round 0 Target: 15 🏆"
+    );
+    expect(document.getElementById("cli-round").textContent).toBe("Round 0 Target: 15 🏆");
   });
 });

--- a/tests/pages/battleCLI.roundHeader.test.js
+++ b/tests/pages/battleCLI.roundHeader.test.js
@@ -65,8 +65,10 @@ describe("battleCLI round header", () => {
   it("updates round header each round", async () => {
     const mod = await loadBattleCLI();
     await mod.__test.startRoundWrapper();
-    expect(document.getElementById("cli-round").textContent).toBe("Round 2 of 10");
-    expect(document.getElementById("cli-root").dataset.round).toBe("2");
+    expect(document.getElementById("cli-round").textContent).toBe("Round 2 Target: 10 🏆");
+    const root = document.getElementById("cli-root");
+    expect(root.dataset.round).toBe("2");
+    expect(root.dataset.target).toBe("10");
   });
 
   it("battleCLI.html exposes required selectors", () => {
@@ -75,7 +77,9 @@ describe("battleCLI round header", () => {
     expect(doc.querySelector("#cli-countdown")).toBeTruthy();
     expect(doc.querySelector("#round-message")).toBeTruthy();
     expect(doc.querySelector("#cli-score")).toBeTruthy();
-    expect(doc.querySelector("#cli-root")?.getAttribute("data-round")).not.toBeNull();
+    const root = doc.querySelector("#cli-root");
+    expect(root?.getAttribute("data-round")).not.toBeNull();
+    expect(root?.getAttribute("data-target")).not.toBeNull();
     expect(doc.querySelector("#cli-countdown")?.getAttribute("data-remaining-time")).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- show current target alongside round in CLI header
- keep points target when toggling verbose mode
- document new round header behaviour

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b7fd11c154832680e290de6d3e286a