### PR TITLE
fix: quantize sample embeddings in loader test

### DIFF
--- a/tests/helpers/vectorSearch/loader.test.js
+++ b/tests/helpers/vectorSearch/loader.test.js
@@ -24,7 +24,12 @@ describe("vectorSearch loader helpers", () => {
       vectorLength: 2,
       items: sample.map(({ id, text, source, tags }) => ({ id, text, source, tags }))
     };
-    const vec = Buffer.from(Int8Array.from(sample.flatMap((s) => s.embedding)).buffer);
+    // Quantize sample embeddings to Int8 with rounding and clamping
+    const vec = Buffer.from(
+      Int8Array.from(
+        sample.flatMap((s) => s.embedding.map((v) => Math.max(-128, Math.min(127, Math.round(v)))))
+      ).buffer
+    );
     const { readFile } = await import("node:fs/promises");
     readFile.mockImplementation((path) => {
       if (String(path).includes("offline_rag_metadata.json")) {


### PR DESCRIPTION
## Summary
- quantize sample embeddings to Int8 in offline loader test

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run`
- `npx playwright test` *(fails: 13 failed, 71 passed)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bfdc5304ac832684ab34c0e502789c