### PR TITLE
Refactor stat selection outcomes tests

### DIFF
--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -14,7 +14,7 @@ This directory contains unit tests for Classic Battle helpers.
 - `opponentDelay.test.js`: shows snackbar feedback during opponent delays.
 - `scheduleNextRound.test.js`: schedules and auto-dispatches the next round.
 - `statButtons.state.test.js`: toggles stat buttons based on battle state.
-- `statSelection.test.js`: resolves round outcomes and covers outcome display and match-end logic via parameterized tests.
+- `statSelection.test.js`: resolves round outcomes and match-end logic. Outcome message and score checks use a table-driven `describe.each`.
 - `statSelectionTiming.test.js`: stat selection timing behaviors (auto-select, countdown resets, stall recovery, pause/resume).
 - `stateTransitions.test.js`: validates `src/helpers/classicBattle/stateTable.js` transitions.
 - `timerService.drift.test.js`: falls back to messaging when timers drift.

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -114,15 +114,45 @@ describe("classicBattle stat selection", () => {
     expect(btn.style.backgroundColor).toBe("");
   });
 
-  it("shows tie message when values are equal", async () => {
-    document.getElementById("player-card").innerHTML =
-      `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    document.getElementById("opponent-card").innerHTML =
-      `<ul><li class="stat"><strong>Power</strong> <span>3</span></li></ul>`;
-    await selectStat("power");
-    expect(document.querySelector("header #round-message").textContent).toMatch(/Tie/);
-    expect(document.querySelector("header #score-display").textContent).toBe("You: 0\nOpponent: 0");
-  });
+  describe.each([
+    {
+      playerValue: 3,
+      opponentValue: 3,
+      expectedMessage: /Tie/,
+      expectedScore: "You: 0\nOpponent: 0"
+    },
+    {
+      playerValue: 5,
+      opponentValue: 3,
+      expectedMessage: /You win the round/,
+      expectedScore: "You: 1\nOpponent: 0"
+    },
+    {
+      playerValue: 3,
+      opponentValue: 5,
+      expectedMessage: /Opponent wins the round/,
+      expectedScore: "You: 0\nOpponent: 1"
+    }
+  ])(
+    "handles outcome when player=$playerValue and opponent=$opponentValue",
+    ({ playerValue, opponentValue, expectedMessage, expectedScore }) => {
+      beforeEach(() => {
+        _resetForTest(store);
+        document.getElementById("player-card").innerHTML =
+          `<ul><li class="stat"><strong>Power</strong> <span>${playerValue}</span></li></ul>`;
+        document.getElementById("opponent-card").innerHTML =
+          `<ul><li class="stat"><strong>Power</strong> <span>${opponentValue}</span></li></ul>`;
+      });
+
+      it("updates message and score", async () => {
+        await selectStat("power");
+        expect(document.querySelector("header #round-message").textContent).toMatch(
+          expectedMessage
+        );
+        expect(document.querySelector("header #score-display").textContent).toBe(expectedScore);
+      });
+    }
+  );
 
   it("shows stat comparison after selection", async () => {
     document.getElementById("player-card").innerHTML =


### PR DESCRIPTION
## Summary
- refactor stat selection helper tests using a `describe.each` table for tie/win/loss scenarios
- document table-driven approach in Classic Battle helper README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: see log)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b8a0ebfb948326a9ff0a0ba4929c85