### PR TITLE
test: guard scoreboard mock before init

### DIFF
--- a/tests/helpers/scoreboard.integration.test.js
+++ b/tests/helpers/scoreboard.integration.test.js
@@ -5,7 +5,18 @@ vi.mock("../../src/helpers/motionUtils.js", () => ({
 }));
 
 let roundDrift;
-let scoreboard;
+const scoreboardStub = {
+  showMessage: () => {},
+  updateScore: () => {},
+  clearMessage: () => {},
+  showTemporaryMessage: () => {},
+  clearTimer: () => {},
+  updateTimer: () => {},
+  showAutoSelect: () => {},
+  updateRoundCounter: () => {},
+  clearRoundCounter: () => {}
+};
+let scoreboard = scoreboardStub;
 
 vi.doMock("../../src/helpers/setupScoreboard.js", () => ({
   setupScoreboard: vi.fn(),
@@ -25,7 +36,7 @@ describe("Scoreboard integration without setupScoreboard", () => {
     vi.useFakeTimers();
     vi.resetModules();
     roundDrift = undefined;
-    scoreboard = undefined;
+    scoreboard = scoreboardStub;
     document.body.innerHTML = "";
 
     // Header structure as in battleJudoka.html


### PR DESCRIPTION
## Summary
- prevent pre-test reference errors by stubbing scoreboard methods

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 178 missing)*
- `npx vitest run`
- `npx playwright test` *(100 passed)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["tests/helpers/scoreboard.integration.test.js"],
  "outputs": ["tests/helpers/scoreboard.integration.test.js"],
  "success": [
    "prettier: PASS",
    "eslint: PASS",
    "jsdoc: FAIL",
    "vitest: PASS",
    "playwright: PASS",
    "contrast: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Files
- `tests/helpers/scoreboard.integration.test.js`: add scoreboard stub to satisfy module-scope mock

## Verification
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 178 missing)*
- `npx vitest run`
- `npx playwright test` *(100 passed)*
- `npm run check:contrast`

## Risk
- Low: test-only stub to prevent early reference errors


------
https://chatgpt.com/codex/tasks/task_e_68bd4f24d2708326afa4d354c6a90e28