### PR TITLE
Clear fallback timer on cooldown skip

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -321,6 +321,8 @@ function wireNextRoundTimer(controls, btn, cooldownSeconds, scheduler) {
   const timer = createRoundTimer();
   attachCooldownRenderer(timer, cooldownSeconds);
   let expired = false;
+  /** @type {ReturnType<typeof setTimeout>|null|undefined} */
+  let fallbackId;
   const onExpired = () => {
     if (expired) return;
     expired = true;
@@ -340,6 +342,7 @@ function wireNextRoundTimer(controls, btn, cooldownSeconds, scheduler) {
     try {
       console.warn("[test] skip: stop nextRoundTimer");
     } catch {}
+    clearTimeout(fallbackId);
     controls.timer?.stop();
   });
   scheduler.setTimeout(() => controls.timer.start(cooldownSeconds), 0);
@@ -354,7 +357,7 @@ function wireNextRoundTimer(controls, btn, cooldownSeconds, scheduler) {
     const ms = !Number.isFinite(secsNum) || secsNum <= 0 ? 10 : Math.max(0, secsNum * 1000);
     // Use both global and injected scheduler timeouts to maximize compatibility
     // with test environments that mock timers differently.
-    setupFallbackTimer(ms, onExpired);
+    fallbackId = setupFallbackTimer(ms, onExpired);
     try {
       scheduler.setTimeout(() => onExpired(), ms);
       if (typeof process !== "undefined" && process.env && process.env.VITEST) {

--- a/tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js
+++ b/tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTimerNodes } from "./domUtils.js";
+import { createMockScheduler } from "../mockScheduler.js";
+
+describe("skip handler clears fallback timer", () => {
+  let scheduler;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    scheduler = createMockScheduler();
+    document.body.innerHTML = "";
+    createTimerNodes();
+    document.body.dataset.battleState = "cooldown";
+    vi.resetModules();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.doMock("../../../src/helpers/setupScoreboard.js", () => ({
+      clearTimer: vi.fn(),
+      showMessage: () => {},
+      showAutoSelect: () => {},
+      showTemporaryMessage: () => () => {},
+      updateTimer: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/showSnackbar.js", () => ({
+      showSnackbar: vi.fn(),
+      updateSnackbar: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
+      updateDebugPanel: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/classicBattle/orchestrator.js", () => ({
+      dispatchBattleEvent: vi.fn().mockResolvedValue(undefined)
+    }));
+    vi.doMock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
+      onBattleEvent: vi.fn(),
+      offBattleEvent: vi.fn(),
+      emitBattleEvent: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/timers/createRoundTimer.js", () => ({
+      createRoundTimer: () => {
+        const handlers = {};
+        return {
+          on: (ev, fn) => {
+            handlers[ev] = fn;
+          },
+          start: vi.fn(),
+          stop: () => {
+            handlers.expired && handlers.expired();
+          }
+        };
+      }
+    }));
+    vi.doMock("../../../src/helpers/CooldownRenderer.js", () => ({
+      attachCooldownRenderer: vi.fn()
+    }));
+    vi.doMock("../../../src/helpers/timers/computeNextRoundCooldown.js", () => ({
+      computeNextRoundCooldown: () => 0
+    }));
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    const { resetSkipState } = await import("../../../src/helpers/classicBattle/skipHandler.js");
+    resetSkipState();
+  });
+
+  it("fires ready once after skipping", async () => {
+    const orchestrator = await import("../../../src/helpers/classicBattle/orchestrator.js");
+    const { startCooldown } = await import("../../../src/helpers/classicBattle/roundManager.js");
+    const { skipCurrentPhase } = await import("../../../src/helpers/classicBattle/skipHandler.js");
+    startCooldown({}, scheduler);
+    skipCurrentPhase();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(orchestrator.dispatchBattleEvent).toHaveBeenCalledWith("ready");
+    expect(orchestrator.dispatchBattleEvent).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(orchestrator.dispatchBattleEvent).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- store fallback timer ID in `wireNextRoundTimer`
- clear fallback timer when skip handler runs
- add regression test ensuring skipped cooldown fires `ready` once

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: Timed out waiting for battle state "cooldown" in `battle-next-skip.spec.js`)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b8771961fc8326a20edd794b69267c