### PR TITLE
feat(cli): add start reset and round prompt

### DIFF
--- a/docs/battleCLI.md
+++ b/docs/battleCLI.md
@@ -25,6 +25,7 @@ import { battleCLI, onKeyDown } from "src/pages/index.js";
 - The `battleCLI` export exposes test helpers and utilities such as `renderStatList`.
 - `getEscapeHandledPromise` resolves after Escape key processing, simplifying async tests.
 - Background clicks advance from **round over** or **cooldown** states; clicks on stat rows are ignored.
+- Matches start via a **Start match** button that opens a round selection modal to choose the points target.
 
 ## Headless simulations
 

--- a/tests/pages/battleCLI.init.test.js
+++ b/tests/pages/battleCLI.init.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { BATTLE_POINTS_TO_WIN } from "../../src/config/storageKeys.js";
+import { waitFor } from "../waitFor.js";
 import { loadBattleCLI, cleanupBattleCLI } from "./utils/loadBattleCLI.js";
 import * as battleEvents from "../../src/helpers/classicBattle/battleEvents.js";
 
@@ -25,7 +26,22 @@ describe("battleCLI init helpers", () => {
     expect(startBtn).toBeTruthy();
     expect(emitSpy).not.toHaveBeenCalledWith("startClicked");
     startBtn?.click();
-    expect(emitSpy).toHaveBeenCalledWith("startClicked");
+    await waitFor(() => emitSpy.mock.calls.some((c) => c[0] === "startClicked"));
+  });
+
+  it("shows round modal when no saved target", async () => {
+    localStorage.removeItem(BATTLE_POINTS_TO_WIN);
+    const mod = await loadBattleCLI({
+      stats: [{ statIndex: 1, name: "Speed" }],
+      mockBattleEvents: false
+    });
+    const emitSpy = vi.spyOn(battleEvents, "emitBattleEvent");
+    await mod.init();
+    document.getElementById("start-match-button")?.click();
+    await waitFor(() => !!document.getElementById("round-select-title"));
+    await waitFor(() => !!document.getElementById("round-select-1"));
+    document.getElementById("round-select-1")?.click();
+    await waitFor(() => emitSpy.mock.calls.some((c) => c[0] === "startClicked"));
   });
 
   it("renders stats list", async () => {

--- a/tests/pages/battleCLI.pointsToWin.startOnce.test.js
+++ b/tests/pages/battleCLI.pointsToWin.startOnce.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as debugHooks from "../../src/helpers/classicBattle/debugHooks.js";
+import { waitFor } from "../waitFor.js";
 import { loadBattleCLI, cleanupBattleCLI } from "./utils/loadBattleCLI.js";
 
 describe("battleCLI points to win start", () => {
@@ -63,9 +64,11 @@ describe("battleCLI points to win start", () => {
     });
     expect(btn).toBeTruthy();
     btn.click();
-    expect(emitBattleEvent).toHaveBeenCalledWith("battleStateChange", {
-      to: "waitingForPlayerAction"
-    });
+    await waitFor(() =>
+      emitBattleEvent.mock.calls.some(
+        (c) => c[0] === "battleStateChange" && c[1]?.to === "waitingForPlayerAction"
+      )
+    );
     confirmSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- ensure match reset precedes start button rendering
- start button and replay now open round selection modal
- document CLI start control and tests cover modal flow

## Testing
- `npx prettier . --check`
- `npx eslint .` *(fails: 2 warnings)*
- `npm run check:jsdoc` *(fails: missing docs)*
- `npx vitest run` *(fails: 1 test failed)*
- `npx playwright test` *(fails: tests failed)*
- `npm run check:contrast`

## Risk
- Round modal integration may expose hidden state issues; monitor match start and replay flows.

------
https://chatgpt.com/codex/tasks/task_e_68bfc5dc0a3c832695d905def837d2fe