### PR TITLE
Guard next cooldown stall

### DIFF
--- a/tests/helpers/timerService.cooldownGuard.test.js
+++ b/tests/helpers/timerService.cooldownGuard.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+let mockState = "cooldown";
+vi.mock("../../src/helpers/classicBattle/battleDebug.js", () => ({
+  getStateSnapshot: () => ({ state: mockState }),
+  __setStateSnapshot: (next) => {
+    mockState = next.state;
+  }
+}));
+import { __setStateSnapshot } from "../../src/helpers/classicBattle/battleDebug.js";
+
+vi.mock("../../src/helpers/classicBattle/orchestrator.js", () => ({
+  dispatchBattleEvent: vi.fn(() => Promise.resolve())
+}));
+
+vi.mock("../../src/helpers/classicBattle/skipHandler.js", () => ({
+  setSkipHandler: vi.fn()
+}));
+
+describe("onNextButtonClick cooldown guard", () => {
+  let btn;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '<button id="next-button" data-testid="next-button"></button>';
+    btn = document.querySelector('[data-testid="next-button"]');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not warn when state changes", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    __setStateSnapshot({ state: "cooldown" });
+    const { onNextButtonClick } = await import("../../src/helpers/classicBattle/timerService.js");
+    btn.dataset.nextReady = "true";
+    await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
+    __setStateSnapshot({ state: "roundDecision" });
+    await vi.runAllTimersAsync();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("warns if still in cooldown", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    __setStateSnapshot({ state: "cooldown" });
+    const { onNextButtonClick } = await import("../../src/helpers/classicBattle/timerService.js");
+    btn.dataset.nextReady = "true";
+    await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
+    await vi.runAllTimersAsync();
+    expect(warnSpy).toHaveBeenCalledWith("[next] stuck in cooldown");
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/helpers/timerService.onNextButtonClick.test.js
+++ b/tests/helpers/timerService.onNextButtonClick.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { __setStateSnapshot } from "../../src/helpers/classicBattle/battleDebug.js";
 
 vi.mock("../../src/helpers/classicBattle/orchestrator.js", () => ({
@@ -11,11 +11,20 @@ vi.mock("../../src/helpers/classicBattle/skipHandler.js", () => ({
 
 describe("onNextButtonClick", () => {
   let btn;
+  let warnSpy;
 
   beforeEach(() => {
+    vi.useFakeTimers();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     document.body.innerHTML = '<button id="next-button" data-testid="next-button"></button>';
     btn = document.querySelector('[data-testid="next-button"]');
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    warnSpy.mockRestore();
+    vi.useRealTimers();
   });
 
   it("advances when button is marked ready", async () => {


### PR DESCRIPTION
## Summary
- guard against the Next button being stuck in cooldown
- cover cooldown watchdog logic with tests and mute warnings in existing tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: Timed out waiting for battle state "cooldown")*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b877017e8083269a75bfe9a6def166