### PR TITLE
refactor battle advance handlers

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -1472,6 +1472,22 @@ function clearAdvanceTimers() {
 }
 
 /**
+ * Record state machine dispatch error without logging to console.
+ *
+ * @param {unknown} err Error to record.
+ * @pseudocode
+ * if window exists
+ *   window.__battleDispatchError = String(err)
+ */
+function recordDispatchError(err) {
+  try {
+    if (typeof window !== "undefined") {
+      window.__battleDispatchError = String(err);
+    }
+  } catch {}
+}
+
+/**
  * Dispatch continue on round over.
  *
  * @pseudocode
@@ -1483,7 +1499,7 @@ function advanceRoundOver() {
     const machine = getMachine();
     if (machine) machine.dispatch("continue");
   } catch (err) {
-    console.error(err);
+    recordDispatchError(err);
   }
 }
 
@@ -1501,7 +1517,7 @@ function advanceCooldown() {
     const machine = getMachine();
     if (machine) machine.dispatch("ready");
   } catch (err) {
-    console.error(err);
+    recordDispatchError(err);
   }
 }
 


### PR DESCRIPTION
## Summary
- record state machine dispatch errors without console logging

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Total missing: 183)*
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd89ea44e483268aed7981294e3181