### PR TITLE
Refactor BattleEngine timer control

### DIFF
--- a/src/helpers/battle/engineTimer.js
+++ b/src/helpers/battle/engineTimer.js
@@ -1,0 +1,148 @@
+/**
+ * Timer control helpers for the BattleEngine.
+ */
+
+/**
+ * Start the round/stat selection timer.
+ *
+ * @pseudocode
+ * 1. Emit `roundStarted` with incremented round number.
+ * 2. Delegate to `TimerController.startRound`.
+ * 3. Emit `timerTick` on each tick and guard the expiration callback.
+ *
+ * @param {object} engine - Battle engine instance.
+ * @param {function(number): void} onTick - Tick callback.
+ * @param {function(): Promise<void>} onExpired - Expiration callback.
+ * @param {number} [duration] - Timer duration in seconds.
+ * @param {function(number): void} [onDrift] - Drift handler.
+ * @returns {Promise<void>}
+ */
+export function startRoundTimer(engine, onTick, onExpired, duration, onDrift) {
+  const round = engine.roundsPlayed + 1;
+  engine.emit("roundStarted", { round });
+  return engine.timer.startRound(
+    (r) => {
+      engine.emit("timerTick", { remaining: r, phase: "round" });
+      if (typeof onTick === "function") onTick(r);
+    },
+    async () => {
+      if (!engine.matchEnded && typeof onExpired === "function") await onExpired();
+    },
+    duration,
+    onDrift
+  );
+}
+
+/**
+ * Start the cooldown timer between rounds.
+ *
+ * @pseudocode
+ * 1. Delegate to `TimerController.startCoolDown`.
+ * 2. Emit `timerTick` on each tick and guard the expiration callback.
+ *
+ * @param {object} engine - Battle engine instance.
+ * @param {function(number): void} onTick - Tick callback.
+ * @param {function(): (void|Promise<void>)} onExpired - Expiration callback.
+ * @param {number} [duration] - Timer duration in seconds.
+ * @param {function(number): void} [onDrift] - Drift handler.
+ * @returns {Promise<void>}
+ */
+export function startCoolDownTimer(engine, onTick, onExpired, duration, onDrift) {
+  return engine.timer.startCoolDown(
+    (r) => {
+      engine.emit("timerTick", { remaining: r, phase: "cooldown" });
+      if (typeof onTick === "function") onTick(r);
+    },
+    async () => {
+      if (!engine.matchEnded && typeof onExpired === "function") await onExpired();
+    },
+    duration,
+    onDrift
+  );
+}
+
+/**
+ * Pause the active timer.
+ *
+ * @pseudocode
+ * 1. Invoke `pause()` on the underlying timer.
+ *
+ * @param {object} engine - Battle engine instance.
+ * @returns {void}
+ */
+export function pauseTimer(engine) {
+  engine.timer.pause();
+}
+
+/**
+ * Resume the active timer.
+ *
+ * @pseudocode
+ * 1. Invoke `resume()` on the underlying timer.
+ *
+ * @param {object} engine - Battle engine instance.
+ * @returns {void}
+ */
+export function resumeTimer(engine) {
+  engine.timer.resume();
+}
+
+/**
+ * Stop the active timer.
+ *
+ * @pseudocode
+ * 1. Invoke `stop()` on the underlying timer.
+ *
+ * @param {object} engine - Battle engine instance.
+ * @returns {void}
+ */
+export function stopTimer(engine) {
+  engine.timer.stop();
+}
+
+/**
+ * Mark the tab inactive and pause the timer.
+ *
+ * @pseudocode
+ * 1. Pause the timer.
+ * 2. Set `tabInactive` flag.
+ *
+ * @param {object} engine - Battle engine instance.
+ * @returns {void}
+ */
+export function handleTabInactive(engine) {
+  pauseTimer(engine);
+  engine.tabInactive = true;
+}
+
+/**
+ * Resume the timer if the tab becomes active.
+ *
+ * @pseudocode
+ * 1. If previously inactive, resume timer and clear flag.
+ *
+ * @param {object} engine - Battle engine instance.
+ * @returns {void}
+ */
+export function handleTabActive(engine) {
+  if (engine.tabInactive) {
+    resumeTimer(engine);
+    engine.tabInactive = false;
+  }
+}
+
+/**
+ * Handle timer drift by stopping the timer and recording the amount.
+ *
+ * @pseudocode
+ * 1. Stop the timer.
+ * 2. Record the drift amount on the engine.
+ *
+ * @param {object} engine - Battle engine instance.
+ * @param {number} driftAmount - Amount of drift detected.
+ * @returns {void}
+ */
+export function handleTimerDrift(engine, driftAmount) {
+  stopTimer(engine);
+  engine.lastTimerDrift = driftAmount;
+}

--- a/src/helpers/battle/index.js
+++ b/src/helpers/battle/index.js
@@ -1,2 +1,3 @@
 export * from "./score.js";
 export * from "./battleUI.js";
+export * from "./engineTimer.js";

--- a/src/helpers/events/SimpleEmitter.js
+++ b/src/helpers/events/SimpleEmitter.js
@@ -1,0 +1,34 @@
+/**
+ * Lightweight event emitter used for internal messaging.
+ *
+ * @pseudocode
+ * 1. Maintain a map of event type to handler sets.
+ * 2. `on` adds handlers to a type set.
+ * 3. `off` removes handlers.
+ * 4. `emit` invokes handlers with provided detail.
+ */
+export class SimpleEmitter {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  on(type, handler) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type).add(handler);
+  }
+
+  off(type, handler) {
+    this.listeners.get(type)?.delete(handler);
+  }
+
+  emit(type, detail) {
+    const handlers = Array.from(this.listeners.get(type) || []);
+    for (const h of handlers) {
+      try {
+        h(detail);
+      } catch (err) {
+        console.error("Error in event handler for type '" + type + "':", err);
+      }
+    }
+  }
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,0 +1,1 @@
+export { compareStats, determineOutcome, applyOutcome, BattleEngine } from "./BattleEngine.js";

--- a/tests/helpers/BattleEngine.test.js
+++ b/tests/helpers/BattleEngine.test.js
@@ -1,6 +1,17 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { compareStats } from "../../src/helpers/BattleEngine.js";
+import {
+  compareStats,
+  determineOutcome,
+  applyOutcome,
+  BattleEngine
+} from "../../src/helpers/index.js";
+import {
+  startRoundTimer,
+  pauseTimer as pauseEngineTimer,
+  resumeTimer as resumeEngineTimer
+} from "../../src/helpers/battle/engineTimer.js";
+import { SimpleEmitter } from "../../src/helpers/events/SimpleEmitter.js";
 
 describe("compareStats", () => {
   it("detects player win", () => {
@@ -18,28 +29,26 @@ describe("compareStats", () => {
 
 describe("BattleEngine robustness scenarios", () => {
   let engine;
-  beforeEach(async () => {
-    const { BattleEngine } = await import("../../src/helpers/BattleEngine.js");
+  beforeEach(() => {
     engine = new BattleEngine();
   });
 
   it("pauses and resumes timer on tab inactivity", () => {
-    engine.timer.startRound = vi.fn();
-    engine.pauseTimer = vi.fn();
-    engine.resumeTimer = vi.fn();
+    engine.timer.pause = vi.fn();
+    engine.timer.resume = vi.fn();
     engine.handleTabInactive();
     expect(engine.tabInactive).toBe(true);
-    expect(engine.pauseTimer).toHaveBeenCalled();
+    expect(engine.timer.pause).toHaveBeenCalled();
     engine.handleTabActive();
     expect(engine.tabInactive).toBe(false);
-    expect(engine.resumeTimer).toHaveBeenCalled();
+    expect(engine.timer.resume).toHaveBeenCalled();
   });
 
   it("handles timer drift", () => {
-    engine.stopTimer = vi.fn();
+    engine.timer.stop = vi.fn();
     engine.handleTimerDrift(5);
     expect(engine.lastTimerDrift).toBe(5);
-    expect(engine.stopTimer).toHaveBeenCalled();
+    expect(engine.timer.stop).toHaveBeenCalled();
   });
 
   it("handles error injection", () => {
@@ -52,8 +61,7 @@ describe("BattleEngine robustness scenarios", () => {
 
 describe("BattleEngine timer pause/resume and drift correction", () => {
   let engine;
-  beforeEach(async () => {
-    const { BattleEngine } = await import("../../src/helpers/BattleEngine.js");
+  beforeEach(() => {
     engine = new BattleEngine();
   });
 
@@ -67,9 +75,56 @@ describe("BattleEngine timer pause/resume and drift correction", () => {
   });
 
   it("detects and handles timer drift", () => {
-    engine.stopTimer = vi.fn();
+    engine.timer.stop = vi.fn();
     engine.handleTimerDrift(3);
     expect(engine.lastTimerDrift).toBe(3);
-    expect(engine.stopTimer).toHaveBeenCalled();
+    expect(engine.timer.stop).toHaveBeenCalled();
+  });
+});
+
+describe("helpers index exports", () => {
+  it("exposes public API", () => {
+    expect(typeof compareStats).toBe("function");
+    expect(typeof determineOutcome).toBe("function");
+    expect(typeof applyOutcome).toBe("function");
+    expect(typeof BattleEngine).toBe("function");
+  });
+});
+
+describe("engineTimer helpers", () => {
+  it("starts round and emits ticks", async () => {
+    const engine = new BattleEngine();
+    engine.timer.startRound = vi.fn((tick, expired) => {
+      tick(3);
+      return Promise.resolve(expired());
+    });
+    const onTick = vi.fn();
+    const onExpired = vi.fn();
+    await startRoundTimer(engine, onTick, onExpired);
+    expect(engine.timer.startRound).toHaveBeenCalled();
+    expect(onTick).toHaveBeenCalledWith(3);
+    expect(onExpired).toHaveBeenCalled();
+  });
+
+  it("pauses and resumes via helpers", () => {
+    const engine = new BattleEngine();
+    engine.timer.pause = vi.fn();
+    engine.timer.resume = vi.fn();
+    pauseEngineTimer(engine);
+    resumeEngineTimer(engine);
+    expect(engine.timer.pause).toHaveBeenCalled();
+    expect(engine.timer.resume).toHaveBeenCalled();
+  });
+});
+
+describe("SimpleEmitter", () => {
+  it("registers and removes handlers", () => {
+    const emitter = new SimpleEmitter();
+    const handler = vi.fn();
+    emitter.on("test", handler);
+    emitter.emit("test", 1);
+    emitter.off("test", handler);
+    emitter.emit("test", 2);
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- extract SimpleEmitter and use dedicated timer helpers
- delegate BattleEngine timers to engineTimer and streamline constructor
- add tests for engineTimer helpers and SimpleEmitter

## Testing
- `npx prettier . --check`
- `npx eslint src/helpers/BattleEngine.js src/helpers/events/SimpleEmitter.js src/helpers/battle/engineTimer.js tests/helpers/BattleEngine.test.js && echo 'ESLint success'`
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd4f3e292483269a0474aaea04d721