### PR TITLE
test: cover hamburger cleanup

### DIFF
--- a/src/helpers/navigation/navigationUI.js
+++ b/src/helpers/navigation/navigationUI.js
@@ -117,7 +117,7 @@ export function buildMenu(gameModes, { orientation }) {
  * 3. Define `update()` to insert the button and hide the list when the width is below the breakpoint; otherwise remove the button.
  * 4. Define `toggle()` to flip `aria-expanded` and the `.expanded` class on the list.
  * 5. Attach `click` and `resize` listeners and invoke `update()` once.
- * 6. Return a cleanup function that removes the `resize` listener.
+ * 6. Return a cleanup function that removes the `resize` listener and the button.
  *
  * @param {number} [breakpoint=480] - Maximum width to show the hamburger menu.
  * @returns {() => void} Cleanup function to remove the `resize` listener.
@@ -164,5 +164,7 @@ export function setupHamburger(breakpoint = 480) {
 
   return () => {
     window.removeEventListener("resize", update);
+    button.removeEventListener("click", toggle);
+    button.remove();
   };
 }

--- a/tests/helpers/navMenuResponsive.test.js
+++ b/tests/helpers/navMenuResponsive.test.js
@@ -1,16 +1,22 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { setupHamburger } from "../../src/helpers/navigation/navigationUI.js";
 
 describe("setupHamburger", () => {
   let cleanup;
+  let addSpy;
+  let removeSpy;
 
   beforeEach(() => {
     document.body.innerHTML = '<nav class="bottom-navbar"><ul><li></li></ul></nav>';
     window.innerWidth = 320;
     cleanup = () => {};
+    addSpy = undefined;
+    removeSpy = undefined;
   });
 
   afterEach(() => {
+    addSpy?.mockRestore();
+    removeSpy?.mockRestore();
     cleanup();
   });
 
@@ -30,5 +36,26 @@ describe("setupHamburger", () => {
     window.innerWidth = 1024;
     window.dispatchEvent(new Event("resize"));
     expect(document.querySelector(".nav-toggle")).toBeNull();
+  });
+
+  it("cleanup removes the button and listeners", () => {
+    cleanup = setupHamburger();
+    addSpy = vi.spyOn(window, "addEventListener");
+    removeSpy = vi.spyOn(window, "removeEventListener");
+    const button = document.querySelector(".nav-toggle");
+    expect(button).toBeTruthy();
+    cleanup();
+    expect(removeSpy).toHaveBeenCalledWith("resize", expect.any(Function));
+    expect(addSpy).not.toHaveBeenCalled();
+    expect(document.querySelector(".nav-toggle")).toBeNull();
+  });
+
+  it("does not duplicate button on multiple resizes", () => {
+    cleanup = setupHamburger();
+    for (let i = 0; i < 3; i++) {
+      window.innerWidth = 320;
+      window.dispatchEvent(new Event("resize"));
+    }
+    expect(document.querySelectorAll(".nav-toggle").length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- ensure `setupHamburger` cleanup detaches resize and click handlers and removes toggle button
- expand `setupHamburger` tests for listener cleanup and resize idempotency

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: Test timeout of 30000ms exceeded, 2 failed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bc7380324483268a7763ae68f50513