### PR TITLE
test: document headless timing helper

### DIFF
--- a/tests/helpers/headlessMode.timing.test.js
+++ b/tests/helpers/headlessMode.timing.test.js
@@ -1,9 +1,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+const MULTIPLIER = 10000;
+const BASE_DELAY = 300;
+const DELAY_RANGE = 401;
+
+/**
+ * Computes deterministic reveal delay when test mode is seeded.
+ *
+ * @pseudocode
+ * 1. Multiply Math.sin(1) by MULTIPLIER to create a value with a stable fractional part.
+ * 2. Extract the fractional component from the result.
+ * 3. Scale the fraction by DELAY_RANGE and floor it to get an offset.
+ * 4. Add BASE_DELAY to obtain the expected delay in milliseconds.
+ *
+ * @returns {number} expected delay in milliseconds
+ */
 const computeExpectedDelay = () => {
-  const x = Math.sin(1) * 10000;
+  const x = Math.sin(1) * MULTIPLIER;
   const frac = x - Math.floor(x);
-  return 300 + Math.floor(frac * 401);
+  return BASE_DELAY + Math.floor(frac * DELAY_RANGE);
 };
 
 describe("headless mode timing", () => {


### PR DESCRIPTION
## Summary
- extract delay constants for computeExpectedDelay
- add JSDoc with @pseudocode to document deterministic delay helper

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: Total missing: 185)*
- `npx vitest run` *(fails: tests/pages/battleCLI.onKeyDown.test.js)*
- `npx playwright test` *(fails: playwright/battle-cli.spec.js, playwright/screenshot.spec.js)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["tests/helpers/headlessMode.timing.test.js"],
  "outputs": ["tests/helpers/headlessMode.timing.test.js"],
  "success": ["prettier: PASS", "eslint: PASS", "jsdoc: FAIL", "vitest: 246 passed, 1 failed", "playwright: 98 passed, 2 failed", "contrast: PASS"],
  "errorMode": "ask_on_public_api_change"
}
```

## Files
- `tests/helpers/headlessMode.timing.test.js`: clarify delay calculation and document helper

## Verification
- `npx prettier . --check`: pass
- `npx eslint .`: pass
- `npm run check:jsdoc`: **fail** (Total missing: 185)
- `npx vitest run`: **fail** (tests/pages/battleCLI.onKeyDown.test.js)
- `npx playwright test`: **fail** (playwright/battle-cli.spec.js, playwright/screenshot.spec.js)
- `npm run check:contrast`: pass

## Risk
Low; test-only constants and comments.

## Follow-up
Resolve outstanding vitest/playwright failures and missing JSDoc.


------
https://chatgpt.com/codex/tasks/task_e_68bdf3a32a688326930cfad78df790a4