### PR TITLE
feat(cli): expose stat index and next button

### DIFF
--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -149,8 +149,8 @@ Shortcuts: [1–5] Select [Enter]/[Space] Next [H] Help [Q] Quit [Esc] Back
 **DOM & Test Hooks**
 
 - Containers: `#cli-root`, `#cli-header`, `#cli-countdown`, `#cli-stats`, `#round-message`, `#cli-score`, `#cli-shortcuts`, `#cli-settings`.
-- Data: `#cli-root[data-round="N"]`, `#cli-countdown[data-remaining-time="S"]`.
-- Primary action: `#next-round-button` (render only when available).
+- Data: `#cli-root[data-round="N"]`, `#cli-countdown[data-remaining-time="S"]`, `#cli-stats[data-selected-index="I"]`.
+- Primary action: `#next-round-button` (stable id each round; removed on state change).
 
 Additional test-contract details and page-level helpers
 
@@ -246,8 +246,6 @@ Additional test-contract details and page-level helpers
 - Classic Battle engine and state table (single source of truth).
 - Settings storage helper (for points-to-win, flags, seed).
 - Logger utility capable of CI silencing.
-
- 
 
 ---
 

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -787,6 +787,7 @@ function selectStat(stat) {
   const list = byId("cli-stats");
   list?.querySelectorAll(".selected").forEach((el) => el.classList.remove("selected"));
   const idx = STATS.indexOf(stat) + 1;
+  if (list) list.dataset.selectedIndex = String(idx);
   const choiceEl = list?.querySelector(`[data-stat-index="${idx}"]`);
   choiceEl?.classList.add("selected");
   try {

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -184,4 +184,22 @@ describe("battleCLI event handlers", () => {
     expect(updateBattleStateBadge).toHaveBeenCalledWith("roundOver");
     expect(document.querySelector(".snackbar").textContent).toBe("Press Enter to continue");
   });
+
+  it("renders next-round-button only during roundOver", async () => {
+    const { handlers } = await setupHandlers();
+    const { setAutoContinue } = await import(
+      "../../src/helpers/classicBattle/orchestratorHandlers.js"
+    );
+    setAutoContinue(false);
+    handlers.handleBattleState({ detail: { from: "waiting", to: "roundOver" } });
+    const firstBtn = document.getElementById("next-round-button");
+    expect(firstBtn).toBeTruthy();
+    handlers.handleBattleState({ detail: { from: "roundOver", to: "waitingForPlayerAction" } });
+    expect(document.getElementById("next-round-button")).toBeFalsy();
+    handlers.handleBattleState({ detail: { from: "waitingForPlayerAction", to: "roundOver" } });
+    const secondBtn = document.getElementById("next-round-button");
+    expect(secondBtn).toBeTruthy();
+    expect(secondBtn.id).toBe("next-round-button");
+    expect(secondBtn).not.toBe(firstBtn);
+  });
 });

--- a/tests/pages/battleCLI.selectedStat.test.js
+++ b/tests/pages/battleCLI.selectedStat.test.js
@@ -73,6 +73,13 @@ describe("battleCLI stat interactions", () => {
     );
   });
 
+  it("sets data-selected-index on cli-stats", async () => {
+    const { mod } = await loadBattleCLI();
+    await mod.renderStatList();
+    mod.handleWaitingForPlayerActionKey("2");
+    expect(document.getElementById("cli-stats").dataset.selectedIndex).toBe("2");
+  });
+
   it("shows stat values and responds to clicks", async () => {
     const { mod, startRound } = await loadBattleCLI();
     await mod.renderStatList();


### PR DESCRIPTION
## Summary
- record selected stat index on `#cli-stats`
- ensure `#next-round-button` renders only during `roundOver`
- document new CLI data hooks

## Testing
- `npx prettier src/pages/battleCLI.js tests/pages/battleCLI.selectedStat.test.js tests/pages/battleCLI.handlers.test.js design/productRequirementsDocuments/prdBattleCLI.md --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 171 missing blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b84c019b848326a4e5689b01329282