### PR TITLE
refactor random card helpers

### DIFF
--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -105,9 +105,10 @@ export async function pickJudoka(activeCards, onSelect) {
  * Renders a card for the specified judoka and appends it to the container.
  *
  * @pseudocode
- * 1. Build a `JudokaCard` for `judoka`.
- * 2. When rendering succeeds, display the card.
- * 3. Log and ignore any rendering errors.
+ * 1. Ensure `containerEl` exists; throw if missing.
+ * 2. Build a `JudokaCard` for `judoka`.
+ * 3. When rendering succeeds, display the card.
+ * 4. Log and ignore any rendering errors.
  *
  * @param {Judoka} judoka - Judoka data used to build the card.
  * @param {Object<string, GokyoEntry>} gokyoLookup - Lookup of gokyo moves.
@@ -123,7 +124,9 @@ export async function renderJudokaCard(
   prefersReducedMotion,
   enableInspector
 ) {
-  if (!containerEl) return;
+  if (!containerEl) {
+    throw new Error("renderJudokaCard: containerEl is required but was not provided.");
+  }
   try {
     const card = await new JudokaCard(judoka, gokyoLookup, { enableInspector }).render();
     if (card) {
@@ -176,12 +179,6 @@ export async function generateRandomCard(
   const judoka = await pickJudoka(activeCards, onSelect);
 
   if (!skipRender && containerEl) {
-    await renderJudokaCard(
-      judoka,
-      gokyoLookup,
-      containerEl,
-      prefersReducedMotion,
-      enableInspector
-    );
+    await renderJudokaCard(judoka, gokyoLookup, containerEl, prefersReducedMotion, enableInspector);
   }
 }

--- a/tests/helpers/randomCard.test.js
+++ b/tests/helpers/randomCard.test.js
@@ -65,9 +65,7 @@ describe("loadGokyoLookup", () => {
       const result = await loadGokyoLookup();
 
       expect(fetchJsonMock).toHaveBeenCalled();
-      expect(createGokyoLookupMock).toHaveBeenCalledWith([
-        { id: 0, name: "Jigoku-guruma" }
-      ]);
+      expect(createGokyoLookupMock).toHaveBeenCalledWith([{ id: 0, name: "Jigoku-guruma" }]);
       expect(showSnackbarMock).toHaveBeenCalled();
       expect(result).toBe(lookup);
     });
@@ -134,6 +132,18 @@ describe("renderJudokaCard", () => {
 
       expect(container.childNodes.length).toBe(0);
     });
+  });
+
+  it("throws when container element is missing", async () => {
+    renderMock.mockClear();
+    const { renderJudokaCard } = await import("../../src/helpers/randomCard.js");
+    await expect(renderJudokaCard({ id: 1 }, {}, null, true)).rejects.toThrow(
+      "renderJudokaCard: containerEl is required but was not provided."
+    );
+    await expect(renderJudokaCard({ id: 1 }, {}, undefined, true)).rejects.toThrow(
+      "renderJudokaCard: containerEl is required but was not provided."
+    );
+    expect(JudokaCardMock).not.toHaveBeenCalled();
   });
 });
 
@@ -293,4 +303,3 @@ describe("generateRandomCard", () => {
     expect(container.childNodes.length).toBe(0);
   });
 });
-


### PR DESCRIPTION
## Summary
- throw descriptive error when `renderJudokaCard` is called without a container
- add unit tests for missing-container path

## Testing
- ✅ `npx prettier . --check`
- ✅ `npx eslint .`
- ❌ `npm run check:jsdoc` (148 functions missing or incomplete JSDoc)
- ✅ `npx vitest run`
- ❌ `npx playwright test` (2 failed)
- ✅ `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/helpers/randomCard.js", "tests/helpers/randomCard.test.js"],
  "outputs": ["src/helpers/randomCard.js", "tests/helpers/randomCard.test.js"],
  "success": [
    "npx prettier . --check",
    "npx eslint .",
    "npm run check:jsdoc",
    "npx vitest run",
    "npx playwright test",
    "npm run check:contrast"
  ],
  "errorMode": "throw"
}
```

## Files Changed
- `src/helpers/randomCard.js`: enforce container presence and throw descriptive error
- `tests/helpers/randomCard.test.js`: cover missing-container edge case

## Verification Summary
- `npx prettier . --check`: PASS
- `npx eslint .`: WARN (0 errors)
- `npm run check:jsdoc`: FAIL (148 functions missing JSDoc)
- `npx vitest run`: PASS (923 passed)
- `npx playwright test`: FAIL (2 failed)
- `npm run check:contrast`: PASS

## Risks & Mitigations
- Throwing an error may surface callers lacking a container; ensure call sites supply an element.
- Follow up to address failing Playwright tests and missing JSDoc coverage.


------
https://chatgpt.com/codex/tasks/task_e_68bf5147ec808326b51ee619cb763b02