### PR TITLE
feat: add next button fallback

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -867,16 +867,24 @@ export function registerRoundStartErrorHandler(retryFn) {
 /**
  * @summary Attach the Next button click handler and warn when absent.
  *
- * Logs a warning when the button is missing.
+ * Logs a warning when the button is missing or when a fallback is used.
  *
  * @pseudocode
- * 1. Query `#next-button`.
- * 2. If not found, throw an error.
- * 3. Bind `onNextButtonClick` to `click`.
+ * 1. Query `#next-button` and store in `btn`.
+ * 2. If `btn` is `null`, warn and query `[data-role="next-round"]`.
+ * 3. If `btn` is still `null`, warn and return.
+ * 4. Bind `onNextButtonClick` to the `click` event of `btn`.
  */
 export function setupNextButton() {
-  const btn = document.getElementById("next-button");
-  if (!btn) throw new Error("setupNextButton: #next-button missing");
+  let btn = document.getElementById("next-button");
+  if (!btn) {
+    console.warn('[uiHelpers] #next-button missing, falling back to [data-role="next-round"]');
+    btn = document.querySelector('[data-role="next-round"]');
+    if (!btn) {
+      console.warn("[uiHelpers] next round button missing");
+      return;
+    }
+  }
   btn.addEventListener("click", onNextButtonClick);
 }
 

--- a/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
+++ b/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
@@ -10,9 +10,31 @@ describe("uiHelpers element assertions", () => {
     vi.restoreAllMocks();
   });
 
-  it("throws when next button is missing", async () => {
+  it("warns and returns when next round button is missing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
-    expect(() => mod.setupNextButton()).toThrow("setupNextButton: #next-button missing");
+    mod.setupNextButton();
+    expect(warnSpy).toHaveBeenNthCalledWith(
+      1,
+      '[uiHelpers] #next-button missing, falling back to [data-role="next-round"]'
+    );
+    expect(warnSpy).toHaveBeenNthCalledWith(2, "[uiHelpers] next round button missing");
+  });
+
+  it("falls back to data-role when #next-button is missing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const timerSvc = await import("../../../src/helpers/classicBattle/timerService.js");
+    const onClick = vi.spyOn(timerSvc, "onNextButtonClick").mockImplementation(() => {});
+    const btn = document.createElement("button");
+    btn.setAttribute("data-role", "next-round");
+    document.body.appendChild(btn);
+    const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
+    mod.setupNextButton();
+    btn.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[uiHelpers] #next-button missing, falling back to [data-role="next-round"]'
+    );
   });
 
   it("throws when stat buttons container is missing", async () => {


### PR DESCRIPTION
## Summary
- allow `setupNextButton` to fall back to `[data-role="next-round"]` when `#next-button` is absent and warn when missing
- expand classic battle UI helper tests for fallback and missing next button scenarios

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: missing JSDoc for 162 functions)*
- `npx vitest run`
- `npx playwright test` *(fails: Next button cooldown skip spec)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b8a0cfdb7c8326916abbe081eea7c6