### PR TITLE
chore: streamline eslint ignore handling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-.eslintcache
-eslint-dry.json

--- a/.github/workflows/lintAutofix.yml
+++ b/.github/workflows/lintAutofix.yml
@@ -93,9 +93,8 @@ jobs:
         id: lint-stats
         run: |
           set -euo pipefail
-          # Make sure ESLint uses the ignore file so the dry-run output doesn't
-          # include .eslintcache or eslint-dry.json itself.
-          npx eslint . --fix-dry-run -f json --ignore-path .eslintignore > eslint-dry.json || true
+          # ESLint config already ignores cache and report files.
+          npx eslint . --fix-dry-run -f json > eslint-dry.json || true
           node -e '
             const fs = require("fs");
             if (!fs.existsSync("eslint-dry.json")) { process.exit(0); }
@@ -116,7 +115,7 @@ jobs:
           '
 
       - name: Run ESLint with auto-fix
-        run: npx eslint . --fix --cache --ignore-path .eslintignore
+        run: npx eslint . --fix --cache
 
       - name: Check for changes
         id: git-check

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ export default defineConfig([
       "*.log",
       "*.tmp",
       ".eslintcache",
+      "eslint-dry.json",
       ".git/**",
       "src/vendor/**"
     ], // 🔥 Updated ignores


### PR DESCRIPTION
## Summary
- stop passing `--ignore-path .eslintignore` in the lintAutofix workflow
- ignore `eslint-dry.json` directly in eslint config
- remove redundant `.eslintignore`

## Testing
- `npm run lint`
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: 2 interrupted, 74 did not run)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd6c4ba1a0832696f4ce24dd1f16e5