### PR TITLE
feat: centralize modal escape handling

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,3 +1,5 @@
+import { registerModal, unregisterModal } from "../helpers/modalManager.js";
+
 /**
  * Create a reusable modal dialog with accessible behavior.
  *
@@ -9,7 +11,7 @@
  * 4. Append provided content nodes into the modal.
  * 5. Expose `open()` and `close()` instance methods to toggle the backdrop,
  *    manage focus and `aria-expanded` on the trigger.
- * 6. Clicking the backdrop or pressing Escape closes the modal.
+ * 6. Clicking the backdrop closes the modal.
  * 7. While open, trap focus inside the modal container.
  * 8. Provide `destroy()` to remove listeners and detach the element.
  *
@@ -49,7 +51,6 @@ export class Modal {
     this.removeTrap = () => {};
 
     this.handleBackdropClick = this.handleBackdropClick.bind(this);
-    this.handleEscape = this.handleEscape.bind(this);
     this.open = this.open.bind(this);
     this.close = this.close.bind(this);
     this.element.addEventListener("click", this.handleBackdropClick);
@@ -100,20 +101,6 @@ export class Modal {
   }
 
   /**
-   * Handles the keydown event to close the modal when the Escape key is pressed.
-   *
-   * @pseudocode
-   * 1. Check if the pressed key is 'Escape'.
-   * 2. If it is, close the modal.
-   *
-   * @param {KeyboardEvent} e - The keyboard event object.
-   * @returns {void}
-   */
-  handleEscape(e) {
-    if (e.key === "Escape") this.close();
-  }
-
-  /**
    * Handles clicks on the modal backdrop to close the modal.
    *
    * @pseudocode
@@ -137,7 +124,7 @@ export class Modal {
    * 4. If a trigger element exists, set its 'aria-expanded' attribute to 'true'.
    * 5. Activate focus trapping within the dialog.
    * 6. Identify the first focusable element within the dialog and move focus to it.
-   * 7. Add a keydown event listener to the document for handling the Escape key.
+   * 7. Register the modal with the global Escape handler.
    *
    * @param {HTMLElement} [trigger] - The element that triggered the modal to open, used for focus management.
    * @returns {void}
@@ -152,7 +139,7 @@ export class Modal {
       "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])"
     );
     (focusTarget || this.dialog).focus();
-    document.addEventListener("keydown", this.handleEscape);
+    registerModal(this);
   }
 
   /**
@@ -162,7 +149,7 @@ export class Modal {
    * 1. Remove the 'open' class from the dialog.
    * 2. Set the 'hidden' attribute on the modal backdrop.
    * 3. Deactivate the focus trap.
-   * 4. Remove the keydown event listener for handling the Escape key.
+   * 4. Unregister from the global Escape handler.
    * 5. If a triggering element was stored, set its 'aria-expanded' attribute to 'false' and return focus to it.
    * 6. Dispatch a `close` event on the modal backdrop.
    *
@@ -172,7 +159,7 @@ export class Modal {
     this.dialog.classList.remove("open");
     this.element.setAttribute("hidden", "");
     this.removeTrap();
-    document.removeEventListener("keydown", this.handleEscape);
+    unregisterModal(this);
     if (this.returnFocus) {
       this.returnFocus.setAttribute("aria-expanded", "false");
       this.returnFocus.focus();
@@ -186,7 +173,7 @@ export class Modal {
    */
   destroy() {
     this.element.removeEventListener("click", this.handleBackdropClick);
-    document.removeEventListener("keydown", this.handleEscape);
+    unregisterModal(this);
     this.element.remove();
   }
 }

--- a/src/helpers/modalManager.js
+++ b/src/helpers/modalManager.js
@@ -1,0 +1,79 @@
+/**
+ * Manage a stack of overlay objects and handle Escape key globally.
+ *
+ * @pseudocode
+ * 1. Maintain an array `stack` of registered overlays with a `close()` method.
+ * 2. Listen for `keydown` events on `document`.
+ * 3. On `Escape` key:
+ *    a. Pop the top overlay from `stack`.
+ *    b. If an overlay exists, call its `close()` method.
+ *    c. Notify registered callbacks that Escape was handled.
+ * 4. Expose functions to register/unregister overlays and to subscribe/unsubscribe to Escape events.
+ */
+const stack = [];
+const escCallbacks = new Set();
+
+function handleKeydown(e) {
+  if (e.key !== "Escape") return;
+  const top = stack[stack.length - 1];
+  if (top) top.close();
+  escCallbacks.forEach((cb) => cb());
+}
+
+if (typeof document?.addEventListener === "function") {
+  document.addEventListener("keydown", handleKeydown);
+}
+
+/**
+ * Register an overlay so it responds to the shared Escape handler.
+ *
+ * @pseudocode
+ * push `overlay` onto `stack` if not already present
+ *
+ * @param {{ close: () => void }} overlay
+ * @returns {void}
+ */
+export function registerModal(overlay) {
+  if (!stack.includes(overlay)) stack.push(overlay);
+}
+
+/**
+ * Remove an overlay from the Escape stack.
+ *
+ * @pseudocode
+ * find last index of `overlay` in `stack`
+ * IF index >= 0: remove it
+ *
+ * @param {{ close: () => void }} overlay
+ * @returns {void}
+ */
+export function unregisterModal(overlay) {
+  const idx = stack.lastIndexOf(overlay);
+  if (idx >= 0) stack.splice(idx, 1);
+}
+
+/**
+ * Subscribe to Escape events triggered by the manager.
+ *
+ * @pseudocode
+ * add `cb` to `escCallbacks`
+ *
+ * @param {() => void} cb
+ * @returns {void}
+ */
+export function onEsc(cb) {
+  escCallbacks.add(cb);
+}
+
+/**
+ * Unsubscribe a previously registered Escape callback.
+ *
+ * @pseudocode
+ * delete `cb` from `escCallbacks`
+ *
+ * @param {() => void} cb
+ * @returns {void}
+ */
+export function offEsc(cb) {
+  escCallbacks.delete(cb);
+}

--- a/tests/helpers/modalManager.stack.test.js
+++ b/tests/helpers/modalManager.stack.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { createModal } from "../../src/components/Modal.js";
+
+function buildModal(id) {
+  const frag = document.createDocumentFragment();
+  const btn = document.createElement("button");
+  btn.id = id;
+  frag.append(btn);
+  const modal = createModal(frag);
+  document.body.appendChild(modal.element);
+  return { modal, trigger: btn };
+}
+
+describe("modal manager stack", () => {
+  it("closes only the top modal on Escape", () => {
+    const first = buildModal("first-btn");
+    const second = buildModal("second-btn");
+
+    const trigger1 = document.createElement("button");
+    const trigger2 = document.createElement("button");
+    document.body.append(trigger1, trigger2);
+
+    first.modal.open(trigger1);
+    second.modal.open(trigger2);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(second.modal.element.hasAttribute("hidden")).toBe(true);
+    expect(document.activeElement).toBe(trigger2);
+    expect(first.modal.element.hasAttribute("hidden")).toBe(false);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(first.modal.element.hasAttribute("hidden")).toBe(true);
+    expect(document.activeElement).toBe(trigger1);
+
+    first.modal.destroy();
+    second.modal.destroy();
+  });
+});

--- a/tests/pages/battleCLI.escape.test.js
+++ b/tests/pages/battleCLI.escape.test.js
@@ -61,7 +61,7 @@ describe("battleCLI Escape key", () => {
     const sec = document.getElementById("cli-shortcuts");
     expect(sec.hidden).toBe(false);
     const handled = mod.getEscapeHandledPromise();
-    mod.onKeyDown(new KeyboardEvent("keydown", { key: "Escape" }));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     await handled;
     expect(sec.hidden).toBe(true);
     expect(document.activeElement).toBe(focusBtn);
@@ -72,7 +72,7 @@ describe("battleCLI Escape key", () => {
     const confirm = document.getElementById("confirm-quit-button");
     expect(confirm).toBeTruthy();
     const handled = mod.getEscapeHandledPromise();
-    mod.onKeyDown(new KeyboardEvent("keydown", { key: "Escape" }));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     await handled;
     const backdrop = confirm.closest(".modal-backdrop");
     expect(backdrop?.hasAttribute("hidden")).toBe(true);


### PR DESCRIPTION
## Summary
- add modal manager to track active overlays and close the topmost on ESC
- register Modal component and CLI shortcuts overlay with the shared ESC handler
- cover stacked modals and CLI overlays in regression tests

## Testing
- `npx prettier . --check --log-level warn`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 171 missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b808b0d494832696677fe07b673872