### PR TITLE
refactor: modularize embeddings loader

### DIFF
--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -267,6 +267,7 @@ export async function handleStatSelection(store, stat, { playerVal, opponentVal,
   // avoid resolving locally to prevent duplicate dispatches.
   try {
     // If the machine cleared the player's choice, it took over resolution.
+    // eslint-disable-next-line eqeqeq
     if (store.playerChoice == null) {
       return;
     }

--- a/src/helpers/vectorSearch/loader.js
+++ b/src/helpers/vectorSearch/loader.js
@@ -21,76 +21,118 @@ let cachedEmbeddings;
 export const CURRENT_EMBEDDING_VERSION = 1;
 
 /**
- * Load vector embeddings from `client_embeddings.json`.
+ * Load embeddings from the compact offline dataset.
  *
  * @pseudocode
- * 1. Return cached embeddings when available.
- * 2. Otherwise load via manifest + shards (`client_embeddings.manifest.json`).
- *    - On any failure (manifest or shard), log the error and resolve to `null`.
- * 3. Await the promise, store the result, and return it.
+ * 1. Skip when not running under Node or when `RAG_FORCE_JSON` is set.
+ * 2. Read metadata and vector files from the data directory.
+ * 3. Construct embedding objects by combining metadata with vectors.
+ * 4. Return the array on success or `null` on failure.
  *
- * @returns {Promise<Array<{id:string,text:string,embedding:number[],source:string,tags?:string[],qaContext?:string}>>} Parsed embeddings array.
+ * @returns {Promise<Array<{id:string,text:string,embedding:number[],source:string,tags?:string[],qaContext?:string}>|null>} Parsed embeddings or `null`.
+ */
+export async function loadOfflineEmbeddings() {
+  if (!isNodeEnvironment() || process?.env?.RAG_FORCE_JSON) return null;
+  try {
+    const metaUrl = new URL(`${DATA_DIR}offline_rag_metadata.json`);
+    const vecUrl = new URL(`${DATA_DIR}offline_rag_vectors.bin`);
+    const { fileURLToPath } = await import("node:url");
+    const { readFile } = await import("node:fs/promises");
+    const metaPath = fileURLToPath(metaUrl);
+    const vecPath = fileURLToPath(vecUrl);
+
+    const metaRaw = await readFile(metaPath, "utf8");
+    const { vectorLength, items } = JSON.parse(metaRaw);
+    if (!vectorLength || !Array.isArray(items)) throw new Error("Invalid offline metadata");
+
+    const buffer = await readFile(vecPath);
+    const out = new Array(items.length);
+    for (let i = 0; i < items.length; i++) {
+      const offset = i * vectorLength;
+      const view = new Int8Array(buffer.buffer, buffer.byteOffset + offset, vectorLength);
+      out[i] = { ...items[i], embedding: Array.from(view) };
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load embeddings from a single JSON file.
+ *
+ * @pseudocode
+ * 1. Skip when `window` is undefined.
+ * 2. Fetch `client_embeddings.json`.
+ * 3. Return the array when valid; otherwise `null`.
+ *
+ * @returns {Promise<Array<{id:string,text:string,embedding:number[],source:string,tags?:string[],qaContext?:string}>|null>} Parsed embeddings or `null`.
+ */
+export async function loadSingleFileEmbeddings() {
+  if (typeof window === "undefined") return null;
+  try {
+    const single = await fetchJson(`${DATA_DIR}client_embeddings.json`);
+    return Array.isArray(single) ? single : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load embeddings using a manifest and shard files.
+ *
+ * @pseudocode
+ * 1. Fetch `client_embeddings.manifest.json`.
+ * 2. Fetch each shard listed in the manifest.
+ * 3. Flatten shards into a single array.
+ * 4. Return the array or `null` on failure.
+ *
+ * @returns {Promise<Array<{id:string,text:string,embedding:number[],source:string,tags?:string[],qaContext?:string}>|null>} Parsed embeddings or `null`.
+ */
+export async function loadManifestEmbeddings() {
+  try {
+    const manifest = await fetchJson(`${DATA_DIR}client_embeddings.manifest.json`);
+    const shardPromises = (manifest?.shards ?? []).map((shardFile) =>
+      fetchJson(`${DATA_DIR}${shardFile}`)
+    );
+    const shards = await Promise.all(shardPromises);
+    return shards.flat();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load vector embeddings from available sources.
+ *
+ * @pseudocode
+ * 1. Return cached embeddings when already loaded.
+ * 2. Sequentially attempt offline, single-file, and manifest loaders.
+ * 3. Cache and return the first successful result or `null` on total failure.
+ *
+ * @returns {Promise<Array<{id:string,text:string,embedding:number[],source:string,tags?:string[],qaContext?:string}>|null>} Parsed embeddings array.
  */
 export async function loadEmbeddings() {
   if (cachedEmbeddings !== undefined) return cachedEmbeddings;
   if (!embeddingsPromise) {
     embeddingsPromise = (async () => {
-      try {
-        // Prefer the compact offline index in Node (binary vectors + JSON metadata),
-        // unless tests explicitly force JSON via RAG_FORCE_JSON env flag.
-        if (isNodeEnvironment() && !process?.env?.RAG_FORCE_JSON) {
-          try {
-            const metaUrl = new URL(`${DATA_DIR}offline_rag_metadata.json`);
-            const vecUrl = new URL(`${DATA_DIR}offline_rag_vectors.bin`);
-            const { fileURLToPath } = await import("node:url");
-            const { readFile } = await import("node:fs/promises");
-            const metaPath = fileURLToPath(metaUrl);
-            const vecPath = fileURLToPath(vecUrl);
-
-            const metaRaw = await readFile(metaPath, "utf8");
-            const { vectorLength, items } = JSON.parse(metaRaw);
-            if (!vectorLength || !Array.isArray(items)) throw new Error("Invalid offline metadata");
-
-            const buffer = await readFile(vecPath);
-            const out = new Array(items.length);
-            for (let i = 0; i < items.length; i++) {
-              const offset = i * vectorLength;
-              // Create a signed view over the Buffer's underlying ArrayBuffer
-              const view = new Int8Array(buffer.buffer, buffer.byteOffset + offset, vectorLength);
-              out[i] = { ...items[i], embedding: Array.from(view) };
-            }
-            return out;
-          } catch {
-            // Fall back to JSON manifest path if offline assets are missing
-          }
+      let lastError;
+      const loaders = [
+        loadOfflineEmbeddings,
+        loadSingleFileEmbeddings,
+        loadManifestEmbeddings,
+        loadSingleFileEmbeddings
+      ];
+      for (const loader of loaders) {
+        try {
+          const result = await loader();
+          if (result) return result;
+        } catch (err) {
+          lastError = err;
         }
-        // In browser contexts, allow a lightweight single-file override used by tests
-        if (typeof window !== "undefined") {
-          try {
-            const single = await fetchJson(`${DATA_DIR}client_embeddings.json`);
-            if (Array.isArray(single)) return single;
-          } catch {}
-        }
-        // Load via manifest + shards
-        const manifest = await fetchJson(`${DATA_DIR}client_embeddings.manifest.json`);
-        const shardPromises = (manifest?.shards ?? []).map((shardFile) =>
-          fetchJson(`${DATA_DIR}${shardFile}`)
-        );
-        const shards = await Promise.all(shardPromises);
-        return shards.flat();
-      } catch (err) {
-        // Final fallback in browser: legacy single-file
-        if (typeof window !== "undefined") {
-          try {
-            return await fetchJson(`${DATA_DIR}client_embeddings.json`);
-          } catch (legacyError) {
-            console.error("Failed to load embeddings:", err, legacyError);
-            return null;
-          }
-        }
-        console.error("Failed to load embeddings:", err);
-        return null;
       }
+      console.error("Failed to load embeddings:", lastError);
+      return null;
     })();
   }
   cachedEmbeddings = await embeddingsPromise;

--- a/tests/helpers/vectorSearch/loaderPaths.test.js
+++ b/tests/helpers/vectorSearch/loaderPaths.test.js
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { sample, setupMockDataset } from "./mockDataset.js";
+
+vi.mock("../../../src/helpers/dataUtils.js", () => ({
+  fetchJson: vi.fn(),
+  validateWithSchema: vi.fn().mockResolvedValue(undefined)
+}));
+
+const fetchJsonMock = () => import("../../../src/helpers/dataUtils.js").then((m) => m.fetchJson);
+
+beforeEach(() => {
+  vi.resetModules();
+  delete global.window;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  delete process.env.RAG_FORCE_JSON;
+  delete global.window;
+  vi.unmock("../../../src/helpers/constants.js");
+});
+
+describe("loader environment paths", () => {
+  it("loads offline embeddings when available", async () => {
+    const meta = { vectorLength: 2, items: [{ id: "a", text: "A", source: "doc1" }] };
+    const vectors = Buffer.from([1, 0]);
+    const { mkdtempSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "emb-"));
+    writeFileSync(join(dir, "offline_rag_metadata.json"), JSON.stringify(meta));
+    writeFileSync(join(dir, "offline_rag_vectors.bin"), vectors);
+    vi.doMock("../../../src/helpers/constants.js", () => ({
+      DATA_DIR: new URL(`file://${dir}/`).href
+    }));
+    const { loadOfflineEmbeddings } = await import("../../../src/helpers/vectorSearch/loader.js");
+    const result = await loadOfflineEmbeddings();
+    expect(result).toEqual([{ id: "a", text: "A", source: "doc1", embedding: [1, 0] }]);
+  });
+
+  it("uses single-file override in browser", async () => {
+    process.env.RAG_FORCE_JSON = "1";
+    global.window = {};
+    const fetch = await fetchJsonMock();
+    fetch.mockResolvedValue(sample);
+    const { loadEmbeddings } = await import("../../../src/helpers/vectorSearch/loader.js");
+    const result = await loadEmbeddings();
+    expect(result).toEqual(sample);
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("client_embeddings.json"));
+  });
+
+  it("falls back to manifest shards", async () => {
+    process.env.RAG_FORCE_JSON = "1";
+    const fetch = await setupMockDataset(sample);
+    const { loadEmbeddings } = await import("../../../src/helpers/vectorSearch/loader.js");
+    const result = await loadEmbeddings();
+    expect(result).toEqual(sample);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -25,7 +25,7 @@ vi.mock("../src/helpers/classicBattle/orchestrator.js", async (importOriginal) =
         return Promise.resolve(true);
       }
       return mod.dispatchBattleEvent(eventName);
-    }),
+    })
   };
 });
 
@@ -86,7 +86,7 @@ afterEach(() => {
 // Simulate URL changes by updating history without performing a real navigation.
 beforeEach(async () => {
   // Mute noisy console methods by default; tests can opt-in to logging
-// muteConsole(["warn", "error", "debug", "log"]);
+  // muteConsole(["warn", "error", "debug", "log"]);
   try {
     // Ensure snackbars are enabled for tests by default
     if (typeof window !== "undefined" && window.__disableSnackbars) {


### PR DESCRIPTION
## Summary
- factor embedding loading into offline, single-file, and manifest helpers used in sequence
- cover loader paths with targeted tests for node, browser, and manifest environments
- silence eqeqeq warning in selection handler and format test setup

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run tests/helpers/vectorSearch/loaderPaths.test.js tests/helpers/vectorSearch.loader.test.js`
- `npx playwright test` *(fails: 2)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bec8341cd48326b3dcb5b85710e959