### PR TITLE
refactor: add playRounds helper

### DIFF
--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -25,6 +25,7 @@ This directory contains unit tests for Classic Battle helpers.
 - `setupTestEnv.js`: exposes `setupClassicBattleHooks()` to wire DOM and mocks.
 - `mockSetup.js`: shared mock helper to reduce duplication.
 - `utils.js` / `mocks.js`: shared DOM setup and legacy mocks for these suites.
+- `playRounds.js`: loops identical power selections for multi-round tests.
 
 ## Guidelines
 
@@ -45,3 +46,7 @@ const getEnv = setupClassicBattleHooks();
 ```
 
 `commonMocks.js` and `setupTestEnv.js` provide shared mocks and DOM wiring—new tests should import them instead of duplicating setup.
+
+### Helpers
+
+Use `playRounds(selectStat, times)` from `playRounds.js` when a suite requires repeating the same stat selection multiple times.

--- a/tests/helpers/classicBattle/matchEnd.test.js
+++ b/tests/helpers/classicBattle/matchEnd.test.js
@@ -3,6 +3,7 @@ import "./commonMocks.js";
 import { setupClassicBattleDom } from "./utils.js";
 import { CLASSIC_BATTLE_POINTS_TO_WIN } from "../../../src/helpers/constants.js";
 import { applyMockSetup } from "./mockSetup.js";
+import { playRounds } from "./playRounds.js";
 
 vi.mock("../../../src/components/Modal.js", () => ({
   createModal: (content) => {
@@ -65,15 +66,13 @@ async function playRound(battleMod, store, playerValue, opponentValue) {
 }
 
 async function playerWinsRounds(battleMod, store, count) {
-  for (let i = 0; i < count; i++) {
-    await playRound(battleMod, store, 5, 3);
-  }
+  const select = () => playRound(battleMod, store, 5, 3);
+  await playRounds(select, count);
 }
 
 async function opponentWinsRounds(battleMod, store, count) {
-  for (let i = 0; i < count; i++) {
-    await playRound(battleMod, store, 3, 5);
-  }
+  const select = () => playRound(battleMod, store, 3, 5);
+  await playRounds(select, count);
 }
 
 describe("classicBattle match end", () => {

--- a/tests/helpers/classicBattle/playRounds.js
+++ b/tests/helpers/classicBattle/playRounds.js
@@ -1,0 +1,15 @@
+/**
+ * Repeat power stat selection for a number of rounds.
+ *
+ * @param {Function} selectStat - selects the desired stat.
+ * @param {number} times - number of rounds to play.
+ * @returns {Promise<void>}
+ * @pseudocode
+ * for i from 0 to times
+ *   await selectStat('power')
+ */
+export async function playRounds(selectStat, times) {
+  for (let i = 0; i < times; i++) {
+    await selectStat("power");
+  }
+}

--- a/tests/helpers/classicBattle/statSelection.test.js
+++ b/tests/helpers/classicBattle/statSelection.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "./commonMocks.js";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
 import { applyMockSetup } from "./mockSetup.js";
+import { playRounds as playRoundsHelper } from "./playRounds.js";
 
 let fetchJsonMock;
 let generateRandomCardMock;
@@ -99,6 +100,10 @@ describe("classicBattle stat selection", () => {
       await p;
     };
   });
+
+  async function playRounds(times) {
+    await playRoundsHelper(selectStat, times);
+  }
 
   afterEach(() => {
     timerSpy.clearAllTimers();
@@ -212,9 +217,7 @@ describe("classicBattle stat selection", () => {
       document.getElementById("opponent-card").innerHTML =
         `<ul><li class="stat"><strong>Power</strong> <span>${opponentStat}</span></li></ul>`;
 
-      for (let i = 0; i < rounds; i++) {
-        await selectStat("power");
-      }
+      await playRounds(rounds);
 
       expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(1, "statSelected");
       expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "evaluate");


### PR DESCRIPTION
## Summary
- add reusable `playRounds` helper to repeat power stat selections
- refactor stat-selection and match-end tests to use the helper
- document helper in classic battle test README

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: [data-role="next-round"] disabled in battle-next-skip.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b8b19e4dfc83268ff4d86a8d682fa4