### PR TITLE
Guard next cooldown stall: handle timer cancellation

### DIFF
--- a/tests/helpers/timerService.cooldownGuard.test.js
+++ b/tests/helpers/timerService.cooldownGuard.test.js
@@ -53,4 +53,17 @@ describe("onNextButtonClick cooldown guard", () => {
     expect(warnSpy).toHaveBeenCalledWith("[next] stuck in cooldown");
     warnSpy.mockRestore();
   });
+
+  it("clears previous warning timer on rapid clicks", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    __setStateSnapshot({ state: "cooldown" });
+    const { onNextButtonClick } = await import("../../src/helpers/classicBattle/timerService.js");
+    btn.dataset.nextReady = "true";
+    await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
+    btn.dataset.nextReady = "true";
+    await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
+    await vi.runAllTimersAsync();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- clear existing cooldown warning timeouts before scheduling new ones
- log snapshot errors in cooldown watchdog
- test that rapid clicks trigger only one cooldown warning

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: Timed out waiting for battle state "cooldown")*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/helpers/classicBattle/timerService.js", "tests/helpers/timerService.cooldownGuard.test.js"],
  "outputs": ["src/helpers/classicBattle/timerService.js", "tests/helpers/timerService.cooldownGuard.test.js"],
  "success": ["prettier: PASS", "eslint: WARN", "jsdoc: FAIL", "vitest: PASS", "playwright: FAIL", "check:contrast: PASS"],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `src/helpers/classicBattle/timerService.js`: avoid overlapping cooldown warnings and surface snapshot errors
- `tests/helpers/timerService.cooldownGuard.test.js`: ensure rapid clicks do not duplicate warnings

## Verification
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: Timed out waiting for battle state "cooldown")*
- `npm run check:contrast`

## Risk
- Low risk: changes scoped to cooldown watchdog; failure would only affect Next-button warning behavior.

## Follow-Up
- Address repository-wide JSDoc gaps and Playwright timeout in future pass.


------
https://chatgpt.com/codex/tasks/task_e_68b87e22b368832694d2829bf26393d4