### PR TITLE
feat: skip cooldown on next clicks

### DIFF
--- a/playwright/battle-next-skip.spec.js
+++ b/playwright/battle-next-skip.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { waitForBattleReady, waitForBattleState } from "./fixtures/waits.js";
+import { waitForBattleReady } from "./fixtures/waits.js";
 
 /**
  * Verify that clicking Next during cooldown skips the delay.
@@ -14,6 +14,12 @@ test.describe("Next button cooldown skip", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
       window.__NEXT_ROUND_COOLDOWN_MS = 1000;
+      const settings = JSON.parse(localStorage.getItem("settings") || "{}");
+      settings.featureFlags = {
+        ...(settings.featureFlags || {}),
+        skipRoundCooldown: { enabled: false }
+      };
+      localStorage.setItem("settings", JSON.stringify(settings));
     });
   });
 
@@ -25,7 +31,6 @@ test.describe("Next button cooldown skip", () => {
     await page.locator("#stat-buttons button").first().click();
     await page.locator("#stat-buttons[data-buttons-ready='false']").waitFor();
     await page.evaluate(() => window.getRoundResolvedPromise?.());
-    await waitForBattleState(page, "cooldown");
 
     const counter = page.locator("#round-counter");
     await expect(counter).toHaveText(/Round 1/);

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -25,7 +25,8 @@ describe("timerService next round handling", () => {
     vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
       enableNextRoundButton: vi.fn(),
       disableNextRoundButton: vi.fn(),
-      updateDebugPanel: vi.fn()
+      updateDebugPanel: vi.fn(),
+      skipRoundCooldownIfEnabled: vi.fn(() => false)
     }));
     vi.doMock("../../../src/helpers/classicBattle/skipHandler.js", () => ({
       setSkipHandler: vi.fn()

--- a/tests/helpers/timerService.cooldownGuard.test.js
+++ b/tests/helpers/timerService.cooldownGuard.test.js
@@ -16,6 +16,12 @@ vi.mock("../../src/helpers/classicBattle/orchestrator.js", () => ({
 vi.mock("../../src/helpers/classicBattle/skipHandler.js", () => ({
   setSkipHandler: vi.fn()
 }));
+vi.mock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+  emitBattleEvent: vi.fn()
+}));
+vi.mock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
+  skipRoundCooldownIfEnabled: vi.fn(() => false)
+}));
 
 describe("onNextButtonClick cooldown guard", () => {
   let btn;

--- a/tests/helpers/timerService.onNextButtonClick.test.js
+++ b/tests/helpers/timerService.onNextButtonClick.test.js
@@ -8,6 +8,12 @@ vi.mock("../../src/helpers/classicBattle/orchestrator.js", () => ({
 vi.mock("../../src/helpers/classicBattle/skipHandler.js", () => ({
   setSkipHandler: vi.fn()
 }));
+vi.mock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+  emitBattleEvent: vi.fn()
+}));
+vi.mock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
+  skipRoundCooldownIfEnabled: vi.fn(() => false)
+}));
 
 describe("onNextButtonClick", () => {
   let btn;
@@ -34,8 +40,11 @@ describe("onNextButtonClick", () => {
     const resolveReady = vi.fn();
     await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady });
     const dispatcher = await import("../../src/helpers/classicBattle/orchestrator.js");
+    const events = await import("../../src/helpers/classicBattle/battleEvents.js");
     expect(btn.disabled).toBe(true);
     expect(btn.dataset.nextReady).toBeUndefined();
+    expect(events.emitBattleEvent).toHaveBeenCalledWith("countdownFinished");
+    expect(events.emitBattleEvent).toHaveBeenCalledBefore(dispatcher.dispatchBattleEvent);
     expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
     expect(resolveReady).toHaveBeenCalledTimes(1);
   });
@@ -46,7 +55,9 @@ describe("onNextButtonClick", () => {
     __setStateSnapshot({ state: "roundDecision" });
     await onNextButtonClick(new MouseEvent("click"), { timer: { stop }, resolveReady: null });
     const dispatcher = await import("../../src/helpers/classicBattle/orchestrator.js");
+    const events = await import("../../src/helpers/classicBattle/battleEvents.js");
     expect(stop).toHaveBeenCalledTimes(1);
+    expect(events.emitBattleEvent).toHaveBeenCalledWith("countdownFinished");
     expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
   });
 
@@ -56,7 +67,22 @@ describe("onNextButtonClick", () => {
     const resolveReady = vi.fn();
     await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady });
     const dispatcher = await import("../../src/helpers/classicBattle/orchestrator.js");
+    const events = await import("../../src/helpers/classicBattle/battleEvents.js");
+    expect(events.emitBattleEvent).toHaveBeenCalledWith("countdownFinished");
     expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
     expect(resolveReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns early when feature flag skips cooldown", async () => {
+    const uiHelpers = await import("../../src/helpers/classicBattle/uiHelpers.js");
+    uiHelpers.skipRoundCooldownIfEnabled.mockReturnValue(true);
+    const { onNextButtonClick } = await import("../../src/helpers/classicBattle/timerService.js");
+    btn.dataset.nextReady = "true";
+    await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
+    const dispatcher = await import("../../src/helpers/classicBattle/orchestrator.js");
+    const events = await import("../../src/helpers/classicBattle/battleEvents.js");
+    expect(events.emitBattleEvent).not.toHaveBeenCalled();
+    expect(dispatcher.dispatchBattleEvent).not.toHaveBeenCalled();
+    expect(btn.disabled).toBe(false);
   });
 });

--- a/tests/helpers/timerService.ordering.test.js
+++ b/tests/helpers/timerService.ordering.test.js
@@ -17,7 +17,8 @@ describe("timerService timeout ordering", () => {
       updateTimer: () => {}
     }));
     vi.doMock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
-      updateDebugPanel: () => {}
+      updateDebugPanel: () => {},
+      skipRoundCooldownIfEnabled: () => false
     }));
     vi.doMock("../../src/helpers/showSnackbar.js", () => ({
       showSnackbar: () => {},


### PR DESCRIPTION
## Summary
- trigger countdownFinished on every Next click to bypass inter-round cooldown
- return early when skipRoundCooldown flag skips the Next button entirely
- cover manual and flagged skips with updated unit and e2e tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: Next button cooldown skip > advances immediately when clicked)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b88ec1d9f08326ab606b9b79c31600