### PR TITLE
test: avoid reading html in focus test

### DIFF
--- a/tests/pages/battleCLI.a11y.focus.test.js
+++ b/tests/pages/battleCLI.a11y.focus.test.js
@@ -14,7 +14,8 @@ describe("battleCLI accessibility", () => {
 
     it("shifts focus between stat list and next prompt", async () => {
       const mod = await loadBattleCLI();
-      await mod.__test.init();
+      await mod.__test.renderStatList();
+      mod.__test.installEventBindings();
       const { emitBattleEvent } = await import("../../src/helpers/classicBattle/battleEvents.js");
       emitBattleEvent("battleStateChange", { to: "waitingForPlayerAction" });
       expect(document.activeElement?.id).toBe("cli-stats");


### PR DESCRIPTION
## Summary
- remove indirect `readFileSync` usage in battleCLI focus test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: Next readiness only in cooldown; Next button cooldown skip)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bc8ecc22808326bc008fe40aefa9d0