### PR TITLE
test: await init and readiness

### DIFF
--- a/tests/classicBattle/stat-buttons.test.js
+++ b/tests/classicBattle/stat-buttons.test.js
@@ -45,6 +45,8 @@ describe("Classic Battle stat buttons", () => {
       // Buttons should be enabled
       buttons.forEach((b) => expect(b.disabled).toBe(false));
 
+      // Start awaiting cooldown before triggering event (promise self-resets after dispatch)
+      const nextRoundTimerReady = window.nextRoundTimerReadyPromise;
       // Click the first stat button
       buttons[0].click();
 
@@ -56,7 +58,7 @@ describe("Classic Battle stat buttons", () => {
       expect(scoreEl.textContent || "").toMatch(/You:\s*1/);
       expect(scoreEl.textContent || "").toMatch(/Opponent:\s*0/);
       // Cooldown should begin and Next should be ready
-      await window.nextRoundTimerReadyPromise;
+      await nextRoundTimerReady;
       const next = document.getElementById("next-button");
       expect(next.disabled).toBe(false);
       expect(next.getAttribute("data-next-ready")).toBe("true");


### PR DESCRIPTION
## Summary
- wait on next round timer readiness before stat click to avoid awaiting reset promise

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: Code style issues found in 2 files)*
- `npx eslint .`
- `npx vitest run` *(aborted: errors and hanging in tests)*
- `npx playwright test` *(fails: 4 failed, 2 interrupted, 97 skipped)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: ENETUNREACH network errors)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle`
- `grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c463271720832696b463fedffe58f8