### PR TITLE
test: stub missing battle engine helpers in round select modal test

### DIFF
--- a/tests/helpers/classicBattle/roundSelectModal.test.js
+++ b/tests/helpers/classicBattle/roundSelectModal.test.js
@@ -40,11 +40,13 @@ vi.mock("../../../src/components/Modal.js", () => ({
 vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
   createBattleEngine: vi.fn(),
   getPointsToWin: vi.fn(),
+  getScores: vi.fn(() => ({ playerScore: 0, opponentScore: 0 })),
   setPointsToWin: mocks.setPointsToWin
 }));
 vi.mock("../../../src/helpers/tooltip.js", () => ({ initTooltips: mocks.initTooltips }));
 vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
-  emitBattleEvent: mocks.emit
+  emitBattleEvent: mocks.emit,
+  onBattleEvent: vi.fn()
 }));
 vi.mock("../../../src/helpers/telemetry.js", () => ({ logEvent: mocks.logEvent }));
 


### PR DESCRIPTION
## Summary
- stub `getScores` in battleEngineFacade mock
- add `onBattleEvent` stub to battleEvents mock

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: progress.md, progressPhase3.md)*
- `npx eslint tests/helpers/classicBattle/roundSelectModal.test.js`
- `npx vitest run tests/helpers/classicBattle/roundSelectModal.test.js`
- `npx playwright test` *(12 failed)*
- `npm run check:contrast`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json`
- `grep -RInE "console.(warn|error)(" tests --exclude=client_embeddings.json | grep -v tests/utils/console.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4620d791883269e5a811111228b53