### PR TITLE
fix(cli): await orchestrator reset

### DIFF
--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -211,8 +211,10 @@ export const __test = {
  *   updateRoundHeader(0, engineFacade.getPointsToWin?.())
  *   updateScoreLine()
  *   setRoundMessage("")
- * } followed by initClassicBattleOrchestrator()
- * return resetPromise // waits for orchestrator
+ * }
+ * await initClassicBattleOrchestrator()
+ * // Return a promise that resolves after both reset and orchestrator initialization are complete.
+ * // Callers should await the returned promise to ensure the reset is finished.
  */
 let resetPromise = Promise.resolve();
 async function resetMatch() {


### PR DESCRIPTION
## Summary
- clarify resetMatch pseudocode so callers await orchestrator initialization

## Testing
- `npx prettier src/pages/battleCLI/init.js --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run --reporter=basic` *(fails: 2 failed, 935 passed)*
- `npx playwright test` *(fails: 6 failed, 1 interrupted, 70 passed)*
- `npm run check:contrast`

## Task Contract
```json
{
  "inputs": ["src/pages/battleCLI/init.js"],
  "outputs": ["src/pages/battleCLI/init.js"],
  "success": [
    "eslint: PASS",
    "vitest: 935 passed, 2 failed",
    "playwright: 70 passed, 6 failed, 1 interrupted, 7 did not run",
    "jsdoc: 148 missing (non-blocking)",
    "contrast: PASS"
  ],
  "errorMode": "standard"
}
```

## Risks
- none

## Follow-Up
- Investigate failing vitest and playwright tests


------
https://chatgpt.com/codex/tasks/task_e_68c006880f088326a10d83e9e6e33c91