### PR TITLE
test: add a11y checks for navigation and stats

### DIFF
--- a/tests/pages/battleCLI.a11y.smoke.test.js
+++ b/tests/pages/battleCLI.a11y.smoke.test.js
@@ -14,4 +14,24 @@ describe("battleCLI.html static selectors", () => {
     const countdown = document.getElementById("cli-countdown");
     expect(countdown?.getAttribute("data-remaining-time")).not.toBeNull();
   });
+
+  it("includes skip link and landmark roles", () => {
+    const html = readFileSync("src/pages/battleCLI.html", "utf8");
+    document.documentElement.innerHTML = html;
+    const skip = document.querySelector("a.skip-link");
+    expect(skip).toBeTruthy();
+    expect(skip?.getAttribute("href")).toBe("#cli-main");
+    expect(document.querySelector("header[role='banner']")).toBeTruthy();
+    expect(document.querySelector("main[role='main']")).toBeTruthy();
+  });
+
+  it("places skip link first in focus order", () => {
+    const html = readFileSync("src/pages/battleCLI.html", "utf8");
+    document.documentElement.innerHTML = html;
+    const focusables = Array.from(document.querySelectorAll("a[href], button, [tabindex]")).filter(
+      (el) => !el.hasAttribute("disabled") && el.tabIndex >= 0
+    );
+    expect(focusables[0]?.classList.contains("skip-link")).toBe(true);
+    expect(focusables[1]?.getAttribute("data-testid")).toBe("home-link");
+  });
 });

--- a/tests/pages/battleClassic.a11y.smoke.test.js
+++ b/tests/pages/battleClassic.a11y.smoke.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
+import { withMutedConsole } from "../utils/console.js";
 
 describe("battleClassic.html a11y regions", () => {
   it("includes main ARIA regions and labeled stat buttons", () => {
@@ -24,6 +25,35 @@ describe("battleClassic.html a11y regions", () => {
       const hasLabel = !!b.getAttribute("aria-label");
       const hasDesc = !!b.getAttribute("aria-describedby");
       expect(hasLabel || hasDesc).toBe(true);
+    });
+  });
+
+  it("provides landmark roles and focusable stat button", () => {
+    const html = readFileSync("src/pages/battleClassic.html", "utf8");
+    document.documentElement.innerHTML = html;
+    expect(document.querySelector("header[role='banner']")).toBeTruthy();
+    expect(document.querySelector("main[role='main']")).toBeTruthy();
+    const firstBtn = document.querySelector("#stat-buttons button");
+    expect(firstBtn).toBeTruthy();
+    expect(firstBtn?.hasAttribute("disabled")).toBe(false);
+    expect(firstBtn?.tabIndex).toBe(0);
+  });
+
+  it("detects duplicate ARIA region ids", async () => {
+    const html = readFileSync("src/pages/battleClassic.html", "utf8");
+    document.documentElement.innerHTML = html;
+    const regionIds = Array.from(document.querySelectorAll("[role][id]")).map((el) => el.id);
+    const unique = new Set(regionIds);
+    expect(unique.size).toBe(regionIds.length);
+
+    await withMutedConsole(async () => {
+      const dup = document.createElement("div");
+      dup.id = regionIds[0];
+      dup.setAttribute("role", "status");
+      document.body.appendChild(dup);
+      const ids = Array.from(document.querySelectorAll("[role][id]")).map((el) => el.id);
+      const uniqueAfter = new Set(ids);
+      expect(uniqueAfter.size).toBeLessThan(ids.length);
     });
   });
 });


### PR DESCRIPTION
## Summary
- expand battle CLI smoke tests with skip-link, focus order and landmark role coverage
- ensure classic battle page exposes landmark roles and keyboard-focusable stat buttons
- guard against duplicate ARIA region IDs with negative-case test using `withMutedConsole`

## Testing
- `npx prettier . --check`
- `npx eslint tests/pages/battleCLI.a11y.smoke.test.js tests/pages/battleClassic.a11y.smoke.test.js`
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: 1 failed, 2 interrupted, 84 skipped)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bc883de3b88326a3903729bbc9b500