### PR TITLE
refactor: modularize vector search helpers

### DIFF
--- a/docs/vector-search.md
+++ b/docs/vector-search.md
@@ -1,0 +1,18 @@
+# Vector Search Workflow
+
+This document outlines the data flow behind the Vector Search page.
+
+1. **Query expansion and encoding** – `buildQueryVector` splits the user's
+   query into terms, expands synonyms via `vectorSearch.expandQueryWithSynonyms`,
+   and uses the MiniLM extractor to generate an embedding vector.
+2. **Match selection** – `vectorSearch.findMatches` returns scored results which
+   `selectTopMatches` partitions into strong and weak groups before choosing the
+   subset to render.
+3. **UI state management** – `applyResultsState` applies one of four declarative
+   states (`loading`, `results`, `empty`, `error`) to control spinner visibility
+   and messaging.
+4. **Orchestration** – `handleSearch` composes the above steps, updating the UI
+   and rendering results once matches are available.
+
+The workflow keeps heavy logic out of the DOM layer and enables unit testing of
+pure utilities.

--- a/src/helpers/vectorSearchPage/buildQueryVector.js
+++ b/src/helpers/vectorSearchPage/buildQueryVector.js
@@ -1,0 +1,44 @@
+import vectorSearch from "../vectorSearch/index.js";
+import { getExtractor } from "../api/vectorSearchPage.js";
+
+function isIterable(value) {
+  return value !== null && value !== undefined && typeof value[Symbol.iterator] === "function";
+}
+
+/**
+ * Expand the query and generate its vector representation.
+ *
+ * @summary Expand query with synonyms and encode a vector.
+ * @pseudocode
+ * 1. Split the query into lowercase terms.
+ * 2. Expand the query using domain-specific synonyms.
+ * 3. Obtain the feature extractor and generate a mean-pooled embedding.
+ *    - If the result has a `data` property, ensure it is iterable.
+ *    - Otherwise ensure the result itself is iterable.
+ * 4. Convert the iterable into a plain array and return the terms and vector.
+ *
+ * @param {string} query - Raw query string from the user.
+ * @returns {Promise<{terms: string[], vector: number[]}>} Processed query data.
+ */
+export async function buildQueryVector(query) {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  const expanded = await vectorSearch.expandQueryWithSynonyms(query);
+  const model = await getExtractor();
+  const result = await model(expanded, { pooling: "mean" });
+  let source;
+  if (result && typeof result === "object" && "data" in result) {
+    if (!isIterable(result.data)) {
+      throw new TypeError("Extractor result.data is not iterable");
+    }
+    source = result.data;
+  } else {
+    if (!isIterable(result)) {
+      throw new TypeError("Extractor result is not iterable");
+    }
+    source = result;
+  }
+  const vector = Array.from(source);
+  return { terms, vector };
+}
+
+export default buildQueryVector;

--- a/src/helpers/vectorSearchPage/resultsState.js
+++ b/src/helpers/vectorSearchPage/resultsState.js
@@ -1,0 +1,50 @@
+/**
+ * Map of result states to their UI handlers.
+ *
+ * @summary Declarative mapping for search result UI states.
+ * @pseudocode
+ * 1. Define messages, CSS classes, and spinner actions for each state.
+ * 2. Provide a helper to apply a state's configuration.
+ */
+export const RESULTS_STATE = {
+  loading: { text: "Searching...", className: null, spinner: "show" },
+  results: { text: "", className: null, spinner: "hide" },
+  empty: {
+    text: "No close matches found — refine your query.",
+    className: "search-result-empty",
+    spinner: "hide"
+  },
+  error: {
+    text: "An error occurred while searching.",
+    className: "search-result-empty",
+    spinner: "hide"
+  }
+};
+
+/**
+ * Apply a results state to the UI.
+ *
+ * @summary Update spinner and message element based on search state.
+ * @pseudocode
+ * 1. Look up the configuration for the given state.
+ * 2. Toggle spinner visibility using the mapped action.
+ * 3. Update message text and toggle the `search-result-empty` class.
+ * 4. Allow optional `overrideText` to customize the message.
+ *
+ * @param {{show:Function, hide:Function}} spinner - Spinner controller.
+ * @param {HTMLElement} messageEl - Message display element.
+ * @param {keyof typeof RESULTS_STATE} state - Desired results state.
+ * @param {string} [overrideText] - Optional replacement message.
+ * @returns {void}
+ */
+export function applyResultsState(spinner, messageEl, state, overrideText) {
+  const cfg = RESULTS_STATE[state];
+  if (!cfg) return;
+  spinner?.[cfg.spinner]?.();
+  if (messageEl) {
+    messageEl.textContent = overrideText ?? cfg.text;
+    messageEl.classList.toggle("search-result-empty", cfg.className === "search-result-empty");
+  }
+}
+
+export default applyResultsState;

--- a/src/helpers/vectorSearchPage/selectTopMatches.js
+++ b/src/helpers/vectorSearchPage/selectTopMatches.js
@@ -1,0 +1,36 @@
+import { SIMILARITY_THRESHOLD } from "../api/vectorSearchPage.js";
+
+/**
+ * Partition matches into strong and weak groups and choose which to render.
+ *
+ * @summary Classify matches by similarity and select results to display.
+ * @pseudocode
+ * 1. Split `matches` into `strongMatches` and `weakMatches` by `SIMILARITY_THRESHOLD`.
+ * 2. If multiple strong matches exist and the gap between the top two exceeds
+ *    `DROP_OFF_THRESHOLD`, keep only the top match.
+ * 3. Otherwise render all strong matches when present.
+ * 4. When no strong matches, return the first three weak matches.
+ * 5. Return both the strong set and the final selection.
+ *
+ * @param {Array<{score:number}>} matches - All matches sorted by score.
+ * @returns {{strongMatches: Array, toRender: Array}} Partitioned selections.
+ */
+export function selectTopMatches(matches) {
+  const DROP_OFF_THRESHOLD = 0.4;
+  const strongMatches = matches.filter((m) => m.score >= SIMILARITY_THRESHOLD);
+  const weakMatches = matches.filter((m) => m.score < SIMILARITY_THRESHOLD);
+  let toRender;
+  if (
+    strongMatches.length > 1 &&
+    strongMatches[0].score - strongMatches[1].score > DROP_OFF_THRESHOLD
+  ) {
+    toRender = [strongMatches[0]];
+  } else if (strongMatches.length > 0) {
+    toRender = strongMatches;
+  } else {
+    toRender = weakMatches.slice(0, 3);
+  }
+  return { strongMatches, toRender };
+}
+
+export default selectTopMatches;

--- a/tests/helpers/vectorSearchPage/buildQueryVector.test.js
+++ b/tests/helpers/vectorSearchPage/buildQueryVector.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mockVectorSearch, mockExtractor } from "./fixtures.js";
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("buildQueryVector", () => {
+  it("expands the query and returns a vector", async () => {
+    const expandQueryWithSynonyms = vi.fn().mockResolvedValue("expanded");
+    mockVectorSearch({ expandQueryWithSynonyms });
+    await mockExtractor(async () => ({ data: [1, 2, 3] }));
+    const { buildQueryVector } = await import(
+      "../../../src/helpers/vectorSearchPage/buildQueryVector.js"
+    );
+    const result = await buildQueryVector("Hello World");
+    expect(expandQueryWithSynonyms).toHaveBeenCalledWith("Hello World");
+    expect(result.terms).toEqual(["hello", "world"]);
+    expect(result.vector).toEqual([1, 2, 3]);
+  });
+
+  it("throws when extractor returns non-iterable data", async () => {
+    mockVectorSearch();
+    await mockExtractor(async () => ({ data: 123 }));
+    const { buildQueryVector } = await import(
+      "../../../src/helpers/vectorSearchPage/buildQueryVector.js"
+    );
+    await expect(buildQueryVector("test")).rejects.toThrow("Extractor result.data is not iterable");
+  });
+});

--- a/tests/helpers/vectorSearchPage/selectTopMatches.test.js
+++ b/tests/helpers/vectorSearchPage/selectTopMatches.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("selectTopMatches", () => {
+  it("returns only the top match when score gap is large", async () => {
+    vi.doMock("../../../src/helpers/api/vectorSearchPage.js", () => ({
+      SIMILARITY_THRESHOLD: 0.4
+    }));
+    const { selectTopMatches } = await import(
+      "../../../src/helpers/vectorSearchPage/selectTopMatches.js"
+    );
+    const matches = [{ score: 0.9 }, { score: 0.4 }, { score: 0.39 }, { score: 0.1 }];
+    const { strongMatches, toRender } = selectTopMatches(matches);
+    expect(strongMatches).toHaveLength(2);
+    expect(toRender).toEqual([matches[0]]);
+  });
+
+  it("returns top three weak matches when no strong ones", async () => {
+    vi.doMock("../../../src/helpers/api/vectorSearchPage.js", () => ({
+      SIMILARITY_THRESHOLD: 0.9
+    }));
+    const { selectTopMatches } = await import(
+      "../../../src/helpers/vectorSearchPage/selectTopMatches.js"
+    );
+    const matches = [{ score: 0.5 }, { score: 0.4 }, { score: 0.3 }, { score: 0.2 }];
+    const { strongMatches, toRender } = selectTopMatches(matches);
+    expect(strongMatches).toHaveLength(0);
+    expect(toRender).toEqual(matches.slice(0, 3));
+  });
+});


### PR DESCRIPTION
## Summary
- factor out query vector builder and match selector into dedicated helpers
- add declarative results state mapping and compose handleSearch from pure helpers
- test query expansion and match selection; document vector search workflow

## Testing
- `npx prettier . --check`
- `npx eslint src/helpers/vectorSearchPage.js src/helpers/vectorSearchPage/buildQueryVector.js src/helpers/vectorSearchPage/selectTopMatches.js src/helpers/vectorSearchPage/resultsState.js tests/helpers/vectorSearchPage/buildQueryVector.test.js tests/helpers/vectorSearchPage/selectTopMatches.test.js docs/vector-search.md`
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: playwright/battle-next-readiness.spec.js, playwright/battle-next-skip.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bc9558db348326acf1d3ab3b479e22