### PR TITLE
fix: notify escape callbacks with popped overlay

### DIFF
--- a/src/helpers/modalManager.js
+++ b/src/helpers/modalManager.js
@@ -6,8 +6,8 @@
  * 2. Listen for `keydown` events on `document`.
  * 3. On `Escape` key:
  *    a. Pop the top overlay from `stack`.
- *    b. If an overlay exists, call its `close()` method.
- *    c. Notify registered callbacks that Escape was handled.
+ *    b. Notify registered callbacks, passing the popped overlay.
+ *    c. If an overlay exists, call its `close()` method.
  * 4. Expose functions to register/unregister overlays and to subscribe/unsubscribe to Escape events.
  */
 const stack = [];
@@ -15,9 +15,15 @@ const escCallbacks = new Set();
 
 function handleKeydown(e) {
   if (e.key !== "Escape") return;
-  const top = stack[stack.length - 1];
-  if (top) top.close();
-  escCallbacks.forEach((cb) => cb());
+  const top = stack.pop();
+  escCallbacks.forEach((cb) => cb(top));
+  if (top) {
+    try {
+      top.close();
+    } catch {
+      // swallow error: ESC handling should proceed
+    }
+  }
 }
 
 if (typeof document?.addEventListener === "function") {

--- a/tests/helpers/modalManager.callbacks.test.js
+++ b/tests/helpers/modalManager.callbacks.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
+import { registerModal, onEsc, offEsc } from "../../src/helpers/modalManager.js";
+
+describe("modal manager callbacks", () => {
+  it("notifies callbacks with overlay before closing", () => {
+    const overlay = { close: vi.fn() };
+    registerModal(overlay);
+    const cb = vi.fn();
+    onEsc(cb);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(cb).toHaveBeenCalledWith(overlay);
+    expect(overlay.close).toHaveBeenCalledTimes(1);
+    offEsc(cb);
+  });
+
+  it("removes overlay even if close throws", () => {
+    const overlay = {
+      close: vi.fn(() => {
+        throw new Error("boom");
+      })
+    };
+    registerModal(overlay);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(overlay.close).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- pop modal stack before closing to avoid repeated calls
- notify escape callbacks with the popped modal object
- test callback notification and failure-tolerant stack removal

## Testing
- `npx prettier . --check --log-level warn` *(fails: design/productRequirementsDocuments/prdBattleCLI.md)*
- `npx eslint .` *(warnings: quitModal.js, createRoundTimer.js, settingsPage.test.js)*
- `npm run check:jsdoc` *(fails: 171 missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b84b7e9f5c8326a3c7456c7ad3450d