### PR TITLE
Handle invalid Battle CLI seed

### DIFF
--- a/docs/battleCLI.md
+++ b/docs/battleCLI.md
@@ -26,6 +26,7 @@ import { battleCLI, onKeyDown } from "src/pages/index.js";
 - `getEscapeHandledPromise` resolves after Escape key processing, simplifying async tests.
 - Background clicks advance from **round over** or **cooldown** states; clicks on stat rows are ignored.
 - The page requests a round target via `initRoundSelectModal` and falls back to a **Start match** button if the modal cannot load.
+- Entering a numeric seed enables deterministic test mode; blank or non-numeric input clears the seed, disables test mode, and uses default randomness.
 
 ## Headless simulations
 

--- a/progressRAG.md
+++ b/progressRAG.md
@@ -245,6 +245,7 @@ Based on the comprehensive evaluation and analysis of barriers to RAG adoption, 
 - **Action:** Simplify the RAG decision tree for agents
 - **Current Issue:** Complex categorization ("How-to", "Definitions", "Conventions", "Implementations")
 - **Solution:** Replace with simple trigger patterns:
+
   ```markdown
   🔍 **When to use RAG (Simple Rule):**
 
@@ -276,6 +277,7 @@ Based on the comprehensive evaluation and analysis of barriers to RAG adoption, 
 **5. Real-Time Success Feedback**
 
 - **Implementation:** Add success metrics display to agent instructions:
+
   ```markdown
   ## 📊 RAG Performance Dashboard
 

--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -336,12 +336,11 @@ async function renderStartButton() {
  * define apply(n): enable test mode and persist n
  * if query param numeric: apply and set input
  * else if stored seed numeric: populate input
- * lastValid <- numeric seed used or stored
  * on input change:
- *   if value is NaN:
- *     revert to lastValid and show error
+ *   if value empty or NaN:
+ *     clear input, show error, disable test mode, remove stored seed
  *   else:
- *     clear error, apply value, update lastValid
+ *     clear error and apply value
  */
 function initSeed() {
   const input = byId("seed-input");
@@ -359,37 +358,33 @@ function initSeed() {
       localStorage.setItem("battleCLI.seed", String(n));
     } catch {}
   };
-  let lastValid = null;
   // Only auto-enable test mode when an explicit seed query param is provided.
   if (seedParam !== null && seedParam !== "") {
     const num = Number(seedParam);
     if (!Number.isNaN(num)) {
       apply(num);
       if (input) input.value = String(num);
-      lastValid = num;
     }
   } else if (storedSeed) {
     const num = Number(storedSeed);
     if (!Number.isNaN(num)) {
       // Populate the input from previous choice without enabling test mode implicitly.
       if (input) input.value = String(num);
-      lastValid = num;
     }
   }
   input?.addEventListener("change", () => {
     const val = Number(input.value);
     if (input.value.trim() === "" || Number.isNaN(val)) {
-      if (lastValid !== null) {
-        input.value = String(lastValid);
-      } else {
-        input.value = "";
-      }
-      if (errorEl) errorEl.textContent = "Seed must be numeric and non-empty.";
+      input.value = "";
+      if (errorEl) errorEl.textContent = "Invalid seed. Using default.";
+      setTestMode({ enabled: false });
+      try {
+        localStorage.removeItem("battleCLI.seed");
+      } catch {}
       return;
     }
     if (errorEl) errorEl.textContent = "";
     apply(val);
-    lastValid = val;
   });
 }
 

--- a/tests/pages/battleCLI.seedValidation.test.js
+++ b/tests/pages/battleCLI.seedValidation.test.js
@@ -34,7 +34,7 @@ describe("battleCLI seed validation", () => {
     expect(document.getElementById("seed-error").textContent).toBe("");
   });
 
-  it("shows error and reverts for NaN", async () => {
+  it("shows error and clears for NaN", async () => {
     const mod = await loadBattleCLI({
       url: "http://localhost/battleCLI.html?seed=3",
       html: seedHtml
@@ -43,11 +43,10 @@ describe("battleCLI seed validation", () => {
     const input = document.getElementById("seed-input");
     input.value = "abc";
     input.dispatchEvent(new Event("change"));
-    expect(input.value).toBe("3");
-    expect(document.getElementById("seed-error").textContent).toBe(
-      "Seed must be numeric and non-empty."
-    );
-    expect(localStorage.getItem("battleCLI.seed")).toBe("3");
+    expect(input.value).toBe("");
+    expect(document.getElementById("seed-error").textContent).toBe("Invalid seed. Using default.");
+    expect(localStorage.getItem("battleCLI.seed")).toBeNull();
+    expect(window.__testMode).toBe(false);
   });
 
   it("clears error after recovery", async () => {
@@ -59,10 +58,12 @@ describe("battleCLI seed validation", () => {
     const input = document.getElementById("seed-input");
     input.value = "abc";
     input.dispatchEvent(new Event("change"));
+    expect(window.__testMode).toBe(false);
     input.value = "4";
     input.dispatchEvent(new Event("change"));
     expect(document.getElementById("seed-error").textContent).toBe("");
     expect(input.value).toBe("4");
     expect(localStorage.getItem("battleCLI.seed")).toBe("4");
+    expect(window.__testMode).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- clear invalid Battle CLI seed input, disable test mode, remove saved seed
- assert seed field clears and test mode toggles in validation tests
- document default seed fallback

## Testing
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc` *(fails: missing JSDoc for many helpers)*
- `npx vitest run` *(fails: 4 tests failed)*
- `npx vitest run tests/pages/battleCLI.seedValidation.test.js`
- `npx playwright test` *(fails: 12 tests failed)*
- `npm run check:contrast`

## Risk
- Requires follow-up to address failing Vitest/Playwright suites and JSDoc gaps.

------
https://chatgpt.com/codex/tasks/task_e_68c1c9fd2d108326809f874e7f8a038b