### PR TITLE
fix: resolve stat buttons promise only on success

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -112,6 +112,19 @@ function ensureDebugCopyButton(panel) {
 }
 
 /**
+ * Resolve the global stat buttons ready promise if present.
+ */
+function resolveStatButtonsReady() {
+  if (typeof window === "undefined") return;
+  if (typeof window.__resolveStatButtonsReady !== "function") {
+    const { resolve } = resetStatButtonsReadyPromise();
+    resolve();
+  } else {
+    window.__resolveStatButtonsReady();
+  }
+}
+
+/**
  * Display a snackbar prompting the player to choose a stat.
  *
  * @pseudocode
@@ -1134,27 +1147,12 @@ export function clearScoreboardAndMessages() {
 export function initStatButtons(store) {
   const statContainer = document.getElementById("stat-buttons");
   if (!statContainer) {
-    if (typeof window !== "undefined") {
-      if (typeof window.__resolveStatButtonsReady !== "function") {
-        const { resolve } = resetStatButtonsReadyPromise();
-        resolve();
-      } else {
-        window.__resolveStatButtonsReady();
-      }
-    }
     throw new Error("initStatButtons: #stat-buttons missing");
   }
 
   const statButtons = statContainer.querySelectorAll("button");
   if (!statButtons.length) {
-    if (typeof window !== "undefined") {
-      if (typeof window.__resolveStatButtonsReady !== "function") {
-        const { resolve } = resetStatButtonsReadyPromise();
-        resolve();
-      } else {
-        window.__resolveStatButtonsReady();
-      }
-    }
+    resolveStatButtonsReady();
     guard(() => console.warn("[uiHelpers] #stat-buttons has no buttons"));
     return { enable: () => {}, disable: () => {} };
   }

--- a/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
+++ b/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
@@ -16,26 +16,23 @@ describe("uiHelpers element assertions", () => {
   });
 
   it("throws when stat buttons container is missing", async () => {
+    const resolveSpy = vi.fn();
+    window.__resolveStatButtonsReady = resolveSpy;
     const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
     expect(() => mod.initStatButtons({})).toThrow("initStatButtons: #stat-buttons missing");
-    await expect(window.statButtonsReadyPromise).resolves.toBeUndefined();
+    expect(resolveSpy).not.toHaveBeenCalled();
   });
 
   it("warns when no stat buttons are found", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const resolveSpy = vi.fn();
+    window.__resolveStatButtonsReady = resolveSpy;
     const container = document.createElement("div");
     container.id = "stat-buttons";
     document.body.appendChild(container);
     const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
     mod.initStatButtons({});
     expect(warnSpy).toHaveBeenCalledWith("[uiHelpers] #stat-buttons has no buttons");
-  });
-
-  it("resolves stat button promise when resolver missing", async () => {
-    window.statButtonsReadyPromise = new Promise(() => {});
-    delete window.__resolveStatButtonsReady;
-    const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
-    expect(() => mod.initStatButtons({})).toThrow("initStatButtons: #stat-buttons missing");
-    await expect(window.statButtonsReadyPromise).resolves.toBeUndefined();
+    expect(resolveSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- remove stat buttons ready resolution when container is missing
- extract stat buttons readiness resolution into helper function
- assert no resolution in tests for missing container and ensure resolution when empty

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: Timed out waiting for battle state "cooldown")*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b876dd52288326bb86e2fbfca8aa54