### PR TITLE
refactor tooltip helpers and tests

### DIFF
--- a/src/helpers/tooltip.js
+++ b/src/helpers/tooltip.js
@@ -220,6 +220,7 @@ export function positionTooltip(tip, target) {
   if (left + tip.offsetWidth > viewportWidth) {
     left = viewportWidth - tip.offsetWidth;
   }
+  left = Math.max(0, left);
   tip.style.top = `${top}px`;
   tip.style.left = `${left}px`;
 }

--- a/tests/helpers/tooltip.test.js
+++ b/tests/helpers/tooltip.test.js
@@ -163,6 +163,43 @@ describe("initTooltips", () => {
     });
   });
 
+  it("clamps left to zero when tip wider than viewport", async () => {
+    vi.doMock("../../src/helpers/dataUtils.js", () => ({
+      fetchJson: vi.fn().mockResolvedValue({ stat: { fix: "text" } })
+    }));
+
+    const { initTooltips } = await import("../../src/helpers/tooltip.js");
+
+    const el = document.createElement("div");
+    el.dataset.tooltipId = "stat.fix";
+    document.body.appendChild(el);
+
+    await initTooltips();
+
+    const tip = document.querySelector(".tooltip");
+    Object.defineProperty(tip, "offsetWidth", { value: 150 });
+    const originalWidth = document.documentElement.clientWidth;
+    Object.defineProperty(document.documentElement, "clientWidth", {
+      value: 100,
+      configurable: true
+    });
+    el.getBoundingClientRect = () => ({
+      bottom: 10,
+      left: 0,
+      width: 10,
+      height: 10
+    });
+
+    el.dispatchEvent(new Event("mouseover"));
+
+    expect(tip.style.left).toBe("0px");
+
+    Object.defineProperty(document.documentElement, "clientWidth", {
+      value: originalWidth,
+      configurable: true
+    });
+  });
+
   it("loads tooltip text for new UI elements", async () => {
     vi.doMock("../../src/helpers/dataUtils.js", () => ({
       fetchJson: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- clamp tooltip left offset to stay within viewport
- test wide tooltip clamping behavior

## Testing
- `npx prettier . --check` *(fails: src/helpers/randomCard.js, tests/helpers/randomCard.test.js)*
- `npx eslint .` *(fails: 3 errors, 2 warnings)*
- `npm run check:jsdoc` *(warnings: 148 missing)*
- `npx vitest run`
- `npx playwright test` *(fails: playwright/battle-classic/smoke.spec.js: loads without console errors and has scoreboard nodes)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bf531eb2048326a5a10e9a3b76791f