### PR TITLE
fix battleCLI export and docs

### DIFF
--- a/src/pages/battleCLI/dom.js
+++ b/src/pages/battleCLI/dom.js
@@ -2,15 +2,27 @@ import * as engineFacade from "../../helpers/battleEngineFacade.js";
 
 /**
  * Get a DOM element by id.
+ *
+ * @summary Retrieve a DOM element using its id.
  * @param {string} id
  * @returns {HTMLElement | null}
+ * @pseudocode
+ * return document.getElementById(id)
  */
 export const byId = (id) => document.getElementById(id);
 
 /**
  * Update the round header line.
+ *
+ * @summary Render round number and target points.
  * @param {number} round
  * @param {number} target
+ * @returns {void}
+ * @pseudocode
+ * el = byId("cli-round")
+ * if el -> set text to `Round ${round} Target: ${target} 🏆`
+ * root = byId("cli-root")
+ * if root -> set dataset.round and dataset.target
  */
 export function updateRoundHeader(round, target) {
   const el = byId("cli-round");
@@ -24,7 +36,13 @@ export function updateRoundHeader(round, target) {
 
 /**
  * Set the round message text.
+ *
+ * @summary Display a message in the round banner.
  * @param {string} text
+ * @returns {void}
+ * @pseudocode
+ * el = byId("round-message")
+ * if el -> set textContent to text or ""
  */
 export function setRoundMessage(text) {
   const el = byId("round-message");
@@ -33,6 +51,13 @@ export function setRoundMessage(text) {
 
 /**
  * Update the scoreboard line.
+ *
+ * @summary Refresh scores for player and opponent.
+ * @returns {void}
+ * @pseudocode
+ * scores = engineFacade.getScores() or {0,0}
+ * el = byId("cli-score")
+ * if el -> update textContent and data attributes with scores
  */
 export function updateScoreLine() {
   const { playerScore, opponentScore } = engineFacade.getScores?.() || {
@@ -49,6 +74,12 @@ export function updateScoreLine() {
 
 /**
  * Clear verbose log output.
+ *
+ * @summary Remove any text from the verbose log.
+ * @returns {void}
+ * @pseudocode
+ * el = byId("cli-verbose-log")
+ * if el -> set textContent to ""
  */
 export function clearVerboseLog() {
   const el = byId("cli-verbose-log");

--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -1,5 +1,11 @@
-// Classic Battle CLI bootstrap and controller
-// Wires the existing Classic Battle engine/state machine to a terminal-style UI.
+/**
+ * Classic Battle CLI bootstrap and controller.
+ * Wires the classic battle engine/state machine to a terminal-style UI.
+ *
+ * Exports the `init` entry point and helper handlers used by tests.
+ *
+ * @module pages/battleCLI/init
+ */
 
 import {
   createBattleStore,
@@ -1286,26 +1292,6 @@ export function handleGlobalKey(key) {
  * return false
  */
 /**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
  * Handle key input while waiting for the player's stat selection.
  *
  * @summary Convert numeric key presses into stat selections when appropriate.
@@ -1344,26 +1330,6 @@ export function handleWaitingForPlayerActionKey(key) {
  * return false
  */
 /**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
  * Handle key input after a round has resolved.
  *
  * @summary Treat Enter/Space as confirmation to continue to the next state.
@@ -1397,26 +1363,6 @@ export function handleRoundOverKey(key) {
  * return false
  */
 /**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
  * Handle key input during cooldown between rounds.
  *
  * @summary Allow Enter/Space to skip cooldown, clear timers, and mark machine as ready.
@@ -1447,17 +1393,6 @@ registerBattleHandlers({
   handleCooldownKey,
   handleStatListArrowKey
 });
-
-/**
- * Global keyboard handler that routes input based on the current battle state.
- *
- * @summary Normalize keyboard events, run global handlers, then state-specific handlers.
- * @param {KeyboardEvent} e - Browser keyboard event.
- * @returns {void}
- * @pseudocode
- * key = lowercased key from event
- * if cliShortcuts disabled AND key != 'q': return
-
 
 /**
  * Advance battle state when clicking outside interactive areas.
@@ -1928,8 +1863,24 @@ export function wireEvents() {
   } catch {}
 }
 
-async function init() {
-  console.log("init called");
+/**
+ * Boot the battle CLI page.
+ *
+ * @summary Initialize store, flags, UI, and orchestrator wiring.
+ * @returns {Promise<void>}
+ * @pseudocode
+ * initSeed()
+ * store = createBattleStore()
+ * expose store on window
+ * await renderStatList()
+ * restorePointsToWin()
+ * await setupFlags()
+ * subscribeEngine()
+ * battleOrchestrator.initClassicBattleOrchestrator(store, startRoundWrapper)
+ * await renderStartButton()
+ * wireEvents()
+ */
+export async function init() {
   initSeed();
   store = createBattleStore();
   try {


### PR DESCRIPTION
## Summary
- export `init` from battle CLI module and remove stray debug log
- document battle CLI module and DOM helpers with JSDoc and pseudocode

## Testing
- `npx prettier src/pages/battleCLI/dom.js src/pages/battleCLI/init.js --check`
- `npx eslint src/pages/battleCLI/dom.js src/pages/battleCLI/init.js -f json`
- `npm run check:jsdoc` *(fails: Total missing: 153)*
- `npx vitest run`
- `npx playwright test` *(fails: 2 failed, 82 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bfdc87e4708326ad9647ec317954e6