### PR TITLE
test: isolate CLI round header

### DIFF
--- a/tests/pages/battleCLI.a11y.smoke.test.js
+++ b/tests/pages/battleCLI.a11y.smoke.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+describe("battleCLI.html static selectors", () => {
+  it("exposes required DOM hooks", () => {
+    const html = readFileSync("src/pages/battleCLI.html", "utf8");
+    document.documentElement.innerHTML = html;
+    expect(document.getElementById("cli-countdown")).toBeTruthy();
+    expect(document.getElementById("round-message")).toBeTruthy();
+    expect(document.getElementById("cli-score")).toBeTruthy();
+    const root = document.getElementById("cli-root");
+    expect(root?.getAttribute("data-round")).not.toBeNull();
+    expect(root?.getAttribute("data-target")).not.toBeNull();
+    const countdown = document.getElementById("cli-countdown");
+    expect(countdown?.getAttribute("data-remaining-time")).not.toBeNull();
+  });
+});

--- a/tests/pages/battleCLI.roundHeader.test.js
+++ b/tests/pages/battleCLI.roundHeader.test.js
@@ -1,32 +1,20 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { readFileSync } from "node:fs";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { loadBattleCLI, cleanupBattleCLI } from "./utils/loadBattleCLI.js";
 
 describe("battleCLI round header", () => {
   afterEach(async () => {
+    vi.restoreAllMocks();
     await cleanupBattleCLI();
   });
 
   it("updates round header each round", async () => {
     const mod = await loadBattleCLI();
-    const { startRound } = await import("../../src/helpers/classicBattle/roundManager.js");
-    startRound.mockResolvedValue({ playerJudoka: null, roundNumber: 2 });
+    const roundManager = await import("../../src/helpers/classicBattle/roundManager.js");
+    vi.spyOn(roundManager, "startRound").mockResolvedValue({ playerJudoka: null, roundNumber: 2 });
     await mod.__test.startRoundWrapper();
     expect(document.getElementById("cli-round").textContent).toBe("Round 2 Target: 10 🏆");
     const root = document.getElementById("cli-root");
-    expect(root.dataset.round).toBe("2");
-    expect(root.dataset.target).toBe("10");
-  });
-
-  it("battleCLI.html exposes required selectors", () => {
-    const html = readFileSync("src/pages/battleCLI.html", "utf8");
-    const doc = new DOMParser().parseFromString(html, "text/html");
-    expect(doc.querySelector("#cli-countdown")).toBeTruthy();
-    expect(doc.querySelector("#round-message")).toBeTruthy();
-    expect(doc.querySelector("#cli-score")).toBeTruthy();
-    const root = doc.querySelector("#cli-root");
-    expect(root?.getAttribute("data-round")).not.toBeNull();
-    expect(root?.getAttribute("data-target")).not.toBeNull();
-    expect(doc.querySelector("#cli-countdown")?.getAttribute("data-remaining-time")).not.toBeNull();
+    expect(root.getAttribute("data-round")).toBe("2");
+    expect(root.getAttribute("data-target")).toBe("10");
   });
 });


### PR DESCRIPTION
## Summary
- focus round header test on startRoundWrapper DOM updates and clean up spies
- add battleCLI.a11y.smoke test for static selectors

## Testing
- `npx prettier . --check` *(fails: design/codeStandards/evaluatingPlaywrightTests.md, design/codeStandards/evaluatingUnitTests.md, docs/TestValuePolicy.md, progress.md)*
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 169 functions missing JSDoc)*
- `npx vitest run tests/pages/battleCLI.roundHeader.test.js tests/pages/battleCLI.a11y.smoke.test.js`
- `npx vitest run` *(fails: tests/helpers/prdReaderPage.test.js > supports keyboard-only navigation with focus management)*
- `npx playwright test` *(fails: playwright/battle-next-readiness.spec.js, playwright/battle-next-skip.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bc60d1bb6c83269881ac275f1e33c1