### PR TITLE
test: mock createBattleEngine in round select modal test

### DIFF
--- a/tests/helpers/classicBattle/roundSelectModal.test.js
+++ b/tests/helpers/classicBattle/roundSelectModal.test.js
@@ -38,6 +38,8 @@ vi.mock("../../../src/components/Modal.js", () => ({
   createModal: (...args) => mocks.createModal(...args)
 }));
 vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
+  createBattleEngine: vi.fn(),
+  getPointsToWin: vi.fn(),
   setPointsToWin: mocks.setPointsToWin
 }));
 vi.mock("../../../src/helpers/tooltip.js", () => ({ initTooltips: mocks.initTooltips }));


### PR DESCRIPTION
## Summary
- extend battleEngineFacade mock in roundSelectModal test to include createBattleEngine and related stubs

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: code style issues in progress.md, progressPhase3.md)*
- `npx eslint tests/helpers/classicBattle/roundSelectModal.test.js`
- `npx vitest run tests/helpers/classicBattle/roundSelectModal.test.js` *(passes but reports missing mock exports)*
- `npx playwright test` *(terminated early)*
- `npm run check:contrast`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json`
- `grep -RInE "console.(warn|error)(" tests --exclude=client_embeddings.json | grep -v tests/utils/console.js`

## Risk
- low: affects test mocks only; ensure additional battle engine methods are mocked if more are required by future tests.


------
https://chatgpt.com/codex/tasks/task_e_68c45b4346ac83269fc4319272e448e3