### PR TITLE
Refactor classic battle transition helpers

### DIFF
--- a/design/architecture.md
+++ b/design/architecture.md
@@ -172,6 +172,7 @@ AI agents are encouraged to parse, test, and modify the system using these archi
 - `detail` is an object `{ from: string|null, to: string, event?: string|null }`.
 - Consumers listen with `onBattleEvent('battleStateChange', handler)` and read `detail.to`.
 - The current state is also mirrored on `document.body.dataset.battleState` for debug UIs.
+- Transition handling uses helpers (`emitDiagnostics`, `emitReadiness`, `emitStateChange`) and an `{event: outcome}` map for interrupt resolutions.
 
 ### Classic Battle State Manager
 

--- a/design/productRequirementsDocuments/prdBattleEngine.md
+++ b/design/productRequirementsDocuments/prdBattleEngine.md
@@ -199,6 +199,8 @@ Note:
 
 - After each readiness or timer-triggered transition, the orchestrator must emit `control.state.changed`.
 - UI modules must not infer transitions from domain/timer events directly; they consume only `control.state.changed` for authoritative rendering and logic.
+- Transition handling is composed through helpers (`emitDiagnostics`, `emitReadiness`, `emitStateChange`) to isolate diagnostics, control, and taxonomy concerns.
+- Interrupt resolutions use an explicit `{ event: outcome }` map (e.g., `restartMatch → restartRound`).
 
 ---
 

--- a/tests/helpers/classicBattle/onTransition.test.js
+++ b/tests/helpers/classicBattle/onTransition.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../src/helpers/classicBattle/roundSelectModal.js", () => ({
+  initRoundSelectModal: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+  resetGame: vi.fn(),
+  startRound: vi.fn(),
+  _resetForTest: vi.fn()
+}));
+vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
+  clearMessage: vi.fn(),
+  showMessage: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/debugPanel.js", () => ({
+  updateDebugPanel: vi.fn()
+}));
+
+const engineMock = {
+  getRoundsPlayed: () => 0,
+  getScores: () => ({ playerScore: 0, opponentScore: 0 }),
+  getSeed: () => 1,
+  getTimerState: () => ({ remaining: 30, paused: false })
+};
+
+vi.mock("../../../src/helpers/classicBattle/stateManager.js", () => ({
+  createStateManager: async (_onEnter, { store }, onTransition) => {
+    const machine = {
+      context: { store, engine: engineMock },
+      current: "init",
+      async dispatch(event) {
+        const from = this.current;
+        const to = event;
+        this.current = to;
+        await onTransition({ from, to, event });
+      },
+      getState() {
+        return this.current;
+      }
+    };
+    return machine;
+  }
+}));
+
+describe("classic battle onTransition", () => {
+  let machine;
+  let onBattleEvent;
+  let offBattleEvent;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    document.body.innerHTML = "";
+    const events = await import("../../../src/helpers/classicBattle/battleEvents.js");
+    events.__resetBattleEventTarget();
+    onBattleEvent = events.onBattleEvent;
+    offBattleEvent = events.offBattleEvent;
+    const orchestrator = await import("../../../src/helpers/classicBattle/orchestrator.js");
+    await orchestrator.initClassicBattleOrchestrator({});
+    machine = orchestrator.getBattleStateMachine();
+  });
+
+  it("emits readiness events when match starts", async () => {
+    const requiredSpy = vi.fn();
+    const confirmedSpy = vi.fn();
+    onBattleEvent("control.readiness.required", requiredSpy);
+    onBattleEvent("control.readiness.confirmed", confirmedSpy);
+
+    await machine.dispatch("matchStart");
+    await machine.dispatch("ready");
+
+    expect(requiredSpy).toHaveBeenCalledTimes(1);
+    expect(requiredSpy.mock.calls[0][0].detail).toEqual({ for: "match" });
+    expect(confirmedSpy).toHaveBeenCalledTimes(1);
+    expect(confirmedSpy.mock.calls[0][0].detail).toEqual({ for: "match" });
+
+    offBattleEvent("control.readiness.required", requiredSpy);
+    offBattleEvent("control.readiness.confirmed", confirmedSpy);
+  });
+
+  it("maps interrupt resolution events", async () => {
+    const resolvedSpy = vi.fn();
+    onBattleEvent("interrupt.resolved", resolvedSpy);
+
+    await machine.dispatch("restartMatch");
+
+    expect(resolvedSpy).toHaveBeenCalledTimes(1);
+    expect(resolvedSpy.mock.calls[0][0].detail).toEqual({
+      outcome: "restartRound"
+    });
+
+    offBattleEvent("interrupt.resolved", resolvedSpy);
+  });
+});


### PR DESCRIPTION
## Summary
- modularize Classic Battle orchestrator transitions with `emitDiagnostics`, `emitReadiness`, `emitStateChange`, and `emitResolution`
- simplify interrupt resolution via event→outcome map and compose helpers in a lean `onTransition`
- document helper-based transition handling and resolution mapping in design docs; add readiness and interrupt tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd5aa4eb488326b7209f6a3811378f