### PR TITLE
test: cover next button fallback

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -882,7 +882,7 @@ export function setupNextButton() {
     btn = document.querySelector('[data-role="next-round"]');
     if (!btn) {
       console.warn("[uiHelpers] next round button missing");
-      return;
+      throw new Error("setupNextButton: next round button missing");
     }
   }
   btn.addEventListener("click", onNextButtonClick);

--- a/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
+++ b/tests/helpers/classicBattle/uiHelpers.missingElements.test.js
@@ -8,17 +8,30 @@ describe("uiHelpers element assertions", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    document.body.innerHTML = "";
   });
 
-  it("warns and returns when next round button is missing", async () => {
+  it("throws when next round button selectors are missing", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
-    mod.setupNextButton();
+    expect(() => mod.setupNextButton()).toThrow("setupNextButton: next round button missing");
     expect(warnSpy).toHaveBeenNthCalledWith(
       1,
       '[uiHelpers] #next-button missing, falling back to [data-role="next-round"]'
     );
     expect(warnSpy).toHaveBeenNthCalledWith(2, "[uiHelpers] next round button missing");
+  });
+
+  it('warns but continues when only [data-role="next-round"] exists', async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const btn = document.createElement("button");
+    btn.setAttribute("data-role", "next-round");
+    document.body.appendChild(btn);
+    const mod = await import("../../../src/helpers/classicBattle/uiHelpers.js");
+    expect(() => mod.setupNextButton()).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[uiHelpers] #next-button missing, falling back to [data-role="next-round"]'
+    );
   });
 
   it("falls back to data-role when #next-button is missing", async () => {


### PR DESCRIPTION
## Summary
- throw when next round button selectors missing
- test warnings and fallback for data-role next button

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: 2 tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b8b02543fc83268ac762a62b2c052e