### PR TITLE
test: mock battle event listeners

### DIFF
--- a/tests/helpers/classicBattle/roundSelectModal.test.js
+++ b/tests/helpers/classicBattle/roundSelectModal.test.js
@@ -44,7 +44,8 @@ vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
 }));
 vi.mock("../../../src/helpers/tooltip.js", () => ({ initTooltips: mocks.initTooltips }));
 vi.mock("../../../src/helpers/classicBattle/battleEvents.js", () => ({
-  emitBattleEvent: mocks.emit
+  emitBattleEvent: mocks.emit,
+  onBattleEvent: vi.fn()
 }));
 vi.mock("../../../src/helpers/telemetry.js", () => ({ logEvent: mocks.logEvent }));
 


### PR DESCRIPTION
## Summary
- add missing `onBattleEvent` mock to round select modal tests

## Testing
- `npx prettier tests/helpers/classicBattle/roundSelectModal.test.js --check`
- `npx eslint tests/helpers/classicBattle/roundSelectModal.test.js`
- `npx vitest run tests/helpers/classicBattle/roundSelectModal.test.js`
- `npm run check:contrast`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json && echo "❌ Dynamic import in hot path" || true`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c47368533083268a97c02eeb9c17f1