### PR TITLE
feat: warn on missing battle buttons

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -852,24 +852,21 @@ export function registerRoundStartErrorHandler(retryFn) {
  * 1. TODO: Add pseudocode
  */
 /**
- * Wire the Next button's click handler to `onNextButtonClick`.
+ * @summary Attach the Next button click handler and warn when absent.
+ *
+ * Logs a warning when the button is missing.
  *
  * @pseudocode
- * 1. Find `#next-button` and attach event listener for `click`.
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
+ * 1. Query `#next-button`.
+ * 2. If not found, warn and exit.
+ * 3. Bind `onNextButtonClick` to `click`.
  */
 export function setupNextButton() {
   const btn = document.getElementById("next-button");
-  if (!btn) return;
+  if (!btn) {
+    guard(() => console.warn("[uiHelpers] #next-button not found"));
+    return;
+  }
   btn.addEventListener("click", onNextButtonClick);
 }
 
@@ -1123,28 +1120,32 @@ export function clearScoreboardAndMessages() {
  * 1. TODO: Add pseudocode
  */
 /**
- * Initialize stat selection buttons with click/keyboard handlers and expose controls.
+ * @summary Initialize stat selection buttons; warn when container missing.
+ *
+ * Logs a warning and resolves the readiness promise when the container is
+ * absent.
  *
  * @pseudocode
- * 1. Locate `#stat-buttons` and wire click/keydown handlers for each button.
- * 2. Implement `setEnabled` to toggle button enabled state and resolve a global readiness promise.
- * 3. Return an API `{ enable, disable }`.
+ * 1. Locate `#stat-buttons`; warn and return noop controls if absent.
+ * 2. Gather buttons and helpers to toggle enabled state.
+ * 3. Disable buttons initially.
+ * 4. Wire click and keyboard handlers for stat selection.
+ * 5. Return an API `{ enable, disable }`.
  *
- * @param {object} store
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
+ * @param {object} store Battle store for selection handling.
+ * @returns {{ enable: () => void, disable: () => void }} Control API.
  */
 export function initStatButtons(store) {
-  const statButtons = document.querySelectorAll("#stat-buttons button");
   const statContainer = document.getElementById("stat-buttons");
+  if (!statContainer) {
+    guard(() => {
+      console.warn("[uiHelpers] #stat-buttons container not found");
+      if (typeof window !== "undefined") window.__resolveStatButtonsReady?.();
+    });
+    return { enable: () => {}, disable: () => {} };
+  }
+
+  const statButtons = statContainer.querySelectorAll("button");
   let resolveReady = typeof window !== "undefined" ? window.__resolveStatButtonsReady : undefined;
   const resetReadyPromise = () => {
     ({ resolve: resolveReady } = resetStatButtonsReadyPromise());

--- a/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
+++ b/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("uiHelpers missing element warnings", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("warns when next button is missing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
+    mod.setupNextButton();
+    expect(warnSpy).toHaveBeenCalledWith("[uiHelpers] #next-button not found");
+  });
+
+  it("warns when stat buttons container is missing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
+    mod.initStatButtons({});
+    expect(warnSpy).toHaveBeenCalledWith("[uiHelpers] #stat-buttons container not found");
+    await expect(window.statButtonsReadyPromise).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- warn if `#next-button` is missing before wiring click handlers
- warn and resolve readiness when `#stat-buttons` container is missing
- test missing elements and readiness promise behavior

## Testing
- `npx prettier src/helpers/classicBattle/uiHelpers.js tests/helpers/classicBattle/uiHelpers.missingElements.test.js --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: navigation-navigation-links-navigate-to-expected-pages)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/helpers/classicBattle/uiHelpers.js", "tests/helpers/classicBattle/uiHelpers.missingElements.test.js"],
  "outputs": ["src/helpers/classicBattle/uiHelpers.js", "tests/helpers/classicBattle/uiHelpers.missingElements.test.js"],
  "success": ["prettier: PASS (target files)", "eslint: WARNINGS", "jsdoc: FAIL (non-blocking)", "vitest: PASS", "playwright: FAIL", "contrast: PASS"],
  "errorMode": "ask_on_public_api_change"
}
```

## Verification Checklist
- [ ] prettier, eslint, jsdoc PASS
- [ ] vitest + playwright PASS
- [ ] no unsuppressed console logs
- [ ] tests: happy + edge
- [ ] CI green

## Risk
- Low: only adds logging and early returns when DOM elements are absent.


------
https://chatgpt.com/codex/tasks/task_e_68b84b1238688326b5c1ab2a4fda681c