### PR TITLE
refactor round ui handlers

### DIFF
--- a/docs/roundUI.md
+++ b/docs/roundUI.md
@@ -1,0 +1,14 @@
+# Round UI Flow
+
+Classic battle rounds emit three UI events. Each handler operates on a shared
+battle store that caches commonly used DOM elements.
+
+1. **`roundStarted`** – resets button state, syncs the scoreboard and kicks off
+   timers via `applyRoundUI`.
+2. **`statSelected`** – adds a `selected` class to the chosen button, optionally
+   surfaces a "You Picked" snackbar and disables further stat picks.
+3. **`roundResolved`** – displays the outcome, updates the score, schedules the
+   next-round countdown and clears any stat highlight.
+
+Caching the player card, opponent card and stat buttons on the store avoids
+repeated DOM queries inside timers and event handlers.

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -45,7 +45,7 @@ export function isOrchestrated() {
  * 1. Initialize battle state values.
  * 2. Return the store.
  *
- * @returns {{quitModal: ReturnType<import("../../components/Modal.js").createModal>|null, statTimeoutId: ReturnType<typeof setTimeout>|null, autoSelectId: ReturnType<typeof setTimeout>|null, compareRaf: number, selectionMade: boolean, stallTimeoutMs: number, playerChoice: string|null}}
+ * @returns {{quitModal: ReturnType<import("../../components/Modal.js").createModal>|null, statTimeoutId: ReturnType<typeof setTimeout>|null, autoSelectId: ReturnType<typeof setTimeout>|null, compareRaf: number, selectionMade: boolean, stallTimeoutMs: number, playerChoice: string|null, playerCardEl: HTMLElement|null, opponentCardEl: HTMLElement|null, statButtonEls: Record<string, HTMLButtonElement>|null}}
  */
 export function createBattleStore() {
   return {
@@ -55,7 +55,10 @@ export function createBattleStore() {
     compareRaf: 0,
     selectionMade: false,
     stallTimeoutMs: 35000,
-    playerChoice: null
+    playerChoice: null,
+    playerCardEl: null,
+    opponentCardEl: null,
+    statButtonEls: null
   };
 }
 

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -47,9 +47,20 @@ export function applyRoundUI(store, roundNumber, stallTimeoutMs = 5000) {
   syncScoreDisplay();
   scoreboard.updateRoundCounter(roundNumber);
   showSelectionPrompt();
+  const playerCard =
+    store.playerCardEl || (store.playerCardEl = document.getElementById("player-card"));
+  const opponentCard =
+    store.opponentCardEl || (store.opponentCardEl = document.getElementById("opponent-card"));
+  if (!store.statButtonEls) {
+    store.statButtonEls = Array.from(
+      document.querySelectorAll("#stat-buttons button[data-stat]")
+    ).reduce((acc, btn) => {
+      const s = btn.dataset.stat;
+      if (s) acc[s] = btn;
+      return acc;
+    }, {});
+  }
   startTimer((stat, opts) => {
-    const playerCard = document.getElementById("player-card");
-    const opponentCard = document.getElementById("opponent-card");
     const playerVal = getCardStatValue(playerCard, stat);
     let opponentVal = getCardStatValue(opponentCard, stat);
     try {
@@ -66,8 +77,6 @@ export function applyRoundUI(store, roundNumber, stallTimeoutMs = 5000) {
   handleStatSelectionTimeout(
     store,
     (s, opts) => {
-      const playerCard = document.getElementById("player-card");
-      const opponentCard = document.getElementById("opponent-card");
       const playerVal = getCardStatValue(playerCard, s);
       let opponentVal = getCardStatValue(opponentCard, s);
       try {
@@ -85,57 +94,67 @@ export function applyRoundUI(store, roundNumber, stallTimeoutMs = 5000) {
 // --- Event bindings ---
 
 /**
- * Bind static event handlers for round UI updates.
- *
- * These handlers listen for `roundStarted`, `statSelected`, and `roundResolved`
- * events to update the DOM, scoreboard, and timers. In production, binding
- * happens once per module load to avoid duplicate listeners.
+ * Bind handler for `roundStarted` events.
  *
  * @pseudocode
- * 1. On `roundStarted` → call `applyRoundUI(store, roundNumber)`.
- * 2. On `statSelected` → add `selected` class to the chosen button, optionally show “You Picked…”, then disable stat buttons.
- * 3. On `roundResolved` → show outcome and update score; if match ended show summary, else surface next-round countdown and schedule failsafe transitions; clear selection highlight and refresh debug panel.
- *
- * @returns {void}
+ * 1. Listen for `roundStarted`.
+ * 2. Extract store and round number.
+ * 3. Invoke `applyRoundUI`.
  */
-export function bindRoundUIEventHandlers() {
+export function bindRoundStarted() {
   onBattleEvent("roundStarted", (e) => {
     const { store, roundNumber } = e.detail || {};
     if (store && typeof roundNumber === "number") {
       applyRoundUI(store, roundNumber);
     }
   });
+}
 
+/**
+ * Bind handler for `statSelected` events.
+ *
+ * @pseudocode
+ * 1. Listen for `statSelected`.
+ * 2. Highlight the chosen button and optionally show feedback.
+ * 3. Disable further stat selections.
+ */
+export function bindStatSelected() {
   onBattleEvent("statSelected", (e) => {
     try {
       if (!IS_VITEST) console.log("INFO: statSelected event handler");
     } catch {}
-    const { stat, opts } = e.detail || {};
+    const { stat, store, opts } = e.detail || {};
     if (!stat) return;
-    const btn = document.querySelector(`#stat-buttons button[data-stat="${stat}"]`);
+    const btn = store?.statButtonEls?.[stat];
     if (btn) {
       try {
         if (!IS_VITEST)
           console.warn(`[test] addSelected: stat=${stat} label=${btn.textContent?.trim() || ""}`);
       } catch {}
       btn.classList.add("selected");
-      // Suppress the immediate snackbar when the stat was auto-selected due to
-      // stall/timeout so the upcoming cooldown countdown can occupy the snackbar.
       if (!opts || !opts.delayOpponentMessage) {
         showSnackbar(`You Picked: ${btn.textContent}`);
       }
     }
     emitBattleEvent("statButtons:disable");
   });
+}
 
+/**
+ * Bind handler for `roundResolved` events.
+ *
+ * @pseudocode
+ * 1. Listen for `roundResolved`.
+ * 2. Surface outcome, update score, maybe show summary.
+ * 3. Clear selection highlight and refresh debug panel.
+ */
+export function bindRoundResolved() {
   onBattleEvent("roundResolved", (e) => {
     const { store, result } = e.detail || {};
     if (!result) return;
     try {
       if (!IS_VITEST) console.warn("[test] roundResolved event received");
     } catch {}
-    // Update the round message and score using the resolved values to avoid
-    // relying on engine singletons in test environments.
     try {
       scoreboard.showMessage(result.message || "", { outcome: true });
     } catch {}
@@ -153,18 +172,9 @@ export function bindRoundUIEventHandlers() {
       });
       emitBattleEvent("matchOver");
     } else {
-      // The orchestrator now handles cooldown initiation when the state machine
-      // enters the 'cooldown' state. This call is no longer needed.
-      // proactively surface the countdown text in the snackbar so tests can
-      // observe it even if timer wiring races with other snackbar messages.
       try {
         const secs = computeNextRoundCooldown();
-        // Use explicit text to avoid depending on i18n in tests
         updateSnackbar(`Next round in: ${secs}s`);
-        // Fallback sequential updates when the orchestrator is not running
-        if (!isOrchestrated && typeof isOrchestrated === "function") {
-          // no-op; typo guard
-        }
         const orchestrated = (() => {
           try {
             return typeof isOrchestrated === "function" && isOrchestrated();
@@ -173,15 +183,11 @@ export function bindRoundUIEventHandlers() {
           }
         })();
         if (!orchestrated) {
-          // Delay updates by 2s/3s to align with test expectations
           if (secs >= 2) setTimeout(() => updateSnackbar(`Next round in: ${secs - 1}s`), 2000);
           if (secs >= 3) setTimeout(() => updateSnackbar(`Next round in: ${secs - 2}s`), 3000);
         }
       } catch {}
-      // Failsafe removed as it conflicts with the orchestrator.
     }
-    // Keep the selected stat highlighted for two frames to allow tests and
-    // users to perceive the selection before it clears.
     try {
       requestAnimationFrame(() =>
         requestAnimationFrame(() => {
@@ -191,7 +197,6 @@ export function bindRoundUIEventHandlers() {
         })
       );
     } catch {
-      // Fallback for environments without rAF
       setTimeout(() => {
         try {
           if (typeof resetStatButtons === "function") resetStatButtons();
@@ -200,6 +205,20 @@ export function bindRoundUIEventHandlers() {
     }
     updateDebugPanel();
   });
+}
+
+/**
+ * Bind all round UI event handlers.
+ *
+ * @pseudocode
+ * 1. Bind `roundStarted` handler.
+ * 2. Bind `statSelected` handler.
+ * 3. Bind `roundResolved` handler.
+ */
+export function bindRoundUIEventHandlers() {
+  bindRoundStarted();
+  bindStatSelected();
+  bindRoundResolved();
 }
 
 // Bind once on module load for production/runtime usage. Guard against
@@ -260,19 +279,21 @@ export function bindRoundUIEventHandlersDynamic() {
     }
   });
   onBattleEvent("statSelected", async (e) => {
-    const { stat } = e.detail || {};
+    const { stat, store, opts } = e.detail || {};
     if (!stat) return;
-    const btn = document.querySelector(`#stat-buttons button[data-stat="${stat}"]`);
+    const btn = store?.statButtonEls?.[stat];
     if (btn) {
       try {
         if (!IS_VITEST)
           console.warn(`[test] addSelected: stat=${stat} label=${btn.textContent?.trim() || ""}`);
       } catch {}
       btn.classList.add("selected");
-      try {
-        const { showSnackbar } = await showSnackbarP;
-        showSnackbar(`You Picked: ${btn.textContent}`);
-      } catch {}
+      if (!opts || !opts.delayOpponentMessage) {
+        try {
+          const { showSnackbar } = await showSnackbarP;
+          showSnackbar(`You Picked: ${btn.textContent}`);
+        } catch {}
+      }
     }
     emitBattleEvent("statButtons:disable");
   });
@@ -336,7 +357,6 @@ export function bindRoundUIEventHandlersDynamic() {
           if (secs >= 3) setTimeout(() => uSb(`Next round in: ${secs - 2}s`), 3000);
         }
       } catch {}
-      // Failsafe removed as it conflicts with the orchestrator.
     }
     // Keep the selected stat highlighted for two frames to mirror the static path
     try {

--- a/tests/helpers/classicBattle/roundUI.handlers.test.js
+++ b/tests/helpers/classicBattle/roundUI.handlers.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
+  showMessage: vi.fn(),
+  updateScore: vi.fn(),
+  clearRoundCounter: vi.fn(),
+  updateRoundCounter: vi.fn()
+}));
+vi.mock("../../../src/helpers/showSnackbar.js", () => ({
+  showSnackbar: vi.fn(),
+  updateSnackbar: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+  handleReplay: vi.fn(),
+  isOrchestrated: () => false
+}));
+vi.mock("../../../src/helpers/classicBattle/debugPanel.js", () => ({
+  updateDebugPanel: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/uiService.js", () => ({
+  syncScoreDisplay: vi.fn(),
+  showMatchSummaryModal: vi.fn()
+}));
+vi.mock("../../../src/helpers/battle/index.js", () => ({
+  resetStatButtons: vi.fn()
+}));
+vi.mock("../../../src/helpers/timers/computeNextRoundCooldown.js", () => ({
+  computeNextRoundCooldown: () => 3
+}));
+
+vi.mock("../../../src/helpers/classicBattle/snackbar.js", () => ({
+  showSelectionPrompt: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
+  startTimer: vi.fn(),
+  handleStatSelectionTimeout: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/selectionHandler.js", () => ({
+  handleStatSelection: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/cardStatUtils.js", () => ({
+  getCardStatValue: () => 0
+}));
+vi.mock("../../../src/helpers/classicBattle/cardSelection.js", () => ({
+  getOpponentJudoka: () => ({ stats: {} })
+}));
+
+describe("round UI handlers", () => {
+  it("calls applyRoundUI on roundStarted", async () => {
+    vi.resetModules();
+    globalThis.__classicBattleRoundUIBound = true;
+    const events = await import("../../../src/helpers/classicBattle/battleEvents.js");
+    events.__resetBattleEventTarget();
+    const ui = await import("../../../src/helpers/classicBattle/roundUI.js");
+    ui.bindRoundStarted();
+    const { emitBattleEvent } = events;
+    document.body.innerHTML =
+      '<div id="player-card"></div><div id="opponent-card"></div><div id="stat-buttons"><button data-stat="power"></button></div><div id="round-result"></div>';
+    const store = {};
+    emitBattleEvent("roundStarted", { store, roundNumber: 2 });
+    expect(store.playerCardEl).toBeTruthy();
+    expect(store.statButtonEls?.power).toBeTruthy();
+  });
+
+  it("highlights selected stat button", async () => {
+    vi.resetModules();
+    globalThis.__classicBattleRoundUIBound = true;
+    const events = await import("../../../src/helpers/classicBattle/battleEvents.js");
+    events.__resetBattleEventTarget();
+    const ui = await import("../../../src/helpers/classicBattle/roundUI.js");
+    ui.bindStatSelected();
+    const { emitBattleEvent } = events;
+    document.body.innerHTML = '<div id="stat-buttons"><button data-stat="power"></button></div>';
+    const btn = document.querySelector('[data-stat="power"]');
+    const store = { statButtonEls: { power: btn } };
+    emitBattleEvent("statSelected", { stat: "power", store });
+    expect(btn.classList.contains("selected")).toBe(true);
+  });
+
+  it("shows outcome on roundResolved", async () => {
+    vi.resetModules();
+    globalThis.__classicBattleRoundUIBound = true;
+    const events = await import("../../../src/helpers/classicBattle/battleEvents.js");
+    events.__resetBattleEventTarget();
+    const ui = await import("../../../src/helpers/classicBattle/roundUI.js");
+    ui.bindRoundResolved();
+    const { emitBattleEvent } = events;
+    const store = {};
+    emitBattleEvent("roundResolved", {
+      store,
+      result: { matchEnded: false, message: "Win", playerScore: 1, opponentScore: 0 }
+    });
+    const scoreboard = await import("../../../src/helpers/setupScoreboard.js");
+    expect(scoreboard.showMessage).toHaveBeenCalledWith("Win", { outcome: true });
+  });
+});


### PR DESCRIPTION
## Summary
- cache battle DOM references in store
- split round UI handlers by event type
- document round UI flow and add focused tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd31ecbfe88326bbf2de12f2695a60