### PR TITLE
test: mock battleCLI init in roundSelectModal positioning

### DIFF
--- a/tests/helpers/classicBattle/roundSelectModal.positioning.test.js
+++ b/tests/helpers/classicBattle/roundSelectModal.positioning.test.js
@@ -33,6 +33,10 @@ describe("roundSelectModal positioning and skinning", () => {
     backdrop.className = "modal-backdrop";
     mockModalReturning(backdrop);
 
+    vi.doMock("../../../src/pages/battleCLI/init.js", () => ({
+      syncWinTargetDropdown: vi.fn()
+    }));
+
     const { initRoundSelectModal } = await import(
       "../../../src/helpers/classicBattle/roundSelectModal.js"
     );
@@ -61,6 +65,10 @@ describe("roundSelectModal positioning and skinning", () => {
     const backdrop = document.createElement("div");
     backdrop.className = "modal-backdrop";
     mockModalReturning(backdrop);
+
+    vi.doMock("../../../src/pages/battleCLI/init.js", () => ({
+      syncWinTargetDropdown: vi.fn()
+    }));
 
     const { initRoundSelectModal } = await import(
       "../../../src/helpers/classicBattle/roundSelectModal.js"


### PR DESCRIPTION
## Summary
- mock `battleCLI` init in `roundSelectModal.positioning.test`

## Testing
- `npm run check:jsdoc` *(fails: npm not found)*
- `npx prettier . --check` *(fails: npx not found)*
- `npx eslint .` *(fails: npx not found)*
- `npx vitest run` *(fails: npx not found)*
- `npx playwright test` *(fails: npx not found)*
- `npm run check:contrast` *(fails: npm not found)*
- `npm run rag:validate` *(fails: npm not found)*
- `npm run validate:data` *(fails: npm not found)*
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json`
- `grep -RInE "console.(warn|error)(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c45b47cf8c8326b99711ed0ec9476f