### PR TITLE
refactor: extract idle callback helper

### DIFF
--- a/src/helpers/classicBattle/idleCallback.js
+++ b/src/helpers/classicBattle/idleCallback.js
@@ -1,0 +1,30 @@
+/**
+ * @summary Run a task when idle with timeout fallback.
+ *
+ * @pseudocode
+ * 1. If `requestIdleCallback` exists, schedule `fn` with it and also set a
+ *    timeout to cancel the idle callback and run `fn` after `timeout` ms.
+ * 2. Otherwise, queue a microtask to run `fn`.
+ * 3. On any error, invoke `fn` immediately.
+ *
+ * @param {() => void} fn - Function to execute.
+ * @param {number} [timeout=2000] - Fallback timeout in milliseconds.
+ * @returns {void}
+ */
+export function runWhenIdle(fn, timeout = 2000) {
+  try {
+    if (typeof window !== "undefined" && "requestIdleCallback" in window) {
+      const id = window.requestIdleCallback(fn);
+      window.setTimeout(() => {
+        try {
+          if ("cancelIdleCallback" in window) window.cancelIdleCallback(id);
+        } catch {}
+        fn();
+      }, timeout);
+    } else {
+      queueMicrotask(fn);
+    }
+  } catch {
+    fn();
+  }
+}

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -14,6 +14,7 @@ import { getOpponentJudoka } from "./cardSelection.js";
 import { showSnackbar, updateSnackbar } from "../showSnackbar.js";
 import { computeNextRoundCooldown } from "../timers/computeNextRoundCooldown.js";
 import { syncScoreDisplay } from "./uiHelpers.js";
+import { runWhenIdle } from "./idleCallback.js";
 const IS_VITEST = typeof process !== "undefined" && !!process.env?.VITEST;
 let showMatchSummaryModal = null;
 function preloadUiService() {
@@ -23,25 +24,7 @@ function preloadUiService() {
     })
     .catch(() => {});
 }
-const UI_SERVICE_IDLE_TIMEOUT = 2000;
-function scheduleUiServicePreload() {
-  try {
-    if (typeof window !== "undefined" && "requestIdleCallback" in window) {
-      const id = window.requestIdleCallback(preloadUiService);
-      window.setTimeout(() => {
-        try {
-          if ("cancelIdleCallback" in window) window.cancelIdleCallback(id);
-        } catch {}
-        preloadUiService();
-      }, UI_SERVICE_IDLE_TIMEOUT);
-    } else {
-      queueMicrotask(preloadUiService);
-    }
-  } catch {
-    preloadUiService();
-  }
-}
-scheduleUiServicePreload();
+runWhenIdle(preloadUiService);
 
 /**
  * Apply UI updates for a newly started round.

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -30,8 +30,7 @@ import { guard } from "./guard.js";
 import { updateDebugPanel, setDebugPanelEnabled } from "./debugPanel.js";
 import { getOpponentDelay } from "./snackbar.js";
 export { showSelectionPrompt, setOpponentDelay, getOpponentDelay } from "./snackbar.js";
-
-const UI_SERVICE_IDLE_TIMEOUT = 2000;
+import { runWhenIdle } from "./idleCallback.js";
 
 export const INITIAL_SCOREBOARD_TEXT = "You: 0\nOpponent: 0";
 
@@ -55,24 +54,7 @@ function preloadUiService() {
     })
     .catch(() => {});
 }
-function scheduleUiServicePreload() {
-  try {
-    if (typeof window !== "undefined" && "requestIdleCallback" in window) {
-      const id = window.requestIdleCallback(preloadUiService);
-      window.setTimeout(() => {
-        try {
-          if ("cancelIdleCallback" in window) window.cancelIdleCallback(id);
-        } catch {}
-        preloadUiService();
-      }, UI_SERVICE_IDLE_TIMEOUT);
-    } else {
-      queueMicrotask(preloadUiService);
-    }
-  } catch {
-    preloadUiService();
-  }
-}
-scheduleUiServicePreload();
+runWhenIdle(preloadUiService);
 /**
  * Skip the inter-round cooldown when the corresponding feature flag is enabled.
  *

--- a/tests/helpers/classicBattle/idleCallback.test.js
+++ b/tests/helpers/classicBattle/idleCallback.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { runWhenIdle } from "../../../src/helpers/classicBattle/idleCallback.js";
+
+describe("runWhenIdle", () => {
+  let originalRic;
+  let originalSt;
+  let originalQm;
+
+  beforeEach(() => {
+    originalRic = window.requestIdleCallback;
+    originalSt = window.setTimeout;
+    originalQm = globalThis.queueMicrotask;
+  });
+
+  afterEach(() => {
+    window.requestIdleCallback = originalRic;
+    window.setTimeout = originalSt;
+    globalThis.queueMicrotask = originalQm;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("uses requestIdleCallback with timeout fallback", () => {
+    const fn = vi.fn();
+    const ric = vi.fn((cb) => {
+      cb();
+      return 1;
+    });
+    const st = vi.fn();
+    window.requestIdleCallback = ric;
+    window.setTimeout = st;
+    runWhenIdle(fn);
+    expect(ric).toHaveBeenCalledWith(fn);
+    expect(st).toHaveBeenCalledTimes(1);
+    expect(st.mock.calls[0][1]).toBe(2000);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to queueMicrotask when idle callback missing", () => {
+    const fn = vi.fn();
+    const qm = vi.fn((cb) => cb());
+    delete window.requestIdleCallback;
+    globalThis.queueMicrotask = qm;
+    runWhenIdle(fn);
+    expect(qm).toHaveBeenCalledWith(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- factor idle preload pattern into reusable `runWhenIdle`
- use shared helper to preload `uiService`
- test idle fallback behavior

## Testing
- `npx prettier src/helpers/classicBattle/idleCallback.js src/helpers/classicBattle/uiHelpers.js src/helpers/classicBattle/roundUI.js tests/helpers/classicBattle/idleCallback.test.js --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: functions missing or incomplete JSDoc blocks)*
- `npx vitest run tests/helpers/classicBattle/idleCallback.test.js`
- `npx playwright test` *(fails: navigation links navigate to expected pages)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/helpers/classicBattle/uiHelpers.js", "src/helpers/classicBattle/roundUI.js"],
  "outputs": [
    "src/helpers/classicBattle/idleCallback.js",
    "src/helpers/classicBattle/uiHelpers.js",
    "src/helpers/classicBattle/roundUI.js",
    "tests/helpers/classicBattle/idleCallback.test.js"
  ],
  "success": [
    "prettier: PASS",
    "eslint: PASS",
    "jsdoc: FAIL",
    "vitest: PASS",
    "playwright: FAIL",
    "contrast: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Files
- `src/helpers/classicBattle/idleCallback.js`: add runWhenIdle helper to schedule work during idle with timeout
- `src/helpers/classicBattle/uiHelpers.js`: replace inline idle preload with runWhenIdle
- `src/helpers/classicBattle/roundUI.js`: use runWhenIdle for uiService preload
- `tests/helpers/classicBattle/idleCallback.test.js`: test runWhenIdle for requestIdleCallback and microtask paths

## Verification
- `npx prettier src/helpers/classicBattle/idleCallback.js src/helpers/classicBattle/uiHelpers.js src/helpers/classicBattle/roundUI.js tests/helpers/classicBattle/idleCallback.test.js --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: functions missing or incomplete JSDoc blocks)*
- `npx vitest run tests/helpers/classicBattle/idleCallback.test.js`
- `npx playwright test` *(fails: navigation links navigate to expected pages)*
- `npm run check:contrast`

## Risk
- Low; shared idle helper only reorganizes existing preload logic


------
https://chatgpt.com/codex/tasks/task_e_68bd8a0531e88326918b5fbab67c205d