### PR TITLE
refactor: consolidate score sync stub

### DIFF
--- a/tests/helpers/classicBattle/nextButton.countdownFinished.test.js
+++ b/tests/helpers/classicBattle/nextButton.countdownFinished.test.js
@@ -10,7 +10,8 @@ vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
   emitBattleEvent: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
-  skipRoundCooldownIfEnabled: vi.fn(() => false)
+  skipRoundCooldownIfEnabled: vi.fn(() => false),
+  syncScoreDisplay: vi.fn()
 }));
 
 import { emitBattleEvent } from "../../../src/helpers/classicBattle/battleEvents.js";

--- a/tests/helpers/classicBattle/roundResolved.statButton.test.js
+++ b/tests/helpers/classicBattle/roundResolved.statButton.test.js
@@ -29,7 +29,8 @@ vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   updateRoundCounter: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
-  disableNextRoundButton: vi.fn()
+  disableNextRoundButton: vi.fn(),
+  syncScoreDisplay: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/snackbar.js", () => ({
   showSelectionPrompt: vi.fn(),

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -49,7 +49,8 @@ describe("timerService drift handling", () => {
     }));
     vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
       enableNextRoundButton: vi.fn(),
-      disableNextRoundButton: vi.fn()
+      disableNextRoundButton: vi.fn(),
+      syncScoreDisplay: vi.fn()
     }));
     vi.doMock("../../../src/helpers/classicBattle/debugPanel.js", () => ({
       updateDebugPanel: vi.fn()

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -25,7 +25,8 @@ describe("timerService next round handling", () => {
     vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
       enableNextRoundButton: vi.fn(),
       disableNextRoundButton: vi.fn(),
-      skipRoundCooldownIfEnabled: vi.fn(() => false)
+      skipRoundCooldownIfEnabled: vi.fn(() => false),
+      syncScoreDisplay: vi.fn()
     }));
     vi.doMock("../../../src/helpers/classicBattle/debugPanel.js", () => ({
       updateDebugPanel: vi.fn()


### PR DESCRIPTION
## Summary
- centralize `syncScoreDisplay` stub and scoreboard text
- ensure `uiService` preload runs even without idle time
- update classic battle tests for new `syncScoreDisplay` export

## Testing
- `npx prettier src/helpers/classicBattle/roundUI.js src/helpers/classicBattle/uiHelpers.js tests/helpers/classicBattle/nextButton.countdownFinished.test.js tests/helpers/classicBattle/roundResolved.statButton.test.js tests/helpers/classicBattle/timerService.drift.test.js tests/helpers/classicBattle/timerService.nextRound.test.js --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd855ff1fc8326891b526350507e17