### PR TITLE
Refactor BattleEngine timer control

### DIFF
--- a/src/helpers/BattleEngine.js
+++ b/src/helpers/BattleEngine.js
@@ -112,7 +112,7 @@ export class BattleEngine {
    */
   constructor(config = {}) {
     const emitter = this.#initFromConfig(config);
-    this.#bindEmitter(emitter || new SimpleEmitter());
+    this.#bindEmitter(emitter);
   }
 
   #initFromConfig(config) {
@@ -139,7 +139,7 @@ export class BattleEngine {
     this.lastError = "";
     this.lastModification = null;
     this._initialConfig = { pointsToWin, maxRounds, stats, debugHooks, seed: this.seed };
-    return emitter;
+    return emitter || new SimpleEmitter();
   }
 
   #bindEmitter(emitter) {

--- a/tests/helpers/BattleEngine.test.js
+++ b/tests/helpers/BattleEngine.test.js
@@ -96,7 +96,7 @@ describe("engineTimer helpers", () => {
     const engine = new BattleEngine();
     engine.timer.startRound = vi.fn((tick, expired) => {
       tick(3);
-      return Promise.resolve(expired());
+      return expired();
     });
     const onTick = vi.fn();
     const onExpired = vi.fn();


### PR DESCRIPTION
## Summary
- handle async expired callback in timer test
- return provided emitter or fallback in BattleEngine

## Testing
- `npx prettier . --check`
- `npx eslint src/helpers/BattleEngine.js tests/helpers/BattleEngine.test.js`
- `npm run check:jsdoc` *(fails: 184 incomplete JSDoc blocks)*
- `npx vitest run tests/helpers/BattleEngine.test.js`
- `npx playwright test` *(2 interrupted, 79 skipped)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd570066dc83269a6a082a455ebf55