### PR TITLE
refactor: preload uiService during idle

### DIFF
--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -14,15 +14,30 @@ import { getOpponentJudoka } from "./cardSelection.js";
 import { showSnackbar, updateSnackbar } from "../showSnackbar.js";
 import { computeNextRoundCooldown } from "../timers/computeNextRoundCooldown.js";
 const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
-
-let syncScoreDisplay = () => {};
+let syncScoreDisplay = () => {
+  try {
+    const el = document.querySelector("header #score-display");
+    if (el && !el.textContent) el.textContent = "You: 0\nOpponent: 0";
+  } catch {}
+};
 let showMatchSummaryModal = null;
-import("./uiService.js")
-  .then((m) => {
-    syncScoreDisplay = m.syncScoreDisplay || (() => {});
-    showMatchSummaryModal = m.showMatchSummaryModal;
-  })
-  .catch(() => {});
+function preloadUiService() {
+  import("./uiService.js")
+    .then((m) => {
+      syncScoreDisplay = m.syncScoreDisplay || syncScoreDisplay;
+      showMatchSummaryModal = m.showMatchSummaryModal;
+    })
+    .catch(() => {});
+}
+try {
+  if (typeof window !== "undefined" && "requestIdleCallback" in window) {
+    window.requestIdleCallback(preloadUiService);
+  } else {
+    queueMicrotask(preloadUiService);
+  }
+} catch {
+  preloadUiService();
+}
 
 /**
  * Apply UI updates for a newly started round.

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -30,13 +30,28 @@ import { guard } from "./guard.js";
 import { updateDebugPanel, setDebugPanelEnabled } from "./debugPanel.js";
 import { getOpponentDelay } from "./snackbar.js";
 export { showSelectionPrompt, setOpponentDelay, getOpponentDelay } from "./snackbar.js";
-
-let syncScoreDisplay = () => {};
-import("./uiService.js")
-  .then((m) => {
-    syncScoreDisplay = m.syncScoreDisplay || (() => {});
-  })
-  .catch(() => {});
+let syncScoreDisplay = () => {
+  try {
+    const el = document.querySelector("header #score-display");
+    if (el && !el.textContent) el.textContent = "You: 0\nOpponent: 0";
+  } catch {}
+};
+function preloadUiService() {
+  import("./uiService.js")
+    .then((m) => {
+      syncScoreDisplay = m.syncScoreDisplay || syncScoreDisplay;
+    })
+    .catch(() => {});
+}
+try {
+  if (typeof window !== "undefined" && "requestIdleCallback" in window) {
+    window.requestIdleCallback(preloadUiService);
+  } else {
+    queueMicrotask(preloadUiService);
+  }
+} catch {
+  preloadUiService();
+}
 /**
  * Skip the inter-round cooldown when the corresponding feature flag is enabled.
  *


### PR DESCRIPTION
## Summary
- preload `uiService` in `roundUI` and `uiHelpers` during idle time instead of immediate dynamic import
- provide fallback score sync to preserve initial scoreboard text

## Testing
- `npx prettier src/helpers/classicBattle/roundUI.js src/helpers/classicBattle/uiHelpers.js --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/helpers/classicBattle/roundUI.js", "src/helpers/classicBattle/uiHelpers.js"],
  "outputs": ["src/helpers/classicBattle/roundUI.js", "src/helpers/classicBattle/uiHelpers.js"],
  "success": ["prettier: PASS", "eslint: PASS", "jsdoc: WARN", "vitest: PASS", "playwright: FAIL", "contrast: PASS"],
  "errorMode": "ask_on_public_api_change"
}
```

## Files
- `src/helpers/classicBattle/roundUI.js`: preload `uiService` on idle with microtask fallback and scoreboard stub
- `src/helpers/classicBattle/uiHelpers.js`: same idle preload pattern for `syncScoreDisplay`

## Verification
- `prettier`: PASS
- `eslint`: PASS
- `jsdoc`: WARN (missing JSDoc on 183 items)
- `vitest`: PASS (243 passed, 1 skipped)
- `playwright`: FAIL (3 screenshot tests)
- `contrast`: PASS

## Risk
- Idle preloading may delay availability in environments without `requestIdleCallback`, though microtask fallback minimizes impact. Follow-up: confirm screenshot baselines for Playwright tests.


------
https://chatgpt.com/codex/tasks/task_e_68bd7a4db65c8326ad33f92ca82c765e