### PR TITLE
test: cover handleStatSelection machine path

### DIFF
--- a/tests/helpers/classicBattle/handleStatSelection.machine.test.js
+++ b/tests/helpers/classicBattle/handleStatSelection.machine.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
+  STATS: ["power"],
+  stopTimer: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/classicBattle/orchestrator.js", () => ({
+  dispatchBattleEvent: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/classicBattle/roundResolver.js", () => ({
+  resolveRound: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/classicBattle/cardStatUtils.js", () => ({
+  getCardStatValue: vi.fn()
+}));
+
+vi.mock("../../../src/helpers/classicBattle/eventBus.js", () => ({
+  getBattleState: vi.fn(() => "waitingForPlayerAction")
+}));
+
+import * as selection from "../../../src/helpers/classicBattle/selectionHandler.js";
+
+const { handleStatSelection } = selection;
+
+describe("handleStatSelection machine interaction", () => {
+  let store;
+  let dispatchMock;
+  let resolveSpy;
+
+  beforeEach(async () => {
+    store = { selectionMade: false, playerChoice: null, statTimeoutId: null, autoSelectId: null };
+    dispatchMock = (await import("../../../src/helpers/classicBattle/orchestrator.js"))
+      .dispatchBattleEvent;
+    resolveSpy = vi.spyOn(selection, "resolveRoundDirect");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches statSelected once without resolving", async () => {
+    await handleStatSelection(store, "power", { playerVal: 1, opponentVal: 2 });
+    await Promise.resolve();
+    expect(resolveSpy).not.toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith("statSelected");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test verifying that `handleStatSelection` defers resolution when the battle state machine reports `waitingForPlayerAction`

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch in battleJudoka-narrow)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bdc4d020fc8326ae80db396d8e1c07