### PR TITLE
test: improve battle CLI helper

### DIFF
--- a/tests/pages/README.md
+++ b/tests/pages/README.md
@@ -10,9 +10,13 @@ Creates DOM nodes and stubs common battle helpers. Options include:
 - `cliShortcuts` – enable CLI shortcut flag.
 - `pointsToWin` – initial win target.
 - `autoSelect` – enable auto-select flag.
+- `autoContinue` – set initial auto-continue state.
 - `url` – stubbed `location` URL.
 - `html` – extra HTML appended to the body.
 - `stats` – stat metadata returned from `fetchJson`.
 - `battleStats` – values for `BattleEngine.STATS`.
+
+The returned module exposes a `featureFlagsEmitter` property for dispatching
+feature flag events in tests.
 
 Call `cleanupBattleCLI()` in `afterEach` to clear mocks and DOM.


### PR DESCRIPTION
## Summary
- wire battle event mocks to notify handlers
- expose feature flag emitter and configurable auto-continue
- log suppressed cleanup failures

## Testing
- `npx prettier . --check` *(fails: Code style issues found in 7 files)*
- `npx eslint .` *(fails: 1 error, 5 warnings)*
- `npm run check:jsdoc` *(fails: Total missing: 157)*
- `npx vitest run` *(fails: 7 failed, 223 passed)*
- `npx playwright test` *(fails: 2 failed, 99 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68b8be81c954832684751ce1dcfc0886