### PR TITLE
test: assert duplicate selection ignored

### DIFF
--- a/tests/helpers/selectionHandler.test.js
+++ b/tests/helpers/selectionHandler.test.js
@@ -59,7 +59,10 @@ describe("handleStatSelection helpers", () => {
     await handleStatSelection(store, "speed", { playerVal: 3, opponentVal: 4 });
 
     expect(stopTimer).toHaveBeenCalledTimes(1);
-    expect(emitBattleEvent).toHaveBeenCalledTimes(1);
+    expect(emitBattleEvent).toHaveBeenCalledTimes(2);
+    expect(emitBattleEvent).toHaveBeenNthCalledWith(2, "input.ignored", {
+      kind: "duplicateSelection"
+    });
     expect(dispatchBattleEvent).toHaveBeenCalledWith("roundResolved");
     expect(store.selectionMade).toBe(true);
   });


### PR DESCRIPTION
## Summary
- ensure repeated stat selections emit "input.ignored" event

## Testing
- `npx prettier . --check`
- `npx eslint .` (7 warnings)
- `npm run check:jsdoc` (169 missing)
- `npx vitest run`
- `npx playwright test` (2 failed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bb5aee18cc8326bc7e971a001afc16