### PR TITLE
fix: ensure next round button stays ready

### DIFF
--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -139,9 +139,10 @@ export async function initStartCooldown(machine) {
  * 1. Get the cooldown duration from `computeNextRoundCooldown`.
  * 2. Emit the `countdownStart` event with the duration.
  * 3. Enable the "Next" button (`disabled = false`, `data-next-ready = "true"`).
- * 4. Emit the `nextRoundTimerReady` event.
- * 5. Start a timer; on expiry, mark the button ready, emit cooldown events, and dispatch "ready".
- * 6. Schedule a fallback timer to ensure readiness if the main timer fails.
+ * 4. Schedule a zero-delay task to re-query `#next-button` and reapply readiness.
+ * 5. Emit the `nextRoundTimerReady` event.
+ * 6. Start a timer; on expiry, mark the button ready, emit cooldown events, and dispatch "ready".
+ * 7. Schedule a fallback timer to ensure readiness if the main timer fails.
  */
 export async function initInterRoundCooldown(machine) {
   const { computeNextRoundCooldown } = await import("../timers/computeNextRoundCooldown.js");
@@ -170,6 +171,13 @@ export async function initInterRoundCooldown(machine) {
     if (nextButton) {
       nextButton.disabled = false;
       nextButton.dataset.nextReady = "true";
+      setTimeout(() => {
+        const btn = document.getElementById("next-button");
+        if (btn) {
+          btn.disabled = false;
+          btn.dataset.nextReady = "true";
+        }
+      }, 0);
     }
   } catch {}
 


### PR DESCRIPTION
## Summary
- keep the Next button enabled after cooldown by re-checking it in a zero-delay timeout
- document the extra readiness step in the inter-round cooldown pseudocode

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run` *(fails: tests/helpers/selectionHandler.test.js > handleStatSelection helpers > ignores repeated selections)*
- `npx playwright test` *(fails: 2 tests failed: playwright/battle-next-readiness.spec.js, playwright/battle-next-skip.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bb5b0ea0348326b736f73e63ef12cb