### PR TITLE
docs: clarify Playwright default viewport

### DIFF
--- a/docs/battleCLI.md
+++ b/docs/battleCLI.md
@@ -23,7 +23,7 @@ import { battleCLI, onKeyDown } from "src/pages/index.js";
 
 **CLI Layout Status: PRD Compliant** (Last assessed: 2024)
 
-The battleCLI interface has been validated against PRD requirements with comprehensive Playwright testing:
+The battleCLI interface has been validated against PRD requirements with comprehensive Playwright testing (default desktop viewport 1920×1080):
 
 - **✅ Touch Targets**: All interactive elements meet 44px minimum height requirement
 - **✅ Responsive Grid**: CSS Grid layout adapts to viewport with proper column distribution

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -30,6 +30,8 @@ npm run test:style
 
 ## Playwright Testing
 
+Playwright specs default to a 1920×1080 desktop viewport. Use per-test viewport overrides to cover mobile or other sizes.
+
 ### Stable Readiness Patterns
 
 **Preferred readiness waits:**

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -1,5 +1,7 @@
 # Playwright Homepage Specs
 
+Unless overridden, Playwright tests run at a 1920×1080 desktop viewport.
+
 | Spec file | Responsibilities |
 |-----------|------------------|
 | `homepage.spec.js` | Verifies footer navigation link visibility, ordering, and other interactive elements. |


### PR DESCRIPTION
## Summary
- document 1920×1080 default viewport for Playwright tests
- note that specs should override viewport per test when targeting other sizes
- mention default desktop resolution in CLI layout docs

## Testing
- `npm run check:jsdoc` *(fails: functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 9 failed tests)*
- `npx playwright test` *(fails: 6 failed tests)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68c341afde3c83268ef8e828c17029f2