### PR TITLE
refactor: decouple battle CLI handlers

### DIFF
--- a/playwright/battle-cli.spec.js
+++ b/playwright/battle-cli.spec.js
@@ -67,7 +67,7 @@ test.describe("Classic Battle CLI", () => {
     await expect(page.locator("#cli-verbose-section")).toBeVisible();
 
     // Cause a transition by selecting a stat via keyboard (mapped to 1)
-    await page.evaluate(() => window.__test.onKeyDown({ key: "1" }));
+    await page.keyboard.press("1");
 
     // Wait for a later state to appear in the badge and log
     await waitForBattleState(page, "roundDecision", 10000);

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -36,6 +36,7 @@ import { SNACKBAR_REMOVE_MS } from "../helpers/constants.js";
 import { registerModal, unregisterModal, onEsc } from "../helpers/modalManager.js";
 import state, { resolveEscapeHandled, getEscapeHandledPromise } from "./battleCLI/state.js";
 import { onKeyDown } from "./battleCLI/events.js";
+import { registerBattleHandlers } from "./battleCLI/battleHandlers.js";
 
 // Initialize engine and subscribe to engine events when available.
 try {
@@ -171,7 +172,6 @@ export const __test = {
   handleRoundResolved,
   handleMatchOver,
   handleBattleState,
-  onKeyDown,
   handleWaitingForPlayerActionKey
 };
 /**
@@ -1376,6 +1376,14 @@ export function handleCooldownKey(key) {
   }
   return false;
 }
+
+registerBattleHandlers({
+  handleGlobalKey,
+  handleWaitingForPlayerActionKey,
+  handleRoundOverKey,
+  handleCooldownKey,
+  handleStatListArrowKey
+});
 
 /**
  * Global keyboard handler that routes input based on the current battle state.

--- a/src/pages/battleCLI/battleHandlers.js
+++ b/src/pages/battleCLI/battleHandlers.js
@@ -1,0 +1,12 @@
+const handlers = {};
+
+export function registerBattleHandlers(h) {
+  Object.assign(handlers, h);
+}
+
+export const handleGlobalKey = (key) => handlers.handleGlobalKey(key);
+export const handleWaitingForPlayerActionKey = (key) =>
+  handlers.handleWaitingForPlayerActionKey(key);
+export const handleRoundOverKey = (key) => handlers.handleRoundOverKey(key);
+export const handleCooldownKey = (key) => handlers.handleCooldownKey(key);
+export const handleStatListArrowKey = (key) => handlers.handleStatListArrowKey(key);

--- a/src/pages/battleCLI/events.js
+++ b/src/pages/battleCLI/events.js
@@ -5,7 +5,7 @@ import {
   handleRoundOverKey,
   handleCooldownKey,
   handleStatListArrowKey
-} from "../battleCLI.js";
+} from "./battleHandlers.js";
 
 const byId = (id) => document.getElementById(id);
 const arrowKeys = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]);

--- a/tests/pages/battleCLI.a11y.focus.test.js
+++ b/tests/pages/battleCLI.a11y.focus.test.js
@@ -14,8 +14,8 @@ describe("battleCLI accessibility", () => {
 
     it("shifts focus between stat list and next prompt", async () => {
       const mod = await loadBattleCLI();
-      await mod.__test.renderStatList();
-      mod.__test.installEventBindings();
+      await mod.renderStatList();
+      mod.installEventBindings();
       const { emitBattleEvent } = await import("../../src/helpers/classicBattle/battleEvents.js");
       emitBattleEvent("battleStateChange", { to: "waitingForPlayerAction" });
       expect(document.activeElement?.id).toBe("cli-stats");
@@ -47,15 +47,16 @@ describe("battleCLI accessibility", () => {
       expect(rows[0].tabIndex).toBe(0);
       expect(rows[1].tabIndex).toBe(-1);
       list.focus();
-      mod.onKeyDown(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+      const { onKeyDown } = await import("../../src/pages/index.js");
+      onKeyDown(new KeyboardEvent("keydown", { key: "ArrowDown" }));
       expect(document.activeElement).toBe(rows[0]);
-      mod.onKeyDown(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+      onKeyDown(new KeyboardEvent("keydown", { key: "ArrowDown" }));
       expect(document.activeElement).toBe(rows[1]);
-      mod.onKeyDown(new KeyboardEvent("keydown", { key: "ArrowUp" }));
+      onKeyDown(new KeyboardEvent("keydown", { key: "ArrowUp" }));
       expect(document.activeElement).toBe(rows[0]);
-      mod.onKeyDown(new KeyboardEvent("keydown", { key: "ArrowUp" }));
+      onKeyDown(new KeyboardEvent("keydown", { key: "ArrowUp" }));
       expect(document.activeElement).toBe(rows[2]);
-      mod.onKeyDown(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+      onKeyDown(new KeyboardEvent("keydown", { key: "ArrowDown" }));
       expect(document.activeElement).toBe(rows[0]);
       expect(list.getAttribute("aria-activedescendant")).toBe(rows[0].id);
     });

--- a/tests/pages/battleCLI.cliShortcutsFlag.test.js
+++ b/tests/pages/battleCLI.cliShortcutsFlag.test.js
@@ -11,7 +11,8 @@ describe("battleCLI cliShortcuts flag", () => {
     await mod.init();
     const sec = document.getElementById("cli-shortcuts");
     expect(sec.hidden).toBe(true);
-    mod.onKeyDown(new KeyboardEvent("keydown", { key: "h" }));
+    const { onKeyDown } = await import("../../src/pages/index.js");
+    onKeyDown(new KeyboardEvent("keydown", { key: "h" }));
     expect(sec.hidden).toBe(true);
   });
 
@@ -20,7 +21,8 @@ describe("battleCLI cliShortcuts flag", () => {
     await mod.init();
     const sec = document.getElementById("cli-shortcuts");
     expect(sec.hidden).toBe(true);
-    mod.onKeyDown(new KeyboardEvent("keydown", { key: "h" }));
+    const { onKeyDown } = await import("../../src/pages/index.js");
+    onKeyDown(new KeyboardEvent("keydown", { key: "h" }));
     expect(sec.hidden).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- remove test-only `onKeyDown` export to avoid duplication
- route event handlers through a registry to break circular dependency
- adjust tests to use public `onKeyDown` API

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Total missing: 151)*
- `npx vitest run`
- `npx playwright test` *(fails: Next readiness only in cooldown & Next button cooldown skip)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bca09a34848326ab5160056c299e40