### PR TITLE
feat: validate battleCLI seed input

### DIFF
--- a/src/pages/battleCLI.README.md
+++ b/src/pages/battleCLI.README.md
@@ -17,6 +17,13 @@ await page.evaluate(() => window.__battleCLIinit.setSettingsCollapsed(true));
 
 These helpers are intentionally small and synchronous to keep tests deterministic.
 
+## Seed validation
+
+The CLI settings panel includes a numeric seed input used for deterministic randomness.
+Only numeric values are accepted. If a non-numeric value is entered, the input reverts to
+the last valid seed and an inline red error message (`Seed must be numeric.`) appears
+under the field. Entering a valid number clears the error.
+
 ## Round header
 
 The header displays the current round and win target as `Round X Target: Y 🏆`.

--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -435,13 +435,16 @@
             </div>
             <div class="cli-settings-row">
               <label for="seed-input">Seed:</label>
-              <input
-                id="seed-input"
-                type="number"
-                inputmode="numeric"
-                aria-label="Deterministic seed (optional)"
-                style="width: 6ch"
-              />
+              <div style="display: flex; flex-direction: column">
+                <input
+                  id="seed-input"
+                  type="number"
+                  inputmode="numeric"
+                  aria-label="Deterministic seed (optional)"
+                  style="width: 6ch"
+                />
+                <div id="seed-error" style="color: #f88; font-size: 12px"></div>
+              </div>
             </div>
           </div>
         </section>

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -302,8 +302,24 @@ async function renderStartButton() {
   main.append(section);
 }
 
+/**
+ * Initialize deterministic seed input and validation.
+ *
+ * @pseudocode
+ * read seed query param and localStorage
+ * define apply(n): enable test mode and persist n
+ * if query param numeric: apply and set input
+ * else if stored seed numeric: populate input
+ * lastValid <- numeric seed used or stored
+ * on input change:
+ *   if value is NaN:
+ *     revert to lastValid and show error
+ *   else:
+ *     clear error, apply value, update lastValid
+ */
 function initSeed() {
   const input = byId("seed-input");
+  const errorEl = byId("seed-error");
   let seedParam = null;
   let storedSeed = null;
   try {
@@ -317,22 +333,37 @@ function initSeed() {
       localStorage.setItem("battleCLI.seed", String(n));
     } catch {}
   };
+  let lastValid = null;
   // Only auto-enable test mode when an explicit seed query param is provided.
   if (seedParam !== null && seedParam !== "") {
     const num = Number(seedParam);
     if (!Number.isNaN(num)) {
       apply(num);
       if (input) input.value = String(num);
+      lastValid = num;
     }
   } else if (storedSeed) {
-    // Populate the input from previous choice without enabling test mode implicitly.
-    if (input) input.value = String(storedSeed);
+    const num = Number(storedSeed);
+    if (!Number.isNaN(num)) {
+      // Populate the input from previous choice without enabling test mode implicitly.
+      if (input) input.value = String(storedSeed);
+      lastValid = num;
+    }
   }
   input?.addEventListener("change", () => {
     const val = Number(input.value);
-    if (!Number.isNaN(val)) {
-      apply(val);
+    if (input.value.trim() === "" || Number.isNaN(val)) {
+      if (lastValid !== null) {
+        input.value = String(lastValid);
+      } else {
+        input.value = "";
+      }
+      if (errorEl) errorEl.textContent = "Seed must be numeric.";
+      return;
     }
+    if (errorEl) errorEl.textContent = "";
+    apply(val);
+    lastValid = val;
   });
 }
 

--- a/tests/pages/battleCLI.seedValidation.test.js
+++ b/tests/pages/battleCLI.seedValidation.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as debugHooks from "../../src/helpers/classicBattle/debugHooks.js";
+import { BATTLE_POINTS_TO_WIN } from "../../src/config/storageKeys.js";
+
+async function loadBattleCLI(seed) {
+  const emitter = new EventTarget();
+  vi.doMock("../../src/helpers/featureFlags.js", () => ({
+    initFeatureFlags: vi
+      .fn()
+      .mockResolvedValue({ featureFlags: { cliVerbose: { enabled: false } } }),
+    isEnabled: vi.fn().mockReturnValue(false),
+    setFlag: vi.fn(),
+    featureFlagsEmitter: emitter
+  }));
+  vi.doMock("../../src/helpers/classicBattle/roundManager.js", () => ({
+    createBattleStore: vi.fn(() => ({})),
+    startRound: vi.fn(),
+    resetGame: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+    initClassicBattleOrchestrator: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    onBattleEvent: vi.fn(),
+    emitBattleEvent: vi.fn()
+  }));
+  vi.doMock("../../src/helpers/BattleEngine.js", () => ({ STATS: [] }));
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    setPointsToWin: vi.fn(),
+    getPointsToWin: vi.fn(() => 5),
+    getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 }))
+  }));
+  vi.doMock("../../src/helpers/dataUtils.js", () => ({
+    fetchJson: vi.fn().mockResolvedValue([{ statIndex: 1, name: "Speed" }])
+  }));
+  vi.doMock("../../src/helpers/constants.js", () => ({ DATA_DIR: "" }));
+  vi.stubGlobal(
+    "location",
+    new URL(
+      seed === undefined
+        ? "http://localhost/battleCLI.html"
+        : `http://localhost/battleCLI.html?seed=${seed}`
+    )
+  );
+  const mod = await import("../../src/pages/battleCLI.js");
+  return mod;
+}
+
+describe("battleCLI seed validation", () => {
+  beforeEach(() => {
+    window.__TEST__ = true;
+    document.body.innerHTML = `
+      <main id="cli-main"></main>
+      <div id="cli-stats"></div>
+      <div id="cli-help"></div>
+      <select id="points-select"></select>
+      <section id="cli-verbose-section" hidden>
+        <pre id="cli-verbose-log"></pre>
+      </section>
+      <input id="verbose-toggle" type="checkbox" />
+      <div style="display:flex;flex-direction:column">
+        <input id="seed-input" type="number" />
+        <div id="seed-error"></div>
+      </div>
+    `;
+    const machine = { dispatch: vi.fn() };
+    debugHooks.exposeDebugState(
+      "getClassicBattleMachine",
+      vi.fn(() => machine)
+    );
+    window.__TEST_MACHINE__ = machine;
+    localStorage.setItem(BATTLE_POINTS_TO_WIN, "5");
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.__TEST__;
+    debugHooks.exposeDebugState("getClassicBattleMachine", undefined);
+    delete window.__TEST_MACHINE__;
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doUnmock("../../src/helpers/featureFlags.js");
+    vi.doUnmock("../../src/helpers/classicBattle/roundManager.js");
+    vi.doUnmock("../../src/helpers/classicBattle/orchestrator.js");
+    vi.doUnmock("../../src/helpers/classicBattle/battleEvents.js");
+    vi.doUnmock("../../src/helpers/BattleEngine.js");
+    vi.doUnmock("../../src/helpers/battleEngineFacade.js");
+    vi.doUnmock("../../src/helpers/dataUtils.js");
+    vi.doUnmock("../../src/helpers/constants.js");
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts numeric seed", async () => {
+    const mod = await loadBattleCLI();
+    await mod.__test.init();
+    const input = document.getElementById("seed-input");
+    input.value = "9";
+    input.dispatchEvent(new Event("change"));
+    expect(localStorage.getItem("battleCLI.seed")).toBe("9");
+    expect(document.getElementById("seed-error").textContent).toBe("");
+  });
+
+  it("shows error and reverts for NaN", async () => {
+    const mod = await loadBattleCLI(3);
+    await mod.__test.init();
+    const input = document.getElementById("seed-input");
+    input.value = "abc";
+    input.dispatchEvent(new Event("change"));
+    expect(input.value).toBe("3");
+    expect(document.getElementById("seed-error").textContent).toBe("Seed must be numeric.");
+    expect(localStorage.getItem("battleCLI.seed")).toBe("3");
+  });
+
+  it("clears error after recovery", async () => {
+    const mod = await loadBattleCLI(3);
+    await mod.__test.init();
+    const input = document.getElementById("seed-input");
+    input.value = "abc";
+    input.dispatchEvent(new Event("change"));
+    input.value = "4";
+    input.dispatchEvent(new Event("change"));
+    expect(document.getElementById("seed-error").textContent).toBe("");
+    expect(input.value).toBe("4");
+    expect(localStorage.getItem("battleCLI.seed")).toBe("4");
+  });
+});


### PR DESCRIPTION
### Summary
- validate seed changes, reverting and warning on non-numeric entries
- surface inline seed error message and document validation
- add seed input validation tests

### Task Contract
```json
{
  "inputs": ["src/pages/battleCLI.html", "src/pages/battleCLI.js", "src/pages/battleCLI.README.md", "tests/pages/battleCLI.seedValidation.test.js"],
  "outputs": ["src/pages/battleCLI.html", "src/pages/battleCLI.js", "src/pages/battleCLI.README.md", "tests/pages/battleCLI.seedValidation.test.js"],
  "success": ["npx prettier . --check", "npx eslint .", "npm run check:jsdoc", "npx vitest run", "npx playwright test", "npm run check:contrast"],
  "errorMode": "stop_on_error"
}
```

### Validation
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

### Risks
- Seed parsing relies on string emptiness to catch invalid entries; further validation may be needed for locales or non-standard input methods.


------
https://chatgpt.com/codex/tasks/task_e_68b802ea4c508326b9d537ccb51e649f