### PR TITLE
refactor: encapsulate scoreboard state

### DIFF
--- a/tests/helpers/scoreboard.integration.test.js
+++ b/tests/helpers/scoreboard.integration.test.js
@@ -7,6 +7,19 @@ vi.mock("../../src/helpers/motionUtils.js", () => ({
 let roundDrift;
 let scoreboard;
 
+vi.doMock("../../src/helpers/setupScoreboard.js", () => ({
+  setupScoreboard: vi.fn(),
+  showMessage: (...args) => scoreboard.showMessage(...args),
+  updateScore: (...args) => scoreboard.updateScore(...args),
+  clearMessage: (...args) => scoreboard.clearMessage(...args),
+  showTemporaryMessage: (...args) => scoreboard.showTemporaryMessage(...args),
+  clearTimer: (...args) => scoreboard.clearTimer(...args),
+  updateTimer: (...args) => scoreboard.updateTimer(...args),
+  showAutoSelect: (...args) => scoreboard.showAutoSelect(...args),
+  updateRoundCounter: (...args) => scoreboard.updateRoundCounter(...args),
+  clearRoundCounter: (...args) => scoreboard.clearRoundCounter(...args)
+}));
+
 describe("Scoreboard integration without setupScoreboard", () => {
   beforeEach(async () => {
     vi.useFakeTimers();
@@ -80,18 +93,8 @@ describe("Scoreboard integration without setupScoreboard", () => {
       scoreEl: document.getElementById("score-display")
     });
 
-    vi.doMock("../../src/helpers/setupScoreboard.js", () => ({
-      setupScoreboard: vi.fn(),
-      showMessage: scoreboard.showMessage.bind(scoreboard),
-      updateScore: scoreboard.updateScore.bind(scoreboard),
-      clearMessage: scoreboard.clearMessage.bind(scoreboard),
-      showTemporaryMessage: scoreboard.showTemporaryMessage.bind(scoreboard),
-      clearTimer: scoreboard.clearTimer.bind(scoreboard),
-      updateTimer: scoreboard.updateTimer.bind(scoreboard),
-      showAutoSelect: scoreboard.showAutoSelect.bind(scoreboard),
-      updateRoundCounter: scoreboard.updateRoundCounter.bind(scoreboard),
-      clearRoundCounter: scoreboard.clearRoundCounter.bind(scoreboard)
-    }));
+    const { initClassicBattleTest } = await import("./initClassicBattleTest.js");
+    await initClassicBattleTest({ afterMock: true });
   });
 
   it("renders messages, score, round counter, and round timer without setup", async () => {


### PR DESCRIPTION
## Summary
- ensure `setupScoreboard` mock initializes before tests and classic battle bindings reset

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 174 functions missing JSDoc)*
- `npx vitest run`
- `npx playwright test` *(82 passed, 2 interrupted)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["tests/helpers/scoreboard.integration.test.js"],
  "outputs": ["tests/helpers/scoreboard.integration.test.js"],
  "success": [
    "prettier: PASS",
    "eslint: PASS",
    "jsdoc: FAIL",
    "vitest: PASS",
    "playwright: 82 passed, 2 interrupted",
    "contrast: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Files
- `tests/helpers/scoreboard.integration.test.js`: initialize setupScoreboard mock before tests and rebind classic battle helpers

## Verification
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 174 functions missing JSDoc)*
- `npx vitest run`
- `npx playwright test` *(82 passed, 2 interrupted)*
- `npm run check:contrast`

## Risk
- Low: test-only change; JSDoc coverage still incomplete

------
https://chatgpt.com/codex/tasks/task_e_68bd41a4f37883269c0ac4912e49b2b6