### PR TITLE
docs: add missing JSDoc and pseudocode

### DIFF
--- a/src/helpers/signatureMove.js
+++ b/src/helpers/signatureMove.js
@@ -23,18 +23,6 @@ let resolveReady;
  *
  * @type {Promise<void>}
  */
-/**
- * Promise resolved when signature-move UI is ready.
- *
- * Consumers can await this promise to defer behavior until the signature
- * move UI has finished initial rendering/animations.
- *
- * @type {Promise<void>}
- *
- * @pseudocode
- * 1. Construct a Promise and capture its resolve function in `resolveReady`.
- * 2. Export the promise so external code may await readiness.
- */
 export const signatureMoveReadyPromise = new Promise((resolve) => {
   resolveReady = resolve;
 });

--- a/src/helpers/testApi.js
+++ b/src/helpers/testApi.js
@@ -327,8 +327,14 @@ const testApi = {
 };
 
 /**
- * Initialize the test API by exposing it on the window object
- * Only exposes API in test environments
+ * Initialize the test API by exposing it on the window object.
+ *
+ * @pseudocode
+ * 1. If not in test mode, exit early.
+ * 2. If running in a browser, attach the `testApi` and its sub-APIs to
+ *    properties on `window` for debugging.
+ *
+ * @returns {void}
  */
 export function exposeTestAPI() {
   if (!isTestMode()) return;
@@ -345,7 +351,11 @@ export function exposeTestAPI() {
 }
 
 /**
- * Get the test API object (works in both browser and Node environments)
+ * Get the test API object (works in both browser and Node environments).
+ *
+ * @pseudocode
+ * 1. Return the pre-created `testApi` singleton.
+ *
  * @returns {object} Test API object
  */
 export function getTestAPI() {

--- a/src/helpers/vectorSearch/chunkConfig.js
+++ b/src/helpers/vectorSearch/chunkConfig.js
@@ -9,23 +9,6 @@
  * 2. Sentences or headings may be used as natural boundaries before enforcing this limit.
  */
 /**
- * Maximum number of characters per chunk when splitting large texts for
- * embeddings and vector indexing.
- *
- * @description
- * This value controls the upper bound of chunk length. Chunking algorithms
- * should try to split on natural boundaries (sentences/headings) before
- * enforcing this limit.
- *
- * @pseudocode
- * 1. When processing a long document, iterate and produce substrings no larger
- *    than `CHUNK_SIZE` characters.
- * 2. Prefer natural boundaries before splitting to avoid chopping semantic
- *    units (e.g., sentences or markdown headings).
- *
- * @type {number}
- */
-/**
  * Maximum characters per chunk when splitting large texts for embeddings and vector indexing.
  *
  * @description
@@ -43,20 +26,6 @@
  */
 export const CHUNK_SIZE = 1000;
 
-/**
- * Fraction (0..1) of characters to overlap between adjacent chunks.
- *
- * @description
- * Overlap preserves context across chunk boundaries for semantic search and
- * improves recall when queries span a boundary.
- *
- * @pseudocode
- * 1. Calculate `overlapSize = Math.floor(CHUNK_SIZE * OVERLAP_RATIO)`.
- * 2. For each chunk after the first, include the last `overlapSize` characters
- *    from the previous chunk at the start of the current chunk.
- *
- * @type {number}
- */
 /**
  * Fraction (0..1) of characters to overlap between adjacent chunks.
  *

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,30 +1,35 @@
 /**
- * Re-export of the battle CLI test helper used in automated tests.
- *
- * @pseudocode
- * 1. Import the internal `__test` export from `battleCLI.js` and re-export it
- *    under the name `battleCLI` so tests can import it from the public entry.
- */
-/**
  * Test helper re-export for the battle CLI module used by automated tests.
  *
  * @pseudocode
  * 1. Re-export the internal `__test` helper as `battleCLI` for tests.
  */
-/**
- * Test helper re-export for the battle CLI module used by automated tests.
- *
- * @pseudocode
- * 1. Re-export the internal `__test` helper as `battleCLI` for tests.
- */
-export { __test as battleCLI, setupFlags, wireEvents, subscribeEngine } from "./battleCLI/init.js";
+export { __test as battleCLI } from "./battleCLI/init.js";
 
 /**
- * Re-export the global key handler for the battle CLI page.
+ * Re-export the `setupFlags` helper from the battle CLI initializer.
  *
  * @pseudocode
- * 1. Re-export `onKeyDown` so external callers (tests/bootstrappers) can attach it.
+ * 1. Export `setupFlags` so callers can initialize feature flags.
  */
+export { setupFlags } from "./battleCLI/init.js";
+
+/**
+ * Re-export the `wireEvents` helper from the battle CLI initializer.
+ *
+ * @pseudocode
+ * 1. Export `wireEvents` so callers can attach event listeners.
+ */
+export { wireEvents } from "./battleCLI/init.js";
+
+/**
+ * Re-export the `subscribeEngine` helper from the battle CLI initializer.
+ *
+ * @pseudocode
+ * 1. Export `subscribeEngine` so callers can subscribe to engine events.
+ */
+export { subscribeEngine } from "./battleCLI/init.js";
+
 /**
  * Re-export the global key handler for the battle CLI page.
  *
@@ -33,12 +38,6 @@ export { __test as battleCLI, setupFlags, wireEvents, subscribeEngine } from "./
  */
 export { onKeyDown } from "./battleCLI/events.js";
 
-/**
- * Re-export a promise helper that resolves when Escape is handled in the CLI.
- *
- * @pseudocode
- * 1. Re-export `getEscapeHandledPromise` from the battle CLI state module.
- */
 /**
  * Re-export a promise helper that resolves when Escape is handled in the CLI.
  *


### PR DESCRIPTION
## Summary
- document test API helpers with JSDoc and pseudocode
- add pseudocode JSDoc for battle CLI re-exports
- clean duplicate docs for signature move and vector search config

## Testing
- `npx prettier src/helpers/testApi.js src/pages/index.js src/helpers/signatureMove.js src/helpers/vectorSearch/chunkConfig.js --check`
- `npx prettier . --check` (fails: Code style issues found in 21 files)
- `npx eslint .` (fails: 19 errors, 19 warnings)
- `npm run check:jsdoc` (fails: Total missing: 132)
- `npx vitest run`
- `npx playwright test` (fails: 2 failed)
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68c2ad370a788326a984844578146229