### PR TITLE
refactor: lazy load uiService for classic battle helpers

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -18,7 +18,6 @@ import { toggleViewportSimulation } from "../viewportDebug.js";
 import { toggleInspectorPanels } from "../cardUtils.js";
 import { createModal } from "../../components/Modal.js";
 import { createButton } from "../../components/Button.js";
-import { syncScoreDisplay } from "./uiService.js";
 import { onBattleEvent } from "./battleEvents.js";
 import * as battleEvents from "./battleEvents.js";
 import {
@@ -31,6 +30,13 @@ import { guard } from "./guard.js";
 import { updateDebugPanel, setDebugPanelEnabled } from "./debugPanel.js";
 import { getOpponentDelay } from "./snackbar.js";
 export { showSelectionPrompt, setOpponentDelay, getOpponentDelay } from "./snackbar.js";
+
+let syncScoreDisplay = () => {};
+import("./uiService.js")
+  .then((m) => {
+    syncScoreDisplay = m.syncScoreDisplay || (() => {});
+  })
+  .catch(() => {});
 /**
  * Skip the inter-round cooldown when the corresponding feature flag is enabled.
  *


### PR DESCRIPTION
## Summary
- defer `uiService` loading in `uiHelpers` and `roundUI` to avoid preload failures
- guard score syncing and match summary calls with safe dynamic imports

## Testing
- `npx eslint .`
- `npx prettier . --check`
- `npx vitest run tests/helpers/classicBattle/orchestrator.init.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd74c8b6b083269ac4570b1ace577d