### PR TITLE
docs: add jsdoc to helpers

### DIFF
--- a/src/helpers/api/battleUI.js
+++ b/src/helpers/api/battleUI.js
@@ -65,6 +65,10 @@ export function getOutcomeMessage(outcome) {
   return OUTCOME_MESSAGES[outcome] || "";
 }
 
+// Simple score tracking for fallback mode
+let fallbackPlayerScore = 0;
+let fallbackOpponentScore = 0;
+
 /**
  * Evaluate a stat matchup and return engine results with a user-facing message.
  *
@@ -79,10 +83,6 @@ export function getOutcomeMessage(outcome) {
  * @param {number} opponentVal - Opponent's stat value.
  * @returns {{delta: number, outcome: string, matchEnded: boolean, playerScore: number, opponentScore: number, message: string}}
  */
-// Simple score tracking for fallback mode
-let fallbackPlayerScore = 0;
-let fallbackOpponentScore = 0;
-
 export function evaluateRound(playerVal, opponentVal) {
   try {
     // Use the battle engine facade

--- a/src/helpers/battle/battleUI.js
+++ b/src/helpers/battle/battleUI.js
@@ -89,6 +89,8 @@ export function resetStatButtons(
   });
 }
 
+let cancelFade;
+
 /**
  * Display the round result message and fade it out after 2s.
  *
@@ -103,7 +105,6 @@ export function resetStatButtons(
  * @param {object} [scheduler] - Optional scheduler with `onFrame`, `cancel`, `setTimeout`, `clearTimeout`.
  * @returns {void}
  */
-let cancelFade;
 export function showResult(
   message,
   scheduler = {

--- a/src/helpers/battleEngineFacade.js
+++ b/src/helpers/battleEngineFacade.js
@@ -53,15 +53,6 @@ export { BattleEngine, STATS, OUTCOME } from "./BattleEngine.js";
  */
 let battleEngine;
 
-function requireEngine() {
-  if (!battleEngine) {
-    // Provide a clear error for consumers that call helpers before
-    // initialization.
-    throw new Error("Battle engine not initialized. Call createBattleEngine() first.");
-  }
-  return battleEngine;
-}
-
 /**
  * Internal guard that returns the active engine or throws if none exists.
  *
@@ -73,7 +64,14 @@ function requireEngine() {
  * @throws {Error} When no engine has been created.
  * @returns {IBattleEngine}
  */
-// (The function implementation appears above; this comment supplies the required JSDoc.)
+function requireEngine() {
+  if (!battleEngine) {
+    // Provide a clear error for consumers that call helpers before
+    // initialization.
+    throw new Error("Battle engine not initialized. Call createBattleEngine() first.");
+  }
+  return battleEngine;
+}
 
 /**
  * Create a new battle engine instance.

--- a/src/helpers/battleInit.js
+++ b/src/helpers/battleInit.js
@@ -13,14 +13,6 @@
  */
 const readyParts = new Set();
 
-/**
- * Promise that resolves once the battle screen has fully initialized.
- *
- * @pseudocode
- * 1. Create a promise and capture its resolve callback.
- * 2. Add a one-time listener for `battle:init` that resolves the promise.
- * 3. Expose the promise globally via `window.battleReadyPromise`.
- */
 let resolveReady;
 /**
  * Promise that resolves when the battle screen has fully initialized.

--- a/src/helpers/carouselBuilder.js
+++ b/src/helpers/carouselBuilder.js
@@ -6,45 +6,6 @@ import { setupFocusHandlers } from "./carousel/focus.js";
 import { setupLazyPortraits } from "./lazyPortrait.js";
 import { CAROUSEL_SWIPE_THRESHOLD } from "./constants.js";
 import { createSpinner } from "../components/Spinner.js";
-
-/**
- * Adds scroll markers to indicate the user's position in the carousel.
- *
- * @pseudocode
- * 1. Validate inputs: If `container` or `wrapper` is missing, exit early.
- * 2. Check for existing markers: If a `.scroll-markers` element already exists within `wrapper` (meaning a controller has already set them up), exit to avoid duplication.
- * 3. Create the `markers` container: Create a `<div>` element, assign it the class `scroll-markers`.
- * 4. Get card dimensions and calculate page metrics:
- *    a. Query all `.judoka-card` elements within `container`.
- *    b. Get the `firstCard` and its `cardWidth`.
- *    c. Get the `gap` between columns from the computed style of `container`.
- *    d. Calculate `cardsPerPage`: Determine how many cards fit within the `container.clientWidth`, accounting for `gap`, ensuring at least 1 card per page.
- *    e. Calculate `pageCount`: Determine the total number of pages based on `cards.length` and `cardsPerPage`.
- * 5. Create and append page markers:
- *    a. Loop from `i = 0` to `pageCount - 1`:
- *       i. Create a `<span>` element for each `marker`.
- *       ii. Assign it the class `scroll-marker`.
- *       iii. If `i` is 0 (first page), add the "active" class.
- *       iv. Append the `marker` to the `markers` container.
- * 6. Create and append the page counter:
- *    a. Create a `<span>` element for the `counter`.
- *    b. Assign it the class `page-counter`.
- *    c. Set its `aria-live` attribute to "polite" for accessibility.
- *    d. Set its initial `textContent` to "Page 1 of [pageCount]".
- *    e. Append the `counter` to the `markers` container.
- * 7. Append the `markers` container to the `wrapper`.
- * 8. Add a "scroll" event listener to the `container`:
- *    a. Inside the listener, recalculate `gapPx`, `pageWidth`, `maxScroll`, and `remaining` scroll distance.
- *    b. Calculate `currentPage`:
- *       i. If `remaining` is less than or equal to 1px, set `currentPage` to `pageCount - 1` (last page) to handle rounding issues at the end of scroll.
- *       ii. Otherwise, if `pageWidth` is greater than 0, calculate `currentPage` by rounding `container.scrollLeft / pageWidth` and clamping it between 0 and `pageCount - 1`.
- *       iii. If `pageWidth` is 0, set `currentPage` to 0.
- *    c. Update active markers: Iterate through all `.scroll-marker` elements and toggle the "active" class based on whether their index matches `currentPage`.
- *    d. Update counter text: Set `counter.textContent` to `Page [currentPage + 1] of [pageCount]`.
- *
- * @param {HTMLElement} [container] - The carousel container element.
- * @param {HTMLElement} [wrapper] - The carousel wrapper element.
- */
 /**
  * Adds scroll markers to indicate the user's position in the carousel.
  *
@@ -117,17 +78,6 @@ function addScrollMarkers(container, wrapper) {
   });
 }
 
-/**
- * Initialize scroll markers after the carousel is attached to the document.
- *
- * @pseudocode
- * 1. Exit early if `container` or `wrapper` is missing.
- * 2. Schedule `addScrollMarkers` inside `requestAnimationFrame` to ensure
- *    measurements occur after layout.
- *
- * @param {HTMLElement} [container] - The carousel container element.
- * @param {HTMLElement} [wrapper] - The carousel wrapper element.
- */
 /**
  * Initialize scroll markers after the carousel is attached to the document.
  *


### PR DESCRIPTION
## Task Contract
- add JSDoc and pseudocode to helper functions

### Inputs
- codebase functions lacking documentation

### Outputs
- updated helper modules with JSDoc and pseudocode

### Success
- new comments added and formatting/lint/tests run

### Error
- any failing validation command or runtime error

## Files Changed
- `src/helpers/api/battleUI.js` – document `evaluateRound`
- `src/helpers/battle/battleUI.js` – document `showResult`
- `src/helpers/battleEngineFacade.js` – document `requireEngine`
- `src/helpers/battleInit.js` – clean up `battleReadyPromise` comments
- `src/helpers/carouselBuilder.js` – consolidate scroll marker docs and document `initScrollMarkers`

## Verification
- `npx prettier . --check`
- `npx eslint .` (warnings)
- `npm run check:jsdoc` (132 missing)
- `npx vitest run`
- `npx playwright test` (2 failing)
- `npm run check:contrast`

## Risk
- Low: comment-only changes.


------
https://chatgpt.com/codex/tasks/task_e_68c29e8bd5188326b70614c4349f61b7