### PR TITLE
chore(cli): clarify round header format

### DIFF
--- a/src/pages/battleCLI/dom.js
+++ b/src/pages/battleCLI/dom.js
@@ -56,8 +56,8 @@ export function updateRoundHeader(round, target) {
   // Phase 3: Keep CLI element for visual consistency (not primary source)
   const el = byId("cli-round");
   if (el) {
-    // Use compact format to prevent text overlap: "R0 • Target:5"
-    el.textContent = `R${round} • Target:${target}`;
+    // Use clear format: "Round 0 Target: 5"
+    el.textContent = `Round ${round} Target: ${target}`;
   }
 
   const root = byId("cli-root");


### PR DESCRIPTION
## Summary
- clarify CLI round header text format

## Testing
- `npm run check:jsdoc`
- `npx prettier src/pages/battleCLI/dom.js --check`
- `npx eslint .`
- `npx vitest run` *(fails: debug-stat-loading.spec.js, cooldown.test.js, round-select.test.js, stat-buttons.test.js, timer.test.js)*
- `npx playwright test`
- `npm run check:contrast`
- `npm run rag:validate` *(fails: ENETUNREACH)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json`
- `grep -RInE "console.(warn|error)(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c45b3ef28483268ba88304ff5ae74f