### PR TITLE
chore: remove unused wait helper

### DIFF
--- a/playwright/battle-next-skip.spec.js
+++ b/playwright/battle-next-skip.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from "./fixtures/commonSetup.js";
-import { waitForBattleReady, waitForNextRoundReadyEvent } from "./fixtures/waits.js";
+import { waitForBattleReady } from "./fixtures/waits.js";
 
 /**
  * Verify that clicking Next during cooldown skips the delay.


### PR DESCRIPTION
## Summary
- drop `waitForNextRoundReadyEvent` import no longer needed in cooldown skip test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: 2 failed, 1 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68baaa1f37288326b0b079d593da5354