### PR TITLE
test: reset timers for cooldown interrupt

### DIFF
--- a/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
+++ b/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
@@ -3,20 +3,19 @@ import "./commonMocks.js";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
 import { createTimerNodes, createSnackbarContainer } from "./domUtils.js";
 
-vi.mock("../../../src/helpers/classicBattle/roundSelectModal.js", () => ({
-  initRoundSelectModal: vi.fn(async (cb) => {
-    await cb?.();
-  })
-}));
-
-vi.mock("../../../src/helpers/timerUtils.js", () => ({
-  getDefaultTimer: vi.fn(async () => 1)
-}));
-
 describe("timeout → interruptRound → cooldown auto-advance", () => {
   let battleMod;
   let timers;
+
   beforeEach(async () => {
+    vi.mock("../../../src/helpers/classicBattle/roundSelectModal.js", () => ({
+      initRoundSelectModal: vi.fn(async (cb) => {
+        await cb?.();
+      })
+    }));
+    vi.mock("../../../src/helpers/timerUtils.js", () => ({
+      getDefaultTimer: vi.fn(async () => 1)
+    }));
     vi.resetModules();
     document.body.innerHTML = "";
     const { playerCard, opponentCard } = createBattleCardContainers();
@@ -33,6 +32,9 @@ describe("timeout → interruptRound → cooldown auto-advance", () => {
 
   afterEach(() => {
     timers.clearAllTimers();
+    timers.useRealTimers();
+    vi.resetModules();
+    vi.restoreAllMocks();
     delete window.__NEXT_ROUND_COOLDOWN_MS;
   });
 


### PR DESCRIPTION
## Summary
- ensure cooldown interrupt test restores real timers
- scope mocks to the test to avoid cross-suite side effects

## Testing
- `npx prettier tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js --check`
- `npx eslint .` *(fails: 5 warnings)*
- `npm run check:jsdoc` *(fails: 175 missing docs)*
- `npx vitest run tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js` *(fails: timeout)*
- `npx playwright test` *(fails: 9 failed, 75 passed)*
- `npm run check:contrast` *(not run)*


------
https://chatgpt.com/codex/tasks/task_e_68c1416f2ee48326a78ff57bfe8c309d