### PR TITLE
test: fix hamburger listener spy order

### DIFF
--- a/tests/helpers/navMenuResponsive.test.js
+++ b/tests/helpers/navMenuResponsive.test.js
@@ -39,14 +39,14 @@ describe("setupHamburger", () => {
   });
 
   it("cleanup removes the button and listeners", () => {
-    cleanup = setupHamburger();
     addSpy = vi.spyOn(window, "addEventListener");
     removeSpy = vi.spyOn(window, "removeEventListener");
+    cleanup = setupHamburger();
     const button = document.querySelector(".nav-toggle");
     expect(button).toBeTruthy();
+    expect(addSpy).toHaveBeenCalledWith("resize", expect.any(Function));
     cleanup();
     expect(removeSpy).toHaveBeenCalledWith("resize", expect.any(Function));
-    expect(addSpy).not.toHaveBeenCalled();
     expect(document.querySelector(".nav-toggle")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- ensure navMenuResponsive tests spy before calling setupHamburger so initial listeners are captured

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks: 165)*
- `npx vitest run`
- `npx playwright test` *(fails: TimeoutError: locator.waitFor: Timeout 5000ms exceeded)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bc7c2c25f48326bed48ec96b6b21e2