### PR TITLE
refactor: encapsulate scoreboard state

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -18,3 +18,30 @@
 - `setPage(index)` - jump to a specific page.
 - `update()` - refresh button states and markers.
 - `destroy()` - remove listeners and DOM nodes.
+
+## Scoreboard
+
+`Scoreboard` manages round messages, timers, round counters, and match score.
+
+### DOM creation
+
+```js
+import { createScoreboard, Scoreboard } from "../src/components/Scoreboard.js";
+
+const container = createScoreboard();
+document.body.appendChild(container);
+```
+
+### Usage
+
+```js
+const sb = new Scoreboard({
+  messageEl: container.querySelector("#round-message"),
+  timerEl: container.querySelector("#next-round-timer"),
+  roundCounterEl: container.querySelector("#round-counter"),
+  scoreEl: container.querySelector("#score-display")
+});
+
+sb.showMessage("Ready!");
+sb.updateScore(1, 0);
+```

--- a/tests/components/Scoreboard.test.js
+++ b/tests/components/Scoreboard.test.js
@@ -19,6 +19,7 @@ describe("Scoreboard component", () => {
     header = document.createElement("header");
     createScoreboard(header);
     document.body.appendChild(header);
+    initScoreboard(header);
   });
 
   it("creates DOM structure with proper aria attributes", () => {

--- a/tests/helpers/scoreboard.adapter.test.js
+++ b/tests/helpers/scoreboard.adapter.test.js
@@ -24,7 +24,7 @@ describe("scoreboardAdapter maps display.* events to Scoreboard", () => {
     `;
     document.body.appendChild(header);
     const { initScoreboard } = await import("../../src/components/Scoreboard.js");
-    initScoreboard(undefined);
+    initScoreboard(header);
     const { initScoreboardAdapter } = await import(
       "../../src/helpers/classicBattle/scoreboardAdapter.js"
     );

--- a/tests/helpers/selectionHandler.test.js
+++ b/tests/helpers/selectionHandler.test.js
@@ -73,6 +73,9 @@ describe("handleStatSelection helpers", () => {
       <div id="round-message">hi</div>
     `;
 
+    const { initScoreboard } = await import("../../src/components/Scoreboard.js");
+    initScoreboard(document.body);
+
     await handleStatSelection(store, "power", { playerVal: 1, opponentVal: 2 });
 
     expect(document.getElementById("next-round-timer").textContent).toBe("");


### PR DESCRIPTION
## Summary
- rewrite Scoreboard into a class with injected DOM references
- update tests for class-based Scoreboard API
- document Scoreboard usage and initialization

## Testing
- `npx prettier src/components/Scoreboard.js tests/helpers/scoreboard.integration.test.js tests/helpers/scoreboard.adapter.test.js tests/components/Scoreboard.test.js tests/helpers/selectionHandler.test.js docs/components.md --check`
- `npx eslint tests/components/Scoreboard.test.js tests/helpers/selectionHandler.test.js tests/helpers/scoreboard.integration.test.js tests/helpers/scoreboard.adapter.test.js docs/components.md`
- `npm run check:jsdoc` *(fails: 165 missing)*
- `npx vitest run` *(errors: 1 unhandled error)*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bcb63623e483268ad235009668a510