### PR TITLE
Refactor classic battle transition helpers

### DIFF
--- a/src/helpers/classicBattle/orchestrator.js
+++ b/src/helpers/classicBattle/orchestrator.js
@@ -26,9 +26,10 @@ let machine = null;
 let debugLogListener = null;
 let visibilityHandler = null;
 
-// Map resolution events to PRD outcomes
+// Map resolution events to PRD outcomes.
+// Identity mappings are listed explicitly so only recognized events emit taxonomy outcomes.
 const interruptResolutionMap = {
-  restartRound: "restartRound",
+  restartRound: "restartRound", // explicit for consistency
   resumeLobby: "resumeLobby",
   abortMatch: "abortMatch",
   restartMatch: "restartRound", // closest PRD outcome


### PR DESCRIPTION
## Summary
- document explicit identity mapping for `restartRound` to keep interrupt resolution taxonomy constrained

## Task Contract
```json
{
  "inputs": ["src/helpers/classicBattle/orchestrator.js"],
  "outputs": ["src/helpers/classicBattle/orchestrator.js"],
  "success": [
    "npx prettier . --check",
    "npx eslint .",
    "npm run check:jsdoc",
    "npx vitest run",
    "npx playwright test",
    "npm run check:contrast"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `src/helpers/classicBattle/orchestrator.js`: explain explicit identity mapping in `interruptResolutionMap` for clarity

## Verification
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`

## Risk & Follow-Up
- low risk: documentation-only change
- follow-up: ensure future event mappings document identity entries consistently


------
https://chatgpt.com/codex/tasks/task_e_68bd605e1488832684c4d03e168b4851