### PR TITLE
test: cover countdown finished

### DIFF
--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -19,6 +19,7 @@ This directory contains unit tests for Classic Battle helpers.
 - `stateTransitions.test.js`: validates `src/helpers/classicBattle/stateTable.js` transitions.
 - `timerService.drift.test.js`: falls back to messaging when timers drift.
 - `timerService.nextRound.test.js`: manages cooldown and Next button interaction.
+- `nextButton.countdownFinished.test.js`: emits `countdownFinished` on Next clicks, even without the button.
 - `timerStateExposure.test.js`: exposes timer state to window and DOM.
 - `commonMocks.js`: scheduler and motion utility mocks shared across suites.
 - `setupTestEnv.js`: exposes `setupClassicBattleHooks()` to wire DOM and mocks.

--- a/tests/helpers/classicBattle/nextButton.countdownFinished.test.js
+++ b/tests/helpers/classicBattle/nextButton.countdownFinished.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../../src/helpers/classicBattle/orchestrator.js", () => ({
+  dispatchBattleEvent: vi.fn(() => Promise.resolve())
+}));
+vi.mock("../../../src/helpers/classicBattle/skipHandler.js", () => ({
+  setSkipHandler: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
+  emitBattleEvent: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
+  skipRoundCooldownIfEnabled: vi.fn(() => false)
+}));
+
+import { emitBattleEvent } from "../../../src/helpers/classicBattle/battleEvents.js";
+
+describe("Next button countdownFinished", () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    warnSpy.mockRestore();
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  it("emits countdownFinished when button exists", async () => {
+    document.body.innerHTML = '<button id="next-button" data-role="next-round"></button>';
+    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    await mod.onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
+    expect(emitBattleEvent).toHaveBeenCalledTimes(1);
+    expect(emitBattleEvent).toHaveBeenCalledWith("countdownFinished");
+  });
+
+  it("emits countdownFinished when button missing", async () => {
+    const mod = await import("../../../src/helpers/classicBattle/timerService.js");
+    await mod.onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
+    expect(emitBattleEvent).toHaveBeenCalledTimes(1);
+    expect(emitBattleEvent).toHaveBeenCalledWith("countdownFinished");
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for countdownFinished event in Next button
- document test under timerService coverage

## Testing
- `npx prettier tests/helpers/classicBattle/nextButton.countdownFinished.test.js tests/helpers/classicBattle/README.md --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: playwright/battle-cli.spec.js > Classic Battle CLI > plays a full round and skips cooldown)*
- `npm run check:contrast`

## Task Contract
- `inputs`: ["src/helpers/classicBattle/timerService.js"]
- `outputs`: ["tests/helpers/classicBattle/nextButton.countdownFinished.test.js", "tests/helpers/classicBattle/README.md"]
- `success`: ["eslint: PASS", "vitest: PASS", "jsdoc: WARN", "playwright: WARN", "contrast: PASS"]
- `errorMode`: "exit_on_any_error"

------
https://chatgpt.com/codex/tasks/task_e_68b899f27fa0832682b5c4ff9152e187