### PR TITLE
fix: log stat list init errors

### DIFF
--- a/src/pages/battleCLI.js
+++ b/src/pages/battleCLI.js
@@ -1069,7 +1069,11 @@ function buildStatRows(stats, judoka) {
 function renderHelpMapping(stats) {
   try {
     const help = byId("cli-help");
-    if (!help || help.childElementCount !== 0) return;
+    if (!help) {
+      console.error("renderHelpMapping: #cli-help element missing");
+      return;
+    }
+    if (help.childElementCount !== 0) return;
     const mapping = stats
       .slice()
       .sort((a, b) => (a.statIndex || 0) - (b.statIndex || 0))
@@ -1078,7 +1082,9 @@ function renderHelpMapping(stats) {
     const li = document.createElement("li");
     li.textContent = mapping;
     help.appendChild(li);
-  } catch {}
+  } catch (err) {
+    console.error("renderHelpMapping failed", err);
+  }
 }
 
 /**
@@ -1126,10 +1132,14 @@ export async function renderStatList(judoka) {
       ensureStatClickBinding(list);
       try {
         window.__battleCLIinit?.clearSkeletonStats?.();
-      } catch {}
+      } catch (err) {
+        console.error("renderStatList: failed to clear skeleton stats", err);
+      }
       renderHelpMapping(stats);
     }
-  } catch {}
+  } catch (err) {
+    console.error("renderStatList failed", err);
+  }
 }
 
 function renderHiddenPlayerStats(judoka) {


### PR DESCRIPTION
## Summary
- log missing #cli-help and rendering failures
- surface errors when clearing skeleton stats and overall stat list rendering

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: 184 missing JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: screenshot mismatch)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/pages/battleCLI.js"],
  "outputs": ["src/pages/battleCLI.js"],
  "success": [
    "prettier: PASS",
    "eslint: PASS",
    "jsdoc: FAIL (184 missing)",
    "vitest: PASS",
    "playwright: FAIL (screenshot mismatch)",
    "contrast: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `src/pages/battleCLI.js`: log help mapping and skeleton cleanup failures

## Verification Summary
- `npx prettier . --check` (PASS)
- `npx eslint .` (PASS)
- `npm run check:jsdoc` (FAIL - missing JSDoc)
- `npx vitest run` (PASS - 245 files, 916 passed, 1 skipped)
- `npx playwright test` (FAIL - screenshot mismatch)
- `npm run check:contrast` (PASS)

### Risk
Low: logs added for previously silent catch blocks.

### Follow-up
Investigate failing Playwright screenshot and missing JSDoc entries.


------
https://chatgpt.com/codex/tasks/task_e_68bdde62d0a0832685507330ff6e2aa2