### PR TITLE
fix: import opponent delay helper directly

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -29,6 +29,7 @@ import {
 } from "./statButtons.js";
 import { guard } from "./guard.js";
 import { updateDebugPanel, setDebugPanelEnabled } from "./debugPanel.js";
+import { getOpponentDelay } from "./snackbar.js";
 export { showSelectionPrompt, setOpponentDelay, getOpponentDelay } from "./snackbar.js";
 /**
  * Skip the inter-round cooldown when the corresponding feature flag is enabled.


### PR DESCRIPTION
## Summary
- import `getOpponentDelay` directly in `uiHelpers` and re-export

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: PRD Reader sidebar-tab-traversal)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/helpers/classicBattle/uiHelpers.js"],
  "outputs": ["src/helpers/classicBattle/uiHelpers.js"],
  "success": ["eslint: PASS", "vitest: PASS", "jsdoc: WARN", "playwright: FAIL"],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- **src/helpers/classicBattle/uiHelpers.js**: import opponent delay helper to avoid runtime ReferenceError

## Verification
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: PRD Reader sidebar-tab-traversal)*
- `npm run check:contrast`

## Risk
- Low: adjusting imports in battle UI helpers

## Follow-up
- investigate and fix failing Playwright test for PRD Reader sidebar tab traversal


------
https://chatgpt.com/codex/tasks/task_e_68bd2fccd5d88326b6db4d4533b414b0