### PR TITLE
fix: ensure next round button stays ready

### DIFF
--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -168,14 +168,24 @@ export async function initInterRoundCooldown(machine) {
   try {
     const nextButton =
       document.getElementById("next-button") || document.querySelector('[data-role="next-round"]');
+    /**
+     * Mark the Next button as ready for advancement.
+     * @param {HTMLElement} btn
+     */
+    const markReady = (btn) => {
+      btn.disabled = false;
+      btn.dataset.nextReady = "true";
+    };
     if (nextButton) {
-      nextButton.disabled = false;
-      nextButton.dataset.nextReady = "true";
+      markReady(nextButton);
       setTimeout(() => {
         const btn = document.getElementById("next-button");
-        if (btn) {
-          btn.disabled = false;
-          btn.dataset.nextReady = "true";
+        if (
+          btn &&
+          btn.dataset.nextReady === "true" &&
+          machine?.getState?.() === "cooldown"
+        ) {
+          markReady(btn);
         }
       }, 0);
     }


### PR DESCRIPTION
## Summary
- refactor Next button readiness into a helper
- guard zero-delay readiness reapply to prevent double clicks

## Testing
- `npx prettier . --check` *(fails: command not found)*
- `npx eslint .` *(fails: command not found)*
- `npm run check:jsdoc` *(fails: command not found)*
- `npx vitest run` *(fails: command not found)*
- `npx playwright test` *(fails: command not found)*
- `npm run check:contrast` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe27d7e988326872bb9a2b6d6ff19