### PR TITLE
refactor: clarify round select modal helpers

### DIFF
--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -27,7 +27,12 @@ export function shouldAutostart() {
   return false;
 }
 
-function persistRoundSelection(value) {
+/**
+ * Persist round selection and log the event.
+ *
+ * @param {number} value - Points needed to win the round.
+ */
+function persistRoundAndLog(value) {
   try {
     wrap(BATTLE_POINTS_TO_WIN).set(value);
   } catch {}
@@ -50,7 +55,7 @@ async function startRound(value, onStart, emitEvents) {
 }
 
 async function handleRoundSelect({ value, modal, cleanupTooltips, onStart, emitEvents }) {
-  persistRoundSelection(value);
+  persistRoundAndLog(value);
   modal.close();
   try {
     cleanupTooltips();
@@ -112,7 +117,7 @@ export async function initRoundSelectModal(onStart) {
       handleRoundSelect({
         value: r.value,
         modal,
-        cleanupTooltips: () => cleanupTooltips(),
+        cleanupTooltips,
         onStart,
         emitEvents: true
       })


### PR DESCRIPTION
## Summary
- rename `persistRoundSelection` to `persistRoundAndLog`
- pass `cleanupTooltips` directly to remove unnecessary wrapper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Total missing: 185)*
- `npx vitest run` *(fails: 1 failed, 923 passed, 1 skipped)*
- `npx playwright test` *(fails: 2 failed, 98 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bdec07e1d483268a3720db84428980