### PR TITLE
docs: note stat event-based resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Note on Next button behavior:
 - The `Next` button advances only during the inter-round cooldown. Clicking it cancels any remaining cooldown and immediately starts the next round, regardless of the `skipRoundCooldown` setting.
 - It remains disabled while choosing a stat to avoid skipping the cooldown logic accidentally. The cooldown enables `Next` (or auto-advances in test mode); do not expect `Next` to be ready during stat selection.
 
+Stat selections now dispatch events and rely on the state machine for round resolution. `handleStatSelection` performs direct resolution only when the orchestrator is absent (e.g., certain tests or CLI utilities).
+
 See [design/battleMarkup.md](design/battleMarkup.md) for the canonical DOM ids used by classic battle scripts.
 
 ## 🔌 Engine API


### PR DESCRIPTION
## Summary
- document that stat selections dispatch events and rely on the state machine
- clarify that `handleStatSelection` only resolves directly when no orchestrator exists

## Testing
- `npx prettier . --check` *(fails: command not found)*
- `npx eslint .` *(fails: command not found)*
- `npm run check:jsdoc` *(fails: command not found)*
- `npx vitest run` *(fails: command not found)*
- `npx playwright test` *(fails: command not found)*
- `npm run check:contrast` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc4d6c45c8326bf4a94eb916439f7