### PR TITLE
docs: explain deprecated controls

### DIFF
--- a/src/components/Scoreboard.js
+++ b/src/components/Scoreboard.js
@@ -164,7 +164,8 @@ export class Scoreboard {
  * 2. Create model and view bound to them.
  * 3. Store default scoreboard for module-level helpers.
  * @param {HTMLElement|null} container - Header container or null for headless.
- * @param {object} [_controls] - Deprecated controls parameter.
+ * @param {object} [_controls] - Deprecated controls parameter retained only for backward compatibility; ignored.
+ * @deprecated The `_controls` parameter is unused and will be removed in a future release.
  */
 export function initScoreboard(container, _controls) {
   void _controls;


### PR DESCRIPTION
## Summary
- document the legacy `_controls` parameter in `initScoreboard`

## Testing
- `npx prettier . --check` *(fails: Code style issues in 24 files)*
- `npx eslint .` *(fails: 169 errors, 6 warnings)
- `npm run check:jsdoc` *(fails: Total missing: 169)*
- `npx vitest run` *(terminated: output hung)*
- `npx playwright test` *(fails: 2 failed, 2 interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68c06a117d2c8326a7cfa3b68c4b8246