### PR TITLE
refactor classic battle timer utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,13 @@ Use static imports for hot paths and always-required modules; use dynamic import
 
 The game includes a **Skip** button that bypasses the current round and cooldown timers. Use it to fast-forward through matches when debugging or running rapid gameplay tests.
 
+### Timer utilities
+
+Classic Battle timer logic lives in `src/helpers/classicBattle/timerService.js` and its helpers:
+
+- `timerUtils.js` — shared state snapshot and readiness helpers.
+- `autoSelectHandlers.js` — stat-selection fallbacks when timers drift or stall.
+
 On the Browse Judoka page, the country filter panel starts with the `hidden` attribute. When revealed, it must include `aria-label="Country filter panel"` for accessibility and Playwright tests. The country slider loads asynchronously after the panel opens.
 
 Run all Playwright tests with:

--- a/src/helpers/classicBattle/autoSelectHandlers.js
+++ b/src/helpers/classicBattle/autoSelectHandlers.js
@@ -1,0 +1,97 @@
+import { isEnabled } from "../featureFlags.js";
+import { t } from "../i18n.js";
+import * as scoreboard from "../setupScoreboard.js";
+import { showSnackbar } from "../showSnackbar.js";
+import { emitBattleEvent } from "./battleEvents.js";
+import { dispatchBattleEvent } from "./orchestrator.js";
+import { autoSelectStat } from "./autoSelectStat.js";
+import { computeNextRoundCooldown } from "../timers/computeNextRoundCooldown.js";
+import { realScheduler } from "../scheduler.js";
+
+/**
+ * Force a stat auto-select and ensure the state machine advances.
+ *
+ * @param {(stat: string, opts?: { delayOpponentMessage?: boolean }) => Promise<void>} onExpiredSelect
+ * Callback handling auto-selected stat.
+ * @returns {Promise<void>}
+ * @summary Auto-select a stat and dispatch outcome on timer failure.
+ * @pseudocode
+ * 1. Show an error message on the scoreboard.
+ * 2. If auto-select is enabled, call `autoSelectStat(onExpiredSelect)`.
+ * 3. Otherwise dispatch `interrupt`.
+ * 4. On any error, dispatch `interrupt` as a fallback.
+ */
+export async function forceAutoSelectAndDispatch(onExpiredSelect) {
+  scoreboard.showMessage(t("ui.timerErrorAutoSelect"));
+  try {
+    if (isEnabled("autoSelect")) {
+      await autoSelectStat(onExpiredSelect);
+    } else {
+      await dispatchBattleEvent("interrupt");
+    }
+  } catch {
+    await dispatchBattleEvent("interrupt");
+  }
+}
+
+/**
+ * Schedule a stalled-selection prompt and optional auto-select.
+ *
+ * @param {{autoSelectId: ReturnType<typeof setTimeout> | null}} store Battle state store.
+ * @param {(stat: string, opts?: { delayOpponentMessage?: boolean }) => void} onSelect Stat selection callback.
+ * @param {number} [timeoutMs=5000] Delay before prompting.
+ * @param {{ setTimeout: Function }} [scheduler=realScheduler] Scheduler for timeouts.
+ * @returns {void}
+ * @summary Prompt for stalled stat selection and queue auto-select when enabled.
+ * @pseudocode
+ * 1. After `timeoutMs`, if no selection made:
+ *    a. Show stalled snackbar and optionally scoreboard message.
+ *    b. Emit `statSelectionStalled`.
+ *    c. If auto-select enabled:
+ *       i. Announce next-round countdown after a short delay.
+ *       ii. Trigger `autoSelectStat(onSelect)` shortly after.
+ * 2. Store the timeout id on `store.autoSelectId`.
+ */
+export function handleStatSelectionTimeout(
+  store,
+  onSelect,
+  timeoutMs = 5000,
+  scheduler = realScheduler
+) {
+  store.autoSelectId = scheduler.setTimeout(() => {
+    if (store && store.selectionMade) return;
+    const stalledMsg = t("ui.statSelectionStalled");
+    scheduler.setTimeout(() => {
+      try {
+        showSnackbar(stalledMsg);
+      } catch {}
+      if (!isEnabled("autoSelect")) {
+        try {
+          scoreboard.showMessage(stalledMsg);
+        } catch {}
+      }
+      try {
+        emitBattleEvent("statSelectionStalled");
+      } catch {}
+    }, 100);
+    if (isEnabled("autoSelect")) {
+      try {
+        const secs = computeNextRoundCooldown();
+        scheduler.setTimeout(() => {
+          try {
+            showSnackbar(t("ui.nextRoundIn", { seconds: secs }));
+          } catch {}
+        }, 800);
+      } catch {}
+      try {
+        scheduler.setTimeout(() => {
+          try {
+            autoSelectStat(onSelect);
+          } catch {}
+        }, 250);
+      } catch {
+        autoSelectStat(onSelect);
+      }
+    }
+  }, timeoutMs);
+}

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -3,7 +3,8 @@ import { showSelectionPrompt } from "./snackbar.js";
 // Use index re-exports so tests can vi.mock("../battle/index.js") and spy
 import { resetStatButtons } from "../battle/index.js";
 import { syncScoreDisplay } from "./uiService.js";
-import { startTimer, handleStatSelectionTimeout } from "./timerService.js";
+import { startTimer } from "./timerService.js";
+import { handleStatSelectionTimeout } from "./autoSelectHandlers.js";
 
 import * as scoreboard from "../setupScoreboard.js";
 import { handleStatSelection } from "./selectionHandler.js";

--- a/src/helpers/classicBattle/testHooks.js
+++ b/src/helpers/classicBattle/testHooks.js
@@ -120,7 +120,7 @@ export async function triggerStallPromptNow(store) {
   const { getOpponentJudoka } = await import("./cardSelection.js");
   const { getCardStatValue } = await import("./cardStatUtils.js");
   const { handleStatSelection } = await import("./selectionHandler.js");
-  const { handleStatSelectionTimeout } = await import("./timerService.js");
+  const { handleStatSelectionTimeout } = await import("./autoSelectHandlers.js");
 
   const onSelect = (stat, opts) => {
     const playerCard = document.getElementById("player-card");

--- a/src/helpers/classicBattle/timerUtils.js
+++ b/src/helpers/classicBattle/timerUtils.js
@@ -1,0 +1,47 @@
+import { getStateSnapshot } from "./battleDebug.js";
+
+/**
+ * Safely retrieve the current battle state snapshot.
+ *
+ * @returns {{state?: string}} Snapshot object or empty when unavailable.
+ * @summary Get the current battle state without throwing.
+ * @pseudocode
+ * 1. Try `getStateSnapshot()`.
+ * 2. Return the snapshot or `{}` if it fails.
+ */
+export function safeGetSnapshot() {
+  try {
+    return getStateSnapshot() || {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Check if the Next button is flagged ready.
+ *
+ * @param {HTMLButtonElement|null} btn Button to inspect.
+ * @returns {boolean} True when `data-next-ready="true"`.
+ * @summary Determine readiness via dataset flag.
+ * @pseudocode
+ * 1. Return `btn?.dataset.nextReady === "true"`.
+ */
+export function isNextReady(btn) {
+  return btn?.dataset.nextReady === "true";
+}
+
+/**
+ * Clear readiness attributes on the Next button and re-enable it.
+ *
+ * @param {HTMLButtonElement|null} btn Target button.
+ * @returns {void}
+ * @summary Remove readiness flag and enable button.
+ * @pseudocode
+ * 1. If `btn` exists, delete `data-next-ready` and set `disabled=false`.
+ */
+export function resetReadiness(btn) {
+  if (btn) {
+    delete btn.dataset.nextReady;
+    btn.disabled = false;
+  }
+}

--- a/tests/helpers/classicBattle/roundResolved.statButton.test.js
+++ b/tests/helpers/classicBattle/roundResolved.statButton.test.js
@@ -19,7 +19,9 @@ vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
   setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
 }));
 vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
-  startTimer: vi.fn(),
+  startTimer: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/autoSelectHandlers.js", () => ({
   handleStatSelectionTimeout: vi.fn()
 }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -49,6 +49,37 @@ describe("timerService next round handling", () => {
     vi.restoreAllMocks();
   });
 
+  it("chooses advance strategy when ready", async () => {
+    const timerMod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const stop = vi.fn();
+    document.body.innerHTML = '<button id="next-button"></button>';
+    const btn = document.getElementById("next-button");
+    btn.dataset.nextReady = "true";
+    await timerMod.onNextButtonClick(new MouseEvent("click"), {
+      btn,
+      timer: { stop },
+      resolveReady: null
+    });
+    const dispatcher = await import("../../../src/helpers/classicBattle/orchestrator.js");
+    expect(stop).not.toHaveBeenCalled();
+    expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
+  });
+
+  it("chooses cancel strategy when not ready", async () => {
+    const timerMod = await import("../../../src/helpers/classicBattle/timerService.js");
+    const stop = vi.fn();
+    document.body.innerHTML = '<button id="next-button"></button>';
+    const btn = document.getElementById("next-button");
+    await timerMod.onNextButtonClick(new MouseEvent("click"), {
+      btn,
+      timer: { stop },
+      resolveReady: null
+    });
+    const dispatcher = await import("../../../src/helpers/classicBattle/orchestrator.js");
+    expect(stop).toHaveBeenCalled();
+    expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
+  });
+
   it("clicking Next during cooldown skips current phase", async () => {
     const timerMod = await import("../../../src/helpers/classicBattle/timerService.js");
     const roundMod = await import("../../../src/helpers/classicBattle/roundManager.js");

--- a/tests/helpers/timerService.autoSelectDisabled.test.js
+++ b/tests/helpers/timerService.autoSelectDisabled.test.js
@@ -59,9 +59,12 @@ describe("timerService without auto-select", () => {
     }));
 
     const mod = await import("../../src/helpers/classicBattle/timerService.js");
+    const { handleStatSelectionTimeout } = await import(
+      "../../src/helpers/classicBattle/autoSelectHandlers.js"
+    );
     const store = { selectionMade: false, autoSelectId: null };
     await mod.startTimer(async () => {}, store);
-    mod.handleStatSelectionTimeout(store, () => {}, 0);
+    handleStatSelectionTimeout(store, () => {}, 0);
     await vi.runAllTimersAsync();
 
     expect(dispatchSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- extract force auto-select helpers to `autoSelectHandlers`
- centralize snapshot/readiness checks in `timerUtils`
- drive Next-button flow with strategy table

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd31fb1edc83269a200428943a8a8b