### PR TITLE
Codex/fix comments in timerservice.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ When you open `src/pages/battleJudoka.html`, a modal prompts you to choose the m
 For debugging or automated tests, append `?autostart=1` to `battleJudoka.html` to skip the modal and begin a default-length match immediately.
 
 Note on Next button behavior:
-- The `Next` button advances only during the inter-round cooldown. It remains disabled while choosing a stat to avoid skipping the cooldown logic accidentally. The cooldown enables `Next` (or auto-advances in test mode); do not expect `Next` to be ready during stat selection.
+- The `Next` button advances only during the inter-round cooldown. Clicking it cancels any remaining cooldown and immediately starts the next round.
+- It remains disabled while choosing a stat to avoid skipping the cooldown logic accidentally. The cooldown enables `Next` (or auto-advances in test mode); do not expect `Next` to be ready during stat selection.
 
 See [design/battleMarkup.md](design/battleMarkup.md) for the canonical DOM ids used by classic battle scripts.
 

--- a/playwright/battle-next-skip.spec.js
+++ b/playwright/battle-next-skip.spec.js
@@ -1,0 +1,40 @@
+import { test, expect } from "./fixtures/commonSetup.js";
+import { waitForBattleReady, waitForBattleState } from "./fixtures/waits.js";
+
+/**
+ * Verify that clicking Next during cooldown skips the delay.
+ *
+ * @pseudocode
+ * 1. Set a short next-round cooldown.
+ * 2. Start a battle, select the first stat to end round 1.
+ * 3. Click Next as soon as it is enabled.
+ * 4. Expect the round counter to show round 2 within 1s.
+ */
+test.describe("Next button cooldown skip", () => {
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__NEXT_ROUND_COOLDOWN_MS = 1000;
+  });
+});
+
+  test("advances immediately when clicked", async ({ page }) => {
+    await page.goto("/src/pages/battleJudoka.html?autostart=1");
+    await waitForBattleReady(page);
+
+    // Finish round 1 quickly.
+    await page.locator("#stat-buttons button").first().click();
+    await page.locator("#stat-buttons[data-buttons-ready='false']").waitFor();
+    await page.evaluate(() => window.getRoundResolvedPromise?.());
+    await waitForBattleState(page, "cooldown");
+
+    const counter = page.locator("#round-counter");
+    await expect(counter).toHaveText(/Round 1/);
+
+    const nextBtn = page.locator("#next-button");
+    await expect(nextBtn).toBeEnabled();
+    await nextBtn.click();
+
+    await expect(counter).toHaveText(/Round 2/, { timeout: 1000 });
+    await page.evaluate(() => window.freezeBattleHeader?.());
+  });
+});

--- a/playwright/battle-next-skip.spec.js
+++ b/playwright/battle-next-skip.spec.js
@@ -11,11 +11,11 @@ import { waitForBattleReady, waitForBattleState } from "./fixtures/waits.js";
  * 4. Expect the round counter to show round 2 within 1s.
  */
 test.describe("Next button cooldown skip", () => {
-test.beforeEach(async ({ page }) => {
-  await page.addInitScript(() => {
-    window.__NEXT_ROUND_COOLDOWN_MS = 1000;
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__NEXT_ROUND_COOLDOWN_MS = 1000;
+    });
   });
-});
 
   test("advances immediately when clicked", async ({ page }) => {
     await page.goto("/src/pages/battleJudoka.html?autostart=1");

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -78,13 +78,11 @@ export async function advanceWhenReady(btn, resolveReady) {
 export async function cancelTimerOrAdvance(_btn, timer, resolveReady) {
   if (timer) {
     timer.stop();
-    try {
-      const { state } = getStateSnapshot();
-      void state;
-    } catch {}
+    // Clear existing handler before advancing so the next round's handler
+    // installed during `ready` remains intact.
+    setSkipHandler(null);
     await dispatchBattleEvent("ready");
     if (typeof resolveReady === "function") resolveReady();
-    setSkipHandler(null);
     return;
   }
   // No active timer controls: if we're in cooldown (or state is unknown in
@@ -92,9 +90,9 @@ export async function cancelTimerOrAdvance(_btn, timer, resolveReady) {
   try {
     const { state } = getStateSnapshot();
     if (state === "cooldown" || !state) {
+      setSkipHandler(null);
       await dispatchBattleEvent("ready");
       if (typeof resolveReady === "function") resolveReady();
-      setSkipHandler(null);
     }
   } catch {}
 }

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -63,7 +63,10 @@ export async function advanceWhenReady(btn, resolveReady) {
  * Cancel an active cooldown timer or advance immediately when already in cooldown.
  *
  * @pseudocode
- * 1. If a `timer` object is provided, call `timer.stop()` and return.
+ * 1. If a `timer` object is provided:
+ *    a. Call `timer.stop()` to cancel the countdown.
+ *    b. Dispatch `ready`, call `resolveReady`, and clear the skip handler.
+ *    c. Return early.
  * 2. Otherwise, if the state machine is in `cooldown` (or unknown in tests),
  *    dispatch `ready`, call `resolveReady`, and clear the skip handler.
  *
@@ -75,6 +78,13 @@ export async function advanceWhenReady(btn, resolveReady) {
 export async function cancelTimerOrAdvance(_btn, timer, resolveReady) {
   if (timer) {
     timer.stop();
+    try {
+      const { state } = getStateSnapshot();
+      void state;
+    } catch {}
+    await dispatchBattleEvent("ready");
+    if (typeof resolveReady === "function") resolveReady();
+    setSkipHandler(null);
     return;
   }
   // No active timer controls: if we're in cooldown (or state is unknown in

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -59,6 +59,27 @@ describe("timerService next round handling", () => {
     expect(dispatchBattleEvent).toHaveBeenCalledTimes(2);
   });
 
+  it("preserves skip handler after manual skip", async () => {
+    const timerMod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const roundMod = await import("../../../src/helpers/classicBattle/roundManager.js");
+    const { nextButton } = createTimerNodes();
+
+    let controls = roundMod.startCooldown({}, scheduler);
+    nextButton.onclick = (e) => timerMod.onNextButtonClick(e, controls);
+    scheduler.tick(100);
+    nextButton.click();
+    await controls.ready;
+
+    controls = roundMod.startCooldown({}, scheduler);
+    nextButton.onclick = (e) => timerMod.onNextButtonClick(e, controls);
+    scheduler.tick(100);
+    nextButton.click();
+    await controls.ready;
+
+    expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
+    expect(dispatchBattleEvent).toHaveBeenCalledTimes(4);
+  });
+
   it("stopping timer dispatches ready immediately", async () => {
     const { cancelTimerOrAdvance } = await import(
       "../../../src/helpers/classicBattle/timerService.js"

--- a/tests/helpers/timerService.onNextButtonClick.test.js
+++ b/tests/helpers/timerService.onNextButtonClick.test.js
@@ -31,14 +31,14 @@ describe("onNextButtonClick", () => {
     expect(resolveReady).toHaveBeenCalledTimes(1);
   });
 
-  it("stops timer when not ready", async () => {
+  it("stops timer and dispatches ready when not marked ready", async () => {
     const { onNextButtonClick } = await import("../../src/helpers/classicBattle/timerService.js");
     const stop = vi.fn();
     __setStateSnapshot({ state: "roundDecision" });
     await onNextButtonClick(new MouseEvent("click"), { timer: { stop }, resolveReady: null });
     const dispatcher = await import("../../src/helpers/classicBattle/orchestrator.js");
     expect(stop).toHaveBeenCalledTimes(1);
-    expect(dispatcher.dispatchBattleEvent).not.toHaveBeenCalled();
+    expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
   });
 
   it("advances immediately when no timer and in cooldown", async () => {


### PR DESCRIPTION
Summary
Cleared the existing skip handler before dispatching ready and removed an unused state fetch so subsequent rounds retain a working cooldown skip handler
Added a regression test ensuring the skip handler persists after a manual cooldown skip, verifying multiple skip cycles work as expected