### PR TITLE
Parameterize stat selection win/loss tests

### DIFF
--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -177,12 +177,12 @@ describe("classicBattle stat selection", () => {
       const eventDispatcher = await import("../../../src/helpers/classicBattle/orchestrator.js");
       setPointsToWin(pointsToWin);
       eventDispatcher.__reset();
+      document.getElementById("player-card").innerHTML =
+        `<ul><li class="stat"><strong>Power</strong> <span>${playerStat}</span></li></ul>`;
+      document.getElementById("opponent-card").innerHTML =
+        `<ul><li class="stat"><strong>Power</strong> <span>${opponentStat}</span></li></ul>`;
 
       for (let i = 0; i < rounds; i++) {
-        document.getElementById("player-card").innerHTML =
-          `<ul><li class="stat"><strong>Power</strong> <span>${playerStat}</span></li></ul>`;
-        document.getElementById("opponent-card").innerHTML =
-          `<ul><li class="stat"><strong>Power</strong> <span>${opponentStat}</span></li></ul>`;
         await selectStat("power");
       }
 


### PR DESCRIPTION
## Summary
- parameterized win/loss scenarios for stat selection, reducing duplicate setup
- ensure DOM is initialized once before looping through stat selections to preserve previous round data

## Testing
- `npx vitest run tests/helpers/classicBattle/statSelection.test.js`
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: Next button cooldown skip)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b8a06e8444832680e15bca5cef6c2a