### PR TITLE
track CLI stat index and expose next round button

### DIFF
--- a/src/pages/battleCLI.README.md
+++ b/src/pages/battleCLI.README.md
@@ -33,4 +33,10 @@ The `#cli-root` element mirrors these values via `data-round` and `data-target`.
 
 When a round begins, each stat row in `#cli-stats` shows the current player's value in the format `(index) Name: value`. Clicking a row triggers the same selection logic as using the numeric keyboard shortcut.
 
+The list element exposes `data-selected-index` reflecting the numeric index of the last chosen stat.
+
 You can also navigate the stat rows with the arrow keys. When `#cli-stats` has focus, pressing Arrow Up/Down/Left/Right moves the active row, wrapping from the end back to the start. The listbox keeps track of the current item via `aria-activedescendant` and applies a visible focus ring.
+
+## Round end controls
+
+During `roundOver`, a focusable `#next-round-button` is appended to `#cli-main` to continue the match. It is removed automatically on the next state transition.

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -770,6 +770,7 @@ function selectStat(stat) {
   const list = byId("cli-stats");
   list?.querySelectorAll(".selected").forEach((el) => el.classList.remove("selected"));
   const idx = STATS.indexOf(stat) + 1;
+  if (list) list.dataset.selectedIndex = String(idx);
   const choiceEl = list?.querySelector(`[data-stat-index="${idx}"]`);
   choiceEl?.classList.add("selected");
   try {
@@ -1554,7 +1555,7 @@ function handleBattleState(ev) {
   // Clean up any transient Next button when state changes
   try {
     const existing = document.getElementById("next-round-button");
-    if (existing) existing.remove();
+    existing?.parentElement?.remove();
   } catch {}
   if (to === "matchStart") {
     clearVerboseLog();

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -183,5 +183,8 @@ describe("battleCLI event handlers", () => {
     handlers.handleBattleState({ detail: { from: "a", to: "roundOver" } });
     expect(updateBattleStateBadge).toHaveBeenCalledWith("roundOver");
     expect(document.querySelector(".snackbar").textContent).toBe("Press Enter to continue");
+    expect(document.getElementById("next-round-button")).toBeTruthy();
+    handlers.handleBattleState({ detail: { from: "roundOver", to: "waitingForPlayerAction" } });
+    expect(document.getElementById("next-round-button")).toBeNull();
   });
 });

--- a/tests/pages/battleCLI.selectedStat.test.js
+++ b/tests/pages/battleCLI.selectedStat.test.js
@@ -71,6 +71,7 @@ describe("battleCLI stat interactions", () => {
     expect(document.querySelector('[data-stat-index="1"]').classList.contains("selected")).toBe(
       true
     );
+    expect(document.getElementById("cli-stats").dataset.selectedIndex).toBe("1");
   });
 
   it("shows stat values and responds to clicks", async () => {
@@ -88,5 +89,6 @@ describe("battleCLI stat interactions", () => {
     expect(hiddenVal).toBe("5");
     statEl.click();
     expect(statEl.classList.contains("selected")).toBe(true);
+    expect(document.getElementById("cli-stats").dataset.selectedIndex).toBe("1");
   });
 });


### PR DESCRIPTION
## Summary
- track selected stat index on `#cli-stats`
- document and test stable `#next-round-button`
- cover data-selected-index in tests and mention new hooks in battleCLI docs

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 171 missing docs, non-blocking)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`
- `npm run validate:data`

## Risk
- Low: touch UI hooks only; jsdoc check still reports missing docs


------
https://chatgpt.com/codex/tasks/task_e_68b808acfa588326b0c0d8acb0cd435b