### PR TITLE
Add default viewport for Playwright tests

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
   reporter: "dot",
   use: {
     baseURL: "http://localhost:5000",
+    viewport: { width: 1920, height: 1080 },
     // Capture rich artifacts to aid debugging flaky UI timing in CI/local
     screenshot: "only-on-failure",
     trace: "on-first-retry",

--- a/playwright/local.config.js
+++ b/playwright/local.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
   reporter: "list",
   use: {
     // No baseURL needed; specs use file:// URLs directly.
+    viewport: { width: 1920, height: 1080 },
     screenshot: "only-on-failure",
     trace: "on-first-retry",
     video: "retain-on-failure"


### PR DESCRIPTION
## Summary
- set a full HD viewport in shared Playwright config
- set the same viewport in local Playwright config for file:// specs

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check` *(fails: Code style issues found in 2 files)*
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: 4 failed)*
- `npm run check:contrast`
- `npm run rag:validate`
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c30b89a5188326936c6b0e22a73ce6