### PR TITLE
chore: drop custom css variable parser

### DIFF
--- a/tests/helpers/colorContrast.test.js
+++ b/tests/helpers/colorContrast.test.js
@@ -3,23 +3,10 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 import { hex } from "wcag-contrast";
-import postcss from "postcss";
+import { parseCssVars } from "./parseCssVars.js";
 
 function readCss(file) {
   return readFileSync(resolve(file), "utf8");
-}
-
-function parseVars(cssContent) {
-  const vars = {};
-  const root = postcss.parse(cssContent);
-  root.walkRules(":root", (rule) => {
-    rule.walkDecls((decl) => {
-      if (decl.prop.startsWith("--")) {
-        vars[decl.prop] = decl.value.trim();
-      }
-    });
-  });
-  return vars;
 }
 
 function resolveColor(value, vars) {
@@ -61,7 +48,7 @@ function getComponentColors(vars) {
 }
 
 describe("css color contrast", () => {
-  const vars = parseVars(readCss("src/styles/base.css"));
+  const vars = parseCssVars("src/styles/base.css");
   const componentColors = getComponentColors(vars);
 
   const basePairs = [

--- a/tests/helpers/meditationContrast.test.js
+++ b/tests/helpers/meditationContrast.test.js
@@ -1,26 +1,10 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "fs";
-import { resolve } from "path";
 import { hex } from "wcag-contrast";
-import postcss from "postcss";
-
-function getBaseVars() {
-  const css = readFileSync(resolve("src/styles/base.css"), "utf8");
-  const vars = {};
-  const root = postcss.parse(css);
-  root.walkRules(":root", (rule) => {
-    rule.walkDecls((decl) => {
-      if (decl.prop.startsWith("--")) {
-        vars[decl.prop] = decl.value.trim();
-      }
-    });
-  });
-  return vars;
-}
+import { parseCssVars } from "./parseCssVars.js";
 
 describe("meditation quote color contrast", () => {
-  const vars = getBaseVars();
+  const vars = parseCssVars("src/styles/base.css");
 
   it("quote text vs block background is >= 4.5", () => {
     expect(vars["--color-text-inverted"]).toBeDefined();

--- a/tests/helpers/parseCssVars.js
+++ b/tests/helpers/parseCssVars.js
@@ -1,0 +1,29 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import postcss from "postcss";
+
+/**
+ * Extract CSS custom properties from a file.
+ * @param {string} file CSS file path.
+ * @returns {Record<string, string>} map of variable names to values
+ * @pseudocode
+ * read CSS file
+ * parse CSS with PostCSS
+ * for each :root rule
+ *   for each declaration starting with --
+ *     save variable name and value
+ * return variable map
+ */
+export function parseCssVars(file) {
+  const css = readFileSync(resolve(file), "utf8");
+  const vars = {};
+  const root = postcss.parse(css);
+  root.walkRules(":root", (rule) => {
+    rule.walkDecls((decl) => {
+      if (decl.prop.startsWith("--")) {
+        vars[decl.prop] = decl.value.trim();
+      }
+    });
+  });
+  return vars;
+}


### PR DESCRIPTION
## Summary
- extract shared parseCssVars utility for contrast tests
- update meditationContrast and colorContrast tests to use shared parser

## Testing
- `npx prettier . --check` *(fails: Code style issues in src/helpers/classicBattle/orchestrator.js and tests/helpers/classicBattle/orchestrator.init.test.js)*
- `npx eslint .` *(fails: prettier/prettier errors in orchestrator files)*
- `npm run check:jsdoc` *(fails: 184 functions missing or with incomplete JSDoc blocks)*
- `npx vitest run` *(fails: orchestrator.init.test.js mocking error)*
- `npx playwright test`
- `npm run check:contrast`

```json
{
  "inputs": [
    "tests/helpers/meditationContrast.test.js",
    "tests/helpers/colorContrast.test.js"
  ],
  "outputs": [
    "tests/helpers/parseCssVars.js",
    "tests/helpers/meditationContrast.test.js",
    "tests/helpers/colorContrast.test.js"
  ],
  "success": [
    "prettier: FAIL",
    "eslint: FAIL",
    "jsdoc: FAIL",
    "vitest: FAIL",
    "playwright: PASS",
    "check:contrast: PASS"
  ],
  "errorMode": "continue_on_test_failure"
}
```

------
https://chatgpt.com/codex/tasks/task_e_68bd665459508326b66c89db77cd8d46