### PR TITLE
chore: respect orchestrator state before direct resolution

### DIFF
--- a/tests/helpers/classicBattle/selectionHandler.resolve.test.js
+++ b/tests/helpers/classicBattle/selectionHandler.resolve.test.js
@@ -16,6 +16,9 @@ vi.mock("../../../src/helpers/classicBattle/roundResolver.js", () => ({
 vi.mock("../../../src/helpers/classicBattle/cardStatUtils.js", () => ({
   getCardStatValue: vi.fn()
 }));
+vi.mock("../../../src/helpers/classicBattle/eventBus.js", () => ({
+  getBattleState: vi.fn()
+}));
 
 import { handleStatSelection } from "../../../src/helpers/classicBattle.js";
 
@@ -23,6 +26,7 @@ describe("handleStatSelection resolution", () => {
   let store;
   let dispatchMock;
   let resolveMock;
+  let getBattleState;
 
   beforeEach(async () => {
     store = { selectionMade: false, playerChoice: null, statTimeoutId: null, autoSelectId: null };
@@ -30,6 +34,9 @@ describe("handleStatSelection resolution", () => {
       .dispatchBattleEvent;
     resolveMock = (await import("../../../src/helpers/classicBattle/roundResolver.js"))
       .resolveRound;
+    getBattleState = (await import("../../../src/helpers/classicBattle/eventBus.js"))
+      .getBattleState;
+    getBattleState.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -67,6 +74,7 @@ describe("handleStatSelection resolution", () => {
         store.playerChoice = null;
       }
     });
+    getBattleState.mockReturnValue("roundDecision");
     const result = await handleStatSelection(store, "power", {
       playerVal: 1,
       opponentVal: 2

--- a/tests/helpers/selectionHandler.test.js
+++ b/tests/helpers/selectionHandler.test.js
@@ -12,7 +12,7 @@ vi.mock("../../src/helpers/classicBattle/battleEvents.js", () => ({
 }));
 
 vi.mock("../../src/helpers/classicBattle/eventBus.js", () => ({
-  getBattleState: vi.fn(() => "waitingForPlayerAction")
+  getBattleState: vi.fn()
 }));
 
 vi.mock("../../src/helpers/classicBattle/cardStatUtils.js", () => ({
@@ -45,6 +45,7 @@ describe("handleStatSelection helpers", () => {
   let emitBattleEvent;
   let showSnackbar;
   let dispatchBattleEvent;
+  let getBattleState;
 
   beforeEach(async () => {
     store = { selectionMade: false, playerChoice: null, statTimeoutId: null, autoSelectId: null };
@@ -52,6 +53,8 @@ describe("handleStatSelection helpers", () => {
     ({ emitBattleEvent } = await import("../../src/helpers/classicBattle/battleEvents.js"));
     ({ showSnackbar } = await import("../../src/helpers/showSnackbar.js"));
     ({ dispatchBattleEvent } = await import("../../src/helpers/classicBattle/orchestrator.js"));
+    ({ getBattleState } = await import("../../src/helpers/classicBattle/eventBus.js"));
+    getBattleState.mockReturnValue(null);
   });
 
   it("ignores repeated selections", async () => {


### PR DESCRIPTION
## Summary
- short-circuit direct round resolution when battle orchestrator reports a state
- exercise orchestrator fallback in selection handler tests

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bd903ca4948326a81648c0a8818cb8