### PR TITLE
fix: guard stat buttons readiness

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -1140,7 +1140,14 @@ export function initStatButtons(store) {
   if (!statContainer) {
     guard(() => {
       console.warn("[uiHelpers] #stat-buttons container not found");
-      if (typeof window !== "undefined") window.__resolveStatButtonsReady?.();
+      if (typeof window !== "undefined") {
+        if (typeof window.__resolveStatButtonsReady !== "function") {
+          const { resolve } = resetStatButtonsReadyPromise();
+          resolve();
+        } else {
+          window.__resolveStatButtonsReady();
+        }
+      }
     });
     return { enable: () => {}, disable: () => {} };
   }

--- a/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
+++ b/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
@@ -24,4 +24,15 @@ describe("uiHelpers missing element warnings", () => {
     expect(warnSpy).toHaveBeenCalledWith("[uiHelpers] #stat-buttons container not found");
     await expect(window.statButtonsReadyPromise).resolves.toBeUndefined();
   });
+
+  it("resets and resolves stat buttons promise when resolver missing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
+    window.statButtonsReadyPromise = new Promise(() => {});
+    // simulate missing resolver
+    delete window.__resolveStatButtonsReady;
+    mod.initStatButtons({});
+    expect(warnSpy).toHaveBeenCalledWith("[uiHelpers] #stat-buttons container not found");
+    await expect(window.statButtonsReadyPromise).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure stat buttons readiness promise is established before resolving
- test stat buttons readiness when resolver is missing

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: missing docs for 170 functions; non-blocking)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b8625dcd048326948116b3cd451734