### PR TITLE
docs: document classic battle markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ For debugging or automated tests, append `?autostart=1` to `battleJudoka.html` t
 Note on Next button behavior:
 - The `Next` button advances only during the inter-round cooldown. It remains disabled while choosing a stat to avoid skipping the cooldown logic accidentally. The cooldown enables `Next` (or auto-advances in test mode); do not expect `Next` to be ready during stat selection.
 
+See [design/battleMarkup.md](design/battleMarkup.md) for the canonical DOM ids used by classic battle scripts.
+
 ## 🔌 Engine API
 
 ```js

--- a/design/battleMarkup.md
+++ b/design/battleMarkup.md
@@ -1,0 +1,39 @@
+# Classic Battle Markup
+
+Classic battle pages rely on specific element IDs so helper scripts can attach listeners and update the UI. The following IDs must be present for scripts to function.
+
+## Required IDs
+
+| ID                      | Purpose                                         |
+| ----------------------- | ----------------------------------------------- |
+| `round-message`         | Announces prompts and round outcomes.           |
+| `next-round-timer`      | Displays the inter-round countdown.             |
+| `round-counter`         | Shows current round number.                     |
+| `score-display`         | Lists player and opponent scores.               |
+| `test-mode-banner`      | Indicates when test mode is active.             |
+| `debug-panel`           | Collapsible container for debugging info.       |
+| `debug-output`          | `<pre>` element inside the debug panel.         |
+| `battle-area`           | Wrapper containing player and opponent cards.   |
+| `player-card`           | Container for the player's card.                |
+| `opponent-card`         | Container for the opponent's card.              |
+| `stat-buttons`          | Group of stat selection buttons.                |
+| `round-result`          | Displays the result of the round.               |
+| `next-button`           | Advances to the next round when ready.          |
+| `stat-help`             | Opens stat selection help.                      |
+| `quit-match-button`     | Triggers the quit match flow.                   |
+| `battle-state-progress` | Optional list tracking match state transitions. |
+
+## Example Markup
+
+```html
+<div id="stat-buttons" role="group" aria-label="Select a stat to battle">
+  <button data-stat="power"></button>
+  <!-- additional stat buttons -->
+</div>
+
+<div class="action-buttons">
+  <button id="next-button" class="battle-control-button" disabled>Next</button>
+  <button id="stat-help" class="battle-control-button" aria-label="Stat selection help">?</button>
+  <button id="quit-match-button" class="battle-control-button">Quit Match</button>
+</div>
+```

--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -247,8 +247,6 @@ Additional test-contract details and page-level helpers
 - Settings storage helper (for points-to-win, flags, seed).
 - Logger utility capable of CI silencing.
 
- 
-
 ---
 
 ## Open Questions


### PR DESCRIPTION
## Summary
- document canonical DOM ids used by classic battle helpers
- link README to new battle markup guide
- format PRD battle CLI doc to satisfy prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 171 missing or incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Task Contract
- `inputs`: [`README.md`, `design/battleMarkup.md`, `design/productRequirementsDocuments/prdBattleCLI.md`]
- `outputs`: [`README.md`, `design/battleMarkup.md`, `design/productRequirementsDocuments/prdBattleCLI.md`]
- `success`: [`prettier: PASS`, `eslint: PASS (warnings)`, `jsdoc: FAIL`, `vitest: PASS`, `playwright: PASS`, `contrast: PASS`]
- `errorMode`: `ask_on_public_api_change`

## Risks
- jsdoc check reveals existing gaps across helpers; future refactors may require comprehensive documentation.


------
https://chatgpt.com/codex/tasks/task_e_68b84b2689c08326883df4b8a460a6f8