### PR TITLE
refactor: encapsulate scoreboard state

### DIFF
--- a/tests/helpers/scoreboard.integration.test.js
+++ b/tests/helpers/scoreboard.integration.test.js
@@ -80,7 +80,7 @@ describe("Scoreboard integration without setupScoreboard", () => {
       scoreEl: document.getElementById("score-display")
     });
 
-    vi.mock("../../src/helpers/setupScoreboard.js", () => ({
+    vi.doMock("../../src/helpers/setupScoreboard.js", () => ({
       setupScoreboard: vi.fn(),
       showMessage: scoreboard.showMessage.bind(scoreboard),
       updateScore: scoreboard.updateScore.bind(scoreboard),


### PR DESCRIPTION
## Summary
- ensure `setupScoreboard` mock binds to an instantiated `Scoreboard` by using `vi.doMock`

## Testing
- `npx prettier tests/helpers/scoreboard.integration.test.js --check` *(fails: command not found)*
- `npx eslint tests/helpers/scoreboard.integration.test.js` *(fails: command not found)*
- `npm run check:jsdoc` *(fails: command not found)*
- `npx vitest run` *(fails: command not found)*
- `npx playwright test` *(fails: command not found)*
- `npm run check:contrast` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2f91d85c83268ee8fe16bd939a7a