### PR TITLE
feat: add vector search loader helpers

### DIFF
--- a/src/helpers/randomCard.js
+++ b/src/helpers/randomCard.js
@@ -176,12 +176,6 @@ export async function generateRandomCard(
   const judoka = await pickJudoka(activeCards, onSelect);
 
   if (!skipRender && containerEl) {
-    await renderJudokaCard(
-      judoka,
-      gokyoLookup,
-      containerEl,
-      prefersReducedMotion,
-      enableInspector
-    );
+    await renderJudokaCard(judoka, gokyoLookup, containerEl, prefersReducedMotion, enableInspector);
   }
 }

--- a/src/helpers/vectorSearch/loader.js
+++ b/src/helpers/vectorSearch/loader.js
@@ -21,76 +21,110 @@ let cachedEmbeddings;
 export const CURRENT_EMBEDDING_VERSION = 1;
 
 /**
- * Load vector embeddings from `client_embeddings.json`.
+ * Attempt to load compact offline embeddings in Node.
+ *
+ * @pseudocode
+ * 1. Exit early when not in Node or when `RAG_FORCE_JSON` is set.
+ * 2. Read metadata and vector binary files.
+ * 3. For each item, slice the buffer and attach the embedding array.
+ * 4. Return the assembled embeddings array; on error, return `null`.
+ *
+ * @returns {Promise<Array|Null>} Embeddings array on success, otherwise `null`.
+ */
+export async function loadOfflineEmbeddings() {
+  if (!isNodeEnvironment() || process?.env?.RAG_FORCE_JSON) return null;
+  try {
+    const metaUrl = new URL(`${DATA_DIR}offline_rag_metadata.json`);
+    const vecUrl = new URL(`${DATA_DIR}offline_rag_vectors.bin`);
+    const { fileURLToPath } = await import("node:url");
+    const { readFile } = await import("node:fs/promises");
+    const metaRaw = await readFile(fileURLToPath(metaUrl), "utf8");
+    const { vectorLength, items } = JSON.parse(metaRaw);
+    if (!vectorLength || !Array.isArray(items)) return null;
+    const buffer = await readFile(fileURLToPath(vecUrl));
+    const out = new Array(items.length);
+    for (let i = 0; i < items.length; i++) {
+      const offset = i * vectorLength;
+      const view = new Int8Array(buffer.buffer, buffer.byteOffset + offset, vectorLength);
+      out[i] = { ...items[i], embedding: Array.from(view) };
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load single-file embeddings used in browser tests.
+ *
+ * @pseudocode
+ * 1. Skip when `window` is undefined.
+ * 2. Fetch `client_embeddings.json` via `fetchJson`.
+ * 3. Return the array when valid; otherwise return `null`.
+ *
+ * @returns {Promise<Array|Null>} Parsed embeddings or `null`.
+ */
+export async function loadSingleFileEmbeddings() {
+  if (typeof window === "undefined") return null;
+  try {
+    const single = await fetchJson(`${DATA_DIR}client_embeddings.json`);
+    return Array.isArray(single) ? single : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load embeddings via manifest + shards.
+ *
+ * @pseudocode
+ * 1. Fetch the manifest and derive shard URLs.
+ * 2. Fetch all shard files in parallel.
+ * 3. Flatten the shard arrays and return them.
+ * 4. On any error, return `null`.
+ *
+ * @returns {Promise<Array|Null>} Combined shard embeddings or `null`.
+ */
+export async function loadManifestEmbeddings() {
+  try {
+    const manifest = await fetchJson(`${DATA_DIR}client_embeddings.manifest.json`);
+    const shardPromises = (manifest?.shards ?? []).map((shardFile) =>
+      fetchJson(`${DATA_DIR}${shardFile}`)
+    );
+    const shards = await Promise.all(shardPromises);
+    return shards.flat();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load vector embeddings from multiple sources.
  *
  * @pseudocode
  * 1. Return cached embeddings when available.
- * 2. Otherwise load via manifest + shards (`client_embeddings.manifest.json`).
- *    - On any failure (manifest or shard), log the error and resolve to `null`.
- * 3. Await the promise, store the result, and return it.
+ * 2. Sequentially try `loadOfflineEmbeddings`, `loadSingleFileEmbeddings`, and `loadManifestEmbeddings`.
+ * 3. Cache and return the first successful result.
+ * 4. When all loaders fail, log an error and return `null`.
  *
- * @returns {Promise<Array<{id:string,text:string,embedding:number[],source:string,tags?:string[],qaContext?:string}>>} Parsed embeddings array.
+ * @returns {Promise<Array<{id:string,text:string,embedding:number[],source:string,tags?:string[],qaContext?:string}>>|null} Parsed embeddings array or `null`.
  */
 export async function loadEmbeddings() {
   if (cachedEmbeddings !== undefined) return cachedEmbeddings;
   if (!embeddingsPromise) {
     embeddingsPromise = (async () => {
-      try {
-        // Prefer the compact offline index in Node (binary vectors + JSON metadata),
-        // unless tests explicitly force JSON via RAG_FORCE_JSON env flag.
-        if (isNodeEnvironment() && !process?.env?.RAG_FORCE_JSON) {
-          try {
-            const metaUrl = new URL(`${DATA_DIR}offline_rag_metadata.json`);
-            const vecUrl = new URL(`${DATA_DIR}offline_rag_vectors.bin`);
-            const { fileURLToPath } = await import("node:url");
-            const { readFile } = await import("node:fs/promises");
-            const metaPath = fileURLToPath(metaUrl);
-            const vecPath = fileURLToPath(vecUrl);
-
-            const metaRaw = await readFile(metaPath, "utf8");
-            const { vectorLength, items } = JSON.parse(metaRaw);
-            if (!vectorLength || !Array.isArray(items)) throw new Error("Invalid offline metadata");
-
-            const buffer = await readFile(vecPath);
-            const out = new Array(items.length);
-            for (let i = 0; i < items.length; i++) {
-              const offset = i * vectorLength;
-              // Create a signed view over the Buffer's underlying ArrayBuffer
-              const view = new Int8Array(buffer.buffer, buffer.byteOffset + offset, vectorLength);
-              out[i] = { ...items[i], embedding: Array.from(view) };
-            }
-            return out;
-          } catch {
-            // Fall back to JSON manifest path if offline assets are missing
-          }
+      const loaders = [loadOfflineEmbeddings, loadSingleFileEmbeddings, loadManifestEmbeddings];
+      const errors = [];
+      for (const fn of loaders) {
+        try {
+          const result = await fn();
+          if (result) return result;
+        } catch (err) {
+          errors.push(err);
         }
-        // In browser contexts, allow a lightweight single-file override used by tests
-        if (typeof window !== "undefined") {
-          try {
-            const single = await fetchJson(`${DATA_DIR}client_embeddings.json`);
-            if (Array.isArray(single)) return single;
-          } catch {}
-        }
-        // Load via manifest + shards
-        const manifest = await fetchJson(`${DATA_DIR}client_embeddings.manifest.json`);
-        const shardPromises = (manifest?.shards ?? []).map((shardFile) =>
-          fetchJson(`${DATA_DIR}${shardFile}`)
-        );
-        const shards = await Promise.all(shardPromises);
-        return shards.flat();
-      } catch (err) {
-        // Final fallback in browser: legacy single-file
-        if (typeof window !== "undefined") {
-          try {
-            return await fetchJson(`${DATA_DIR}client_embeddings.json`);
-          } catch (legacyError) {
-            console.error("Failed to load embeddings:", err, legacyError);
-            return null;
-          }
-        }
-        console.error("Failed to load embeddings:", err);
-        return null;
       }
+      if (errors.length) console.error("Failed to load embeddings:", ...errors);
+      return null;
     })();
   }
   cachedEmbeddings = await embeddingsPromise;

--- a/tests/helpers/randomCard.test.js
+++ b/tests/helpers/randomCard.test.js
@@ -65,9 +65,7 @@ describe("loadGokyoLookup", () => {
       const result = await loadGokyoLookup();
 
       expect(fetchJsonMock).toHaveBeenCalled();
-      expect(createGokyoLookupMock).toHaveBeenCalledWith([
-        { id: 0, name: "Jigoku-guruma" }
-      ]);
+      expect(createGokyoLookupMock).toHaveBeenCalledWith([{ id: 0, name: "Jigoku-guruma" }]);
       expect(showSnackbarMock).toHaveBeenCalled();
       expect(result).toBe(lookup);
     });
@@ -293,4 +291,3 @@ describe("generateRandomCard", () => {
     expect(container.childNodes.length).toBe(0);
   });
 });
-

--- a/tests/helpers/vectorSearch/loader.test.js
+++ b/tests/helpers/vectorSearch/loader.test.js
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { sample, setupMockDataset } from "./mockDataset.js";
+
+vi.mock("../../../src/helpers/dataUtils.js", () => ({
+  fetchJson: vi.fn(),
+  validateWithSchema: vi.fn()
+}));
+
+describe("vectorSearch loader helpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete global.window;
+    vi.clearAllMocks();
+  });
+
+  it("loads offline embeddings", async () => {
+    vi.doMock("node:url", () => ({ fileURLToPath: (u) => u }));
+    vi.doMock("node:fs/promises", () => ({ readFile: vi.fn() }));
+    const meta = {
+      vectorLength: 2,
+      items: sample.map(({ id, text, source, tags }) => ({ id, text, source, tags }))
+    };
+    const vec = Buffer.from(sample.flatMap((s) => s.embedding));
+    const { readFile } = await import("node:fs/promises");
+    readFile.mockImplementation((path) => {
+      if (String(path).includes("offline_rag_metadata.json")) {
+        return Promise.resolve(JSON.stringify(meta));
+      }
+      return Promise.resolve(Buffer.from(vec));
+    });
+    const { loadOfflineEmbeddings } = await import("../../../src/helpers/vectorSearch/loader.js");
+    const result = await loadOfflineEmbeddings();
+    expect(result).toEqual(sample);
+    expect(readFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("loads single-file embeddings in browser", async () => {
+    const { fetchJson } = await import("../../../src/helpers/dataUtils.js");
+    fetchJson.mockResolvedValue(sample);
+    global.window = {};
+    const { loadSingleFileEmbeddings } = await import(
+      "../../../src/helpers/vectorSearch/loader.js"
+    );
+    const result = await loadSingleFileEmbeddings();
+    expect(result).toEqual(sample);
+  });
+
+  it("returns null when single-file fetch fails", async () => {
+    const { fetchJson } = await import("../../../src/helpers/dataUtils.js");
+    fetchJson.mockRejectedValue(new Error("fail"));
+    global.window = {};
+    const { loadSingleFileEmbeddings } = await import(
+      "../../../src/helpers/vectorSearch/loader.js"
+    );
+    const result = await loadSingleFileEmbeddings();
+    expect(result).toBeNull();
+  });
+
+  it("loads embeddings via manifest and shards", async () => {
+    const fetchJsonMock = await setupMockDataset();
+    const { loadManifestEmbeddings } = await import("../../../src/helpers/vectorSearch/loader.js");
+    const result = await loadManifestEmbeddings();
+    expect(result).toEqual(sample);
+    expect(fetchJsonMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null when manifest fetch fails", async () => {
+    const { fetchJson } = await import("../../../src/helpers/dataUtils.js");
+    fetchJson.mockRejectedValue(new Error("fail"));
+    const { loadManifestEmbeddings } = await import("../../../src/helpers/vectorSearch/loader.js");
+    const result = await loadManifestEmbeddings();
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- refactor vector search loader into discrete helpers for offline, single-file, and manifest loading
- test loader helpers across offline, browser, and manifest scenarios
- format randomCard sources to satisfy prettier

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bf52c50e108326b95b3ed39314aa74