### PR TITLE
test: parametrize quit cancellation

### DIFF
--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -29,6 +29,7 @@ This directory contains unit tests for Classic Battle helpers.
 ## Guidelines
 
 - One behavior per test.
+- Use parameterized tests (e.g., `it.each`) to cover related behaviors with different inputs, such as cancel actions for the quit modal.
 - Prefer shared helpers in `domUtils.js`, `utils/testUtils.js`, `commonMocks.js`, and `setupTestEnv.js`; new tests should rely on these instead of duplicating mocks or manual DOM setup.
 - Do not commit `it.skip`; use `test.todo` or remove obsolete tests instead.
 - Timer drift, state exposure, and Next button behavior belong in `timerService` tests; cooldown tests cover scheduling and ready dispatch.

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -104,47 +104,32 @@ describe("battleCLI onKeyDown", () => {
     expect(dispatchSpy).toHaveBeenCalledWith("interrupt", { reason: "quit" });
   });
 
-  it("resumes timers when quit is canceled", () => {
-    document.body.dataset.battleState = "waitingForPlayerAction";
-    const selT = setTimeout(() => {}, 1000);
-    const selI = setInterval(() => {}, 1000);
-    __test.setSelectionTimers(selT, selI);
-    const countdown = document.getElementById("cli-countdown");
-    countdown.dataset.remainingTime = "3";
-    onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
-    document.getElementById("cancel-quit-button").click();
-    expect(__test.getSelectionTimers().selectionTimer).not.toBeNull();
-  });
-
-  it("resumes timers when quit modal dismissed with Escape", async () => {
-    document.body.dataset.battleState = "waitingForPlayerAction";
-    const selT = setTimeout(() => {}, 1000);
-    const selI = setInterval(() => {}, 1000);
-    __test.setSelectionTimers(selT, selI);
-    const countdown = document.getElementById("cli-countdown");
-    countdown.dataset.remainingTime = "3";
-    onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
-    const confirm = document.getElementById("confirm-quit-button");
-    expect(confirm).toBeTruthy();
-    const handled = getEscapeHandledPromise();
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
-    await handled;
-    expect(__test.getSelectionTimers().selectionTimer).not.toBeNull();
-    const backdrop = confirm.closest(".modal-backdrop");
-    expect(backdrop?.hasAttribute("hidden")).toBe(true);
-  });
-
-  it("resumes timers when backdrop is clicked", () => {
-    document.body.dataset.battleState = "waitingForPlayerAction";
-    const selT = setTimeout(() => {}, 1000);
-    const selI = setInterval(() => {}, 1000);
-    __test.setSelectionTimers(selT, selI);
-    const countdown = document.getElementById("cli-countdown");
-    countdown.dataset.remainingTime = "3";
-    onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
-    document.querySelector(".modal-backdrop").click();
-    expect(__test.getSelectionTimers().selectionTimer).not.toBeNull();
-  });
+  const cancelActions = ["cancel", "escape", "backdrop"];
+  it.each(cancelActions)(
+    "resumes timers and closes modal when quit is canceled via %s",
+    async (action) => {
+      document.body.dataset.battleState = "waitingForPlayerAction";
+      const selT = setTimeout(() => {}, 1000);
+      const selI = setInterval(() => {}, 1000);
+      __test.setSelectionTimers(selT, selI);
+      const countdown = document.getElementById("cli-countdown");
+      countdown.dataset.remainingTime = "3";
+      onKeyDown(new KeyboardEvent("keydown", { key: "q" }));
+      if (action === "cancel") {
+        document.getElementById("cancel-quit-button").click();
+      } else if (action === "escape") {
+        const handled = getEscapeHandledPromise();
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+        await handled;
+      } else {
+        document.querySelector(".modal-backdrop").click();
+      }
+      expect(__test.getSelectionTimers().selectionTimer).not.toBeNull();
+      const confirm = document.getElementById("confirm-quit-button");
+      const backdrop = confirm?.closest(".modal-backdrop");
+      expect(backdrop?.hasAttribute("hidden")).toBe(true);
+    }
+  );
 
   it("clears timers when confirming quit", () => {
     const cooldownT = setTimeout(() => {}, 1000);


### PR DESCRIPTION
## Summary
- consolidate quit modal cancellation tests into an `it.each`
- document parameterized testing for classic battle helpers

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: Next button cooldown skip › advances immediately when clicked)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b8a0dab6248326b96b8749708dd782