### PR TITLE
fix(cli): await orchestrator reset

### DIFF
--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -211,8 +211,8 @@ export const __test = {
  *   updateRoundHeader(0, engineFacade.getPointsToWin?.())
  *   updateScoreLine()
  *   setRoundMessage("")
- * } then initClassicBattleOrchestrator()
- * await resetPromise // waits for orchestrator
+ * } followed by initClassicBattleOrchestrator()
+ * return resetPromise // waits for orchestrator
  */
 let resetPromise = Promise.resolve();
 async function resetMatch() {
@@ -236,9 +236,11 @@ async function resetMatch() {
   resetPromise = next.then(async () => {
     try {
       await battleOrchestrator.initClassicBattleOrchestrator?.(store, startRoundWrapper);
-    } catch {}
+    } catch (err) {
+      console.error("Failed to initialize classic battle orchestrator:", err);
+    }
   });
-  await next;
+  return resetPromise;
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure `resetMatch` returns orchestrator init promise
- clarify pseudocode comment and log orchestrator init errors

## Testing
- `npx prettier src/pages/battleCLI/init.js --check`
- `npx eslint .` *(warn: 2 warnings)*
- `npm run check:jsdoc`
- `npx vitest run --reporter=basic` *(fails: 1 failed, 936 passed)*
- `npx playwright test` *(fails: 3 failed, 2 interrupted, 42 passed)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/pages/battleCLI/init.js"],
  "outputs": ["src/pages/battleCLI/init.js"],
  "success": [
    "eslint: WARN (0 errors, 2 warnings)",
    "vitest: 936 passed, 1 failed",
    "playwright: 42 passed, 3 failed, 2 interrupted, 37 did not run",
    "jsdoc: 156 missing (non-blocking)",
    "contrast: PASS"
  ],
  "errorMode": "standard"
}
```

## Risks
- More verbose console output if orchestrator fails

## Follow-Up
- Investigate failing vitest and playwright tests


------
https://chatgpt.com/codex/tasks/task_e_68c0027ebadc832694c70d3f3175a3b9