### PR TITLE
feat: add next-round role to Next button

### DIFF
--- a/design/battleMarkup.md
+++ b/design/battleMarkup.md
@@ -4,24 +4,24 @@ Classic battle pages rely on specific element IDs so helper scripts can attach l
 
 ## Required IDs
 
-| ID                      | Purpose                                         |
-| ----------------------- | ----------------------------------------------- |
-| `round-message`         | Announces prompts and round outcomes.           |
-| `next-round-timer`      | Displays the inter-round countdown.             |
-| `round-counter`         | Shows current round number.                     |
-| `score-display`         | Lists player and opponent scores.               |
-| `test-mode-banner`      | Indicates when test mode is active.             |
-| `debug-panel`           | Collapsible container for debugging info.       |
-| `debug-output`          | `<pre>` element inside the debug panel.         |
-| `battle-area`           | Wrapper containing player and opponent cards.   |
-| `player-card`           | Container for the player's card.                |
-| `opponent-card`         | Container for the opponent's card.              |
-| `stat-buttons`          | Group of stat selection buttons.                |
-| `round-result`          | Displays the result of the round.               |
-| `next-button`           | Advances to the next round when ready.          |
-| `stat-help`             | Opens stat selection help.                      |
-| `quit-match-button`     | Triggers the quit match flow.                   |
-| `battle-state-progress` | Optional list tracking match state transitions. |
+| ID                                       | Purpose                                         |
+| ---------------------------------------- | ----------------------------------------------- |
+| `round-message`                          | Announces prompts and round outcomes.           |
+| `next-round-timer`                       | Displays the inter-round countdown.             |
+| `round-counter`                          | Shows current round number.                     |
+| `score-display`                          | Lists player and opponent scores.               |
+| `test-mode-banner`                       | Indicates when test mode is active.             |
+| `debug-panel`                            | Collapsible container for debugging info.       |
+| `debug-output`                           | `<pre>` element inside the debug panel.         |
+| `battle-area`                            | Wrapper containing player and opponent cards.   |
+| `player-card`                            | Container for the player's card.                |
+| `opponent-card`                          | Container for the opponent's card.              |
+| `stat-buttons`                           | Group of stat selection buttons.                |
+| `round-result`                           | Displays the result of the round.               |
+| `next-button` (`data-role="next-round"`) | Advances to the next round when ready.          |
+| `stat-help`                              | Opens stat selection help.                      |
+| `quit-match-button`                      | Triggers the quit match flow.                   |
+| `battle-state-progress`                  | Optional list tracking match state transitions. |
 
 ## Example Markup
 
@@ -32,7 +32,9 @@ Classic battle pages rely on specific element IDs so helper scripts can attach l
 </div>
 
 <div class="action-buttons">
-  <button id="next-button" class="battle-control-button" disabled>Next</button>
+  <button id="next-button" class="battle-control-button" disabled data-role="next-round">
+    Next
+  </button>
   <button id="stat-help" class="battle-control-button" aria-label="Stat selection help">?</button>
   <button id="quit-match-button" class="battle-control-button">Quit Match</button>
 </div>

--- a/playwright/battle-next-skip.spec.js
+++ b/playwright/battle-next-skip.spec.js
@@ -30,7 +30,7 @@ test.describe("Next button cooldown skip", () => {
     const counter = page.locator("#round-counter");
     await expect(counter).toHaveText(/Round 1/);
 
-    const nextBtn = page.locator("#next-button");
+    const nextBtn = page.locator('[data-role="next-round"]');
     await expect(nextBtn).toBeEnabled();
     await nextBtn.click();
 

--- a/scripts/diagnosePlaywrightInteractive.js
+++ b/scripts/diagnosePlaywrightInteractive.js
@@ -51,7 +51,7 @@ async function run() {
     console.log("round-result:", (snap.roundResult || "").trim());
 
     // click Next if available
-    const next = await page.$("#next-button");
+    const next = await page.$('[data-role="next-round"]');
     if (next) {
       const isDisabled = await next.getAttribute("disabled");
       if (isDisabled === null) {

--- a/src/pages/battleClassic.html
+++ b/src/pages/battleClassic.html
@@ -117,6 +117,7 @@
                 class="battle-control-button"
                 data-tooltip-id="ui.next"
                 disabled
+                data-role="next-round"
                 data-testid="next-button"
               >
                 Next

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -113,6 +113,7 @@
                 class="battle-control-button"
                 data-tooltip-id="ui.next"
                 disabled
+                data-role="next-round"
                 data-testid="next-button"
               >
                 Next

--- a/tests/helpers/classicBattle/battleStateBadge.test.js
+++ b/tests/helpers/classicBattle/battleStateBadge.test.js
@@ -53,6 +53,7 @@ function createBattleDom() {
   machineState.id = "machine-state";
   const next = document.createElement("button");
   next.id = "next-button";
+  next.setAttribute("data-role", "next-round");
   document.body.append(header, battleArea, stats, progressEl, machineState, next);
 }
 

--- a/tests/helpers/classicBattle/battleStateProgress.test.js
+++ b/tests/helpers/classicBattle/battleStateProgress.test.js
@@ -38,6 +38,7 @@ function createBattleDom() {
   badge.id = "battle-state-badge";
   const next = document.createElement("button");
   next.id = "next-button";
+  next.setAttribute("data-role", "next-round");
   document.body.append(header, battleArea, stats, progressEl, machineState, badge, next);
 }
 

--- a/tests/helpers/classicBattle/controlState.test.js
+++ b/tests/helpers/classicBattle/controlState.test.js
@@ -82,7 +82,7 @@ describe("classicBattle battle control state", () => {
     const { disableNextRoundButton, enableNextRoundButton } = await import(
       "../../../src/helpers/classicBattle.js"
     );
-    const btn = document.querySelector('[data-testid="next-button"]');
+    const btn = document.querySelector('[data-role="next-round"]');
     disableNextRoundButton();
     expect(btn.disabled).toBe(true);
     expect(btn.dataset.nextReady).toBeUndefined();
@@ -94,10 +94,10 @@ describe("classicBattle battle control state", () => {
   it("resetBattleUI replaces Next button and reattaches click handler", async () => {
     const timerSvc = await import("../../../src/helpers/classicBattle/timerService.js");
     const { resetBattleUI } = await import("../../../src/helpers/classicBattle/uiHelpers.js");
-    const btn = document.querySelector('[data-testid="next-button"]');
+    const btn = document.querySelector('[data-role="next-round"]');
     btn.dataset.nextReady = "true";
     resetBattleUI();
-    const cloned = document.querySelector('[data-testid="next-button"]');
+    const cloned = document.querySelector('[data-role="next-round"]');
     expect(cloned).not.toBe(btn);
     expect(cloned.disabled).toBe(true);
     expect(cloned.dataset.nextReady).toBeUndefined();

--- a/tests/helpers/classicBattle/domUtils.js
+++ b/tests/helpers/classicBattle/domUtils.js
@@ -51,14 +51,15 @@ export function createRoundMessage(id = "round-message") {
  * @pseudocode
  * 1. Create a `button` element named `nextButton`.
  * 2. Set its `id` to "next-button".
- * 3. Set its `data-testid` to "next-button".
- * 4. Create a `p` element named `nextRoundTimer`.
- * 5. Set its `id` to "next-round-timer".
- * 6. Set the `aria-live` attribute of `nextRoundTimer` to "polite".
- * 7. Set the `aria-atomic` attribute of `nextRoundTimer` to "true".
- * 8. Set the `role` attribute of `nextRoundTimer` to "status".
- * 9. Append `nextButton` and `nextRoundTimer` to `document.body`.
- * 10. Return an object containing both nodes.
+ * 3. Set its `data-role` to "next-round".
+ * 4. Set its `data-testid` to "next-button".
+ * 5. Create a `p` element named `nextRoundTimer`.
+ * 6. Set its `id` to "next-round-timer".
+ * 7. Set the `aria-live` attribute of `nextRoundTimer` to "polite".
+ * 8. Set the `aria-atomic` attribute of `nextRoundTimer` to "true".
+ * 9. Set the `role` attribute of `nextRoundTimer` to "status".
+ * 10. Append `nextButton` and `nextRoundTimer` to `document.body`.
+ * 11. Return an object containing both nodes.
  *
  * @returns {{nextButton: HTMLButtonElement, nextRoundTimer: HTMLParagraphElement}}
  *   Nodes for controlling the next round timer.
@@ -66,6 +67,7 @@ export function createRoundMessage(id = "round-message") {
 export function createTimerNodes() {
   const nextButton = document.createElement("button");
   nextButton.id = "next-button";
+  nextButton.setAttribute("data-role", "next-round");
   nextButton.setAttribute("data-testid", "next-button");
   const nextRoundTimer = document.createElement("p");
   nextRoundTimer.id = "next-round-timer";

--- a/tests/helpers/classicBattle/drawNextRound.test.js
+++ b/tests/helpers/classicBattle/drawNextRound.test.js
@@ -29,6 +29,7 @@ describe("classicBattle draw next round", () => {
     });
     const nextBtn = document.createElement("button");
     nextBtn.id = "next-button";
+    nextBtn.setAttribute("data-role", "next-round");
     nextBtn.setAttribute("data-testid", "next-button");
     document.body.appendChild(nextBtn);
     window.__NEXT_ROUND_COOLDOWN_MS = 0;
@@ -62,7 +63,7 @@ describe("classicBattle draw next round", () => {
     await playRound(battleMod, store, 5, 5);
     battleMod.startCooldown(store);
     await vi.runAllTimersAsync();
-    const nextBtn = document.querySelector('[data-testid="next-button"]');
+    const nextBtn = document.querySelector('[data-role="next-round"]');
     expect(nextBtn.disabled).toBe(false);
     expect(nextBtn.dataset.nextReady).toBe("true");
 

--- a/tests/helpers/classicBattle/nextButton.cooldown.fallback.test.js
+++ b/tests/helpers/classicBattle/nextButton.cooldown.fallback.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 describe("Next button cooldown fallback", () => {
   beforeEach(async () => {
-    document.body.innerHTML = `<button id="next-button" data-testid="next-button">Next</button>`;
+    document.body.innerHTML = `<button id="next-button" data-role="next-round" data-testid="next-button">Next</button>`;
     const { onBattleEvent, emitBattleEvent, __resetBattleEventTarget } = await import(
       "../../../src/helpers/classicBattle/battleEvents.js"
     );

--- a/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
@@ -58,7 +58,7 @@ describe("startCooldown fallback timer", () => {
 
   it("resolves ready after fallback timer and enables button", async () => {
     const { startCooldown } = await import("../../../src/helpers/classicBattle/roundManager.js");
-    const btn = document.querySelector('[data-testid="next-button"]');
+    const btn = document.querySelector('[data-role="next-round"]');
     btn.disabled = true;
     const controls = startCooldown({}, scheduler);
     let resolved = false;

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -110,7 +110,7 @@ describe("classicBattle startCooldown", () => {
     expect(dispatchSpy).toHaveBeenCalledWith("ready");
     expect(startRoundWrapper).toHaveBeenCalledTimes(1);
     expect(machine.getState()).toBe("waitingForPlayerAction");
-    const btn = document.querySelector('[data-testid="next-button"]');
+    const btn = document.querySelector('[data-role="next-round"]');
     expect(btn?.dataset.nextReady).toBe("true");
     expect(btn?.disabled).toBe(false);
     delete window.__NEXT_ROUND_COOLDOWN_MS;
@@ -144,7 +144,7 @@ describe("classicBattle startCooldown", () => {
     expect(machine.getState()).toBe("cooldown");
 
     const controls = battleMod.startCooldown(store);
-    document.querySelector('[data-testid="next-button"]').click();
+    document.querySelector('[data-role="next-round"]').click();
     await controls.ready;
     // Ensure state progressed before assertions
     await waitForState("waitingForPlayerAction");

--- a/tests/helpers/classicBattle/statDoubleClick.test.js
+++ b/tests/helpers/classicBattle/statDoubleClick.test.js
@@ -29,6 +29,7 @@ describe("classicBattle stat double-click", () => {
     });
     const nextBtn = document.createElement("button");
     nextBtn.id = "next-button";
+    nextBtn.setAttribute("data-role", "next-round");
     nextBtn.setAttribute("data-testid", "next-button");
     document.body.appendChild(nextBtn);
     window.__NEXT_ROUND_COOLDOWN_MS = 0;

--- a/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
+++ b/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
@@ -16,7 +16,7 @@ describe("timeout → interruptRound → cooldown auto-advance", () => {
       <div id="opponent-card"></div>
       <p id="round-message"></p>
       <p id="next-round-timer"></p>
-      <button id="next-button" data-testid="next-button" disabled>Next</button>
+      <button id="next-button" data-role="next-round" data-testid="next-button" disabled>Next</button>
       <div id="snackbar-container"></div>
     `;
     // Use minimal 1s cooldown for auto-advance

--- a/tests/helpers/classicBattle/waitingForPlayerAction.test.js
+++ b/tests/helpers/classicBattle/waitingForPlayerAction.test.js
@@ -6,6 +6,7 @@ describe("waitingForPlayerActionEnter", () => {
     document.body.innerHTML = "";
     const next = document.createElement("button");
     next.id = "next-button";
+    next.setAttribute("data-role", "next-round");
     next.setAttribute("data-testid", "next-button");
     next.disabled = true;
     document.body.appendChild(next);
@@ -16,7 +17,7 @@ describe("waitingForPlayerActionEnter", () => {
     const store = {};
     const machine = { context: { store } };
     await mod.waitingForPlayerActionEnter(machine);
-    const btn = document.querySelector('[data-testid="next-button"]');
+    const btn = document.querySelector('[data-role="next-round"]');
     expect(btn.disabled).toBe(true);
     expect(btn.dataset.nextReady).toBeUndefined();
   });

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -13,6 +13,7 @@ describe("classicBattlePage feature flag updates", () => {
     document.body.innerHTML = "";
     const next = document.createElement("button");
     next.id = "next-button";
+    next.setAttribute("data-role", "next-round");
     document.body.appendChild(next);
     vi.resetModules();
   });

--- a/tests/helpers/classicBattlePage.startRoundWrapper.test.js
+++ b/tests/helpers/classicBattlePage.startRoundWrapper.test.js
@@ -4,6 +4,7 @@ beforeEach(() => {
   document.body.innerHTML = "";
   const next = document.createElement("button");
   next.id = "next-button";
+  next.setAttribute("data-role", "next-round");
   document.body.appendChild(next);
   localStorage.clear();
   vi.resetModules();

--- a/tests/helpers/timerService.onNextButtonClick.test.js
+++ b/tests/helpers/timerService.onNextButtonClick.test.js
@@ -13,8 +13,9 @@ describe("onNextButtonClick", () => {
   let btn;
 
   beforeEach(() => {
-    document.body.innerHTML = '<button id="next-button" data-testid="next-button"></button>';
-    btn = document.querySelector('[data-testid="next-button"]');
+    document.body.innerHTML =
+      '<button id="next-button" data-role="next-round" data-testid="next-button"></button>';
+    btn = document.querySelector('[data-role="next-round"]');
     vi.clearAllMocks();
   });
 

--- a/tests/helpers/timerService.test.js
+++ b/tests/helpers/timerService.test.js
@@ -90,6 +90,7 @@ describe("timerService", () => {
   it("enables next round when skipped before cooldown starts", async () => {
     const btn = document.createElement("button");
     btn.id = "next-button";
+    btn.setAttribute("data-role", "next-round");
     btn.setAttribute("data-testid", "next-button");
     btn.classList.add("disabled");
     document.body.appendChild(btn);

--- a/tests/helpers/uiHelpers.resetBattleUI.test.js
+++ b/tests/helpers/uiHelpers.resetBattleUI.test.js
@@ -35,6 +35,7 @@ describe("resetBattleUI helpers", () => {
   it("resetNextButton clones and disables next button", async () => {
     const btn = document.createElement("button");
     btn.id = "next-button";
+    btn.setAttribute("data-role", "next-round");
     btn.setAttribute("data-testid", "next-button");
     btn.dataset.nextReady = "true";
     document.body.append(btn);
@@ -43,7 +44,7 @@ describe("resetBattleUI helpers", () => {
 
     const timerSvc = await import("../../src/helpers/classicBattle/timerService.js");
 
-    const newBtn = document.querySelector('[data-testid="next-button"]');
+    const newBtn = document.querySelector('[data-role="next-round"]');
     expect(newBtn).not.toBe(btn);
     expect(newBtn.disabled).toBe(true);
     expect(newBtn.dataset.nextReady).toBeUndefined();

--- a/tests/pages/battlePages.dom.test.js
+++ b/tests/pages/battlePages.dom.test.js
@@ -4,7 +4,7 @@ import { readFileSync } from "fs";
 const PAGES = ["battleJudoka", "battleClassic"];
 
 const REQUIRED = [
-  { id: "next-button", testId: "next-button" },
+  { id: "next-button", testId: "next-button", role: "next-round" },
   { id: "stat-help", testId: "stat-help" },
   { id: "quit-match-button", testId: "quit-match" }
 ];
@@ -15,6 +15,17 @@ function getMissingIds(root, ids) {
 
 function getMissingTestIds(root, testIds) {
   return testIds.filter((t) => !root.querySelector(`[data-testid="${t}"]`));
+}
+
+/**
+ * @pseudocode
+ * 1. Filter `roles` lacking a matching `data-role` in `root`.
+ * @param {ParentNode} root
+ * @param {string[]} roles
+ * @returns {string[]} Missing role values.
+ */
+function getMissingRoles(root, roles) {
+  return roles.filter((r) => !root.querySelector(`[data-role="${r}"]`));
 }
 
 describe.each(PAGES)("%s.html required hooks", (page) => {
@@ -36,6 +47,12 @@ describe.each(PAGES)("%s.html required hooks", (page) => {
     expect(missing).toEqual([]);
     const statButtons = document.querySelectorAll("#stat-buttons button");
     statButtons.forEach((btn) => expect(btn.getAttribute("data-testid")).toBe("stat-button"));
+  });
+
+  it("includes all required data-role attributes", () => {
+    const roles = REQUIRED.map((r) => r.role).filter(Boolean);
+    const missing = getMissingRoles(document, roles);
+    expect(missing).toEqual([]);
   });
 
   it("detects when a data-testid is missing", () => {


### PR DESCRIPTION
## Summary
- add `data-role="next-round"` to Next buttons
- document Next button role in battle markup guide
- switch tests and Playwright spec to query `[data-role="next-round"]`

## Testing
- `npx prettier . --check`
- `npx eslint .` (warn)
- `npm run check:jsdoc` (fail: 162 missing)
- `npx vitest run`
- `npx playwright test` (fail: battle-next-skip.spec.js)
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": [
    "src/pages/battleJudoka.html",
    "src/pages/battleClassic.html",
    "design/battleMarkup.md",
    "tests/helpers/*.test.js",
    "tests/pages/battlePages.dom.test.js",
    "playwright/battle-next-skip.spec.js",
    "scripts/diagnosePlaywrightInteractive.js"
  ],
  "outputs": [
    "src/pages/battleJudoka.html",
    "src/pages/battleClassic.html",
    "design/battleMarkup.md",
    "tests/helpers/*.test.js",
    "tests/pages/battlePages.dom.test.js",
    "playwright/battle-next-skip.spec.js",
    "scripts/diagnosePlaywrightInteractive.js"
  ],
  "success": [
    "prettier: PASS",
    "eslint: WARN (3 warnings)",
    "jsdoc: FAIL (162 missing)",
    "vitest: 227 passed",
    "playwright: 1 failed",
    "check:contrast: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `src/pages/battleJudoka.html`: add Next button data-role
- `src/pages/battleClassic.html`: add Next button data-role
- `design/battleMarkup.md`: document data-role requirement
- `tests/pages/battlePages.dom.test.js`: validate required data-role attributes
- `tests/helpers/timerService.onNextButtonClick.test.js`: query Next button by data-role
- `tests/helpers/timerService.test.js`: add data-role to test Next button
- `tests/helpers/uiHelpers.resetBattleUI.test.js`: query Next button by data-role
- `tests/helpers/classicBattlePage.startRoundWrapper.test.js`: add data-role to Next button
- `tests/helpers/classicBattle/waitingForPlayerAction.test.js`: add data-role to Next button
- `tests/helpers/classicBattle/nextButton.cooldown.fallback.test.js`: use data-role selector
- `tests/helpers/classicBattleFlags.test.js`: add data-role to Next button
- `tests/helpers/classicBattle/domUtils.js`: create Next button with data-role
- `tests/helpers/classicBattle/battleStateBadge.test.js`: add data-role to Next button
- `tests/helpers/classicBattle/battleStateProgress.test.js`: add data-role to Next button
- `tests/helpers/classicBattle/drawNextRound.test.js`: add data-role to Next button
- `tests/helpers/classicBattle/controlState.test.js`: query Next button by data-role
- `tests/helpers/classicBattle/scheduleNextRound.fallback.test.js`: query Next button by data-role
- `tests/helpers/classicBattle/scheduleNextRound.test.js`: query Next button by data-role
- `tests/helpers/classicBattle/statDoubleClick.test.js`: add data-role to Next button
- `tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js`: add data-role to Next button
- `playwright/battle-next-skip.spec.js`: query Next button by data-role
- `scripts/diagnosePlaywrightInteractive.js`: query Next button by data-role


------
https://chatgpt.com/codex/tasks/task_e_68b87726df208326bfa455d6cc525e4b