### PR TITLE
Restore stat button exports and respect hotkey feature flag

### DIFF
--- a/src/helpers/classicBattle/statButtons.js
+++ b/src/helpers/classicBattle/statButtons.js
@@ -1,3 +1,5 @@
+import { isEnabled } from "../featureFlags.js";
+
 /** Enable stat buttons. @pseudocode Enable each button, clear disabled styling, mark container ready. */
 export function enableStatButtons(buttons, container) {
   buttons.forEach((btn) => {
@@ -19,10 +21,38 @@ export function disableStatButtons(buttons, container) {
   if (container) container.dataset.buttonsReady = "false";
 }
 
-/** Attach numeric hotkeys 1–5. @pseudocode On keydown without modifiers, click matching enabled button; return cleanup. */
+/** Resolve stat button readiness. @pseudocode Call global resolver or create resolved promise. */
+export function resolveStatButtonsReady(win = window) {
+  if (typeof win.__resolveStatButtonsReady === "function") {
+    win.__resolveStatButtonsReady();
+  } else {
+    win.statButtonsReadyPromise = Promise.resolve();
+  }
+}
+
+/**
+ * Set stat buttons enabled state.
+ * @pseudocode When enabling, call enable helper and resolver; otherwise disable and reset.
+ */
+export function setStatButtonsEnabled(buttons, container, enable, resolveReady, resetReady) {
+  if (enable) {
+    enableStatButtons(buttons, container);
+    resolveReady?.();
+  } else {
+    disableStatButtons(buttons, container);
+    resetReady?.();
+  }
+}
+
+/** Attach numeric hotkeys 1–5.
+ * @pseudocode If flag disabled or focus in input, ignore; on keydown without modifiers, click matching enabled button; return cleanup.
+ */
 export function wireStatHotkeys(buttons) {
   const handler = (e) => {
+    if (!isEnabled("statHotkeys")) return;
     if (e.altKey || e.ctrlKey || e.metaKey) return;
+    const active = document.activeElement;
+    if (active && ["INPUT", "TEXTAREA", "SELECT"].includes(active.tagName)) return;
     const idx = e.key >= "1" && e.key <= "5" ? Number(e.key) - 1 : -1;
     const btn = buttons[idx];
     if (btn && !btn.disabled) {

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -23,7 +23,8 @@ import * as battleEvents from "./battleEvents.js";
 import {
   enableStatButtons,
   disableStatButtons,
-  wireStatHotkeys
+  wireStatHotkeys,
+  resolveStatButtonsReady
 } from "./statButtons.js";
 import { guard } from "./guard.js";
 import { updateDebugPanel, setDebugPanelEnabled } from "./debugPanel.js";
@@ -933,6 +934,7 @@ export function initStatButtons(store) {
   const statButtons = statContainer.querySelectorAll("button");
   if (!statButtons.length) {
     window.statButtonsReadyPromise = Promise.resolve();
+    resolveStatButtonsReady();
     guard(() => console.warn("[uiHelpers] #stat-buttons has no buttons"));
     return { enable: () => {}, disable: () => {} };
   }
@@ -945,13 +947,18 @@ export function initStatButtons(store) {
     });
   };
 
+  let detachHotkeys = null;
+
   const enable = () => {
     enableStatButtons(statButtons, statContainer);
     resolveReady?.();
+    if (!detachHotkeys) detachHotkeys = wireStatHotkeys(statButtons);
   };
   const disable = () => {
     disableStatButtons(statButtons, statContainer);
     resetReady();
+    detachHotkeys?.();
+    detachHotkeys = null;
   };
 
   resetReady();
@@ -986,7 +993,7 @@ export function initStatButtons(store) {
     });
   });
 
-  wireStatHotkeys(statButtons);
+  detachHotkeys = wireStatHotkeys(statButtons);
 
   return { enable, disable };
 }


### PR DESCRIPTION
## Task Contract
- inputs: `src/helpers/classicBattle/statButtons.js`, `src/helpers/classicBattle/uiHelpers.js`, `tests/helpers/classicBattle/controlState.test.js`
- outputs: `src/helpers/classicBattle/statButtons.js`, `src/helpers/classicBattle/uiHelpers.js`, `tests/helpers/classicBattle/controlState.test.js`
- success: prettier/eslint/jsdoc/vitest/playwright/contrast pass
- error mode: ask_on_public_api_change

## Summary
- reinstated `resolveStatButtonsReady` and `setStatButtonsEnabled` exports and gated hotkeys behind feature flag and input focus checks
- ensured stat button wiring cleans up hotkey listeners and resolves readiness when no buttons exist
- updated control state tests to mock feature flags and cover disabled or focused-input hotkey cases

## Verification
- `npx prettier . --check` (fails: code style issues in repo)
- `npx eslint src/helpers/classicBattle/statButtons.js src/helpers/classicBattle/uiHelpers.js tests/helpers/classicBattle/controlState.test.js`
- `npm run check:jsdoc` (fails: functions missing JSDoc)
- `npx vitest run`
- `npx playwright test` (fails: 4 tests)
- `npm run check:contrast`

## Risk
- Low: changes localized to stat button utilities and tests; hotkey feature flag restored but broader integration still advised.

------
https://chatgpt.com/codex/tasks/task_e_68bfee50827c8326839013a5360d1549