### PR TITLE
fix: skip direct resolution after machine clears state

### DIFF
--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -232,9 +232,10 @@ async function emitSelectionEvent(store, stat, playerVal, opponentVal, opts) {
  * 2. Apply selection to `store` and coerce stat values with `applySelectionToStore`.
  * 3. Call `cleanupTimers` to halt timers and clear pending timeouts.
  * 4. Emit `statSelected` with selection details and any testing options.
- * 5. Dispatch the battle machine `statSelected` event then read `getBattleState`.
- * 6. If a state is returned, return early; otherwise call `resolveRoundDirect`
- *    and dispatch `roundResolved`.
+ * 5. Dispatch `statSelected` then query `getBattleState`.
+ * 6. If `getBattleState` returns a state or the machine cleared
+ *    `store.playerChoice`, return early.
+ * 7. Otherwise call `resolveRoundDirect` and dispatch `roundResolved`.
  *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
  * @param {string} stat - Chosen stat key.
@@ -249,14 +250,19 @@ export async function handleStatSelection(store, stat, { playerVal, opponentVal,
   ({ playerVal, opponentVal } = applySelectionToStore(store, stat, playerVal, opponentVal));
   cleanupTimers(store);
   await emitSelectionEvent(store, stat, playerVal, opponentVal, opts);
+  let resolvedByMachine = false;
   try {
     await dispatchBattleEvent("statSelected");
+    resolvedByMachine = store.playerChoice === null;
   } catch {}
   try {
-    if (getBattleState()) {
-      return;
+    if (!resolvedByMachine && getBattleState()) {
+      resolvedByMachine = true;
     }
   } catch {}
+  if (resolvedByMachine) {
+    return;
+  }
   const result = await resolveRoundDirect(store, stat, playerVal, opponentVal, opts);
   try {
     await dispatchBattleEvent("roundResolved");

--- a/tests/helpers/classicBattle/selectionHandler.resolve.test.js
+++ b/tests/helpers/classicBattle/selectionHandler.resolve.test.js
@@ -84,4 +84,21 @@ describe("handleStatSelection resolution", () => {
     expect(result).toBeUndefined();
     expect(store.playerChoice).toBeNull();
   });
+
+  it("skips direct resolution when machine clears playerChoice but state unknown", async () => {
+    dispatchMock.mockImplementation(async (event) => {
+      if (event === "statSelected") {
+        store.playerChoice = null;
+      }
+    });
+    getBattleState.mockReturnValue(null);
+    const result = await handleStatSelection(store, "power", {
+      playerVal: 1,
+      opponentVal: 2
+    });
+    expect(resolveMock).not.toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalledWith("roundResolved");
+    expect(result).toBeUndefined();
+    expect(store.playerChoice).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- guard `handleStatSelection` against unregistered battle state getter
- add regression test for machine-cleared playerChoice without state getter

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 183 functions missing JSDoc)*
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/helpers/classicBattle/selectionHandler.js", "tests/helpers/classicBattle/selectionHandler.resolve.test.js"],
  "outputs": ["src/helpers/classicBattle/selectionHandler.js", "tests/helpers/classicBattle/selectionHandler.resolve.test.js"],
  "success": ["eslint: PASS", "vitest: PASS", "jsdoc: FAIL", "no_unsuppressed_console"],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `src/helpers/classicBattle/selectionHandler.js`: fall back to `store.playerChoice` when `getBattleState` is unavailable
- `tests/helpers/classicBattle/selectionHandler.resolve.test.js`: add coverage for machine-cleared `playerChoice` without state getter

## Verification
- ✅ `npx prettier . --check`
- ✅ `npx eslint .`
- ❌ `npm run check:jsdoc` *(183 functions missing JSDoc blocks)*
- ✅ `npx vitest run`
- ❌ `npx playwright test` *(screenshot mismatch)*
- ✅ `npm run check:contrast`

## Risk
- Low: restores prior safety check; follow-up needed to register battle state getter to rely on orchestrator state.


------
https://chatgpt.com/codex/tasks/task_e_68bda73d3a9883268a2c328fd944ff4a