### PR TITLE
fix: guard next button fallback warnings behind test mode

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -867,21 +867,26 @@ export function registerRoundStartErrorHandler(retryFn) {
 /**
  * @summary Attach the Next button click handler and warn when absent.
  *
- * Logs a warning when the button is missing or when a fallback is used.
+ * Optionally logs a test-mode warning when the button is missing or when a fallback is used.
  *
  * @pseudocode
  * 1. Query `#next-button` and store in `btn`.
- * 2. If `btn` is `null`, warn and query `[data-role="next-round"]`.
- * 3. If `btn` is still `null`, warn and return.
+ * 2. If `btn` is `null`, optionally warn and query `[data-role="next-round"]`.
+ * 3. If `btn` is still `null`, optionally warn and return.
  * 4. Bind `onNextButtonClick` to the `click` event of `btn`.
  */
 export function setupNextButton() {
   let btn = document.getElementById("next-button");
   if (!btn) {
-    console.warn('[uiHelpers] #next-button missing, falling back to [data-role="next-round"]');
+    guard(() => {
+      if (isTestModeEnabled())
+        console.warn('[test] #next-button missing, falling back to [data-role="next-round"]');
+    });
     btn = document.querySelector('[data-role="next-round"]');
     if (!btn) {
-      console.warn("[uiHelpers] next round button missing");
+      guard(() => {
+        if (isTestModeEnabled()) console.warn("[test] next round button missing");
+      });
       return;
     }
   }

--- a/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
+++ b/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
@@ -12,13 +12,15 @@ describe("uiHelpers element assertions", () => {
 
   it("warns and returns when next round button is missing", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { setTestMode } = await import("../../../src/helpers/testModeUtils.js");
+    setTestMode(true);
     const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
     mod.setupNextButton();
     expect(warnSpy).toHaveBeenNthCalledWith(
       1,
-      '[uiHelpers] #next-button missing, falling back to [data-role="next-round"]'
+      '[test] #next-button missing, falling back to [data-role="next-round"]'
     );
-    expect(warnSpy).toHaveBeenNthCalledWith(2, "[uiHelpers] next round button missing");
+    expect(warnSpy).toHaveBeenNthCalledWith(2, "[test] next round button missing");
   });
 
   it("falls back to data-role when #next-button is missing", async () => {
@@ -28,12 +30,14 @@ describe("uiHelpers element assertions", () => {
     const btn = document.createElement("button");
     btn.setAttribute("data-role", "next-round");
     document.body.appendChild(btn);
+    const { setTestMode } = await import("../../../src/helpers/testModeUtils.js");
+    setTestMode(true);
     const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
     mod.setupNextButton();
     btn.click();
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      '[uiHelpers] #next-button missing, falling back to [data-role="next-round"]'
+      '[test] #next-button missing, falling back to [data-role="next-round"]'
     );
   });
 


### PR DESCRIPTION
## Summary
- guard next-button fallback warnings behind test mode
- update UI helper tests to enable test mode when asserting warnings

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 162 missing docs)*
- `npx vitest run`
- `npx playwright test` *(fails: Next button cooldown skip spec; 2 interrupted)*
- `npm run check:contrast`

## Task Contract
- inputs: ["src/helpers/classicBattle/uiHelpers.js", "tests/helpers/classicBattle/uiHelpers.missingElements.test.js"]
- outputs: ["src/helpers/classicBattle/uiHelpers.js", "tests/helpers/classicBattle/uiHelpers.missingElements.test.js"]
- success: ["prettier: PASS", "eslint: WARN", "jsdoc: FAIL", "vitest: PASS", "playwright: FAIL", "contrast: PASS"]
- errorMode: ask_on_public_api_change

## Files
- `src/helpers/classicBattle/uiHelpers.js`: wrap next button warnings behind test mode
- `tests/helpers/classicBattle/uiHelpers.missingElements.test.js`: enable test mode for warning assertions

## Verification
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 162 missing docs)*
- `npx vitest run`
- `npx playwright test` *(fails: Next button cooldown skip spec; 2 interrupted)*
- `npm run check:contrast`

## Risk
- Low: affects only test-mode logging

------
https://chatgpt.com/codex/tasks/task_e_68b8aaa6e1c483269c86381d02549159