### PR TITLE
test: await init and readiness

### DIFF
--- a/tests/classicBattle/stat-buttons.test.js
+++ b/tests/classicBattle/stat-buttons.test.js
@@ -19,7 +19,7 @@ describe("Classic Battle stat buttons", () => {
       document.documentElement.innerHTML = html;
 
       const mod = await import("../../src/pages/battleClassic.init.js");
-      if (typeof mod.init === "function") mod.init();
+      await mod.init();
 
       // Start the match via modal
       const waitForBtn = () =>
@@ -35,9 +35,9 @@ describe("Classic Battle stat buttons", () => {
       startBtn.click();
 
       // Wait for stat buttons to render and be enabled
+      await window.statButtonsReadyPromise;
       const container = document.getElementById("stat-buttons");
       expect(container).toBeTruthy();
-      await new Promise((r) => setTimeout(r, 10));
       // Should have at least one button and be marked ready
       const buttons = container.querySelectorAll("button[data-stat]");
       expect(buttons.length).toBeGreaterThan(0);
@@ -56,8 +56,8 @@ describe("Classic Battle stat buttons", () => {
       expect(scoreEl.textContent || "").toMatch(/You:\s*1/);
       expect(scoreEl.textContent || "").toMatch(/Opponent:\s*0/);
       // Cooldown should begin and Next should be ready
+      await window.nextRoundTimerReadyPromise;
       const next = document.getElementById("next-button");
-      await new Promise((r) => setTimeout(r, 10));
       expect(next.disabled).toBe(false);
       expect(next.getAttribute("data-next-ready")).toBe("true");
     } finally {

--- a/tests/classicBattle/timer.test.js
+++ b/tests/classicBattle/timer.test.js
@@ -15,7 +15,7 @@ describe("Classic Battle round timer", () => {
       document.documentElement.innerHTML = html;
 
       const mod = await import("../../src/pages/battleClassic.init.js");
-      if (typeof mod.init === "function") mod.init();
+      await mod.init();
 
       // Click the 15 button to start the match and timer
       const waitForBtn = () =>
@@ -30,11 +30,17 @@ describe("Classic Battle round timer", () => {
       const btn = await waitForBtn();
       btn.click();
 
+      await window.statButtonsReadyPromise;
       const timerEl = document.getElementById("next-round-timer");
       expect(timerEl).toBeTruthy();
       // It should show a countdown shortly
-      await new Promise((r) => setTimeout(r, 10));
-      expect(timerEl.textContent || "").toMatch(/Time Left:/);
+      await new Promise((resolve) => {
+        const check = () => {
+          if (/Time Left:/.test(timerEl.textContent || "")) return resolve();
+          setTimeout(check, 10);
+        };
+        check();
+      });
       // After ~2s it should clear on expiration
       await new Promise((r) => setTimeout(r, 2200));
       expect(timerEl.textContent || "").toBe("");


### PR DESCRIPTION
## Summary
- ensure battleClassic tests await mod.init for full setup
- synchronize stat button tests with readiness promises
- poll round timer until countdown appears

## Testing
- `npm run check:jsdoc`
- `npx prettier tests/classicBattle/stat-buttons.test.js tests/classicBattle/timer.test.js --check`
- `npx eslint tests/classicBattle/stat-buttons.test.js tests/classicBattle/timer.test.js`
- `npx vitest run tests/classicBattle/stat-buttons.test.js tests/classicBattle/timer.test.js` *(fails: timeout in stat-buttons.test.js)*
- `npx vitest run` *(fails: multiple errors)*
- `npx playwright test` *(fails: 12 failed, 94 passed)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: ENETUNREACH network errors)*
- `npm run validate:data`


------
https://chatgpt.com/codex/tasks/task_e_68c45b39d0f883269e08531d5f5a7fba