### PR TITLE
fix: validate scoreboard patch inputs

### DIFF
--- a/src/components/Scoreboard.js
+++ b/src/components/Scoreboard.js
@@ -114,7 +114,7 @@ export class Scoreboard {
    * Render a partial patch into model/view.
    *
    * @pseudocode
-   * 1. Apply score patch when player & opponent defined.
+   * 1. Apply score patch when player & opponent numbers.
    * 2. Forward message (with outcome) and timer/round updates.
    * 3. Return void.
    * @param {object} patch - Partial state updates.
@@ -122,9 +122,9 @@ export class Scoreboard {
   render(patch = {}) {
     if (patch.score) {
       const { player, opponent } = patch.score;
-      const havePlayer = player !== undefined;
-      const haveOpponent = opponent !== undefined;
-      if (havePlayer && haveOpponent) {
+      const playerIsNumber = typeof player === "number";
+      const opponentIsNumber = typeof opponent === "number";
+      if (playerIsNumber && opponentIsNumber) {
         this.updateScore(player, opponent);
       }
     }
@@ -164,8 +164,10 @@ export class Scoreboard {
  * 2. Create model and view bound to them.
  * 3. Store default scoreboard for module-level helpers.
  * @param {HTMLElement|null} container - Header container or null for headless.
+ * @param {object} [_controls] - Deprecated controls parameter.
  */
-export function initScoreboard(container) {
+export function initScoreboard(container, _controls) {
+  void _controls;
   if (!container) {
     defaultScoreboard = new Scoreboard();
     return;


### PR DESCRIPTION
## Summary
- ensure `render` ignores non-numeric score values
- restore deprecated `_controls` parameter to avoid API change

## Testing
- `npx prettier . --check` *(fails: style issues in 5 files)*
- `npx eslint .` *(fails: 33 errors, 2 warnings)*
- `npm run check:jsdoc` *(fails: 169 missing blocks)*
- `npx vitest run` *(terminated: output hung)*
- `npx playwright test` *(fails: 1 failed, 2 interrupted)*
- `npm run check:contrast`

## Task Contract
- inputs: `src/components/Scoreboard.js`
- outputs: `src/components/Scoreboard.js`
- success: `prettier`, `eslint`, `jsdoc`, `vitest`, `playwright`, `check:contrast`
- errorMode: `ask_on_public_api_change`

## Risk
- Low: restored optional parameter should preserve existing callers, minor type guard in render.


------
https://chatgpt.com/codex/tasks/task_e_68c03a730c4c8326b56ba1546ebad4aa