### PR TITLE
refactor round result pipeline

### DIFF
--- a/docs/roundUI.md
+++ b/docs/roundUI.md
@@ -10,5 +10,10 @@ battle store that caches commonly used DOM elements.
 3. **`roundResolved`** – displays the outcome, updates the score, schedules the
    next-round countdown and clears any stat highlight.
 
+Round resolution uses a chain of helpers for clarity and testability:
+`evaluateOutcome` evaluates numbers, `dispatchOutcomeEvents` sends state
+transitions, `updateScoreboard` syncs scores and `emitRoundResolved` broadcasts
+the final result.
+
 Caching the player card, opponent card and stat buttons on the store avoids
 repeated DOM queries inside timers and event handlers.


### PR DESCRIPTION
## Summary
- split `computeRoundResult` into `evaluateOutcome`, `dispatchOutcomeEvents`, `updateScoreboard` and `emitRoundResolved`
- add win/draw and scoreboard tests for single round resolver
- document new classic battle round resolution helpers

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: countdown timing and screenshot specs)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bda8044f0883269a59547987383250