### PR TITLE
chore: document ignored errors in orchestrator

### DIFF
--- a/tests/helpers/classicBattle/orchestrator.init.test.js
+++ b/tests/helpers/classicBattle/orchestrator.init.test.js
@@ -38,9 +38,7 @@ describe("classic battle orchestrator init preloads", () => {
     const { initClassicBattleTest } = await import("./initClassicBattle.js");
     await initClassicBattleTest({ afterMock: true });
     const orchestrator = await import(`${testPath}/classicBattle/orchestrator.js`);
-    await expect(
-      orchestrator.initClassicBattleOrchestrator({})
-    ).resolves.toBeDefined();
+    await expect(orchestrator.initClassicBattleOrchestrator({})).resolves.toBeDefined();
     expect(preloadTimerUtils).toHaveBeenCalled();
     expect(initScoreboardAdapter).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- annotate non-critical catch blocks in classic battle orchestrator
- format orchestrator init test with Prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: 2 tests interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd664116188326bbea65fa0d289869