### PR TITLE
Guard next cooldown stall: handle timer cancellation

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -138,6 +138,7 @@ export async function onNextButtonClick(_evt, controls = getNextRoundControls())
     } catch (err) {
       guard(() => console.error("Error in next-button cooldown check:", err));
     }
+    cooldownWarningTimeoutId = null;
   }, 1000);
 }
 

--- a/tests/helpers/timerService.cooldownGuard.test.js
+++ b/tests/helpers/timerService.cooldownGuard.test.js
@@ -66,4 +66,19 @@ describe("onNextButtonClick cooldown guard", () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
     warnSpy.mockRestore();
   });
+
+  it("resets warning timer after firing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    __setStateSnapshot({ state: "cooldown" });
+    const { onNextButtonClick } = await import("../../src/helpers/classicBattle/timerService.js");
+    btn.dataset.nextReady = "true";
+    await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
+    await vi.runAllTimersAsync();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    btn.dataset.nextReady = "true";
+    await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
+    await vi.runAllTimersAsync();
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- clear cooldown warning timer id after firing
- test that firing warning allows scheduling another

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: Timed out waiting for battle state "cooldown")*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b882e7a6bc8326986676d5fe061cea