### PR TITLE
fix: parse offline Int8 vectors in loader

### DIFF
--- a/src/helpers/vectorSearch/loader.js
+++ b/src/helpers/vectorSearch/loader.js
@@ -26,7 +26,7 @@ export const CURRENT_EMBEDDING_VERSION = 1;
  * @pseudocode
  * 1. Exit early when not in Node or when `RAG_FORCE_JSON` is set.
  * 2. Read metadata and vector binary files.
- * 3. For each item, slice the buffer with `Float32Array` and attach the embedding array.
+ * 3. For each item, slice the buffer with `Int8Array` and attach the embedding array.
  * 4. Return the assembled embeddings array; on error, return `null`.
  *
  * @returns {Promise<Array|Null>} Embeddings array on success, otherwise `null`.
@@ -44,8 +44,8 @@ export async function loadOfflineEmbeddings() {
     const buffer = await readFile(fileURLToPath(vecUrl));
     const out = new Array(items.length);
     for (let i = 0; i < items.length; i++) {
-      const offset = i * vectorLength * Float32Array.BYTES_PER_ELEMENT;
-      const view = new Float32Array(buffer.buffer, buffer.byteOffset + offset, vectorLength);
+      const offset = i * vectorLength * Int8Array.BYTES_PER_ELEMENT;
+      const view = new Int8Array(buffer.buffer, buffer.byteOffset + offset, vectorLength);
       out[i] = { ...items[i], embedding: Array.from(view) };
     }
     return out;

--- a/tests/helpers/vectorSearch/loader.test.js
+++ b/tests/helpers/vectorSearch/loader.test.js
@@ -24,7 +24,7 @@ describe("vectorSearch loader helpers", () => {
       vectorLength: 2,
       items: sample.map(({ id, text, source, tags }) => ({ id, text, source, tags }))
     };
-    const vec = Buffer.from(new Float32Array(sample.flatMap((s) => s.embedding)).buffer);
+    const vec = Buffer.from(Int8Array.from(sample.flatMap((s) => s.embedding)).buffer);
     const { readFile } = await import("node:fs/promises");
     readFile.mockImplementation((path) => {
       if (String(path).includes("offline_rag_metadata.json")) {


### PR DESCRIPTION
## Summary
- align offline vector parsing with Int8 quantized format
- adjust offline loader test to encode Int8 buffer

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run` *(terminated: repeated "document is not defined")*
- `npx playwright test` *(fails: 1 failed, 2 interrupted, 26 passed)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/helpers/vectorSearch/loader.js", "tests/helpers/vectorSearch/loader.test.js"],
  "outputs": ["src/helpers/vectorSearch/loader.js", "tests/helpers/vectorSearch/loader.test.js"],
  "success": ["npx prettier . --check", "npx eslint .", "npm run check:jsdoc", "npx vitest run", "npx playwright test", "npm run check:contrast"],
  "errorMode": "ask_on_public_api_change"
}
```

## Files Changed
- `src/helpers/vectorSearch/loader.js`: read offline vectors as Int8 array
- `tests/helpers/vectorSearch/loader.test.js`: encode sample embeddings as Int8 buffer

## Verification Summary
- `npx prettier . --check`
- `npx eslint .` *(warnings: unused vars in unrelated tests)*
- `npm run check:jsdoc` *(147 missing)*
- `npx vitest run` *(terminated: repeated "document is not defined")*
- `npx playwright test` *(1 failed, 2 interrupted, 26 passed)*
- `npm run check:contrast`

## Risk and Follow-Up
- **Risk**: Int8 parsing may not preserve original float precision.
- **Follow-Up**: verify offline embedding format and conversions.


------
https://chatgpt.com/codex/tasks/task_e_68bfc7c21148832687aad0a9b8e18647