### PR TITLE
refactor round result pipeline

### DIFF
--- a/src/helpers/classicBattle/roundResolver.js
+++ b/src/helpers/classicBattle/roundResolver.js
@@ -155,7 +155,7 @@ export function evaluateRound(store, stat, playerVal, opponentVal) {
  */
 export function evaluateOutcome(store, stat, playerVal, opponentVal) {
   try {
-    debugLog("DEBUG: computeRoundResult start", { stat, playerVal, opponentVal });
+    debugLog("DEBUG: evaluateOutcome start", { stat, playerVal, opponentVal });
   } catch {}
   const pVal = Number.isFinite(Number(playerVal)) ? Number(playerVal) : 0;
   const oVal = Number.isFinite(Number(opponentVal)) ? Number(opponentVal) : 0;

--- a/tests/helpers/classicBattle/roundResolverOnce.test.js
+++ b/tests/helpers/classicBattle/roundResolverOnce.test.js
@@ -87,11 +87,11 @@ describe.sequential("classicBattle round resolver once", () => {
   it("dispatches win path and updates scoreboard", async () => {
     const store = createBattleStore();
     _resetForTest(store);
-    const result = await computeRoundResult(store, "power", 5, 3);
     const { updateScore } = await import("../../../src/helpers/setupScoreboard.js");
     const { dispatchBattleEvent } = await import(
       "../../../src/helpers/classicBattle/orchestrator.js"
     );
+    const result = await computeRoundResult(store, "power", 5, 3);
     expect(result.outcome).toBe("winPlayer");
     expect(updateScore).toHaveBeenCalledWith(1, 0);
     expect(dispatchBattleEvent).toHaveBeenCalledWith("outcome=winPlayer");
@@ -108,11 +108,11 @@ describe.sequential("classicBattle round resolver once", () => {
       opponentScore: 2,
       outcome: "draw"
     });
-    const result = await computeRoundResult(store, "power", 4, 4);
     const { updateScore } = await import("../../../src/helpers/setupScoreboard.js");
     const { dispatchBattleEvent } = await import(
       "../../../src/helpers/classicBattle/orchestrator.js"
     );
+    const result = await computeRoundResult(store, "power", 4, 4);
     expect(result.outcome).toBe("draw");
     expect(updateScore).toHaveBeenLastCalledWith(2, 2);
     expect(dispatchBattleEvent).toHaveBeenCalledWith("outcome=draw");


### PR DESCRIPTION
## Summary
- fix test mocks by importing score and event helpers before round resolution
- update debug log to reference evaluateOutcome

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: countdown timing and screenshot specs)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bdc47f20dc8326b1a90f0f6e48fe17