### PR TITLE
feat(cli): add round start control

### DIFF
--- a/docs/battleCLI.md
+++ b/docs/battleCLI.md
@@ -25,6 +25,7 @@ import { battleCLI, onKeyDown } from "src/pages/index.js";
 - The `battleCLI` export exposes test helpers and utilities such as `renderStatList`.
 - `getEscapeHandledPromise` resolves after Escape key processing, simplifying async tests.
 - Background clicks advance from **round over** or **cooldown** states; clicks on stat rows are ignored.
+- The page requests a round target via `initRoundSelectModal` and falls back to a **Start match** button if the modal cannot load.
 
 ## Headless simulations
 

--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -38,6 +38,7 @@ import { BATTLE_POINTS_TO_WIN } from "../../config/storageKeys.js";
 import { POINTS_TO_WIN_OPTIONS } from "../../config/battleDefaults.js";
 import * as debugHooks from "../../helpers/classicBattle/debugHooks.js";
 import { setAutoContinue, autoContinue } from "../../helpers/classicBattle/orchestratorHandlers.js";
+import { initRoundSelectModal } from "../../helpers/classicBattle/roundSelectModal.js";
 import { SNACKBAR_REMOVE_MS } from "../../helpers/constants.js";
 import { registerModal, unregisterModal, onEsc } from "../../helpers/modalManager.js";
 import state, { resolveEscapeHandled, getEscapeHandledPromise } from "./state.js";
@@ -1188,7 +1189,7 @@ export function restorePointsToWin() {
         await resetMatch();
         engineFacade.setPointsToWin?.(val);
         updateRoundHeader(0, val);
-        renderStartButton();
+        await renderStartButton();
         current = val;
       } else {
         select.value = String(current);
@@ -1876,8 +1877,9 @@ export function wireEvents() {
  * restorePointsToWin()
  * await setupFlags()
  * subscribeEngine()
- * battleOrchestrator.initClassicBattleOrchestrator(store, startRoundWrapper)
- * await renderStartButton()
+ * await resetMatch()
+ * try initRoundSelectModal()
+ * catch → await renderStartButton()
  * wireEvents()
  */
 export async function init() {
@@ -1890,11 +1892,12 @@ export async function init() {
   restorePointsToWin();
   await setupFlags();
   subscribeEngine();
+  await resetMatch();
   try {
-    const p = battleOrchestrator.initClassicBattleOrchestrator?.(store, startRoundWrapper);
-    void p;
-  } catch {}
-  await renderStartButton();
+    await initRoundSelectModal(() => {});
+  } catch {
+    await renderStartButton();
+  }
   wireEvents();
 }
 


### PR DESCRIPTION
## Summary
- reset CLI match before injecting Start button and invoke round selection modal with fallback
- document Start control and round selection for Battle CLI
- cover Start button fallback with a dedicated test

## Testing
- `npx prettier docs/battleCLI.md src/pages/battleCLI/init.js tests/pages/battleCLI.pointsToWin.startOnce.test.js --check`
- `npx eslint .` *(fails: prettier/prettier in existing files)*
- `npm run check:jsdoc`
- `npx vitest run` *(fails: 3 failing tests)*
- `npx playwright test` *(interrupted: 1 test)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68bfee97f5e08326816538ad22a0f1c6