### PR TITLE
Stop selection timer before cooldown in Vitest stat selection

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -179,6 +179,13 @@ function renderStatButtons(store) {
             nextBtn.disabled = false;
             nextBtn.setAttribute("data-next-ready", "true");
           }
+          if (typeof window !== "undefined" && window.__battleClassicStopSelectionTimer) {
+            try {
+              window.__battleClassicStopSelectionTimer();
+            } catch (err) {
+              console.debug("battleClassic: cancel selection timer failed", err);
+            }
+          }
           startCooldown(store);
           return;
         }


### PR DESCRIPTION
## Summary
- cancel stat-selection timer before starting cooldown when running in Vitest to avoid overlapping timers

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: progress.md, progressPhase3.md)*
- `npx eslint .`
- `npx vitest run` *(fails: multiple tests)*
- `npx playwright test`
- `npm run check:contrast`
- `npm run rag:validate` *(fails: ENETUNREACH)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle` *(found dynamic import in hot path)*
- `grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c471e0036c8326b5bc8a99e64a583e