### PR TITLE
Parameterize stat selection win/loss tests

### DIFF
--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -153,50 +153,51 @@ describe("classicBattle stat selection", () => {
     ]);
   });
 
-  it("dispatches matchPointReached when match ends", async () => {
-    const { setPointsToWin } = await import("../../../src/helpers/battleEngineFacade.js");
-    const eventDispatcher = await import("../../../src/helpers/classicBattle/orchestrator.js");
-    setPointsToWin(1);
-    eventDispatcher.__reset();
-    document.getElementById("player-card").innerHTML =
-      `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
-    document.getElementById("opponent-card").innerHTML =
-      `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    await selectStat("power");
-    await selectStat("power");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "statSelected");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "evaluate");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(3, "outcome=winPlayer");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(4, "matchPointReached");
-    expect(eventDispatcher.__getStateLog()).toEqual([
-      "roundDecision",
-      "processingRound",
-      "roundOver",
-      "matchDecision"
-    ]);
-  });
+  it.each([
+    {
+      description: "player wins match",
+      pointsToWin: 1,
+      playerStat: 5,
+      opponentStat: 3,
+      outcome: "winPlayer",
+      rounds: 2
+    },
+    {
+      description: "opponent wins match",
+      pointsToWin: 1,
+      playerStat: 3,
+      opponentStat: 5,
+      outcome: "winOpponent",
+      rounds: 1
+    }
+  ])(
+    "dispatches matchPointReached when $description",
+    async ({ pointsToWin, playerStat, opponentStat, outcome, rounds }) => {
+      const { setPointsToWin } = await import("../../../src/helpers/battleEngineFacade.js");
+      const eventDispatcher = await import("../../../src/helpers/classicBattle/orchestrator.js");
+      setPointsToWin(pointsToWin);
+      eventDispatcher.__reset();
 
-  it("dispatches opponent win outcome when opponent wins match", async () => {
-    const { setPointsToWin } = await import("../../../src/helpers/battleEngineFacade.js");
-    const eventDispatcher = await import("../../../src/helpers/classicBattle/orchestrator.js");
-    setPointsToWin(1);
-    eventDispatcher.__reset();
-    document.getElementById("player-card").innerHTML =
-      `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    document.getElementById("opponent-card").innerHTML =
-      `<ul><li class="stat"><strong>Power</strong> <span>5</span></li></ul>`;
-    await selectStat("power");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "statSelected");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "evaluate");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(3, "outcome=winOpponent");
-    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(4, "matchPointReached");
-    expect(eventDispatcher.__getStateLog()).toEqual([
-      "roundDecision",
-      "processingRound",
-      "roundOver",
-      "matchDecision"
-    ]);
-  });
+      for (let i = 0; i < rounds; i++) {
+        document.getElementById("player-card").innerHTML =
+          `<ul><li class="stat"><strong>Power</strong> <span>${playerStat}</span></li></ul>`;
+        document.getElementById("opponent-card").innerHTML =
+          `<ul><li class="stat"><strong>Power</strong> <span>${opponentStat}</span></li></ul>`;
+        await selectStat("power");
+      }
+
+      expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "statSelected");
+      expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "evaluate");
+      expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(3, `outcome=${outcome}`);
+      expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(4, "matchPointReached");
+      expect(eventDispatcher.__getStateLog()).toEqual([
+        "roundDecision",
+        "processingRound",
+        "roundOver",
+        "matchDecision"
+      ]);
+    }
+  );
 
   it("simulateOpponentStat returns a valid stat", async () => {
     const { STATS } = await import("../../../src/helpers/battleEngineFacade.js");


### PR DESCRIPTION
## Task Contract
```json
{
  "inputs": ["tests/helpers/classicBattle/statSelection.test.js"],
  "outputs": ["tests/helpers/classicBattle/statSelection.test.js"],
  "success": [
    "eslint: WARN",
    "vitest: PASS",
    "playwright: FAIL",
    "jsdoc: WARN",
    "contrast: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Summary
- parameterized win/loss scenarios for stat selection, reducing duplicate setup

## Testing
- `npx vitest run tests/helpers/classicBattle/statSelection.test.js`
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: Next button cooldown skip)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b89a1c7d088326bbdfb962716740a7