### PR TITLE
refactor battle advance handlers

### DIFF
--- a/docs/battleCLI.md
+++ b/docs/battleCLI.md
@@ -16,3 +16,4 @@ import { battleCLI, onKeyDown } from "src/pages/index.js";
 - `onKeyDown` handles key events for the CLI interface.
 - The `battleCLI` export exposes test helpers and utilities such as `renderStatList`.
 - `getEscapeHandledPromise` resolves after Escape key processing, simplifying async tests.
+- Background clicks advance from **round over** or **cooldown** states; clicks on stat rows are ignored.

--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -172,7 +172,8 @@ export const __test = {
   handleRoundResolved,
   handleMatchOver,
   handleBattleState,
-  handleWaitingForPlayerActionKey
+  handleWaitingForPlayerActionKey,
+  onClickAdvance
 };
 /**
  * Update the round counter line in the header.
@@ -1421,11 +1422,67 @@ function handleStatClick(statDiv, event) {
  * if roundResolving or ignoreNextAdvanceClick -> return
  * state = body.dataset.battleState
  * if click inside .cli-stat or #cli-shortcuts -> return
- * if state == "roundOver" -> dispatch "continue"
- * else if state == "cooldown" -> clear timers, dispatch "ready"
+ * handler = stateAdvanceHandlers[state]
+ * if no handler -> return
+ * call handler()
  *
  * @param {MouseEvent} event - Click event.
  */
+/**
+ * Clear cooldown timers and reset bottom line.
+ *
+ * @pseudocode
+ * if cooldownTimer -> clearTimeout
+ * if cooldownInterval -> clearInterval
+ * null timers and call clearBottomLine()
+ */
+function clearAdvanceTimers() {
+  try {
+    if (cooldownTimer) clearTimeout(cooldownTimer);
+  } catch {}
+  try {
+    if (cooldownInterval) clearInterval(cooldownInterval);
+  } catch {}
+  cooldownTimer = null;
+  cooldownInterval = null;
+  clearBottomLine();
+}
+
+/**
+ * Dispatch continue on round over.
+ *
+ * @pseudocode
+ * machine = getMachine()
+ * machine.dispatch("continue") if available
+ */
+function advanceRoundOver() {
+  try {
+    const machine = getMachine();
+    if (machine) machine.dispatch("continue");
+  } catch {}
+}
+
+/**
+ * Clear timers then dispatch ready.
+ *
+ * @pseudocode
+ * clearAdvanceTimers()
+ * machine = getMachine()
+ * machine.dispatch("ready") if available
+ */
+function advanceCooldown() {
+  clearAdvanceTimers();
+  try {
+    const machine = getMachine();
+    if (machine) machine.dispatch("ready");
+  } catch {}
+}
+
+const stateAdvanceHandlers = {
+  roundOver: advanceRoundOver,
+  cooldown: advanceCooldown
+};
+
 function onClickAdvance(event) {
   try {
     if (state.roundResolving) return;
@@ -1437,38 +1494,14 @@ function onClickAdvance(event) {
   } catch {
     return;
   }
-  // If help panel is open, ignore background clicks to avoid accidental advancement
   const shortcutsPanel = byId("cli-shortcuts");
   if (shortcutsPanel && !shortcutsPanel.hidden) return;
-  let el = event.target;
-  let path = [];
-  while (el) {
-    path.push(el.tagName + (el.id ? "#" + el.id : ""));
-    el = el.parentElement;
-  }
-  const state = document.body?.dataset?.battleState || "";
   if (event.target?.closest?.(".cli-stat")) return;
   if (event.target?.closest?.("#cli-shortcuts")) return;
-  if (state === "roundOver") {
-    try {
-      const machine = getMachine();
-      if (machine) machine.dispatch("continue");
-    } catch {}
-  } else if (state === "cooldown") {
-    try {
-      if (cooldownTimer) clearTimeout(cooldownTimer);
-    } catch {}
-    try {
-      if (cooldownInterval) clearInterval(cooldownInterval);
-    } catch {}
-    cooldownTimer = null;
-    cooldownInterval = null;
-    clearBottomLine();
-    try {
-      const machine = getMachine();
-      if (machine) machine.dispatch("ready");
-    } catch {}
-  }
+  const stateName = document.body?.dataset?.battleState || "";
+  const handler = stateAdvanceHandlers[stateName];
+  if (!handler) return;
+  handler();
 }
 
 function handleScoreboardShowMessage(e) {

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -8,6 +8,7 @@ async function loadHandlers({ autoSelect = false, skipCooldown = false } = {}) {
   const emitBattleEvent = vi.fn();
   const updateBattleStateBadge = vi.fn();
   const resetGame = vi.fn();
+  const mockDispatch = vi.fn();
   vi.doMock("../../src/helpers/featureFlags.js", () => ({
     initFeatureFlags: vi.fn(),
     isEnabled: vi.fn((flag) => (flag === "autoSelect" ? autoSelect : false)),
@@ -51,6 +52,9 @@ async function loadHandlers({ autoSelect = false, skipCooldown = false } = {}) {
   vi.doMock("../../src/helpers/classicBattle/autoSelectStat.js", () => ({
     autoSelectStat: vi.fn()
   }));
+  vi.doMock("../../src/helpers/classicBattle/debugHooks.js", () => ({
+    readDebugState: vi.fn(() => () => ({ dispatch: mockDispatch }))
+  }));
   window.__TEST__ = true;
   const { battleCLI } = await import("../../src/pages/index.js");
   return {
@@ -58,7 +62,8 @@ async function loadHandlers({ autoSelect = false, skipCooldown = false } = {}) {
     emitBattleEvent,
     updateBattleStateBadge,
     resetGame,
-    setAutoContinue
+    setAutoContinue,
+    mockDispatch
   };
 }
 
@@ -95,6 +100,7 @@ describe("battleCLI event handlers", () => {
     vi.doUnmock("../../src/helpers/constants.js");
     vi.doUnmock("../../src/helpers/classicBattle/autoSelectStat.js");
     vi.doUnmock("../../src/helpers/classicBattle/orchestratorHandlers.js");
+    vi.doUnmock("../../src/helpers/classicBattle/debugHooks.js");
     if (typeof cleanupSetAutoContinue === "function") {
       cleanupSetAutoContinue(true);
       cleanupSetAutoContinue = undefined;
@@ -223,5 +229,42 @@ describe("battleCLI event handlers", () => {
     expect(secondBtn).toBeTruthy();
     expect(secondBtn.id).toBe("next-round-button");
     expect(secondBtn).not.toBe(firstBtn);
+  });
+
+  it("advances round over on background click", async () => {
+    const { handlers, mockDispatch } = await setupHandlers();
+    document.body.dataset.battleState = "roundOver";
+    handlers.onClickAdvance({ target: document.body });
+    expect(mockDispatch).toHaveBeenCalledWith("continue");
+  });
+
+  it("clears cooldown timers and dispatches ready", async () => {
+    const { handlers, mockDispatch } = await setupHandlers();
+    document.body.dataset.battleState = "cooldown";
+    handlers.setCooldownTimers(
+      setTimeout(() => {}, 0),
+      setInterval(() => {}, 100)
+    );
+    const bar = document.createElement("div");
+    bar.className = "snackbar";
+    bar.textContent = "Next round in: 3";
+    document.getElementById("snackbar-container").appendChild(bar);
+    handlers.onClickAdvance({ target: document.body });
+    expect(mockDispatch).toHaveBeenCalledWith("ready");
+    expect(handlers.getCooldownTimers()).toEqual({
+      cooldownTimer: null,
+      cooldownInterval: null
+    });
+    expect(document.querySelector(".snackbar").textContent).toBe("");
+  });
+
+  it("ignores clicks on stat elements", async () => {
+    const { handlers, mockDispatch } = await setupHandlers();
+    document.body.dataset.battleState = "roundOver";
+    const stat = document.createElement("div");
+    stat.className = "cli-stat";
+    document.getElementById("cli-stats").appendChild(stat);
+    handlers.onClickAdvance({ target: stat });
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- refactor battle CLI click advance using `stateAdvanceHandlers` and dedicated functions
- document background click behavior in CLI usage guide
- test roundOver/cooldown advancement and stat click ignore

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` (fails: missing/incomplete JSDoc)
- `npx vitest run`
- `npx playwright test` (fails: screenshot mismatch in settings screenshots)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd7a615f708326aa4d028c6b2c1282