### PR TITLE
refactor: add playRounds helper

### DIFF
--- a/tests/helpers/classicBattle/README.md
+++ b/tests/helpers/classicBattle/README.md
@@ -25,7 +25,7 @@ This directory contains unit tests for Classic Battle helpers.
 - `setupTestEnv.js`: exposes `setupClassicBattleHooks()` to wire DOM and mocks.
 - `mockSetup.js`: shared mock helper to reduce duplication.
 - `utils.js` / `mocks.js`: shared DOM setup and legacy mocks for these suites.
-- `playRounds.js`: loops identical power selections for multi-round tests.
+- `playRounds.js`: loops identical stat selections for multi-round tests.
 
 ## Guidelines
 

--- a/tests/helpers/classicBattle/playRounds.js
+++ b/tests/helpers/classicBattle/playRounds.js
@@ -1,12 +1,12 @@
 /**
- * Repeat power stat selection for a number of rounds.
+ * Repeat stat selection for a number of rounds.
  *
  * @param {Function} selectStat - selects the desired stat.
  * @param {number} times - number of rounds to play.
  * @returns {Promise<void>}
  * @pseudocode
  * for i from 0 to times
- *   await selectStat('power')
+ *   await selectStat(stat) // stat is the configured stat to select
  */
 export async function playRounds(selectStat, times) {
   for (let i = 0; i < times; i++) {


### PR DESCRIPTION
## Summary
- generalize playRounds helper description and pseudocode
- update classic battle README reference

## Testing
- `npx prettier . --check` *(fails: Code style issues found in 5 files)*
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Total missing: 157)*
- `npx vitest run`
- `npx playwright test` *(fails: [data-role="next-round"] disabled in battle-next-skip.spec.js)*
- `npm run check:contrast`

## Task Contract
- inputs: `tests/helpers/classicBattle/playRounds.js`, `tests/helpers/classicBattle/README.md`
- outputs: `tests/helpers/classicBattle/playRounds.js`, `tests/helpers/classicBattle/README.md`
- success: `eslint: WARN`, `prettier: FAIL`, `jsdoc: FAIL`, `vitest: PASS`, `playwright: FAIL`, `check:contrast: PASS`
- errorMode: n/a

## Files Changed
- `tests/helpers/classicBattle/playRounds.js`: make JSDoc description and pseudocode stat-agnostic
- `tests/helpers/classicBattle/README.md`: document playRounds as looping stat selections

## Verification
- `npx prettier . --check` *(fails: Code style issues found in 5 files)*
- `npx eslint .` *(warnings: 4 problems)*
- `npm run check:jsdoc` *(fails: Total missing: 157)*
- `npx vitest run`
- `npx playwright test` *(fails: [data-role="next-round"] disabled in battle-next-skip.spec.js)*
- `npm run check:contrast`

## Risk and Follow-Up
- Low risk: documentation-only changes
- Follow-up: address repository-wide prettier and jsdoc issues, fix failing Playwright test


------
https://chatgpt.com/codex/tasks/task_e_68b8ba24d4d88326b20fe44878e6d7ed