### PR TITLE
Handle cooldown failures in vitest round timer

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -236,17 +236,21 @@ async function beginSelectionTimer(store) {
           console.debug("battleClassic: onTick DOM update failed", err);
         }
       },
-      onExpired: () => {
+      onExpired: async () => {
         try {
           document.body.dataset.autoSelected = document.body.dataset.autoSelected || "auto";
         } catch (err) {
           console.debug("battleClassic: set autoSelected failed", err);
         }
         try {
-          computeRoundResult(store, "speed", 5, 3);
-          startCooldown(store);
+          await computeRoundResult(store, "speed", 5, 3);
         } catch (err) {
           console.debug("battleClassic: computeRoundResult (vitest) failed", err);
+        }
+        try {
+          startCooldown(store);
+        } catch (err) {
+          console.debug("battleClassic: startCooldown (vitest) failed", err);
         }
       },
       pauseOnHidden: false


### PR DESCRIPTION
## Summary
- Ensure the Vitest countdown timer asynchronously computes round results
- Isolate cooldown start in its own error handler to keep the Next button responsive

## Testing
- ⚠️ `npm run check:jsdoc` *(command not found: npm)*
- ⚠️ `npx prettier . --check` *(command not found: npx)*
- ⚠️ `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json` *(dynamic imports found in existing files)*
- ✅ `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c46d4227908326a5e0f27c60fcdf39