### PR TITLE
refactor: remove redundant guard wrapper for next button warnings

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -878,15 +878,11 @@ export function registerRoundStartErrorHandler(retryFn) {
 export function setupNextButton() {
   let btn = document.getElementById("next-button");
   if (!btn) {
-    guard(() => {
-      if (isTestModeEnabled())
-        console.warn('[test] #next-button missing, falling back to [data-role="next-round"]');
-    });
+    if (isTestModeEnabled())
+      console.warn('[test] #next-button missing, falling back to [data-role="next-round"]');
     btn = document.querySelector('[data-role="next-round"]');
     if (!btn) {
-      guard(() => {
-        if (isTestModeEnabled()) console.warn("[test] next round button missing");
-      });
+      if (isTestModeEnabled()) console.warn("[test] next round button missing");
       return;
     }
   }


### PR DESCRIPTION
## Summary
- simplify next-button fallback warnings by removing redundant `guard` wrapper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 162 missing docs)*
- `npx vitest run`
- `npx playwright test` *(fails: Next button cooldown skip spec)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b8b180d5f483269ab90a6539cc6fee