### PR TITLE
Handle round-select modal failure

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -267,7 +267,7 @@ function showRoundSelectFallback(store) {
     try {
       await startRoundCycle(store);
     } catch (err) {
-      console.error("battleClassic: fallback start failed", err);
+      console.debug("battleClassic: fallback start failed", err);
     }
   });
 
@@ -444,7 +444,7 @@ async function init() {
         await startRoundCycle(store);
       });
     } catch (err) {
-      console.error("battleClassic: initRoundSelectModal failed", err);
+      console.debug("battleClassic: initRoundSelectModal failed", err);
       showRoundSelectFallback(store);
     }
 
@@ -460,10 +460,10 @@ async function init() {
 
 if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", () => {
-    init().catch((err) => console.error("battleClassic: init failed", err));
+    init().catch((err) => console.debug("battleClassic: init failed", err));
   });
 } else {
-  init().catch((err) => console.error("battleClassic: init failed", err));
+  init().catch((err) => console.debug("battleClassic: init failed", err));
 }
 
 export { init };


### PR DESCRIPTION
### Task Contract
- **Inputs:** `src/pages/battleClassic.init.js`
- **Outputs:** `src/pages/battleClassic.init.js`
- **Success:** `npx prettier . --check`, `npx eslint .`, `npm run check:jsdoc`, `npx vitest run`, `npx playwright test`, `npm run check:contrast`
- **Error mode:** ask_on_public_api_change

### Files Changed
- **src/pages/battleClassic.init.js**: replace console.error logs with console.debug to align with repository logging guidelines.

### Verification
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(reports existing missing docs)*
- `npx vitest run` *(incomplete; process hung before completion)*
- `npx playwright test` *(3 failed, 2 interrupted)*
- `npm run check:contrast`

### Risk
- Low – logging change only; follow-up needed for failing Playwright tests and vitest hang.


------
https://chatgpt.com/codex/tasks/task_e_68bfdcab4ff4832683db3486dae48ef4