### PR TITLE
refactor battle state progress helpers

### DIFF
--- a/design/battleMarkup.md
+++ b/design/battleMarkup.md
@@ -21,7 +21,7 @@ Classic battle pages rely on specific element IDs so helper scripts can attach l
 | `next-button`           | Advances to the next round when ready; also uses `data-role="next-round"`. Pressing it always skips the cooldown regardless of the `skipRoundCooldown` flag. |
 | `stat-help`             | Opens stat selection help.                                                                                                                                   |
 | `quit-match-button`     | Triggers the quit match flow.                                                                                                                                |
-| `battle-state-progress` | Optional list tracking match state transitions.                                                                                                              |
+| `battle-state-progress` | Optional list tracking match state transitions; pre-populates from the current state and remaps interrupts to core states.                                   |
 
 ### Data attributes and test hooks
 

--- a/design/productRequirementsDocuments/prdBattleClassic.md
+++ b/design/productRequirementsDocuments/prdBattleClassic.md
@@ -97,7 +97,7 @@ Currently, only ~45% of new players complete their first battle across all modes
 - During this delay, the Scoreboard displays "Opponent is choosing..." in `#round-message` to reinforce turn flow.
 - The cooldown timer between rounds begins only after round results are shown in the Scoreboard and is displayed using one persistent snackbar that updates its text each second.
 - The debug panel is available when the `enableTestMode` feature flag is enabled, appears above the player and opponent cards, and includes a copy button for exporting its text.
-- A battle state progress list can be enabled via the `battleStateProgress` feature flag to show the sequence of match states beneath the battle area; disabled by default.
+- A battle state progress list can be enabled via the `battleStateProgress` feature flag to show the sequence of match states beneath the battle area. The list pre-populates from `data-battle-state` and remaps interrupt states to their nearest core state. Disabled by default.
 
 ### Round Data Fallback
 


### PR DESCRIPTION
## Task Contract
```json
{
  "inputs": ["src/helpers/battleStateProgress.js","tests/helpers/classicBattle/battleStateProgress.test.js","design/productRequirementsDocuments/prdBattleClassic.md","design/battleMarkup.md"],
  "outputs": ["src/helpers/battleStateProgress.js","tests/helpers/classicBattle/battleStateProgress.test.js","design/productRequirementsDocuments/prdBattleClassic.md","design/battleMarkup.md"],
  "success": ["prettier: PASS","eslint: PASS","jsdoc: FAIL","vitest: PASS","playwright: FAIL","check:contrast: PASS"],
  "errorMode": "none"
}
```

## Summary
- factor battle state progress rendering into `renderStateList`, `updateActiveState`, and `initProgressListener` helpers and return cleanup closures【F:src/helpers/battleStateProgress.js†L70-L165】【F:src/helpers/battleStateProgress.js†L182-L212】
- expand tests for disabled flag, initial state prepopulation, and interrupt remapping of the progress list【F:tests/helpers/classicBattle/battleStateProgress.test.js†L75-L132】
- clarify design docs with prepopulation and interrupt mapping details for the battle state progress UI【F:design/productRequirementsDocuments/prdBattleClassic.md†L100-L100】【F:design/battleMarkup.md†L20-L24】

## Testing
- ✅ `npx prettier . --check`【abc892†L1-L3】
- ✅ `npx eslint .`【af1028†L1-L2】
- ❌ `npm run check:jsdoc` (missing docs across repo)【598567†L1-L40】
- ✅ `npx vitest run`【175db1†L1-L20】
- ❌ `npx playwright test` (2 interrupted)【3cb9dd†L1-L21】
- ✅ `npm run check:contrast`【192581†L1-L11】

## Risk & Follow-Up
- Playwright suite had interrupted tests; investigate flakiness around classic battle flow.


------
https://chatgpt.com/codex/tasks/task_e_68bda8189d848326958a51f0e44bba13