### PR TITLE
fix fixture import path

### DIFF
--- a/playwright/debug-stat-loading.spec.js
+++ b/playwright/debug-stat-loading.spec.js
@@ -1,4 +1,4 @@
-import { test } from "./playwright/fixtures/commonSetup.js";
+import { test } from "./fixtures/commonSetup.js";
 
 test("debug stat loading issue", async ({ page }) => {
   const logs = [];


### PR DESCRIPTION
## Summary
- correct fixture path in debug stat loading Playwright spec

## Testing
- `rg "await import\(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle && echo "❌ Dynamic import in hot path"`
- `rg "console\.(warn|error)\(" tests -g '!tests/utils/console.js'`
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: progress.md, progressPhase3.md)*
- `npx eslint .`
- `npx vitest run` *(fails: 4 tests)*
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68c4786e1068832683b230b1120760e8