### PR TITLE
fix: handle Float32 buffers in vector loader

### DIFF
--- a/src/helpers/vectorSearch/loader.js
+++ b/src/helpers/vectorSearch/loader.js
@@ -26,7 +26,7 @@ export const CURRENT_EMBEDDING_VERSION = 1;
  * @pseudocode
  * 1. Exit early when not in Node or when `RAG_FORCE_JSON` is set.
  * 2. Read metadata and vector binary files.
- * 3. For each item, slice the buffer and attach the embedding array.
+ * 3. For each item, slice the buffer with `Float32Array` and attach the embedding array.
  * 4. Return the assembled embeddings array; on error, return `null`.
  *
  * @returns {Promise<Array|Null>} Embeddings array on success, otherwise `null`.
@@ -44,8 +44,8 @@ export async function loadOfflineEmbeddings() {
     const buffer = await readFile(fileURLToPath(vecUrl));
     const out = new Array(items.length);
     for (let i = 0; i < items.length; i++) {
-      const offset = i * vectorLength;
-      const view = new Int8Array(buffer.buffer, buffer.byteOffset + offset, vectorLength);
+      const offset = i * vectorLength * Float32Array.BYTES_PER_ELEMENT;
+      const view = new Float32Array(buffer.buffer, buffer.byteOffset + offset, vectorLength);
       out[i] = { ...items[i], embedding: Array.from(view) };
     }
     return out;
@@ -107,7 +107,7 @@ export async function loadManifestEmbeddings() {
  * 3. Cache and return the first successful result.
  * 4. When all loaders fail, log an error and return `null`.
  *
- * @returns {Promise<Array<{id:string,text:string,embedding:number[],source:string,tags?:string[],qaContext?:string}>>|null} Parsed embeddings array or `null`.
+ * @returns {Promise<Array<{id:string,text:string,embedding:number[],source:string,tags?:string[],qaContext?:string}>|null>} Parsed embeddings array or `null`.
  */
 export async function loadEmbeddings() {
   if (cachedEmbeddings !== undefined) return cachedEmbeddings;

--- a/tests/helpers/vectorSearch/loader.test.js
+++ b/tests/helpers/vectorSearch/loader.test.js
@@ -24,13 +24,13 @@ describe("vectorSearch loader helpers", () => {
       vectorLength: 2,
       items: sample.map(({ id, text, source, tags }) => ({ id, text, source, tags }))
     };
-    const vec = Buffer.from(sample.flatMap((s) => s.embedding));
+    const vec = Buffer.from(new Float32Array(sample.flatMap((s) => s.embedding)).buffer);
     const { readFile } = await import("node:fs/promises");
     readFile.mockImplementation((path) => {
       if (String(path).includes("offline_rag_metadata.json")) {
         return Promise.resolve(JSON.stringify(meta));
       }
-      return Promise.resolve(Buffer.from(vec));
+      return Promise.resolve(vec);
     });
     const { loadOfflineEmbeddings } = await import("../../../src/helpers/vectorSearch/loader.js");
     const result = await loadOfflineEmbeddings();


### PR DESCRIPTION
## Summary
- parse offline vector buffer using Float32Array to preserve embedding values
- correct `loadEmbeddings` JSDoc to reflect nullable return
- refine offline loader test to use Float32 buffer and avoid extra Buffer copy

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: 1 failed)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/helpers/vectorSearch/loader.js", "tests/helpers/vectorSearch/loader.test.js"],
  "outputs": ["src/helpers/vectorSearch/loader.js", "tests/helpers/vectorSearch/loader.test.js"],
  "success": ["npx prettier . --check", "npx eslint .", "npm run check:jsdoc", "npx vitest run", "npx playwright test", "npm run check:contrast"],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `src/helpers/vectorSearch/loader.js`: read offline vectors as Float32 and update return type docs
- `tests/helpers/vectorSearch/loader.test.js`: encode sample embeddings as Float32 and avoid buffer copy

## Verification Summary
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: 1 failed)*
- `npm run check:contrast`

## Risk and Follow-Up
- **Risk**: changing offline loader to Float32 may diverge from existing binary format.
- **Follow-Up**: confirm offline embedding file format matches Float32 expectations before deployment.


------
https://chatgpt.com/codex/tasks/task_e_68bf586c4ffc83268c616e9073115921