### PR TITLE
feat: add next-round attribute

### DIFF
--- a/design/battleMarkup.md
+++ b/design/battleMarkup.md
@@ -4,24 +4,24 @@ Classic battle pages rely on specific element IDs so helper scripts can attach l
 
 ## Required IDs
 
-| ID                      | Purpose                                         |
-| ----------------------- | ----------------------------------------------- |
-| `round-message`         | Announces prompts and round outcomes.           |
-| `next-round-timer`      | Displays the inter-round countdown.             |
-| `round-counter`         | Shows current round number.                     |
-| `score-display`         | Lists player and opponent scores.               |
-| `test-mode-banner`      | Indicates when test mode is active.             |
-| `debug-panel`           | Collapsible container for debugging info.       |
-| `debug-output`          | `<pre>` element inside the debug panel.         |
-| `battle-area`           | Wrapper containing player and opponent cards.   |
-| `player-card`           | Container for the player's card.                |
-| `opponent-card`         | Container for the opponent's card.              |
-| `stat-buttons`          | Group of stat selection buttons.                |
-| `round-result`          | Displays the result of the round.               |
-| `next-button`           | Advances to the next round when ready.          |
-| `stat-help`             | Opens stat selection help.                      |
-| `quit-match-button`     | Triggers the quit match flow.                   |
-| `battle-state-progress` | Optional list tracking match state transitions. |
+| ID                      | Purpose                                                                    |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `round-message`         | Announces prompts and round outcomes.                                      |
+| `next-round-timer`      | Displays the inter-round countdown.                                        |
+| `round-counter`         | Shows current round number.                                                |
+| `score-display`         | Lists player and opponent scores.                                          |
+| `test-mode-banner`      | Indicates when test mode is active.                                        |
+| `debug-panel`           | Collapsible container for debugging info.                                  |
+| `debug-output`          | `<pre>` element inside the debug panel.                                    |
+| `battle-area`           | Wrapper containing player and opponent cards.                              |
+| `player-card`           | Container for the player's card.                                           |
+| `opponent-card`         | Container for the opponent's card.                                         |
+| `stat-buttons`          | Group of stat selection buttons.                                           |
+| `round-result`          | Displays the result of the round.                                          |
+| `next-button`           | Advances to the next round when ready; also uses `data-role="next-round"`. |
+| `stat-help`             | Opens stat selection help.                                                 |
+| `quit-match-button`     | Triggers the quit match flow.                                              |
+| `battle-state-progress` | Optional list tracking match state transitions.                            |
 
 ## Example Markup
 
@@ -32,7 +32,9 @@ Classic battle pages rely on specific element IDs so helper scripts can attach l
 </div>
 
 <div class="action-buttons">
-  <button id="next-button" class="battle-control-button" disabled>Next</button>
+  <button id="next-button" data-role="next-round" class="battle-control-button" disabled>
+    Next
+  </button>
   <button id="stat-help" class="battle-control-button" aria-label="Stat selection help">?</button>
   <button id="quit-match-button" class="battle-control-button">Quit Match</button>
 </div>

--- a/playwright/battle-next-skip.spec.js
+++ b/playwright/battle-next-skip.spec.js
@@ -30,7 +30,7 @@ test.describe("Next button cooldown skip", () => {
     const counter = page.locator("#round-counter");
     await expect(counter).toHaveText(/Round 1/);
 
-    const nextBtn = page.locator("#next-button");
+    const nextBtn = page.locator('[data-role="next-round"]');
     await expect(nextBtn).toBeEnabled();
     await nextBtn.click();
 

--- a/scripts/diagnosePlaywrightInteractive.js
+++ b/scripts/diagnosePlaywrightInteractive.js
@@ -51,7 +51,7 @@ async function run() {
     console.log("round-result:", (snap.roundResult || "").trim());
 
     // click Next if available
-    const next = await page.$("#next-button");
+    const next = await page.$('[data-role="next-round"]');
     if (next) {
       const isDisabled = await next.getAttribute("disabled");
       if (isDisabled === null) {

--- a/src/pages/battleClassic.html
+++ b/src/pages/battleClassic.html
@@ -114,6 +114,7 @@
             <div class="action-buttons">
               <button
                 id="next-button"
+                data-role="next-round"
                 class="battle-control-button"
                 data-tooltip-id="ui.next"
                 disabled

--- a/src/pages/battleJudoka.html
+++ b/src/pages/battleJudoka.html
@@ -110,6 +110,7 @@
             <div class="action-buttons">
               <button
                 id="next-button"
+                data-role="next-round"
                 class="battle-control-button"
                 data-tooltip-id="ui.next"
                 disabled

--- a/tests/helpers/classicBattle/battleStateBadge.test.js
+++ b/tests/helpers/classicBattle/battleStateBadge.test.js
@@ -53,6 +53,7 @@ function createBattleDom() {
   machineState.id = "machine-state";
   const next = document.createElement("button");
   next.id = "next-button";
+  next.setAttribute("data-role", "next-round");
   document.body.append(header, battleArea, stats, progressEl, machineState, next);
 }
 

--- a/tests/helpers/classicBattle/battleStateProgress.test.js
+++ b/tests/helpers/classicBattle/battleStateProgress.test.js
@@ -38,6 +38,7 @@ function createBattleDom() {
   badge.id = "battle-state-badge";
   const next = document.createElement("button");
   next.id = "next-button";
+  next.setAttribute("data-role", "next-round");
   document.body.append(header, battleArea, stats, progressEl, machineState, badge, next);
 }
 

--- a/tests/helpers/classicBattle/controlState.test.js
+++ b/tests/helpers/classicBattle/controlState.test.js
@@ -82,7 +82,7 @@ describe("classicBattle battle control state", () => {
     const { disableNextRoundButton, enableNextRoundButton } = await import(
       "../../../src/helpers/classicBattle.js"
     );
-    const btn = document.querySelector('[data-testid="next-button"]');
+    const btn = document.querySelector('[data-role="next-round"]');
     disableNextRoundButton();
     expect(btn.disabled).toBe(true);
     expect(btn.dataset.nextReady).toBeUndefined();
@@ -94,10 +94,10 @@ describe("classicBattle battle control state", () => {
   it("resetBattleUI replaces Next button and reattaches click handler", async () => {
     const timerSvc = await import("../../../src/helpers/classicBattle/timerService.js");
     const { resetBattleUI } = await import("../../../src/helpers/classicBattle/uiHelpers.js");
-    const btn = document.querySelector('[data-testid="next-button"]');
+    const btn = document.querySelector('[data-role="next-round"]');
     btn.dataset.nextReady = "true";
     resetBattleUI();
-    const cloned = document.querySelector('[data-testid="next-button"]');
+    const cloned = document.querySelector('[data-role="next-round"]');
     expect(cloned).not.toBe(btn);
     expect(cloned.disabled).toBe(true);
     expect(cloned.dataset.nextReady).toBeUndefined();

--- a/tests/helpers/classicBattle/domUtils.js
+++ b/tests/helpers/classicBattle/domUtils.js
@@ -51,7 +51,7 @@ export function createRoundMessage(id = "round-message") {
  * @pseudocode
  * 1. Create a `button` element named `nextButton`.
  * 2. Set its `id` to "next-button".
- * 3. Then set its `data-testid` to "next-button".
+ * 3. Set its `data-role` to "next-round".
  * 4. Create a `p` element named `nextRoundTimer`.
  * 5. Set its `id` to "next-round-timer".
  * 6. Set the `aria-live` attribute of `nextRoundTimer` to "polite".
@@ -66,7 +66,7 @@ export function createRoundMessage(id = "round-message") {
 export function createTimerNodes() {
   const nextButton = document.createElement("button");
   nextButton.id = "next-button";
-  nextButton.setAttribute("data-testid", "next-button");
+  nextButton.setAttribute("data-role", "next-round");
   const nextRoundTimer = document.createElement("p");
   nextRoundTimer.id = "next-round-timer";
   nextRoundTimer.setAttribute("aria-live", "polite");

--- a/tests/helpers/classicBattle/drawNextRound.test.js
+++ b/tests/helpers/classicBattle/drawNextRound.test.js
@@ -29,7 +29,7 @@ describe("classicBattle draw next round", () => {
     });
     const nextBtn = document.createElement("button");
     nextBtn.id = "next-button";
-    nextBtn.setAttribute("data-testid", "next-button");
+    nextBtn.setAttribute("data-role", "next-round");
     document.body.appendChild(nextBtn);
     window.__NEXT_ROUND_COOLDOWN_MS = 0;
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -62,7 +62,7 @@ describe("classicBattle draw next round", () => {
     await playRound(battleMod, store, 5, 5);
     battleMod.startCooldown(store);
     await vi.runAllTimersAsync();
-    const nextBtn = document.querySelector('[data-testid="next-button"]');
+    const nextBtn = document.querySelector('[data-role="next-round"]');
     expect(nextBtn.disabled).toBe(false);
     expect(nextBtn.dataset.nextReady).toBe("true");
 

--- a/tests/helpers/classicBattle/nextButton.cooldown.fallback.test.js
+++ b/tests/helpers/classicBattle/nextButton.cooldown.fallback.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 describe("Next button cooldown fallback", () => {
   beforeEach(async () => {
-    document.body.innerHTML = `<button id="next-button" data-testid="next-button">Next</button>`;
+    document.body.innerHTML = `<button id="next-button" data-role="next-round">Next</button>`;
     const { onBattleEvent, emitBattleEvent, __resetBattleEventTarget } = await import(
       "../../../src/helpers/classicBattle/battleEvents.js"
     );

--- a/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
@@ -58,7 +58,7 @@ describe("startCooldown fallback timer", () => {
 
   it("resolves ready after fallback timer and enables button", async () => {
     const { startCooldown } = await import("../../../src/helpers/classicBattle/roundManager.js");
-    const btn = document.querySelector('[data-testid="next-button"]');
+    const btn = document.querySelector('[data-role="next-round"]');
     btn.disabled = true;
     const controls = startCooldown({}, scheduler);
     let resolved = false;

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -110,7 +110,7 @@ describe("classicBattle startCooldown", () => {
     expect(dispatchSpy).toHaveBeenCalledWith("ready");
     expect(startRoundWrapper).toHaveBeenCalledTimes(1);
     expect(machine.getState()).toBe("waitingForPlayerAction");
-    const btn = document.querySelector('[data-testid="next-button"]');
+    const btn = document.querySelector('[data-role="next-round"]');
     expect(btn?.dataset.nextReady).toBe("true");
     expect(btn?.disabled).toBe(false);
     delete window.__NEXT_ROUND_COOLDOWN_MS;
@@ -144,7 +144,7 @@ describe("classicBattle startCooldown", () => {
     expect(machine.getState()).toBe("cooldown");
 
     const controls = battleMod.startCooldown(store);
-    document.querySelector('[data-testid="next-button"]').click();
+    document.querySelector('[data-role="next-round"]').click();
     await controls.ready;
     // Ensure state progressed before assertions
     await waitForState("waitingForPlayerAction");

--- a/tests/helpers/classicBattle/statDoubleClick.test.js
+++ b/tests/helpers/classicBattle/statDoubleClick.test.js
@@ -29,7 +29,7 @@ describe("classicBattle stat double-click", () => {
     });
     const nextBtn = document.createElement("button");
     nextBtn.id = "next-button";
-    nextBtn.setAttribute("data-testid", "next-button");
+    nextBtn.setAttribute("data-role", "next-round");
     document.body.appendChild(nextBtn);
     window.__NEXT_ROUND_COOLDOWN_MS = 0;
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
+++ b/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
@@ -16,7 +16,7 @@ describe("timeout → interruptRound → cooldown auto-advance", () => {
       <div id="opponent-card"></div>
       <p id="round-message"></p>
       <p id="next-round-timer"></p>
-      <button id="next-button" data-testid="next-button" disabled>Next</button>
+      <button id="next-button" data-role="next-round" disabled>Next</button>
       <div id="snackbar-container"></div>
     `;
     // Use minimal 1s cooldown for auto-advance

--- a/tests/helpers/classicBattle/waitingForPlayerAction.test.js
+++ b/tests/helpers/classicBattle/waitingForPlayerAction.test.js
@@ -6,7 +6,7 @@ describe("waitingForPlayerActionEnter", () => {
     document.body.innerHTML = "";
     const next = document.createElement("button");
     next.id = "next-button";
-    next.setAttribute("data-testid", "next-button");
+    next.setAttribute("data-role", "next-round");
     next.disabled = true;
     document.body.appendChild(next);
   });
@@ -16,7 +16,7 @@ describe("waitingForPlayerActionEnter", () => {
     const store = {};
     const machine = { context: { store } };
     await mod.waitingForPlayerActionEnter(machine);
-    const btn = document.querySelector('[data-testid="next-button"]');
+    const btn = document.querySelector('[data-role="next-round"]');
     expect(btn.disabled).toBe(true);
     expect(btn.dataset.nextReady).toBeUndefined();
   });

--- a/tests/helpers/classicBattleFlags.test.js
+++ b/tests/helpers/classicBattleFlags.test.js
@@ -13,6 +13,7 @@ describe("classicBattlePage feature flag updates", () => {
     document.body.innerHTML = "";
     const next = document.createElement("button");
     next.id = "next-button";
+    next.setAttribute("data-role", "next-round");
     document.body.appendChild(next);
     vi.resetModules();
   });

--- a/tests/helpers/classicBattlePage.startRoundWrapper.test.js
+++ b/tests/helpers/classicBattlePage.startRoundWrapper.test.js
@@ -4,6 +4,7 @@ beforeEach(() => {
   document.body.innerHTML = "";
   const next = document.createElement("button");
   next.id = "next-button";
+  next.setAttribute("data-role", "next-round");
   document.body.appendChild(next);
   localStorage.clear();
   vi.resetModules();

--- a/tests/helpers/timerService.cooldownGuard.test.js
+++ b/tests/helpers/timerService.cooldownGuard.test.js
@@ -22,8 +22,8 @@ describe("onNextButtonClick cooldown guard", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    document.body.innerHTML = '<button id="next-button" data-testid="next-button"></button>';
-    btn = document.querySelector('[data-testid="next-button"]');
+    document.body.innerHTML = '<button id="next-button" data-role="next-round"></button>';
+    btn = document.querySelector('[data-role="next-round"]');
     vi.clearAllMocks();
   });
 

--- a/tests/helpers/timerService.onNextButtonClick.test.js
+++ b/tests/helpers/timerService.onNextButtonClick.test.js
@@ -16,8 +16,8 @@ describe("onNextButtonClick", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    document.body.innerHTML = '<button id="next-button" data-testid="next-button"></button>';
-    btn = document.querySelector('[data-testid="next-button"]');
+    document.body.innerHTML = '<button id="next-button" data-role="next-round"></button>';
+    btn = document.querySelector('[data-role="next-round"]');
     vi.clearAllMocks();
   });
 

--- a/tests/helpers/timerService.test.js
+++ b/tests/helpers/timerService.test.js
@@ -90,7 +90,7 @@ describe("timerService", () => {
   it("enables next round when skipped before cooldown starts", async () => {
     const btn = document.createElement("button");
     btn.id = "next-button";
-    btn.setAttribute("data-testid", "next-button");
+    btn.setAttribute("data-role", "next-round");
     btn.classList.add("disabled");
     document.body.appendChild(btn);
     const timerEl = document.createElement("div");

--- a/tests/helpers/uiHelpers.resetBattleUI.test.js
+++ b/tests/helpers/uiHelpers.resetBattleUI.test.js
@@ -35,7 +35,7 @@ describe("resetBattleUI helpers", () => {
   it("resetNextButton clones and disables next button", async () => {
     const btn = document.createElement("button");
     btn.id = "next-button";
-    btn.setAttribute("data-testid", "next-button");
+    btn.setAttribute("data-role", "next-round");
     btn.dataset.nextReady = "true";
     document.body.append(btn);
 
@@ -43,7 +43,7 @@ describe("resetBattleUI helpers", () => {
 
     const timerSvc = await import("../../src/helpers/classicBattle/timerService.js");
 
-    const newBtn = document.querySelector('[data-testid="next-button"]');
+    const newBtn = document.querySelector('[data-role="next-round"]');
     expect(newBtn).not.toBe(btn);
     expect(newBtn.disabled).toBe(true);
     expect(newBtn.dataset.nextReady).toBeUndefined();

--- a/tests/pages/battlePages.dom.test.js
+++ b/tests/pages/battlePages.dom.test.js
@@ -3,14 +3,12 @@ import { readFileSync } from "fs";
 
 const PAGES = ["battleJudoka", "battleClassic"];
 
-const REQUIRED = [
-  { id: "next-button", testId: "next-button" },
-  { id: "stat-help", testId: "stat-help" },
-  { id: "quit-match-button", testId: "quit-match" }
-];
+const REQUIRED_SELECTORS = ['[data-role="next-round"]', "#stat-help", "#quit-match-button"];
 
-function getMissingIds(root, ids) {
-  return ids.filter((id) => !root.querySelector(`#${id}`));
+const REQUIRED_TEST_IDS = ["next-button", "stat-help", "quit-match"];
+
+function getMissingSelectors(root, selectors) {
+  return selectors.filter((s) => !root.querySelector(s));
 }
 
 function getMissingTestIds(root, testIds) {
@@ -24,15 +22,12 @@ describe.each(PAGES)("%s.html required hooks", (page) => {
   });
 
   it("includes all required IDs", () => {
-    const missing = getMissingIds(document, [...REQUIRED.map((r) => r.id), "stat-buttons"]);
+    const missing = getMissingSelectors(document, [...REQUIRED_SELECTORS, "#stat-buttons"]);
     expect(missing).toEqual([]);
   });
 
   it("includes all required data-testid attributes", () => {
-    const missing = getMissingTestIds(
-      document,
-      REQUIRED.map((r) => r.testId)
-    );
+    const missing = getMissingTestIds(document, REQUIRED_TEST_IDS);
     expect(missing).toEqual([]);
     const statButtons = document.querySelectorAll("#stat-buttons button");
     statButtons.forEach((btn) => expect(btn.getAttribute("data-testid")).toBe("stat-button"));
@@ -41,10 +36,12 @@ describe.each(PAGES)("%s.html required hooks", (page) => {
   it("detects when a data-testid is missing", () => {
     const el = document.querySelector('[data-testid="stat-help"]');
     el?.removeAttribute("data-testid");
-    const missing = getMissingTestIds(
-      document,
-      REQUIRED.map((r) => r.testId)
-    );
+    const missing = getMissingTestIds(document, REQUIRED_TEST_IDS);
     expect(missing).toEqual(["stat-help"]);
+  });
+
+  it("next button has id next-button", () => {
+    const next = document.querySelector('[data-role="next-round"]');
+    expect(next?.id).toBe("next-button");
   });
 });


### PR DESCRIPTION
## Summary
- add `data-role="next-round"` to Next buttons on battle pages
- document new `data-role` in battle markup guide
- refactor tests and scripts to select Next via `[data-role="next-round"]`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: Timed out waiting for battle state "cooldown")*
- `npm run check:contrast`

## Risk
- Medium: Playwright tests failing indicate potential issues with battle flow or selectors; further investigation needed.

------
https://chatgpt.com/codex/tasks/task_e_68b87ed160e88326a954357d9eb7e89f