### PR TITLE
fix: refine battleCLI seed validation

### DIFF
--- a/src/pages/battleCLI.README.md
+++ b/src/pages/battleCLI.README.md
@@ -20,9 +20,9 @@ These helpers are intentionally small and synchronous to keep tests deterministi
 ## Seed validation
 
 The CLI settings panel includes a numeric seed input used for deterministic randomness.
-Only numeric values are accepted. If a non-numeric value is entered, the input reverts to
-the last valid seed and an inline red error message (`Seed must be numeric.`) appears
-under the field. Entering a valid number clears the error.
+Only numeric values are accepted. If a non-numeric or empty value is entered, the input
+reverts to the last valid seed and an inline red error message (`Seed must be numeric and
+non-empty.`) appears under the field. Entering a valid number clears the error.
 
 ## Round header
 

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -359,7 +359,7 @@ function initSeed() {
     const num = Number(storedSeed);
     if (!Number.isNaN(num)) {
       // Populate the input from previous choice without enabling test mode implicitly.
-      if (input) input.value = String(storedSeed);
+      if (input) input.value = String(num);
       lastValid = num;
     }
   }
@@ -371,7 +371,7 @@ function initSeed() {
       } else {
         input.value = "";
       }
-      if (errorEl) errorEl.textContent = "Seed must be numeric.";
+      if (errorEl) errorEl.textContent = "Seed must be numeric and non-empty.";
       return;
     }
     if (errorEl) errorEl.textContent = "";

--- a/tests/pages/battleCLI.seedValidation.test.js
+++ b/tests/pages/battleCLI.seedValidation.test.js
@@ -108,7 +108,9 @@ describe("battleCLI seed validation", () => {
     input.value = "abc";
     input.dispatchEvent(new Event("change"));
     expect(input.value).toBe("3");
-    expect(document.getElementById("seed-error").textContent).toBe("Seed must be numeric.");
+    expect(document.getElementById("seed-error").textContent).toBe(
+      "Seed must be numeric and non-empty."
+    );
     expect(localStorage.getItem("battleCLI.seed")).toBe("3");
   });
 


### PR DESCRIPTION
### Summary
- use parsed numeric seed when restoring stored value
- clarify inline error message to cover empty input
- update seed validation tests and docs

### Task Contract
```json
{
  "inputs": ["src/pages/battleCLI.js", "src/pages/battleCLI.README.md", "tests/pages/battleCLI.seedValidation.test.js"],
  "outputs": ["src/pages/battleCLI.js", "src/pages/battleCLI.README.md", "tests/pages/battleCLI.seedValidation.test.js"],
  "success": ["npx prettier . --check", "npx eslint .", "npm run check:jsdoc", "npx vitest run", "npx playwright test", "npm run check:contrast"],
  "errorMode": "stop_on_error"
}
```

### Verification
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: functions missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

### Risks
- none expected


------
https://chatgpt.com/codex/tasks/task_e_68b8089c70fc8326b0401fd731ec2828