### PR TITLE
chore: remove duplicate orchestrator handler docs

### DIFF
--- a/src/helpers/classicBattle/orchestratorHandlers.js
+++ b/src/helpers/classicBattle/orchestratorHandlers.js
@@ -27,12 +27,6 @@ export { interruptMatchEnter } from "./stateHandlers/interruptMatchEnter.js";
 export { roundModificationEnter } from "./stateHandlers/roundModificationEnter.js";
 
 /**
- * Lookup onEnter handler for a state.
- *
- * @param {string} state
- * @returns {Function|undefined}
- */
-/**
  * Look up the onEnter handler for a state.
  *
  * @pseudocode
@@ -45,12 +39,6 @@ export function getOnEnterHandler(state) {
   return stateHandlers[state]?.onEnter;
 }
 
-/**
- * Lookup onExit handler for a state.
- *
- * @param {string} state
- * @returns {Function|undefined}
- */
 /**
  * Look up the onExit handler for a state.
  *


### PR DESCRIPTION
## Summary
- remove redundant JSDoc blocks for getOnEnterHandler and getOnExitHandler
- retain single @pseudocode JSDoc for each handler

## Testing
- `npx prettier . --check` *(fails: Code style issues in 12 files)*
- `npx prettier src/helpers/classicBattle/orchestratorHandlers.js --check`
- `npx eslint .` *(fails: 9 errors, 18 warnings)*
- `npx eslint src/helpers/classicBattle/orchestratorHandlers.js`
- `npm run check:jsdoc` *(fails: 134 missing docs)*
- `npx vitest run`
- `npx playwright test` *(fails: 3 failed)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68c2a71846c8832698b090522a69e983