### PR TITLE
docs: add pseudocode comments

### DIFF
--- a/src/components/Scoreboard.js
+++ b/src/components/Scoreboard.js
@@ -183,18 +183,136 @@ export function initScoreboard(container, _controls) {
   defaultScoreboard = new Scoreboard(model, view);
 }
 
+/**
+ * Display a message via the default scoreboard if available.
+ *
+ * @pseudocode
+ * 1. If `defaultScoreboard` exists, call `showMessage` with the provided args.
+ * 2. Otherwise, do nothing.
+ *
+ * @param {string} text - Message to show.
+ * @param {{outcome?: boolean}} [opts] - Outcome flag locking the message.
+ * @returns {void}
+ */
 export const showMessage = (text, opts) => defaultScoreboard?.showMessage(text, opts);
+
+/**
+ * Clear any scoreboard message.
+ *
+ * @pseudocode
+ * 1. Invoke `clearMessage` on `defaultScoreboard` when present.
+ *
+ * @returns {void}
+ */
 export const clearMessage = () => defaultScoreboard?.clearMessage();
+
+/**
+ * Show a temporary message that disappears automatically.
+ *
+ * @pseudocode
+ * 1. Forward text to `showTemporaryMessage` on the default scoreboard.
+ *
+ * @param {string} text - Message to display briefly.
+ * @returns {Promise<void>|void} Result of the underlying call.
+ */
 export const showTemporaryMessage = (text) => defaultScoreboard?.showTemporaryMessage(text);
+
+/**
+ * Update the visible round timer.
+ *
+ * @pseudocode
+ * 1. If the scoreboard exists, call `updateTimer(seconds)`.
+ *
+ * @param {number} s - Seconds remaining.
+ * @returns {void}
+ */
 export const updateTimer = (s) => defaultScoreboard?.updateTimer(s);
+
+/**
+ * Clear the round timer display.
+ *
+ * @pseudocode
+ * 1. Delegate to `clearTimer` on the default scoreboard when present.
+ *
+ * @returns {void}
+ */
 export const clearTimer = () => defaultScoreboard?.clearTimer();
+
+/**
+ * Update the round counter on the scoreboard.
+ *
+ * @pseudocode
+ * 1. Forward the round number to `updateRoundCounter` if the scoreboard exists.
+ *
+ * @param {number} n - Current round number.
+ * @returns {void}
+ */
 export const updateRoundCounter = (n) => defaultScoreboard?.updateRoundCounter(n);
+
+/**
+ * Clear the round counter display.
+ *
+ * @pseudocode
+ * 1. Call `clearRoundCounter` on the default scoreboard when available.
+ *
+ * @returns {void}
+ */
 export const clearRoundCounter = () => defaultScoreboard?.clearRoundCounter();
+
+/**
+ * Update player and opponent scores.
+ *
+ * @pseudocode
+ * 1. Delegate to `updateScore(player, opponent)` on the default scoreboard.
+ *
+ * @param {number} p - Player score.
+ * @param {number} o - Opponent score.
+ * @returns {void}
+ */
 export const updateScore = (p, o) => defaultScoreboard?.updateScore(p, o);
+
+/**
+ * Highlight an auto-selected stat on the scoreboard.
+ *
+ * @pseudocode
+ * 1. Forward the stat key to `showAutoSelect` when a scoreboard exists.
+ *
+ * @param {string} stat - Stat identifier.
+ * @returns {void}
+ */
 export const showAutoSelect = (stat) => defaultScoreboard?.showAutoSelect(stat);
+
+/**
+ * Render a partial state patch into the default scoreboard.
+ *
+ * @pseudocode
+ * 1. If the scoreboard exists, call its `render(patch)`.
+ *
+ * @param {object} patch - Partial scoreboard state.
+ * @returns {void}
+ */
 export const render = (patch) => defaultScoreboard?.render(patch);
+
+/**
+ * Get the current scoreboard state or a default structure.
+ *
+ * @pseudocode
+ * 1. Return `defaultScoreboard.getState()` when available.
+ * 2. Otherwise return zeroed score object.
+ *
+ * @returns {{score:{player:number,opponent:number}}}
+ */
 export const getState = () =>
   defaultScoreboard?.getState() ?? { score: { player: 0, opponent: 0 } };
+
+/**
+ * Destroy the default scoreboard instance.
+ *
+ * @pseudocode
+ * 1. Set `defaultScoreboard` to `null` so helpers no longer forward calls.
+ *
+ * @returns {void}
+ */
 export const destroy = () => {
   defaultScoreboard = null;
 };

--- a/src/helpers/api/battleUI.js
+++ b/src/helpers/api/battleUI.js
@@ -66,11 +66,14 @@ export function getOutcomeMessage(outcome) {
 }
 
 /**
- * @summary Evaluate a round and map the outcome to a message.
+ * Evaluate a stat matchup and return engine results with a user-facing message.
  *
  * @pseudocode
- * 1. Delegate to `handleStatSelection` on the battle engine with the provided values.
- * 2. Map the returned outcome code to a user-facing message.
+ * 1. Invoke `handleStatSelection(playerVal, opponentVal)` on the battle engine.
+ * 2. Map the outcome code to a localized message.
+ * 3. In Vitest, mirror message and scores into DOM nodes for assertions.
+ * 4. If the engine throws, compute a simple delta outcome and track fallback scores.
+ * 5. Return the result merged with the message.
  *
  * @param {number} playerVal - Player's stat value.
  * @param {number} opponentVal - Opponent's stat value.

--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -29,8 +29,9 @@ export const browseJudokaReadyPromise =
  * @pseudocode
  * 1. If layoutBtn exists, add click listener to toggle panel display mode.
  *
- * @param {HTMLButtonElement} layoutBtn
- * @param {Element} panel
+ * @param {HTMLButtonElement} layoutBtn - Toggle button.
+ * @param {Element} panel - Panel element to switch layout.
+ * @returns {void}
  */
 export function setupLayoutToggle(layoutBtn, panel) {
   if (layoutBtn) {
@@ -213,6 +214,8 @@ export async function setupBrowseJudokaPage() {
 
   await init();
   initTooltips();
+  // Function is async for historical reasons; resolves when page is ready.
+  return;
 }
 
 setupBrowseJudokaPage();

--- a/src/helpers/cardFlip.js
+++ b/src/helpers/cardFlip.js
@@ -7,6 +7,7 @@
  * 3. Attach click and key handlers that invoke `toggle`.
  *
  * @param {HTMLElement} cardElement - Card container to enable flipping on.
+ * @returns {void}
  */
 export function enableCardFlip(cardElement) {
   if (!cardElement) return;

--- a/src/helpers/carousel/accessibility.js
+++ b/src/helpers/carousel/accessibility.js
@@ -51,27 +51,6 @@ export function applyAccessibilityImprovements(wrapper) {
     card.style.color = "var(--color-text-inverted)";
   });
 }
-
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
-/**
- * @summary TODO: Add summary
- * @pseudocode
- * 1. TODO: Add pseudocode
- */
 export { ensureTouchTargetSize };
 
 /**

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -276,11 +276,6 @@ export { addScrollMarkers };
  *
  * @pseudocode
  * 1. Set a global flag so `buildCardCarousel` shows the spinner without delay.
- */
-/**
- * Force the carousel spinner to appear immediately for testing.
- *
- * Sets a global flag so `buildCardCarousel` will show the spinner without a delay.
  *
  * @returns {void}
  */

--- a/src/helpers/classicBattle/autoContinue.js
+++ b/src/helpers/classicBattle/autoContinue.js
@@ -1,6 +1,10 @@
 /**
  * Control automatic continuation after round outcomes.
  *
+ * @pseudocode
+ * 1. Default to `true` so rounds advance automatically.
+ * 2. Can be toggled via `setAutoContinue(false)` to pause between rounds.
+ *
  * @type {boolean}
  */
 export let autoContinue = true;

--- a/src/helpers/classicBattle/battleEvents.js
+++ b/src/helpers/classicBattle/battleEvents.js
@@ -56,6 +56,8 @@ function getTarget() {
  * @pseudocode
  * 1. Retrieve the shared target.
  * 2. Add `handler` as a listener.
+ *
+ * @returns {void}
  */
 export function onBattleEvent(type, handler) {
   getTarget().addEventListener(type, handler);
@@ -70,6 +72,8 @@ export function onBattleEvent(type, handler) {
  * @pseudocode
  * 1. Retrieve the shared target.
  * 2. Remove `handler`.
+ *
+ * @returns {void}
  */
 export function offBattleEvent(type, handler) {
   getTarget().removeEventListener(type, handler);
@@ -85,6 +89,8 @@ export function offBattleEvent(type, handler) {
  * 1. Create a `CustomEvent` with the provided detail.
  * 2. Retrieve the shared target.
  * 3. Dispatch the event.
+ *
+ * @returns {void}
  */
 export function emitBattleEvent(type, detail) {
   try {
@@ -107,10 +113,11 @@ export function emitBattleEvent(type, detail) {
  * @param {boolean} [options.warnDeprecated] - Warn about deprecated usage.
  * @summary Emit a battle event with backward-compatible aliases.
  * @pseudocode
- * 1. Check if event name is deprecated, convert to standardized name.
- * 2. Emit standardized event name.
- * 3. Emit deprecated aliases for backward compatibility.
- * 4. Show deprecation warnings in development mode.
+ * 1. Check if event name is deprecated and map to its standard name.
+ * 2. Emit the standardized event and any legacy aliases.
+ * 3. Optionally warn about deprecated usage.
+ *
+ * @returns {void}
  */
 export function emitBattleEventWithAliases(type, detail, options = {}) {
   try {
@@ -138,6 +145,8 @@ export function emitBattleEventWithAliases(type, detail, options = {}) {
  * @pseudocode
  * 1. Create a new `EventTarget`.
  * 2. Store it under `EVENT_TARGET_KEY` on `globalThis`.
+ *
+ * @returns {void}
  */
 export function __resetBattleEventTarget() {
   const t = new EventTarget();
@@ -154,6 +163,9 @@ export function __resetBattleEventTarget() {
  */
 /**
  * Get the global EventTarget used by classic battle.
+ *
+ * @pseudocode
+ * 1. Return the shared target via `getTarget()`.
  *
  * @returns {EventTarget}
  */

--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -340,6 +340,8 @@ export async function getOrLoadGokyoLookup() {
  *
  * @pseudocode
  * 1. Clear cached `judokaData`, `gokyoLookup`, `opponentJudoka`, and `loadErrorModal`.
+ *
+ * @returns {void}
  */
 export function _resetForTest() {
   judokaData = null;
@@ -347,14 +349,3 @@ export function _resetForTest() {
   opponentJudoka = null;
   loadErrorModal = null;
 }
-
-/**
- * @summary Test helper: reset module-scoped caches and UI artifacts.
- *
- * This is safe to call from unit tests to ensure a clean module state
- * between cases. It clears cached datasets, lookup tables and any modal
- * references to avoid cross-test leakage.
- *
- * @pseudocode
- * 1. Set `judokaData`, `gokyoLookup`, `opponentJudoka`, and `loadErrorModal` to `null`.
- */

--- a/src/helpers/classicBattle/debugLogger.js
+++ b/src/helpers/classicBattle/debugLogger.js
@@ -355,6 +355,9 @@ export class BattleDebugLogger {
 /**
  * Default logger instance for battle debugging
  * Explicitly enabled for testing and development use
+ *
+ * @pseudocode
+ * 1. Instantiate `BattleDebugLogger` with `enabled` flag true in tests or development.
  */
 export const debugLogger = new BattleDebugLogger({
   enabled:
@@ -374,6 +377,10 @@ export const debugLogger = new BattleDebugLogger({
  * @param {string} trigger - Transition trigger
  * @param {object} context - Additional context
  * @returns {void}
+ *
+ * @pseudocode
+ * 1. Use `debugLogger.log` with category STATE and INFO level.
+ * 2. Include from/to/trigger and extra context.
  */
 export function logStateTransition(from, to, trigger, context = {}) {
   debugLogger.log(
@@ -391,6 +398,10 @@ export function logStateTransition(from, to, trigger, context = {}) {
  * @param {any} payload - Event payload
  * @param {object} context - Additional context
  * @returns {void}
+ *
+ * @pseudocode
+ * 1. Call `debugLogger.log` with EVENT category and INFO level.
+ * 2. Attach event name, payload and context.
  */
 export function logEventEmit(eventName, payload, context = {}) {
   debugLogger.log(DEBUG_CATEGORIES.EVENT, LOG_LEVELS.INFO, `Event emitted: ${eventName}`, {
@@ -408,6 +419,9 @@ export function logEventEmit(eventName, payload, context = {}) {
  * @param {number} duration - Timer duration (for start operations)
  * @param {object} context - Additional context
  * @returns {void}
+ *
+ * @pseudocode
+ * 1. Forward details to `debugLogger.log` with TIMER category.
  */
 export function logTimerOperation(operation, name, duration, context = {}) {
   debugLogger.log(DEBUG_CATEGORIES.TIMER, LOG_LEVELS.INFO, `Timer ${operation}: ${name}`, {
@@ -425,6 +439,9 @@ export function logTimerOperation(operation, name, duration, context = {}) {
  * @param {Error} error - Error object
  * @param {object} context - Additional context
  * @returns {void}
+ *
+ * @pseudocode
+ * 1. Use ERROR category and include error object and context.
  */
 export function logError(message, error, context = {}) {
   debugLogger.log(DEBUG_CATEGORIES.ERROR, LOG_LEVELS.ERROR, message, { error, ...context });
@@ -437,6 +454,9 @@ export function logError(message, error, context = {}) {
  * @param {number} duration - Duration in milliseconds
  * @param {object} context - Additional context
  * @returns {void}
+ *
+ * @pseudocode
+ * 1. Log with PERFORMANCE category, INFO level and timing data.
  */
 export function logPerformance(operation, duration, context = {}) {
   debugLogger.log(
@@ -452,8 +472,13 @@ export function logPerformance(operation, duration, context = {}) {
 /**
  * Log state handler entry with timing and context.
  * @pseudocode
- * 1. Log when entering a state handler
- * 2. Include store state and handler context
+ * 1. Log when entering a state handler.
+ * 2. Include store state and handler context.
+ *
+ * @param {string} handlerName - Name of handler.
+ * @param {string} state - Current state.
+ * @param {object} data - Extra context.
+ * @returns {void}
  */
 export function logStateHandlerEnter(handlerName, state, data = {}) {
   debugLogger.log("state", "debug", `Handler Enter: ${handlerName}`, {
@@ -466,9 +491,15 @@ export function logStateHandlerEnter(handlerName, state, data = {}) {
 
 /**
  * Log state handler exit with timing and results.
+ *
  * @pseudocode
- * 1. Log when exiting a state handler
- * 2. Include any results or next actions
+ * 1. Log when exiting a state handler.
+ * 2. Include any results or next actions.
+ *
+ * @param {string} handlerName - Name of handler.
+ * @param {object} [results={}] - Result data.
+ * @param {object} [data={}] - Extra context.
+ * @returns {void}
  */
 export function logStateHandlerExit(handlerName, results = {}, data = {}) {
   debugLogger.log("state", "debug", `Handler Exit: ${handlerName}`, {
@@ -481,9 +512,15 @@ export function logStateHandlerExit(handlerName, results = {}, data = {}) {
 
 /**
  * Log UI events and interactions.
+ *
  * @pseudocode
- * 1. Log UI events like button clicks, state changes
- * 2. Include user interaction context
+ * 1. Log UI events like button clicks or state changes.
+ * 2. Include user interaction context.
+ *
+ * @param {string} interaction - Description of interaction.
+ * @param {any} element - Associated element or identifier.
+ * @param {object} [data={}] - Extra context.
+ * @returns {void}
  */
 export function logUIInteraction(interaction, element, data = {}) {
   debugLogger.log("ui", "info", `UI: ${interaction}`, {
@@ -496,9 +533,15 @@ export function logUIInteraction(interaction, element, data = {}) {
 
 /**
  * Log battle errors with enhanced context.
+ *
  * @pseudocode
- * 1. Log errors with context about where they occurred
- * 2. Include stack trace and error details
+ * 1. Log errors with context about where they occurred.
+ * 2. Include stack trace and error details.
+ *
+ * @param {Error} error - Error instance or message.
+ * @param {string} context - Where the error happened.
+ * @param {object} [data={}] - Additional context.
+ * @returns {void}
  */
 export function logBattleError(error, context, data = {}) {
   debugLogger.log("error", "error", `Battle Error in ${context}`, {
@@ -511,9 +554,13 @@ export function logBattleError(error, context, data = {}) {
 
 /**
  * Create a logger instance for a specific battle component.
+ *
  * @pseudocode
- * 1. Create logger scoped to a specific component
- * 2. Enable easy identification of log source
+ * 1. Return helper methods that call `debugLogger` with the component name.
+ * 2. Provide info/debug/error/timer/event/ui logging wrappers.
+ *
+ * @param {string} componentName - Component label for log prefixing.
+ * @returns {object} Component-scoped logging helpers.
  */
 export function createComponentLogger(componentName) {
   return {

--- a/src/helpers/classicBattle/eventAliases.js
+++ b/src/helpers/classicBattle/eventAliases.js
@@ -75,6 +75,11 @@ for (const [newName, oldNames] of Object.entries(EVENT_ALIASES)) {
  * @param {boolean} options.skipAliases - Skip emitting alias events
  * @param {boolean} options.warnDeprecated - Warn about deprecated usage
  * @returns {void}
+ *
+ * @pseudocode
+ * 1. Dispatch the standardized event on `eventTarget`.
+ * 2. Unless `skipAliases`, loop through alias names and dispatch each.
+ * 3. Optionally warn in development/test when deprecated aliases are used.
  */
 export function emitEventWithAliases(eventTarget, eventName, payload, options = {}) {
   const { skipAliases = false, warnDeprecated = true } = options;
@@ -109,6 +114,11 @@ export function emitEventWithAliases(eventTarget, eventName, payload, options = 
  * @param {any} payload - Event payload
  * @param {object} options - Emission options
  * @returns {void}
+ *
+ * @pseudocode
+ * 1. Resolve the battle event target via `getBattleEventTarget`.
+ * 2. If `eventName` is deprecated, warn and emit both new and old names.
+ * 3. Otherwise delegate to `emitEventWithAliases` with the given name.
  */
 export function emitBattleEventWithAliases(eventName, payload, options = {}) {
   // Import the battle event target dynamically to avoid circular deps
@@ -150,6 +160,10 @@ export function emitBattleEventWithAliases(eventName, payload, options = {}) {
  *
  * @param {string} oldEventName - Deprecated event name
  * @returns {object} Migration information
+ *
+ * @pseudocode
+ * 1. Look up new name in `REVERSE_EVENT_ALIASES`.
+ * 2. Return info indicating whether migration is needed and recommended name.
  */
 export function getMigrationInfo(oldEventName) {
   const newName = REVERSE_EVENT_ALIASES[oldEventName];
@@ -175,6 +189,9 @@ export function getMigrationInfo(oldEventName) {
  *
  * @param {string[]} aliasesToDisable - Array of old event names to stop aliasing
  * @returns {void}
+ *
+ * @pseudocode
+ * 1. For each alias, remove it from the mapping in `EVENT_ALIASES`.
  */
 export function disableAliases(aliasesToDisable) {
   for (const alias of aliasesToDisable) {
@@ -190,6 +207,9 @@ export function disableAliases(aliasesToDisable) {
  *
  * @param {string} eventName - Event name to check
  * @returns {boolean} True if the event name is deprecated
+ *
+ * @pseudocode
+ * 1. Return `true` when `eventName` exists in `REVERSE_EVENT_ALIASES`.
  */
 export function isDeprecatedEventName(eventName) {
   return eventName in REVERSE_EVENT_ALIASES;

--- a/src/helpers/classicBattle/orchestrator.js
+++ b/src/helpers/classicBattle/orchestrator.js
@@ -437,4 +437,10 @@ export function getBattleStateMachine() {
 }
 
 // Re-export for test compatibility
+/**
+ * Re-export battle event dispatcher for external modules.
+ *
+ * @pseudocode
+ * 1. Provide thin alias to `eventDispatcher.dispatchBattleEvent`.
+ */
 export { dispatchBattleEvent };

--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -32,6 +32,15 @@ export { roundModificationEnter } from "./stateHandlers/roundModificationEnter.j
  * @param {string} state
  * @returns {Function|undefined}
  */
+/**
+ * Look up the onEnter handler for a state.
+ *
+ * @pseudocode
+ * 1. Return `stateHandlers[state]?.onEnter`.
+ *
+ * @param {string} state - State name.
+ * @returns {Function|undefined} Handler function or undefined.
+ */
 export function getOnEnterHandler(state) {
   return stateHandlers[state]?.onEnter;
 }
@@ -41,6 +50,15 @@ export function getOnEnterHandler(state) {
  *
  * @param {string} state
  * @returns {Function|undefined}
+ */
+/**
+ * Look up the onExit handler for a state.
+ *
+ * @pseudocode
+ * 1. Return `stateHandlers[state]?.onExit`.
+ *
+ * @param {string} state - State name.
+ * @returns {Function|undefined} Handler function or undefined.
  */
 export function getOnExitHandler(state) {
   return stateHandlers[state]?.onExit;

--- a/src/helpers/classicBattle/quitModal.js
+++ b/src/helpers/classicBattle/quitModal.js
@@ -64,6 +64,10 @@ function createQuitConfirmation(store, onConfirm) {
  * confirmation modal is presented. Tests can await `window.quitConfirmButtonPromise`
  * to interact with the modal's confirm button.
  *
+ * @pseudocode
+ * 1. Initialize to a resolved promise until `quitMatch` sets a new one.
+ * 2. Expose the promise globally for tests.
+ *
  * @type {Promise<HTMLButtonElement>}
  */
 export let quitConfirmButtonPromise = Promise.resolve();

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -17,12 +17,13 @@ import { attachCooldownRenderer } from "../CooldownRenderer.js";
 import { getStateSnapshot } from "./battleDebug.js";
 
 /**
- * Check if the classic battle orchestrator is active.
+ * Detect whether the classic battle orchestrator is active.
  *
- * The presence of `data-battle-state` on the body is a reliable indicator
- * that the state machine is running and managing the battle flow.
+ * @pseudocode
+ * 1. Read `document.body.dataset.battleState` inside a try/catch.
+ * 2. Return `true` when the attribute exists, otherwise `false`.
  *
- * @returns {boolean} True if the orchestrator is active.
+ * @returns {boolean} True if orchestration appears active.
  */
 export function isOrchestrated() {
   try {
@@ -31,12 +32,6 @@ export function isOrchestrated() {
     return false;
   }
 }
-
-/**
- * @pseudocode
- * 1. Attempt to read `document.body.dataset.battleState`.
- * 2. Return true when present, otherwise false. Swallow errors.
- */
 
 /**
  * Create a new battle state store.
@@ -287,17 +282,15 @@ export function startCooldown(_store, scheduler = realScheduler) {
 /**
  * Expose current cooldown controls for Next button helpers.
  *
+ * @pseudocode
+ * 1. Return the `currentNextRound` object containing timer and readiness resolver.
+ * 2. When no cooldown is active, return `null`.
+ *
  * @returns {{timer: ReturnType<typeof createRoundTimer>|null, resolveReady: (()=>void)|null, ready: Promise<void>|null}|null}
  */
 export function getNextRoundControls() {
   return currentNextRound;
 }
-
-/**
- * @pseudocode
- * 1. Return the `currentNextRound` controls object which contains timer and
- *    readiness resolver. This is null when no cooldown is active.
- */
 
 /**
  * Schedule a fallback timeout and return its id.

--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -15,6 +15,10 @@ import rounds from "../../data/battleRounds.js";
 /**
  * Check if the URL requests an automatic start.
  *
+ * @pseudocode
+ * 1. Parse `location.search` for `autostart=1` inside a try/catch.
+ * 2. Return `true` when present; otherwise `false`.
+ *
  * @returns {boolean} True when `?autostart=1` is present.
  */
 export function shouldAutostart() {

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -47,6 +47,7 @@ runWhenIdle(preloadUiService);
  * @param {ReturnType<typeof import('./roundManager.js').createBattleStore>} store - Battle state store.
  * @param {number} roundNumber - Current round number to display.
  * @param {number} [stallTimeoutMs=5000] - Delay before auto-select kicks in.
+ * @returns {void}
  */
 export function applyRoundUI(store, roundNumber, stallTimeoutMs = 5000) {
   try {
@@ -115,6 +116,8 @@ export function applyRoundUI(store, roundNumber, stallTimeoutMs = 5000) {
  * 1. Listen for `roundStarted`.
  * 2. Extract store and round number.
  * 3. Invoke `applyRoundUI`.
+ *
+ * @returns {void}
  */
 export function bindRoundStarted() {
   onBattleEvent("roundStarted", (e) => {
@@ -132,6 +135,8 @@ export function bindRoundStarted() {
  * 1. Listen for `statSelected`.
  * 2. Highlight the chosen button and optionally show feedback.
  * 3. Disable further stat selections.
+ *
+ * @returns {void}
  */
 export function bindStatSelected() {
   onBattleEvent("statSelected", (e) => {
@@ -162,6 +167,8 @@ export function bindStatSelected() {
  * 1. Listen for `roundResolved`.
  * 2. Surface outcome, update score, maybe show summary.
  * 3. Clear selection highlight and refresh debug panel.
+ *
+ * @returns {void}
  */
 export function bindRoundResolved() {
   onBattleEvent("roundResolved", (e) => {
@@ -237,6 +244,8 @@ export function bindRoundResolved() {
  * 1. Bind `roundStarted` handler.
  * 2. Bind `statSelected` handler.
  * 3. Bind `roundResolved` handler.
+ *
+ * @returns {void}
  */
 export function bindRoundUIEventHandlers() {
   bindRoundStarted();

--- a/src/helpers/classicBattle/stateHandlers/roundStartEnter.js
+++ b/src/helpers/classicBattle/stateHandlers/roundStartEnter.js
@@ -3,17 +3,6 @@ import { isTestModeEnabled } from "../../testModeUtils.js";
 import { guard, guardAsync } from "../guard.js";
 import { handleRoundError } from "../handleRoundError.js";
 
-/**
- * onEnter handler for `roundStart` state.
- *
- * @param {object} machine
- * @returns {Promise<void>}
- * @pseudocode
- * 1. Install test fallback to advance if stalled.
- * 2. Invoke round start routine from context.
- * 3. On failure -> clear fallback and handle round error.
- * 4. If still in `roundStart` -> dispatch `cardsRevealed`.
- */
 function installRoundStartFallback(machine) {
   if (!isTestModeEnabled || !isTestModeEnabled()) return null;
   return setupFallbackTimer(50, () => {
@@ -31,6 +20,18 @@ function invokeRoundStart(ctx) {
   return Promise.resolve();
 }
 
+/**
+ * onEnter handler for `roundStart` state.
+ *
+ * @pseudocode
+ * 1. Install a test fallback timer if test mode is enabled.
+ * 2. Invoke the round start routine from context.
+ * 3. Clear fallback and handle errors via `handleRoundError`.
+ * 4. If still in `roundStart`, dispatch `cardsRevealed`.
+ *
+ * @param {object} machine - State machine instance.
+ * @returns {Promise<void>}
+ */
 export async function roundStartEnter(machine) {
   const fallback = installRoundStartFallback(machine);
   try {

--- a/src/helpers/classicBattle/stateTransitionListeners.js
+++ b/src/helpers/classicBattle/stateTransitionListeners.js
@@ -8,29 +8,16 @@ import { logStateTransition } from "./battleDebug.js";
 import { exposeDebugState } from "./debugHooks.js";
 
 /**
- * Mirror the current battle state to the DOM.
+ * Sync battle state transitions to DOM attributes for UI and tests.
  *
- * @param {CustomEvent<{from:string|null,to:string,event:string|null}>} e
- *   State transition detail.
- * @summary Sync battle state to DOM.
  * @pseudocode
- * 1. Extract `from`, `to`, and `event` from `e.detail`.
- * 2. If `document` is available:
- *    a. Update `document.body.dataset.battleState` to `to`.
- *    b. Set `prevBattleState` when `from` exists, otherwise remove it.
+ * 1. Read `from` and `to` from the event detail.
+ * 2. If `document` exists, update `document.body.dataset.battleState` and `prevBattleState`.
+ *
+ * @param {CustomEvent<{from:string|null,to:string,event:string|null}>} e - Event containing transition detail.
+ * @returns {void}
  */
 export function domStateListener(e) {
-  /**
-   * Sync battle state transitions to DOM attributes for UI and tests.
-   *
-   * @param {CustomEvent<{from:string|null,to:string,event:string|null}>} e
-   *   Event containing transition detail.
-   * @returns {void}
-   * @pseudocode
-   * 1. Read `from` and `to` from event detail.
-   * 2. If `document` exists, update `document.body.dataset.battleState` and
-   *    `prevBattleState` accordingly.
-   */
   const { from, to } = e.detail || {};
   if (typeof document === "undefined") return;
   try {

--- a/src/helpers/classicBattle/uiEventHandlers.js
+++ b/src/helpers/classicBattle/uiEventHandlers.js
@@ -9,23 +9,17 @@ import { getOpponentDelay } from "./snackbar.js";
 
 let opponentSnackbarId = 0;
 
+/**
+ * Bind dynamic UI helper event handlers on the shared battle EventTarget.
+ *
+ * @pseudocode
+ * 1. Track EventTargets in a WeakSet to avoid duplicate bindings.
+ * 2. Attach listeners for opponent reveal, stat selection, and round resolution.
+ * 3. Render opponent card, show snackbar messages, and update debug panel.
+ *
+ * @returns {void}
+ */
 export function bindUIHelperEventHandlersDynamic() {
-  /**
-   * Bind dynamic UI helper event handlers on the shared battle EventTarget.
-   *
-   * This function idempotently attaches listeners for opponent reveals,
-   * stat selection, and round resolved events. Handlers are attached to the
-   * current `getBattleEventTarget()` instance and guarded so multiple calls
-   * against the same target are a no-op.
-   *
-   * @pseudocode
-   * 1. Compute a WeakSet attached to global to track bound EventTargets.
-   * 2. If the current target is already bound, return early.
-   * 3. Attach handlers for `opponentReveal`, `statSelected`, and `roundResolved`.
-   * 4. Each handler renders UI and updates debug panel or shows snackbars.
-   *
-   * @returns {void}
-   */
   // Ensure we only bind once per EventTarget instance
   try {
     const KEY = "__cbUIHelpersDynamicBoundTargets";

--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -132,6 +132,7 @@ runWhenIdle(preloadUiService);
  *
  * @param {object} judoka - Data required by `JudokaCard` (may include `lookup`).
  * @param {HTMLElement|null} container - DOM element to receive the rendered card.
+ * @returns {Promise<void>}
  */
 export async function renderOpponentCard(judoka, container) {
   if (!judoka || !container) return;
@@ -331,6 +332,16 @@ export function showStatComparison(store, stat, playerVal, compVal) {
   store.compareRaf = id;
 }
 
+/**
+ * Watch orientation changes and invoke a callback until it succeeds.
+ *
+ * @pseudocode
+ * 1. Invoke `callback`; if it returns falsey, poll via rAF until it succeeds.
+ * 2. Register `orientationchange` and `resize` listeners to retry invocation.
+ *
+ * @param {() => any} callback - Function returning truthy when orientation applied.
+ * @returns {void}
+ */
 export function watchBattleOrientation(callback) {
   if (typeof callback !== "function") {
     return;


### PR DESCRIPTION
## Summary
- add JSDoc and @pseudocode blocks to scoreboard helpers and battle utilities
- document classic battle debug/logger and event alias helpers
- improve round UI and state-handler annotations

## Testing
- `npx prettier . --check` *(fails: command not found)*
- `npx eslint .` *(fails: command not found)*
- `npm run check:jsdoc` *(fails: command not found)*
- `npx vitest run` *(fails: command not found)*
- `npx playwright test` *(fails: command not found)*
- `npm run check:contrast` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c1d8b37bc48326bac4f12472389ac5