### PR TITLE
Add pauseTimer helper and timer tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ Classic Battle timer logic lives in `src/helpers/classicBattle/timerService.js` 
 - `timerUtils.js` — shared state snapshot and readiness helpers.
 - `autoSelectHandlers.js` — stat-selection fallbacks when timers drift or stall.
 
+The CLI's pause/resume flow uses `pauseTimers` to clear active selection and cooldown timers while recording their remaining time. `resumeTimers` restarts them with the captured values so modals or tab switches do not lose progress.
+
 On the Browse Judoka page, the country filter panel starts with the `hidden` attribute. When revealed, it must include `aria-label="Country filter panel"` for accessibility and Playwright tests. The country slider loads asynchronously after the panel opens.
 
 Run all Playwright tests with:

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -138,6 +138,43 @@ describe("battleCLI event handlers", () => {
     vi.useRealTimers();
   });
 
+  it("captures remaining selection time when paused", async () => {
+    vi.useFakeTimers();
+    const { handlers } = await setupHandlers();
+    const countdown = document.createElement("div");
+    countdown.id = "cli-countdown";
+    countdown.dataset.remainingTime = "5";
+    document.body.appendChild(countdown);
+    handlers.setSelectionTimers(
+      setTimeout(() => {}, 5000),
+      setInterval(() => {}, 1000)
+    );
+    handlers.pauseTimers();
+    const { selection, cooldown } = handlers.getPausedTimes();
+    expect(selection).toBe(5);
+    expect(cooldown).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it("captures remaining cooldown time when paused", async () => {
+    vi.useFakeTimers();
+    const { handlers } = await setupHandlers();
+    const bar = document.getElementById("snackbar-container");
+    const snack = document.createElement("div");
+    snack.className = "snackbar";
+    snack.textContent = "Next round in: 7";
+    bar.appendChild(snack);
+    handlers.setCooldownTimers(
+      setTimeout(() => {}, 7000),
+      setInterval(() => {}, 1000)
+    );
+    handlers.pauseTimers();
+    const { cooldown, selection } = handlers.getPausedTimes();
+    expect(cooldown).toBe(7);
+    expect(selection).toBeNull();
+    vi.useRealTimers();
+  });
+
   it("updates message after round resolved", async () => {
     const { handlers } = await setupHandlers();
     const speedName = statNamesData.find((s) => s.statIndex === 2).name;


### PR DESCRIPTION
## Summary
- factor timer cleanup into pauseTimer helper
- verify selection/cooldown time capture with new tests
- document timer pause/resume flow

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd7a6e632083269c025c32579ae046