### PR TITLE
test: await syncDisplayMode call

### DIFF
--- a/tests/helpers/syncDisplayMode.test.js
+++ b/tests/helpers/syncDisplayMode.test.js
@@ -29,8 +29,8 @@ describe("syncDisplayMode", () => {
     const { syncDisplayMode, applyDisplayMode } = await setup();
     document.getElementById("display-mode-dark").checked = true;
     const handleUpdate = vi.fn().mockResolvedValue();
-    const updated = await withMutedConsole(
-      async () => await syncDisplayMode({ displayMode: "light" }, handleUpdate)
+    const updated = await withMutedConsole(() =>
+      syncDisplayMode({ displayMode: "light" }, handleUpdate)
     );
     expect(updated.displayMode).toBe("dark");
     expect(handleUpdate).toHaveBeenCalledWith("displayMode", "dark", expect.any(Function));
@@ -43,9 +43,7 @@ describe("syncDisplayMode", () => {
     const { syncDisplayMode, applyDisplayMode } = await setup();
     const handleUpdate = vi.fn();
     const current = { displayMode: "light" };
-    const updated = await withMutedConsole(
-      async () => await syncDisplayMode(current, handleUpdate)
-    );
+    const updated = await withMutedConsole(() => syncDisplayMode(current, handleUpdate));
     expect(updated).toEqual(current);
     expect(handleUpdate).not.toHaveBeenCalled();
     expect(applyDisplayMode).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- remove redundant async wrapper when muting console in syncDisplayMode tests

## Testing
- `npx prettier . --check`
- `npx eslint tests/helpers/syncDisplayMode.test.js`
- `npm run check:jsdoc` *(fails: functions missing JSDoc)*
- `npx vitest run tests/helpers/syncDisplayMode.test.js`
- `npx playwright test` *(fails: Next readiness only in cooldown; Next button cooldown skip)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["tests/helpers/syncDisplayMode.test.js"],
  "outputs": ["tests/helpers/syncDisplayMode.test.js"],
  "success": [
    "prettier: PASS",
    "eslint: PASS",
    "jsdoc: FAIL (non-blocking)",
    "vitest: PASS",
    "playwright: FAIL",
    "contrast: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Risks & Mitigations
- Changes limited to tests; low runtime risk
- Playwright failure unrelated to change, investigate flake in `battle-next-*` specs later


------
https://chatgpt.com/codex/tasks/task_e_68bc7efcc5bc8326b1b2a46868145a77