### PR TITLE
test: remove redundant evaluateRound test

### DIFF
--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -124,18 +124,6 @@ describe("classicBattle stat selection", () => {
     expect(document.querySelector("header #score-display").textContent).toBe("You: 0\nOpponent: 0");
   });
 
-  it("evaluateRound updates the score", async () => {
-    const { createBattleStore, evaluateRound, _resetForTest } = await import(
-      "../../../src/helpers/classicBattle.js"
-    );
-    const store = createBattleStore();
-    _resetForTest(store);
-    const result = evaluateRound(store, "power", 5, 3);
-    expect(result.message).toMatch(/win/);
-    expect(result.playerScore).toBe(1);
-    expect(result.opponentScore).toBe(0);
-  });
-
   it("shows stat comparison after selection", async () => {
     document.getElementById("player-card").innerHTML =
       `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;


### PR DESCRIPTION
## Summary
- remove evaluateRound score test from classicBattle stat selection tests

## Testing
- `npx vitest run tests/helpers/classicBattle/statSelection.test.js`
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 162 missing docs)*
- `npx vitest run`
- `npx playwright test` *(fails: connection refused to localhost)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68b88f534ef08326b0f1c905d5c88ef0