### PR TITLE
fix: avoid double execution in runWhenIdle

### DIFF
--- a/tests/helpers/classicBattle/idleCallback.test.js
+++ b/tests/helpers/classicBattle/idleCallback.test.js
@@ -13,7 +13,8 @@ describe("runWhenIdle", () => {
   });
 
   afterEach(() => {
-    window.requestIdleCallback = originalRic;
+    if (originalRic === undefined) delete window.requestIdleCallback;
+    else window.requestIdleCallback = originalRic;
     window.setTimeout = originalSt;
     globalThis.queueMicrotask = originalQm;
     vi.useRealTimers();
@@ -26,11 +27,12 @@ describe("runWhenIdle", () => {
       cb();
       return 1;
     });
-    const st = vi.fn();
+    const st = vi.fn((cb) => cb());
     window.requestIdleCallback = ric;
     window.setTimeout = st;
     runWhenIdle(fn);
-    expect(ric).toHaveBeenCalledWith(fn);
+    expect(ric).toHaveBeenCalledTimes(1);
+    expect(typeof ric.mock.calls[0][0]).toBe("function");
     expect(st).toHaveBeenCalledTimes(1);
     expect(st.mock.calls[0][1]).toBe(2000);
     expect(fn).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- guard runWhenIdle against double invocation when timeout and idle callback race
- clean up requestIdleCallback stub in tests and align expectations

## Testing
- `npx prettier src/helpers/classicBattle/idleCallback.js src/helpers/classicBattle/uiHelpers.js src/helpers/classicBattle/roundUI.js tests/helpers/classicBattle/idleCallback.test.js --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: functions missing or incomplete JSDoc blocks)*
- `npx vitest run tests/helpers/classicBattle/idleCallback.test.js`
- `npx playwright test` *(fails: @battleJudoka-narrow screenshot mismatch)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/helpers/classicBattle/idleCallback.js", "tests/helpers/classicBattle/idleCallback.test.js"],
  "outputs": ["src/helpers/classicBattle/idleCallback.js", "tests/helpers/classicBattle/idleCallback.test.js"],
  "success": ["prettier: PASS", "eslint: PASS", "jsdoc: FAIL", "vitest: PASS", "playwright: FAIL", "contrast: PASS"],
  "errorMode": "ask_on_public_api_change"
}
```

## Files
- `src/helpers/classicBattle/idleCallback.js`: wrap fn to ensure single execution and update pseudocode
- `tests/helpers/classicBattle/idleCallback.test.js`: restore `requestIdleCallback` cleanly and test wrapper execution

## Verification
- `npx prettier src/helpers/classicBattle/idleCallback.js src/helpers/classicBattle/uiHelpers.js src/helpers/classicBattle/roundUI.js tests/helpers/classicBattle/idleCallback.test.js --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: functions missing or incomplete JSDoc blocks)*
- `npx vitest run tests/helpers/classicBattle/idleCallback.test.js`
- `npx playwright test` *(fails: @battleJudoka-narrow screenshot mismatch)*
- `npm run check:contrast`

## Risk
- Low; adds call guard to idle helper and adjusts tests

------
https://chatgpt.com/codex/tasks/task_e_68bda787feb48326895b711fb1727d6b