### PR TITLE
test: extract disabled spy helper

### DIFF
--- a/tests/helpers/classicBattle/initInterRoundCooldown.event.test.js
+++ b/tests/helpers/classicBattle/initInterRoundCooldown.event.test.js
@@ -24,6 +24,22 @@ vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
   setupFallbackTimer: vi.fn()
 }));
 
+function createDisabledSpy(btn) {
+  let count = 0;
+  Object.defineProperty(btn, "disabled", {
+    configurable: true,
+    get() {
+      return this._disabled;
+    },
+    set(val) {
+      count++;
+      this._disabled = val;
+    }
+  });
+  btn._disabled = true;
+  return () => count;
+}
+
 describe("initInterRoundCooldown", () => {
   let machine;
   beforeEach(() => {
@@ -68,24 +84,13 @@ describe("initInterRoundCooldown", () => {
       "../../../src/helpers/classicBattle/orchestratorHandlers.js"
     );
     const btn = document.getElementById("next-button");
-    let disabledSetCount = 0;
-    Object.defineProperty(btn, "disabled", {
-      configurable: true,
-      get() {
-        return this._disabled;
-      },
-      set(val) {
-        disabledSetCount++;
-        this._disabled = val;
-      }
-    });
-    btn._disabled = true;
+    const getDisabledSetCount = createDisabledSpy(btn);
     await initInterRoundCooldown(machine);
-    expect(disabledSetCount).toBe(1);
+    expect(getDisabledSetCount()).toBe(1);
     btn.dataset.nextReady = "";
     await vi.runAllTimersAsync();
     expect(btn.dataset.nextReady).toBe("true");
-    expect(disabledSetCount).toBe(2);
+    expect(getDisabledSetCount()).toBe(2);
   });
 
   it("does not reapply readiness when already ready", async () => {
@@ -94,20 +99,9 @@ describe("initInterRoundCooldown", () => {
       "../../../src/helpers/classicBattle/orchestratorHandlers.js"
     );
     const btn = document.getElementById("next-button");
-    let disabledSetCount = 0;
-    Object.defineProperty(btn, "disabled", {
-      configurable: true,
-      get() {
-        return this._disabled;
-      },
-      set(val) {
-        disabledSetCount++;
-        this._disabled = val;
-      }
-    });
-    btn._disabled = true;
+    const getDisabledSetCount = createDisabledSpy(btn);
     await initInterRoundCooldown(machine);
     await vi.runAllTimersAsync();
-    expect(disabledSetCount).toBe(1);
+    expect(getDisabledSetCount()).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- deduplicate disabled property monkey patching in initInterRoundCooldown tests

## Testing
- `npx prettier . --check` *(fails: command not found)*
- `npx eslint .` *(fails: command not found)*
- `npm run check:jsdoc` *(fails: command not found)*
- `npx vitest run` *(fails: command not found)*
- `npx playwright test` *(fails: command not found)*
- `npm run check:contrast` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc26cfe7a08326a6f6b92d40f963ba