### PR TITLE
feat: assert required battle UI elements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,12 @@ To keep CI and local runs readable, **no test should emit unsilenced `console.wa
 
 ---
 
+### Classic Battle DOM Guardrails
+
+Battle helpers such as `setupNextButton` and `initStatButtons` throw when key elements (e.g. `#next-button`, `#stat-buttons`) are missing. Tests must either provide these nodes or assert the thrown errors to avoid unintended failures.
+
+---
+
 ## 🧭 Module Loading Policy
 
 Use static imports for hot paths and always-required modules; use dynamic imports with preload for optional or heavy features. See the canonical [Module Loading Policy for Agents](./AGENTS.md#module-loading-policy-for-agents) for the full policy.

--- a/tests/helpers/classicBattle/battleStateBadge.test.js
+++ b/tests/helpers/classicBattle/battleStateBadge.test.js
@@ -51,7 +51,9 @@ function createBattleDom() {
   progressEl.id = "battle-state-progress";
   const machineState = document.createElement("div");
   machineState.id = "machine-state";
-  document.body.append(header, battleArea, stats, progressEl, machineState);
+  const next = document.createElement("button");
+  next.id = "next-button";
+  document.body.append(header, battleArea, stats, progressEl, machineState, next);
 }
 
 describe("battleStateBadge displays state transitions", () => {

--- a/tests/helpers/classicBattle/battleStateProgress.test.js
+++ b/tests/helpers/classicBattle/battleStateProgress.test.js
@@ -36,7 +36,9 @@ function createBattleDom() {
   machineState.id = "machine-state";
   const badge = document.createElement("span");
   badge.id = "battle-state-badge";
-  document.body.append(header, battleArea, stats, progressEl, machineState, badge);
+  const next = document.createElement("button");
+  next.id = "next-button";
+  document.body.append(header, battleArea, stats, progressEl, machineState, badge, next);
 }
 
 describe("battleStateProgress updates on object-shaped battleStateChange", () => {

--- a/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
+++ b/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-describe("uiHelpers missing element warnings", () => {
+describe("uiHelpers element assertions", () => {
   beforeEach(() => {
     vi.resetModules();
     document.body.innerHTML = "";
@@ -10,29 +10,32 @@ describe("uiHelpers missing element warnings", () => {
     vi.restoreAllMocks();
   });
 
-  it("warns when next button is missing", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("throws when next button is missing", async () => {
     const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
-    mod.setupNextButton();
-    expect(warnSpy).toHaveBeenCalledWith("[uiHelpers] #next-button not found");
+    expect(() => mod.setupNextButton()).toThrow("setupNextButton: #next-button missing");
   });
 
-  it("warns when stat buttons container is missing", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("throws when stat buttons container is missing", async () => {
     const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
-    mod.initStatButtons({});
-    expect(warnSpy).toHaveBeenCalledWith("[uiHelpers] #stat-buttons container not found");
+    expect(() => mod.initStatButtons({})).toThrow("initStatButtons: #stat-buttons missing");
     await expect(window.statButtonsReadyPromise).resolves.toBeUndefined();
   });
 
-  it("resets and resolves stat buttons promise when resolver missing", async () => {
+  it("warns when no stat buttons are found", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const container = document.createElement("div");
+    container.id = "stat-buttons";
+    document.body.appendChild(container);
     const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
-    window.statButtonsReadyPromise = new Promise(() => {});
-    // simulate missing resolver
-    delete window.__resolveStatButtonsReady;
     mod.initStatButtons({});
-    expect(warnSpy).toHaveBeenCalledWith("[uiHelpers] #stat-buttons container not found");
+    expect(warnSpy).toHaveBeenCalledWith("[uiHelpers] #stat-buttons has no buttons");
+  });
+
+  it("resolves stat button promise when resolver missing", async () => {
+    window.statButtonsReadyPromise = new Promise(() => {});
+    delete window.__resolveStatButtonsReady;
+    const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
+    expect(() => mod.initStatButtons({})).toThrow("initStatButtons: #stat-buttons missing");
     await expect(window.statButtonsReadyPromise).resolves.toBeUndefined();
   });
 });

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -11,6 +11,9 @@ vi.mock("../../src/utils/scheduler.js", () => ({
 describe("classicBattlePage feature flag updates", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
+    const next = document.createElement("button");
+    next.id = "next-button";
+    document.body.appendChild(next);
     vi.resetModules();
   });
 
@@ -106,8 +109,13 @@ describe("classicBattlePage feature flag updates", () => {
   it("copies debug output text to the clipboard", async () => {
     const battleArea = document.createElement("div");
     battleArea.id = "battle-area";
+    const stats = document.createElement("div");
+    stats.id = "stat-buttons";
+    const btn = document.createElement("button");
+    btn.dataset.stat = "power";
+    stats.appendChild(btn);
     const container = document.createElement("div");
-    container.append(battleArea);
+    container.append(battleArea, stats);
     document.body.append(container);
 
     const currentFlags = {

--- a/tests/helpers/classicBattlePage.startRoundWrapper.test.js
+++ b/tests/helpers/classicBattlePage.startRoundWrapper.test.js
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 beforeEach(() => {
   document.body.innerHTML = "";
+  const next = document.createElement("button");
+  next.id = "next-button";
+  document.body.appendChild(next);
   localStorage.clear();
   vi.resetModules();
   vi.doUnmock("../../src/helpers/settingsStorage.js");


### PR DESCRIPTION
## Summary
- throw when `#next-button` or `#stat-buttons` are missing in classic battle helpers
- warn and return no-op controls when `#stat-buttons` has no buttons
- document DOM guardrails for battle helpers and cover error paths with tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b870a2a3b483268430038ceb9ff290