### PR TITLE
fix: notify escape callbacks with popped overlay

### DIFF
--- a/src/helpers/modalManager.js
+++ b/src/helpers/modalManager.js
@@ -16,12 +16,18 @@ const escCallbacks = new Set();
 function handleKeydown(e) {
   if (e.key !== "Escape") return;
   const top = stack.pop();
-  escCallbacks.forEach((cb) => cb(top));
+  escCallbacks.forEach((cb) => {
+    try {
+      cb(top);
+    } catch (err) {
+      console.warn("Error in ESC callback:", err);
+    }
+  });
   if (top) {
     try {
       top.close();
-    } catch {
-      // swallow error: ESC handling should proceed
+    } catch (err) {
+      console.warn("Error closing overlay in ESC handler:", err);
     }
   }
 }

--- a/tests/helpers/modalManager.callbacks.test.js
+++ b/tests/helpers/modalManager.callbacks.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { registerModal, onEsc, offEsc } from "../../src/helpers/modalManager.js";
+import { withMutedConsole } from "../utils/console.js";
 
 describe("modal manager callbacks", () => {
   it("notifies callbacks with overlay before closing", () => {
@@ -13,14 +14,16 @@ describe("modal manager callbacks", () => {
     offEsc(cb);
   });
 
-  it("removes overlay even if close throws", () => {
+  it("removes overlay even if close throws", async () => {
     const overlay = {
       close: vi.fn(() => {
         throw new Error("boom");
       })
     };
     registerModal(overlay);
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await withMutedConsole(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(overlay.close).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary
- guard Escape callbacks so modal still closes and log failures
- record close() errors for easier debugging
- mute modal close warnings during tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b861e3ef888326b3a1eb14ad15d77e