### PR TITLE
Ensure stat list arrow key test sets tabIndex

### DIFF
--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -105,6 +105,7 @@ describe("battleCLI onKeyDown", () => {
     const li = document.createElement("li");
     list.appendChild(li);
     document.getElementById("cli-main").appendChild(list);
+    li.tabIndex = -1;
     li.focus();
     const battleHandlers = await import("../../src/pages/battleCLI/battleHandlers.js");
     const spy = vi.spyOn(battleHandlers, "handleStatListArrowKey");


### PR DESCRIPTION
## Summary
- fix battle CLI arrow key navigation test by setting `tabIndex` before calling `focus`

## Testing
- `npx prettier . --check` *(fails: command not found)*
- `npx eslint .` *(fails: command not found)*
- `npm run check:jsdoc` *(fails: command not found)*
- `npx vitest run` *(fails: command not found)*
- `npx playwright test` *(fails: command not found)*
- `npm run check:contrast` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf37138d48326a2be76931a8a2739