### PR TITLE
Start cooldown after enabling Next in Vitest stat selection

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -179,7 +179,7 @@ function renderStatButtons(store) {
             nextBtn.disabled = false;
             nextBtn.setAttribute("data-next-ready", "true");
           }
-
+          startCooldown(store);
           return;
         }
 


### PR DESCRIPTION
## Summary
- ensure `renderStatButtons` starts cooldown after enabling Next button during Vitest

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: Code style issues in progress.md, progressPhase3.md)*
- `npx eslint .`
- `npx vitest run` *(fails: 3 test files failed)*
- `npx playwright test`
- `npm run check:contrast`
- `npm run rag:validate` *(fails: ENETUNREACH)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json` *(found dynamic import in hot path)*
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c46d4757188326be22f927484c4b86