### PR TITLE
chore: clarify cooldown buffer and document transitions

### DIFF
--- a/src/helpers/classicBattle/cooldowns.js
+++ b/src/helpers/classicBattle/cooldowns.js
@@ -5,6 +5,13 @@ import { emitBattleEvent, onBattleEvent, offBattleEvent } from "./battleEvents.j
 import { guard, guardAsync } from "./guard.js";
 
 /**
+ * Additional buffer to ensure fallback timers fire after engine-backed timers.
+ *
+ * @type {number}
+ */
+const FALLBACK_TIMER_BUFFER_MS = 200;
+
+/**
  * Initialize the match start cooldown timer.
  *
  * @param {object} machine State machine instance.
@@ -39,7 +46,7 @@ export async function initStartCooldown(machine) {
     return;
   }
   const schedule = typeof setupFallbackTimer === "function" ? setupFallbackTimer : setTimeout;
-  fallback = schedule(duration * 1000 + 200, finish);
+  fallback = schedule(duration * 1000 + FALLBACK_TIMER_BUFFER_MS, finish);
 }
 
 /**
@@ -96,7 +103,7 @@ export async function initInterRoundCooldown(machine) {
     )
   );
   timer.start(duration);
-  setupFallbackTimer(duration * 1000 + 200, () => {
+  setupFallbackTimer(duration * 1000 + FALLBACK_TIMER_BUFFER_MS, () => {
     guard(() => {
       const b = document.getElementById("next-button");
       if (b) b.dataset.nextReady = "true";

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -22,6 +22,14 @@ export { getNextRoundControls } from "./roundManager.js";
 // Track timeout for cooldown warning to avoid duplicates.
 let cooldownWarningTimeoutId = null;
 
+/**
+ * Transition events required when advancing from states other than `cooldown`.
+ *
+ * `advanceWhenReady` consults this table to dispatch an interrupt that moves the
+ * state machine into `cooldown` before emitting `ready`.
+ *
+ * @type {Record<string, {event: string, payload: {reason: string}}>} state → transition mapping.
+ */
 const ADVANCE_TRANSITIONS = {
   roundDecision: { event: "interrupt", payload: { reason: "advanceNextFromNonCooldown" } },
   waitingForPlayerAction: { event: "interrupt", payload: { reason: "advanceNextFromNonCooldown" } }


### PR DESCRIPTION
## Summary
- name fallback timer buffer to replace magic number
- document ADVANCE_TRANSITIONS mapping

## Task Contract
```json
{
  "inputs": ["src/helpers/classicBattle/cooldowns.js", "src/helpers/classicBattle/timerService.js"],
  "outputs": ["src/helpers/classicBattle/cooldowns.js", "src/helpers/classicBattle/timerService.js"],
  "success": ["prettier: PASS", "eslint: PASS", "jsdoc: PASS", "vitest: PASS", "playwright: PASS", "contrast: PASS"],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `src/helpers/classicBattle/cooldowns.js`: extract `FALLBACK_TIMER_BUFFER_MS` constant and use it for fallback timers
- `src/helpers/classicBattle/timerService.js`: add JSDoc for `ADVANCE_TRANSITIONS`

## Verification
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Risk
- Low: naming and documentation only; no behavioral change expected.


------
https://chatgpt.com/codex/tasks/task_e_68bd4f350de08326b02e9ac00499a0ca