### PR TITLE
fix: guard roundUI summary modal

### DIFF
--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -302,7 +302,7 @@ export function bindRoundUIEventHandlersDynamic() {
         const ui = await uiServiceP;
         const roundManager = await roundManagerP;
         scoreboard.clearRoundCounter?.();
-        if (typeof ui.showMatchSummaryModal === "function") {
+        if (ui && typeof ui.showMatchSummaryModal === "function") {
           await ui.showMatchSummaryModal(result, async () => {
             if (typeof roundManager.handleReplay === "function") {
               await roundManager.handleReplay(store);


### PR DESCRIPTION
## Summary
- ensure ui object exists before calling match summary modal

## Task Contract
- inputs: `src/helpers/classicBattle/roundUI.js`
- outputs: `src/helpers/classicBattle/roundUI.js`
- success: `prettier` PASS, `eslint` PASS, `jsdoc` FAIL, `vitest` PASS, `playwright` TIMEOUT, `check:contrast` PASS
- errorMode: continue on failed jsdoc/playwright

## Files
- `src/helpers/classicBattle/roundUI.js`: guard match summary modal import by verifying ui object

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 165 functions missing)*
- `npx vitest run`
- `npx playwright test` *(terminated: Next readiness specs timeout)*
- `npm run check:contrast`

## Risk
- Low risk: additional null check only
- Follow-up: address jsdoc completeness and flaky Playwright specs


------
https://chatgpt.com/codex/tasks/task_e_68bc923b8b08832691b161b12abd85a5