### PR TITLE
refactor: dedupe document checks and clarify skipRender guard

### DIFF
--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -649,8 +649,9 @@ export function recordEntry() {
 export async function resolveSelectionIfPresent(store) {
   if (!store.playerChoice) return false;
   const stat = store.playerChoice;
-  const pCard = typeof document !== "undefined" ? document.getElementById("player-card") : null;
-  const oCard = typeof document !== "undefined" ? document.getElementById("opponent-card") : null;
+  const hasDocument = typeof document !== "undefined";
+  const pCard = hasDocument ? document.getElementById("player-card") : null;
+  const oCard = hasDocument ? document.getElementById("opponent-card") : null;
   let playerVal = 0;
   if (store.currentPlayerJudoka?.stats) {
     const raw = Number(store.currentPlayerJudoka.stats[stat]);

--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -93,7 +93,7 @@ export async function generateRandomCard(
   options = {}
 ) {
   const { enableInspector, skipRender = false } = options;
-  if (!containerEl && !skipRender) return;
+  if (!skipRender && !containerEl) return;
 
   let gokyoLookup = {};
   try {


### PR DESCRIPTION
## Summary
- avoid repeating `typeof document !== "undefined"` in stat resolution
- make `skipRender` guard easier to read in `generateRandomCard`

## Testing
- `npx prettier . --check` *(fails: Code style issues found in tests/pages/battleCLI.onKeyDown.test.js)*
- `npx eslint .` *(fails: prettier errors in tests/pages/battleCLI.onKeyDown.test.js)*
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx vitest run` *(interrupted: partial results logged)*
- `npx playwright test` *(fails: 1 failed, 2 interrupted)*
- `npm run check:contrast`



------
https://chatgpt.com/codex/tasks/task_e_68bde48fb528832692f3f21f14cff5ba