### PR TITLE
docs: summarize settings readiness promise

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -53,6 +53,9 @@ import { renderFeatureFlags } from "./settings/renderFeatureFlags.js";
  * 2. Attach it to `window` so tests can await it.
  */
 /**
+ * @summary Resolves once the Settings page dispatches `settings:ready`.
+ */
+/**
  * Promise that resolves when the Settings UI has finished rendering and
  * dispatched the `settings:ready` event.
  *


### PR DESCRIPTION
## Task Contract
- **Inputs:** `src/helpers/settingsPage.js`
- **Outputs:** JSDoc summary describing the `settingsReadyPromise`.
- **Success:** Promise purpose documented without altering existing pseudocode or `@type`.
- **Error Handling:** Note testing limitations if tooling is unavailable.

## Files Changed
- `src/helpers/settingsPage.js` — added a `@summary` block explaining when `settingsReadyPromise` resolves.

## Verification
- `npx prettier . --check` *(fails: command not found)*
- `npx eslint .` *(fails: command not found)*
- `npm run check:jsdoc` *(fails: command not found)*
- `npx vitest run` *(fails: command not found)*
- `npx playwright test` *(fails: command not found)*
- `npm run check:contrast` *(fails: command not found)*

## Risk
- Low: documentation-only change. Future tests should run once Node tooling is installed.


------
https://chatgpt.com/codex/tasks/task_e_68c2bb7028d883269dde94313b9d351c