### PR TITLE
feat: support headless card selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Documented that the Next button skips the inter-round cooldown even when `skipRoundCooldown` is false.
 - Added test coverage verifying manual Next clicks bypass the cooldown regardless of `skipRoundCooldown`, ensuring consistent player control when auto-skip is disabled.
+- Preserve player judoka in battle store and allow headless `generateRandomCard` calls via `skipRender` option to enable stat comparisons without a DOM.

--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -171,7 +171,8 @@ async function renderOpponentPlaceholder(container, placeholder, enableInspector
  *
  * @pseudocode
  * 1. Ensure judoka and gokyo datasets are loaded (fetch if missing).
- * 2. Filter out hidden judoka and generate a random player card.
+ * 2. Filter out hidden judoka and generate a random player card (skip
+ *    rendering when no container exists).
  * 3. Pick an opponent that doesn't match the player where possible.
  * 4. Render an opponent placeholder card with obscured stats.
  * 5. Return the selected player and opponent judoka objects.
@@ -196,6 +197,7 @@ export async function drawCards() {
   const enableInspector = isEnabled("enableCardInspector");
 
   let playerJudoka = null;
+  const skipRender = !playerContainer;
   await generateRandomCard(
     available,
     null,
@@ -204,7 +206,7 @@ export async function drawCards() {
     (j) => {
       playerJudoka = j;
     },
-    { enableInspector }
+    { enableInspector, skipRender }
   );
 
   // Pick an opponent safely; fall back to the built-in judoka when selection fails

--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -639,7 +639,8 @@ export function recordEntry() {
  * @pseudocode
  * ```
  * if no player choice → return false
- * read stat values
+ * read player stat from store or DOM
+ * read opponent stat from store or DOM
  * log debug values
  * await resolveRound
  * return true
@@ -648,9 +649,15 @@ export function recordEntry() {
 export async function resolveSelectionIfPresent(store) {
   if (!store.playerChoice) return false;
   const stat = store.playerChoice;
-  const pCard = document.getElementById("player-card");
-  const oCard = document.getElementById("opponent-card");
-  const playerVal = getStatValue(pCard, stat);
+  const pCard = typeof document !== "undefined" ? document.getElementById("player-card") : null;
+  const oCard = typeof document !== "undefined" ? document.getElementById("opponent-card") : null;
+  let playerVal = 0;
+  if (store.currentPlayerJudoka?.stats) {
+    const raw = Number(store.currentPlayerJudoka.stats[stat]);
+    playerVal = Number.isFinite(raw) ? raw : 0;
+  } else {
+    playerVal = getStatValue(pCard, stat);
+  }
   let opponentVal = 0;
   try {
     const opp = getOpponentJudoka();

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -45,7 +45,7 @@ export function isOrchestrated() {
  * 1. Initialize battle state values.
  * 2. Return the store.
  *
- * @returns {{quitModal: ReturnType<import("../../components/Modal.js").createModal>|null, statTimeoutId: ReturnType<typeof setTimeout>|null, autoSelectId: ReturnType<typeof setTimeout>|null, compareRaf: number, selectionMade: boolean, stallTimeoutMs: number, playerChoice: string|null, playerCardEl: HTMLElement|null, opponentCardEl: HTMLElement|null, statButtonEls: Record<string, HTMLButtonElement>|null}}
+ * @returns {{quitModal: ReturnType<import("../../components/Modal.js").createModal>|null, statTimeoutId: ReturnType<typeof setTimeout>|null, autoSelectId: ReturnType<typeof setTimeout>|null, compareRaf: number, selectionMade: boolean, stallTimeoutMs: number, playerChoice: string|null, playerCardEl: HTMLElement|null, opponentCardEl: HTMLElement|null, statButtonEls: Record<string, HTMLButtonElement>|null, currentPlayerJudoka: object|null}}
  */
 export function createBattleStore() {
   return {
@@ -58,7 +58,8 @@ export function createBattleStore() {
     playerChoice: null,
     playerCardEl: null,
     opponentCardEl: null,
-    statButtonEls: null
+    statButtonEls: null,
+    currentPlayerJudoka: null
   };
 }
 
@@ -168,10 +169,11 @@ export async function handleReplay(store) {
  * @pseudocode
  * 1. Clear `store.selectionMade` and `store.playerChoice`.
  * 2. Await `drawCards()` to get player and opponent cards.
- * 3. Compute `roundNumber` from the engine's rounds played count.
- * 4. If supplied, call `onRoundStart(store, roundNumber)`.
- * 5. Emit `roundStarted` with the store and round number.
- * 6. Return `{...cards, roundNumber}` to callers.
+ * 3. Store the player's judoka on `store.currentPlayerJudoka`.
+ * 4. Compute `roundNumber` from the engine's rounds played count.
+ * 5. If supplied, call `onRoundStart(store, roundNumber)`.
+ * 6. Emit `roundStarted` with the store and round number.
+ * 7. Return `{...cards, roundNumber}` to callers.
  *
  * @param {ReturnType<typeof createBattleStore>} store - Battle state store.
  * @param {(store: ReturnType<typeof createBattleStore>, roundNumber: number) => void} [onRoundStart]
@@ -181,6 +183,7 @@ export async function startRound(store, onRoundStart) {
   store.selectionMade = false;
   store.playerChoice = null;
   const cards = await drawCards();
+  store.currentPlayerJudoka = cards.playerJudoka || null;
   let roundNumber = 1;
   try {
     const fn = battleEngine.getRoundsPlayed;

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -65,6 +65,7 @@ describe.sequential("classicBattle card selection", () => {
     battleMod._resetForTest(store);
     await battleMod.startRound(store);
     const { getOpponentJudoka } = battleMod;
+    expect(store.currentPlayerJudoka).toEqual(expect.objectContaining({ id: 1 }));
     expect(mocks.JudokaCardMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 1 }),
       expect.anything(),
@@ -105,7 +106,7 @@ describe.sequential("classicBattle card selection", () => {
       expect.anything(),
       false,
       expect.any(Function),
-      { enableInspector: false }
+      { enableInspector: false, skipRender: false }
     );
     expect(getRandomJudokaMock).toHaveBeenCalledWith([
       expect.objectContaining({ id: 2, isHidden: false })

--- a/tests/helpers/classicBattle/resolveSelectionIfPresent.test.js
+++ b/tests/helpers/classicBattle/resolveSelectionIfPresent.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../../src/helpers/classicBattle/cardSelection.js", () => ({
+  getOpponentJudoka: () => ({ stats: { speed: 40 } })
+}));
+
+const getStatValue = vi.fn(() => 0);
+vi.mock("../../../src/helpers/battle/score.js", () => ({ getStatValue }));
+
+const resolveRound = vi.fn();
+vi.mock("../../../src/helpers/classicBattle/roundResolver.js", () => ({ resolveRound }));
+
+describe("resolveSelectionIfPresent", () => {
+  it("uses store judoka stats when DOM is missing", async () => {
+    const { resolveSelectionIfPresent } = await import(
+      "../../../src/helpers/classicBattle/orchestratorHandlers.js"
+    );
+    const store = {
+      playerChoice: "speed",
+      currentPlayerJudoka: { stats: { speed: 50 } }
+    };
+    const resolved = await resolveSelectionIfPresent(store);
+    expect(resolved).toBe(true);
+    expect(resolveRound).toHaveBeenCalledWith(store, "speed", 50, 40);
+    expect(getStatValue).not.toHaveBeenCalledWith(null, "speed");
+  });
+
+  it("falls back to DOM when store judoka missing", async () => {
+    getStatValue.mockReset();
+    vi.doMock("../../../src/helpers/classicBattle/cardSelection.js", () => ({
+      getOpponentJudoka: () => null
+    }));
+    vi.resetModules();
+    const { resolveSelectionIfPresent } = await import(
+      "../../../src/helpers/classicBattle/orchestratorHandlers.js"
+    );
+    const p = document.createElement("div");
+    p.id = "player-card";
+    const o = document.createElement("div");
+    o.id = "opponent-card";
+    document.body.append(p, o);
+    getStatValue.mockReturnValueOnce(10).mockReturnValueOnce(20);
+    const store = { playerChoice: "speed", currentPlayerJudoka: null };
+    await resolveSelectionIfPresent(store);
+    expect(getStatValue).toHaveBeenCalledWith(p, "speed");
+    expect(getStatValue).toHaveBeenCalledWith(o, "speed");
+    expect(resolveRound).toHaveBeenLastCalledWith(store, "speed", 10, 20);
+  });
+});

--- a/tests/helpers/randomCard.test.js
+++ b/tests/helpers/randomCard.test.js
@@ -68,6 +68,19 @@ describe("generateRandomCard", () => {
     expect(cb).toHaveBeenCalledWith(judokaData[0]);
   });
 
+  it("selects judoka when rendering is skipped", async () => {
+    const judokaData = getJudokaFixture().slice(0, 2);
+    const gokyoData = getGokyoFixture();
+    getRandomJudokaMock = vi.fn(() => judokaData[0]);
+    getFallbackJudokaMock = vi.fn(async () => ({ id: 0 }));
+    const { generateRandomCard } = await import("../../src/helpers/randomCard.js");
+    const cb = vi.fn();
+    renderMock.mockClear();
+    await generateRandomCard(judokaData, gokyoData, null, true, cb, { skipRender: true });
+    expect(cb).toHaveBeenCalledWith(judokaData[0]);
+    expect(JudokaCardMock).not.toHaveBeenCalled();
+  });
+
   it("falls back to id 0 when selection fails", async () => {
     await withMutedConsole(async () => {
       const container = document.createElement("div");


### PR DESCRIPTION
## Summary
- preserve player judoka in battle store for headless stat comparison
- allow generateRandomCard to select without rendering via `skipRender`
- add tests for headless round resolution

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx vitest run`
- `npx playwright test` *(fails: playwright/screenshot.spec.js:82:3 @battleJudoka-narrow screenshot)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bddaba24808326b8c6a13eff2b3e3c