### PR TITLE
refactor classic battle cooldowns

### DIFF
--- a/src/helpers/classicBattle/handleRoundError.js
+++ b/src/helpers/classicBattle/handleRoundError.js
@@ -1,0 +1,20 @@
+import { emitBattleEvent } from "./battleEvents.js";
+import { guard, guardAsync } from "./guard.js";
+
+/**
+ * Handle round-related errors in a consistent manner.
+ *
+ * @param {object} machine
+ * @param {string} reason
+ * @param {Error} err
+ * @returns {Promise<void>}
+ * @pseudocode
+ * 1. Show a generic round error message.
+ * 2. Update the debug panel.
+ * 3. Dispatch `interrupt` with the reason and error message.
+ */
+export async function handleRoundError(machine, reason, err) {
+  guard(() => emitBattleEvent("scoreboardShowMessage", "Round error. Recovering…"));
+  guard(() => emitBattleEvent("debugPanelUpdate"));
+  await guardAsync(() => machine.dispatch("interrupt", { reason, error: err?.message }));
+}

--- a/tests/helpers/classicBattle/initInterRoundCooldown.event.test.js
+++ b/tests/helpers/classicBattle/initInterRoundCooldown.event.test.js
@@ -55,7 +55,7 @@ describe("initInterRoundCooldown", () => {
 
   it("enables button and emits event", async () => {
     const { initInterRoundCooldown } = await import(
-      "../../../src/helpers/classicBattle/orchestratorHandlers.js"
+      "../../../src/helpers/classicBattle/cooldowns.js"
     );
     await initInterRoundCooldown(machine);
     const btn = document.getElementById("next-button");
@@ -69,7 +69,7 @@ describe("initInterRoundCooldown", () => {
       if (evt === "countdownStart") throw new Error("boom");
     });
     const { initInterRoundCooldown } = await import(
-      "../../../src/helpers/classicBattle/orchestratorHandlers.js"
+      "../../../src/helpers/classicBattle/cooldowns.js"
     );
     await initInterRoundCooldown(machine);
     const btn = document.getElementById("next-button");
@@ -81,7 +81,7 @@ describe("initInterRoundCooldown", () => {
   it("reapplies readiness when reset before timeout", async () => {
     vi.useFakeTimers();
     const { initInterRoundCooldown } = await import(
-      "../../../src/helpers/classicBattle/orchestratorHandlers.js"
+      "../../../src/helpers/classicBattle/cooldowns.js"
     );
     const btn = document.getElementById("next-button");
     const getDisabledSetCount = createDisabledSpy(btn);
@@ -96,7 +96,7 @@ describe("initInterRoundCooldown", () => {
   it("does not reapply readiness when already ready", async () => {
     vi.useFakeTimers();
     const { initInterRoundCooldown } = await import(
-      "../../../src/helpers/classicBattle/orchestratorHandlers.js"
+      "../../../src/helpers/classicBattle/cooldowns.js"
     );
     const btn = document.getElementById("next-button");
     const getDisabledSetCount = createDisabledSpy(btn);

--- a/tests/helpers/classicBattle/initStartCooldown.event.test.js
+++ b/tests/helpers/classicBattle/initStartCooldown.event.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const emitBattleEvent = vi.fn();
+let finished;
+
+vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
+  emitBattleEvent,
+  onBattleEvent: vi.fn((evt, fn) => {
+    if (evt === "countdownFinished") finished = fn;
+  }),
+  offBattleEvent: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/timerUtils.js", () => ({
+  getDefaultTimer: vi.fn(() => 1)
+}));
+
+vi.mock("../../../src/helpers/testModeUtils.js", () => ({
+  isTestModeEnabled: () => false
+}));
+
+vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+  setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
+}));
+
+describe("initStartCooldown", () => {
+  let machine;
+  beforeEach(() => {
+    emitBattleEvent.mockReset();
+    finished = null;
+    machine = { dispatch: vi.fn() };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("dispatches ready when countdown finishes", async () => {
+    const { initStartCooldown } = await import("../../../src/helpers/classicBattle/cooldowns.js");
+    await initStartCooldown(machine);
+    finished();
+    expect(machine.dispatch).toHaveBeenCalledWith("ready");
+  });
+
+  it("dispatches ready via fallback timer", async () => {
+    vi.useFakeTimers();
+    const { initStartCooldown } = await import("../../../src/helpers/classicBattle/cooldowns.js");
+    await initStartCooldown(machine);
+    await vi.runAllTimersAsync();
+    expect(machine.dispatch).toHaveBeenCalledWith("ready");
+  });
+});


### PR DESCRIPTION
## Summary
- extract handleRoundError into its own module
- centralize cooldown initialization in classicBattle/cooldowns
- use state-transition table for next-button advancement
- add unit tests for cooldown logic

## Testing
- `npx prettier . --check`
- `npx eslint src/helpers/classicBattle/cooldowns.js src/helpers/classicBattle/handleRoundError.js src/helpers/classicBattle/timerService.js src/helpers/classicBattle/orchestratorHandlers.js tests/helpers/classicBattle/initStartCooldown.event.test.js tests/helpers/classicBattle/initInterRoundCooldown.event.test.js`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd423256d8832691dd35299f5c1046