### PR TITLE
Ensure Next button always advances round

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -121,6 +121,9 @@ export async function onNextButtonClick(_evt, controls = getNextRoundControls())
   const { timer = null, resolveReady = null } = controls || {};
   const btn = document.getElementById("next-button");
   if (!btn) return;
+  // Manual clicks must attempt to advance regardless of the `skipRoundCooldown`
+  // feature flag. The flag only affects automatic progression, never user
+  // intent signaled via the Next button.
   if (btn.dataset.nextReady === "true") {
     await advanceWhenReady(btn, resolveReady);
   } else {

--- a/tests/helpers/classicBattle/nextButton.manualClick.test.js
+++ b/tests/helpers/classicBattle/nextButton.manualClick.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { __setStateSnapshot } from "../../../src/helpers/classicBattle/battleDebug.js";
+
+vi.mock("../../../src/helpers/classicBattle/skipHandler.js", () => ({
+  setSkipHandler: vi.fn()
+}));
+
+describe("Next button manual click", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches ready within 50ms", async () => {
+    document.body.innerHTML = '<button id="next-button" data-role="next-round"></button>';
+    const dispatcher = await import("../../../src/helpers/classicBattle/orchestrator.js");
+    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    __setStateSnapshot({ state: "cooldown" });
+
+    const readyPromise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("ready not dispatched")), 50);
+      vi.spyOn(dispatcher, "dispatchBattleEvent").mockImplementation(async (evt) => {
+        if (evt === "ready") {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+
+    await mod.onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
+    await readyPromise;
+  });
+});


### PR DESCRIPTION
## Summary
- clarify in `onNextButtonClick` that manual clicks bypass `skipRoundCooldown`
- add integration test ensuring Next button dispatches `ready` promptly

## Testing
- `npx prettier . --check`
- `npx eslint .` (warnings: 4)
- `npm run check:jsdoc` (fails: missing docs)
- `npx vitest run`
- `npx playwright test` (fails: net::ERR_TUNNEL_CONNECTION_FAILED)
- `npm run check:contrast`

## Risk
- Playwright test fails due to network requirement; ensure CDN resources available in CI.


------
https://chatgpt.com/codex/tasks/task_e_68b88d6e9eb8832690c5399578817a64