### PR TITLE
fix timer pause logic

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -580,6 +580,7 @@ function ensureModalContainer() {
  * Clear a timer pair and capture remaining time.
  *
  * @param {"selection"|"cooldown"} type Timer category to pause.
+ * @returns {number|null} Remaining seconds, or null when no timers were active.
  *
  * @pseudocode
  * if pausing selection:
@@ -609,27 +610,31 @@ function pauseTimer(type) {
     selectionTimer = null;
     selectionInterval = null;
     return remaining;
+  } else {
+    const bar = byId("snackbar-container")?.querySelector(".snackbar");
+    const match = bar?.textContent?.match(/Next round in: (\d+)/);
+    cooldownTimer = null;
+    cooldownInterval = null;
+    return match ? Number(match[1]) : null;
   }
-  const bar = byId("snackbar-container")?.querySelector(".snackbar");
-  const match = bar?.textContent?.match(/Next round in: (\d+)/);
-  cooldownTimer = null;
-  cooldownInterval = null;
-  return match ? Number(match[1]) : null;
 }
 
 /**
  * Pause active selection and cooldown timers, preserving remaining time.
  *
  * @pseudocode
- * countdownEl = #cli-countdown
- * if selection timers exist:
- *   call pauseTimer("selection") and store remaining
- * if cooldown timers exist:
- *   call pauseTimer("cooldown") and store remaining
+ * newSelection = pauseTimer("selection")
+ * if newSelection is not null:
+ *   pausedSelectionRemaining = newSelection
+ * newCooldown = pauseTimer("cooldown")
+ * if newCooldown is not null:
+ *   pausedCooldownRemaining = newCooldown
  */
 function pauseTimers() {
-  pausedSelectionRemaining = pauseTimer("selection");
-  pausedCooldownRemaining = pauseTimer("cooldown");
+  const newSelection = pauseTimer("selection");
+  if (newSelection !== null) pausedSelectionRemaining = newSelection;
+  const newCooldown = pauseTimer("cooldown");
+  if (newCooldown !== null) pausedCooldownRemaining = newCooldown;
 }
 
 /**

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -181,6 +181,34 @@ describe("battleCLI event handlers", () => {
     vi.useRealTimers();
   });
 
+  it("preserves remaining time when paused twice", async () => {
+    vi.useFakeTimers();
+    const { handlers } = await setupHandlers();
+    const countdown = document.createElement("div");
+    countdown.id = "cli-countdown";
+    countdown.dataset.remainingTime = "5";
+    document.body.appendChild(countdown);
+    handlers.setSelectionTimers(
+      setTimeout(() => {}, 5000),
+      setInterval(() => {}, 1000)
+    );
+    const bar = document.getElementById("snackbar-container");
+    const snack = document.createElement("div");
+    snack.className = "snackbar";
+    snack.textContent = "Next round in: 7";
+    bar.appendChild(snack);
+    handlers.setCooldownTimers(
+      setTimeout(() => {}, 7000),
+      setInterval(() => {}, 1000)
+    );
+    handlers.pauseTimers();
+    handlers.pauseTimers();
+    const { selection, cooldown } = handlers.getPausedTimes();
+    expect(selection).toBe(5);
+    expect(cooldown).toBe(7);
+    vi.useRealTimers();
+  });
+
   it("updates message after round resolved", async () => {
     const { handlers } = await setupHandlers();
     const speedName = statNamesData.find((s) => s.statIndex === 2).name;


### PR DESCRIPTION
## Summary
- wrap cooldown parsing in `else` for `pauseTimer`
- keep remaining time when pausing multiple times
- test consecutive pauses preserve timer state

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 183 missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/pages/battleCLI.js", "tests/pages/battleCLI.handlers.test.js"],
  "outputs": ["src/pages/battleCLI.js", "tests/pages/battleCLI.handlers.test.js"],
  "success": ["eslint: PASS", "vitest: PASS", "jsdoc: FAIL", "playwright: FAIL"],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `src/pages/battleCLI.js`: document `pauseTimer` return type, guard cooldown parsing with `else`, and retain remaining times across repeated pauses
- `tests/pages/battleCLI.handlers.test.js`: add regression test for consecutive pause calls

## Verification
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 183 missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`

## Risk
- Low: timer handling and tests updated

## Follow-Up
- Address outstanding JSDoc and screenshot test failures in separate PRs


------
https://chatgpt.com/codex/tasks/task_e_68bd85bece70832691ff088bfb719d7a