### PR TITLE
chore(cli): clarify round header spacing comment

### DIFF
--- a/src/pages/battleCLI/dom.js
+++ b/src/pages/battleCLI/dom.js
@@ -56,7 +56,7 @@ export function updateRoundHeader(round, target) {
   // Phase 3: Keep CLI element for visual consistency (not primary source)
   const el = byId("cli-round");
   if (el) {
-    // Use clear format: "Round 0 Target: 5"
+    // Use clear format with space after colon: "Round 0 Target: 5"
     el.textContent = `Round ${round} Target: ${target}`;
   }
 


### PR DESCRIPTION
## Summary
- clarify comment on round header formatting to note space after colon

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: progress.md, progressPhase3.md)*
- `npx prettier src/pages/battleCLI/dom.js --check`
- `npx eslint .`
- `npx vitest run` *(fails: debug-stat-loading.spec.js, cooldown.test.js, resolution.test.js, stat-buttons.test.js, unhandled errors)*
- `npx playwright test`
- `npm run check:contrast`
- `npm run rag:validate` *(fails: ENETUNREACH)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json`
- `grep -RInE "console.(warn|error)(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c463401c3483269e6baa084c20a433