### PR TITLE
fix: advance round when skipping cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ When you open `src/pages/battleJudoka.html`, a modal prompts you to choose the m
 For debugging or automated tests, append `?autostart=1` to `battleJudoka.html` to skip the modal and begin a default-length match immediately.
 
 Note on Next button behavior:
-- The `Next` button advances only during the inter-round cooldown. It remains disabled while choosing a stat to avoid skipping the cooldown logic accidentally. The cooldown enables `Next` (or auto-advances in test mode); do not expect `Next` to be ready during stat selection.
+- The `Next` button advances only during the inter-round cooldown. Clicking it cancels any remaining cooldown and immediately starts the next round.
+- It remains disabled while choosing a stat to avoid skipping the cooldown logic accidentally. The cooldown enables `Next` (or auto-advances in test mode); do not expect `Next` to be ready during stat selection.
 
 See [design/battleMarkup.md](design/battleMarkup.md) for the canonical DOM ids used by classic battle scripts.
 

--- a/playwright/battle-next-skip.spec.js
+++ b/playwright/battle-next-skip.spec.js
@@ -1,0 +1,40 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+import { waitForBattleReady, waitForBattleState } from "./fixtures/waits.js";
+
+/**
+ * Verify that clicking Next during cooldown skips the delay.
+ *
+ * @pseudocode
+ * 1. Set a short next-round cooldown.
+ * 2. Start a battle, select the first stat to end round 1.
+ * 3. Click Next as soon as it is enabled.
+ * 4. Expect the round counter to show round 2 within 1s.
+ */
+test.describe("Next button cooldown skip", () => {
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__NEXT_ROUND_COOLDOWN_MS = 1000;
+  });
+});
+
+  test("advances immediately when clicked", async ({ page }) => {
+    await page.goto("/src/pages/battleJudoka.html?autostart=1");
+    await waitForBattleReady(page);
+
+    // Finish round 1 quickly.
+    await page.locator("#stat-buttons button").first().click();
+    await page.locator("#stat-buttons[data-buttons-ready='false']").waitFor();
+    await page.evaluate(() => window.getRoundResolvedPromise?.());
+    await waitForBattleState(page, "cooldown");
+
+    const counter = page.locator("#round-counter");
+    await expect(counter).toHaveText(/Round 1/);
+
+    const nextBtn = page.locator("#next-button");
+    await expect(nextBtn).toBeEnabled();
+    await nextBtn.click();
+
+    await expect(counter).toHaveText(/Round 2/, { timeout: 1000 });
+    await page.evaluate(() => window.freezeBattleHeader?.());
+  });
+});

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -63,7 +63,10 @@ export async function advanceWhenReady(btn, resolveReady) {
  * Cancel an active cooldown timer or advance immediately when already in cooldown.
  *
  * @pseudocode
- * 1. If a `timer` object is provided, call `timer.stop()` and return.
+ * 1. If a `timer` object is provided:
+ *    a. Call `timer.stop()` to cancel the countdown.
+ *    b. Dispatch `ready`, call `resolveReady`, and clear the skip handler.
+ *    c. Return early.
  * 2. Otherwise, if the state machine is in `cooldown` (or unknown in tests),
  *    dispatch `ready`, call `resolveReady`, and clear the skip handler.
  *
@@ -75,6 +78,13 @@ export async function advanceWhenReady(btn, resolveReady) {
 export async function cancelTimerOrAdvance(_btn, timer, resolveReady) {
   if (timer) {
     timer.stop();
+    try {
+      const { state } = getStateSnapshot();
+      void state;
+    } catch {}
+    await dispatchBattleEvent("ready");
+    if (typeof resolveReady === "function") resolveReady();
+    setSkipHandler(null);
     return;
   }
   // No active timer controls: if we're in cooldown (or state is unknown in

--- a/tests/helpers/timerService.onNextButtonClick.test.js
+++ b/tests/helpers/timerService.onNextButtonClick.test.js
@@ -31,14 +31,14 @@ describe("onNextButtonClick", () => {
     expect(resolveReady).toHaveBeenCalledTimes(1);
   });
 
-  it("stops timer when not ready", async () => {
+  it("stops timer and dispatches ready when not marked ready", async () => {
     const { onNextButtonClick } = await import("../../src/helpers/classicBattle/timerService.js");
     const stop = vi.fn();
     __setStateSnapshot({ state: "roundDecision" });
     await onNextButtonClick(new MouseEvent("click"), { timer: { stop }, resolveReady: null });
     const dispatcher = await import("../../src/helpers/classicBattle/orchestrator.js");
     expect(stop).toHaveBeenCalledTimes(1);
-    expect(dispatcher.dispatchBattleEvent).not.toHaveBeenCalled();
+    expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
   });
 
   it("advances immediately when no timer and in cooldown", async () => {


### PR DESCRIPTION
## Summary
- ensure cancelling inter-round timers dispatches `ready`
- document Next button skip behaviour and cover with tests
- add Playwright scenario for skipping cooldown

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: 3 warnings)*
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: timeout waiting for cooldown)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b868fc95048326a314284a79767102