### PR TITLE
test: remove conflicting battle events mock in init tests

### DIFF
--- a/tests/pages/battleCLI.init.test.js
+++ b/tests/pages/battleCLI.init.test.js
@@ -1,10 +1,3 @@
-vi.mock("../../src/helpers/classicBattle/battleEvents.js", () => ({
-  onBattleEvent: vi.fn(),
-  offBattleEvent: vi.fn(),
-  emitBattleEvent: vi.fn(),
-  getBattleEventTarget: vi.fn(),
-  __resetBattleEventTarget: vi.fn()
-}));
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { BATTLE_POINTS_TO_WIN } from "../../src/config/storageKeys.js";
 import { loadBattleCLI, cleanupBattleCLI } from "./utils/loadBattleCLI.js";


### PR DESCRIPTION
## Summary
- remove conflicting top-level battle events mock in battleCLI init test
- rely on `loadBattleCLI`'s `mockBattleEvents` option when spying on real module

## Task Contract
```json
{
  "inputs": ["tests/pages/battleCLI.init.test.js", "tests/pages/utils/loadBattleCLI.js"],
  "outputs": ["tests/pages/battleCLI.init.test.js"],
  "success": [
    "prettier: PASS",
    "eslint: PASS",
    "jsdoc: FAIL",
    "vitest: PASS",
    "playwright: TERMINATED",
    "check:contrast: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `tests/pages/battleCLI.init.test.js`: remove top-level battleEvents mock to avoid conflicting with conditional mocks.

## Verification
- `npx prettier tests/pages/battleCLI.init.test.js tests/pages/utils/loadBattleCLI.js --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: missing JSDoc in many helpers)*
- `npx vitest run tests/pages/battleCLI.init.test.js`
- `npx playwright test` *(terminated after starting 102 tests)*
- `npm run check:contrast`

## Risk
- Low: test-only change, but Playwright suite did not fully run.


------
https://chatgpt.com/codex/tasks/task_e_68bc7b01e53483269a453086ea5f46c2