### PR TITLE
refactor: avoid optional chain in stat handler

### DIFF
--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -125,12 +125,12 @@ export function bindStatSelected() {
       if (!IS_VITEST) console.log("INFO: statSelected event handler");
     } catch {}
     const { stat, store, opts } = e.detail || {};
-    if (!stat) return;
-    const btn = store?.statButtonEls?.[stat];
+    if (!stat || !store || !store.statButtonEls) return;
+    const btn = store.statButtonEls[stat];
     if (btn) {
       try {
         if (!IS_VITEST)
-          console.warn(`[test] addSelected: stat=${stat} label=${btn.textContent?.trim() || ""}`);
+          console.warn(`[test] addSelected: stat=${stat} label=${(btn.textContent || "").trim()}`);
       } catch {}
       btn.classList.add("selected");
       if (!opts || !opts.delayOpponentMessage) {
@@ -281,12 +281,12 @@ export function bindRoundUIEventHandlersDynamic() {
   });
   onBattleEvent("statSelected", async (e) => {
     const { stat, store, opts } = e.detail || {};
-    if (!stat) return;
-    const btn = store?.statButtonEls?.[stat];
+    if (!stat || !store || !store.statButtonEls) return;
+    const btn = store.statButtonEls[stat];
     if (btn) {
       try {
         if (!IS_VITEST)
-          console.warn(`[test] addSelected: stat=${stat} label=${btn.textContent?.trim() || ""}`);
+          console.warn(`[test] addSelected: stat=${stat} label=${(btn.textContent || "").trim()}`);
       } catch {}
       btn.classList.add("selected");
       if (!opts || !opts.delayOpponentMessage) {


### PR DESCRIPTION
## Summary
- replace optional chaining with explicit checks in round stat selection handlers

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 178 missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/helpers/classicBattle/roundUI.js"],
  "outputs": ["src/helpers/classicBattle/roundUI.js"],
  "success": [
    "prettier: PASS",
    "eslint: PASS",
    "jsdoc: FAIL",
    "vitest: PASS",
    "playwright: PASS",
    "check:contrast: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `src/helpers/classicBattle/roundUI.js`: avoid optional chaining in stat handlers for better hot-path performance

## Verification Summary
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 178 missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Risk
- Low. Refactors defensive checks in stat handlers.

## Follow-Up
- Address repository-wide missing JSDoc blocks to satisfy `check:jsdoc`.


------
https://chatgpt.com/codex/tasks/task_e_68bd421f93c883268c660ad6006c97dd