### PR TITLE
refactor classic battle orchestrator initialization helpers

### DIFF
--- a/design/productRequirementsDocuments/prdBattleClassic.md
+++ b/design/productRequirementsDocuments/prdBattleClassic.md
@@ -87,6 +87,7 @@ Currently, only ~45% of new players complete their first battle across all modes
 ## Technical Considerations
 
 - Classic Battle logic must reuse shared random card draw module (`generateRandomCard`).
+- Orchestrator initialization preloads timer utilities and UI services, builds the state handler map, then attaches listeners before exposing the machine.
 - Round selection modal must use shared `Modal` and `Button` components for consistent accessibility.
 - Card reveal and result animations should use hardware-accelerated CSS for smooth performance on low-end devices.
 - Stat selection timer (30s) must be displayed in `#next-round-timer`; if the timer expires, a random stat is auto-selected. This auto-select behavior is controlled by a feature flag `autoSelect` (enabled by default). The timer must pause if the game tab is inactive or device goes to sleep, and resume on focus (see prdBattleScoreboard.md).

--- a/tests/helpers/classicBattle/orchestrator.init.test.js
+++ b/tests/helpers/classicBattle/orchestrator.init.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const testPath = "../../../src/helpers";
+
+describe("classic battle orchestrator init preloads", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("preloads dependencies successfully", async () => {
+    const preloadTimerUtils = vi.fn().mockResolvedValue();
+    const initScoreboardAdapter = vi.fn();
+    vi.doMock(`${testPath}/TimerController.js`, () => ({ preloadTimerUtils }));
+    vi.doMock(`${testPath}/classicBattle/uiService.js`, () => ({}));
+    vi.doMock(`${testPath}/classicBattle/scoreboardAdapter.js`, () => ({
+      initScoreboardAdapter
+    }));
+    const { initClassicBattleTest } = await import("./initClassicBattle.js");
+    await initClassicBattleTest({ afterMock: true });
+    const orchestrator = await import(`${testPath}/classicBattle/orchestrator.js`);
+    await orchestrator.initClassicBattleOrchestrator({});
+    expect(preloadTimerUtils).toHaveBeenCalled();
+    expect(initScoreboardAdapter).toHaveBeenCalled();
+  });
+
+  it("swallows preload errors", async () => {
+    const preloadTimerUtils = vi.fn().mockRejectedValue(new Error("fail"));
+    const initScoreboardAdapter = vi.fn().mockImplementation(() => {
+      throw new Error("fail");
+    });
+    vi.doMock(`${testPath}/TimerController.js`, () => ({ preloadTimerUtils }));
+    vi.doMock(`${testPath}/classicBattle/uiService.js`, () => {
+      throw new Error("fail");
+    });
+    vi.doMock(`${testPath}/classicBattle/scoreboardAdapter.js`, () => ({
+      initScoreboardAdapter
+    }));
+    const { initClassicBattleTest } = await import("./initClassicBattle.js");
+    await initClassicBattleTest({ afterMock: true });
+    const orchestrator = await import(`${testPath}/classicBattle/orchestrator.js`);
+    await expect(
+      orchestrator.initClassicBattleOrchestrator({})
+    ).resolves.toBeDefined();
+    expect(preloadTimerUtils).toHaveBeenCalled();
+    expect(initScoreboardAdapter).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- extract dependency preloading, state handler mapping, and listener wiring into dedicated orchestrator helpers
- add tests for successful and failing dependency preloads
- document orchestrator initialization flow in PRD

## Testing
- `npx prettier . --check` *(fails: command not found)*
- `npx eslint .` *(fails: command not found)*
- `npm run check:jsdoc` *(fails: command not found)*
- `npx vitest run` *(fails: command not found)*
- `npx playwright test` *(fails: command not found)*
- `npm run check:contrast` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 while attempting to install node)*

## Task Contract
```json
{
  "inputs": [
    "src/helpers/classicBattle/orchestrator.js",
    "tests/helpers/classicBattle/orchestrator.init.test.js",
    "design/productRequirementsDocuments/prdBattleClassic.md"
  ],
  "outputs": [
    "src/helpers/classicBattle/orchestrator.js",
    "tests/helpers/classicBattle/orchestrator.init.test.js",
    "design/productRequirementsDocuments/prdBattleClassic.md"
  ],
  "success": [
    "prettier: PASS",
    "eslint: PASS",
    "jsdoc: PASS",
    "vitest: PASS",
    "playwright: PASS",
    "check:contrast: PASS"
  ],
  "errorMode": "continue_on_missing_deps"
}
```

## Files Changed
- `src/helpers/classicBattle/orchestrator.js`: refactor initialization using helper functions.
- `tests/helpers/classicBattle/orchestrator.init.test.js`: cover dependency preload success and failure.
- `design/productRequirementsDocuments/prdBattleClassic.md`: document new initialization flow.

## Verification Summary
- prettier: FAIL (npx missing)
- eslint: FAIL (npx missing)
- jsdoc: FAIL (npm missing)
- vitest: FAIL (npx missing)
- playwright: FAIL (npx missing)
- check:contrast: FAIL (npm missing)

## Risk
Environment lacked Node tooling; run full lint and test suite after installing dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68bd60b82ea88326826e4285c66fc367