### PR TITLE
refactor prd reader history

### DIFF
--- a/src/helpers/prdReader/history.js
+++ b/src/helpers/prdReader/history.js
@@ -44,7 +44,7 @@ export function replaceHistory(baseNames, index) {
 export function bindHistory(selectDoc) {
   const handler = (e) => {
     const i = e.state && typeof e.state.index === "number" ? e.state.index : null;
-    if (i !== null) selectDoc(i, false);
+    if (i !== null) selectDoc(i);
   };
   window.addEventListener("popstate", handler);
   return () => window.removeEventListener("popstate", handler);

--- a/tests/helpers/prdReaderPage.test.js
+++ b/tests/helpers/prdReaderPage.test.js
@@ -404,7 +404,7 @@ describe("prdReaderPage", () => {
     const fn = vi.fn();
     const unbind = bindHistory(fn);
     window.dispatchEvent(new PopStateEvent("popstate", { state: { index: 2 } }));
-    expect(fn).toHaveBeenCalledWith(2, false);
+    expect(fn).toHaveBeenCalledWith(2);
     unbind();
   });
 


### PR DESCRIPTION
## Summary
- extract PRD reader history helpers
- refactor sidebar state and navigation handlers
- cover history edge cases and document PRD reader
- fix bindHistory callback signature

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd57316af0832690a16be48c63a80e