### PR TITLE
test: ensure battleJudoka ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Example one-liner:
 npm run check:jsdoc && npx prettier . --check && npx eslint . && npx vitest run && npx playwright test && npm run check:contrast
 ```
 
+This suite includes a DOM regression test (`tests/pages/battleJudoka.dom.test.js`) that loads `battleJudoka.html` and fails if required IDs (`next-button`, `stat-help`, `quit-match-button`, `stat-buttons`) are missing.
+
 ### Classic Battle CLI (text-first)
 
 - Page: `src/pages/battleCLI.html` – terminal-style UI that reuses the Classic Battle engine/state machine.

--- a/tests/pages/battleJudoka.dom.test.js
+++ b/tests/pages/battleJudoka.dom.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { readFileSync } from "fs";
+
+const REQUIRED_IDS = ["next-button", "stat-help", "quit-match-button", "stat-buttons"];
+
+function getMissingIds(root, ids) {
+  return ids.filter((id) => !root.getElementById(id));
+}
+
+describe("battleJudoka.html required IDs", () => {
+  beforeEach(() => {
+    const html = readFileSync("src/pages/battleJudoka.html", "utf8");
+    document.documentElement.innerHTML = html;
+  });
+
+  it("includes all required IDs", () => {
+    const missing = getMissingIds(document, REQUIRED_IDS);
+    expect(missing).toEqual([]);
+  });
+
+  it("detects when an ID is missing", () => {
+    document.getElementById("stat-help")?.remove();
+    const missing = getMissingIds(document, REQUIRED_IDS);
+    expect(missing).toEqual(["stat-help"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add DOM test verifying required battleJudoka IDs
- document regression check in README

## Testing
- `npx prettier tests/pages/battleJudoka.dom.test.js README.md --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: missing JSDoc, non-blocking)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/pages/battleJudoka.html"],
  "outputs": ["tests/pages/battleJudoka.dom.test.js", "README.md"],
  "success": ["prettier", "eslint", "vitest", "playwright", "check:contrast"],
  "errorMode": "jsdoc-fail-nonblocking"
}
```

## Files Changed
- `tests/pages/battleJudoka.dom.test.js`: regression test ensures `battleJudoka.html` retains required IDs.
- `README.md`: document the DOM regression test.

## Verification
- eslint: warnings (unused vars in existing files)
- jsdoc: **fail** (170 missing JSDoc entries)
- prettier: pass
- vitest: 227 passed
- playwright: 99 passed
- check:contrast: pass

## Risk
Low; adds non-invasive test and doc update.


------
https://chatgpt.com/codex/tasks/task_e_68b8682cd218832697ae1e2ed199f0bf