### PR TITLE
Refactor battle CLI state handling

### DIFF
--- a/docs/battleCLI.md
+++ b/docs/battleCLI.md
@@ -17,3 +17,11 @@ import { battleCLI, onKeyDown } from "src/pages/index.js";
 - The `battleCLI` export exposes test helpers and utilities such as `renderStatList`.
 - `getEscapeHandledPromise` resolves after Escape key processing, simplifying async tests.
 - Background clicks advance from **round over** or **cooldown** states; clicks on stat rows are ignored.
+
+## Battle state transitions
+
+`handleBattleState` orchestrates UI changes when the battle machine moves between states. It delegates to helpers:
+
+- `updateUiForState(state)` synchronizes badges, countdowns, and prompts.
+- `ensureNextRoundButton()` inserts a Next button during `roundOver` when auto continue is off.
+- `logStateChange(from, to)` appends timestamped lines to the verbose log when verbose mode is enabled.

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -296,6 +296,29 @@ describe("battleCLI event handlers", () => {
     expect(secondBtn).not.toBe(firstBtn);
   });
 
+  it("creates next-round button when round over", async () => {
+    const { handlers, setAutoContinue } = await setupHandlers();
+    setAutoContinue(false);
+    handlers.handleBattleState({ detail: { from: "x", to: "roundOver" } });
+    expect(document.getElementById("next-round-button")).toBeTruthy();
+  });
+
+  it("logs state changes based on verbose flag", async () => {
+    const { handlers } = await setupHandlers();
+    const pre = document.getElementById("cli-verbose-log");
+    const spy = vi.spyOn(console, "info").mockImplementation(() => {});
+    handlers.setVerboseEnabled(false);
+    handlers.handleBattleState({ detail: { from: "a", to: "b" } });
+    expect(pre.textContent).toBe("");
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockClear();
+    handlers.setVerboseEnabled(true);
+    handlers.handleBattleState({ detail: { from: "b", to: "c" } });
+    expect(pre.textContent).toMatch(/b -> c/);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
   it("advances round over on background click", async () => {
     const { handlers, mockDispatch } = await setupHandlers();
     document.body.dataset.battleState = "roundOver";


### PR DESCRIPTION
## Summary
- extract battle state helpers to update UI, create next round button, and log transitions
- orchestrate handleBattleState with new helpers and add test hook for verbose flag
- document CLI battle state transitions and test next button plus verbose logging

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bdd8ca21f08326b44a72fb6d619713