### PR TITLE
fix import path in debug stat loading spec

### DIFF
--- a/debug-stat-loading.spec.js
+++ b/debug-stat-loading.spec.js
@@ -1,4 +1,4 @@
-import { test } from "../playwright/fixtures/commonSetup.js";
+import { test } from "./playwright/fixtures/commonSetup.js";
 
 test("debug stat loading issue", async ({ page }) => {
   const logs = [];


### PR DESCRIPTION
## Summary
- fix Playwright commonSetup import path in debug-stat-loading spec

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: Playwright Test did not expect test() to be called, multiple failing tests)*
- `npx playwright test` *(12 failing, 94 passed)*
- `npm run check:contrast`
- `npm run rag:validate` *(ENETUNREACH network error)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json`
- `grep -RInE "console.(warn|error)(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`

## Risks
- Existing Vitest and Playwright test failures may affect CI


------
https://chatgpt.com/codex/tasks/task_e_68c45b35ac78832686d421e84de4695d