### PR TITLE
refactor prd reader history

### DIFF
--- a/docs/product-docs.md
+++ b/docs/product-docs.md
@@ -1,0 +1,9 @@
+# Product Requirements Document Reader
+
+The PRD reader lists available specifications in a sidebar and renders
+documents into the main content area. Keyboard arrows, swipe gestures and
+explicit navigation buttons move between documents while preserving the URL and
+browser history.
+
+History updates are managed by `src/helpers/prdReader/history.js` which provides
+helpers to push or replace state and to react to `popstate` events.

--- a/src/helpers/prdReader/history.js
+++ b/src/helpers/prdReader/history.js
@@ -1,0 +1,51 @@
+/**
+ * History helpers for the PRD reader.
+ *
+ * @pseudocode
+ * 1. Construct a URL with the current document.
+ * 2. Push the state with index and URL.
+ *
+ * @param {string[]} baseNames
+ * @param {number} index
+ */
+export function pushHistory(baseNames, index) {
+  const url = new URL(window.location);
+  url.searchParams.set("doc", baseNames[index]);
+  history.pushState({ index }, "", url.pathname + url.search);
+}
+
+/**
+ * Replace current history entry with the given document.
+ *
+ * @pseudocode
+ * 1. Construct a URL with the current document.
+ * 2. Replace state with index and URL.
+ *
+ * @param {string[]} baseNames
+ * @param {number} index
+ */
+export function replaceHistory(baseNames, index) {
+  const url = new URL(window.location);
+  url.searchParams.set("doc", baseNames[index]);
+  history.replaceState({ index }, "", url.pathname + url.search);
+}
+
+/**
+ * Bind popstate events to document selection.
+ *
+ * @pseudocode
+ * 1. Listen for window popstate events.
+ * 2. Extract index from state and invoke callback.
+ * 3. Return an unbind function.
+ *
+ * @param {(i:number) => void} selectDoc
+ * @returns {() => void}
+ */
+export function bindHistory(selectDoc) {
+  const handler = (e) => {
+    const i = e.state && typeof e.state.index === "number" ? e.state.index : null;
+    if (i !== null) selectDoc(i, false);
+  };
+  window.addEventListener("popstate", handler);
+  return () => window.removeEventListener("popstate", handler);
+}


### PR DESCRIPTION
## Summary
- extract PRD reader history helpers
- refactor sidebar state and navigation handlers
- cover history edge cases and document PRD reader

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd4f42393083269705408cecc5fe89