### PR TITLE
feat: guard byId without document

### DIFF
--- a/src/pages/battleCLI/dom.js
+++ b/src/pages/battleCLI/dom.js
@@ -27,9 +27,10 @@ try {
  * @param {string} id
  * @returns {HTMLElement | null}
  * @pseudocode
+ * if typeof document is "undefined" -> return null
  * return document.getElementById(id)
  */
-export const byId = (id) => document.getElementById(id);
+export const byId = (id) => (typeof document === "undefined" ? null : document.getElementById(id));
 
 /**
  * Update the round header line.

--- a/tests/pages/battleCLI.byId.test.js
+++ b/tests/pages/battleCLI.byId.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+
+describe("battleCLI byId", () => {
+  it("returns null when document is undefined", async () => {
+    const { byId } = await import("../../src/pages/battleCLI/dom.js");
+    const original = globalThis.document;
+    // @ts-ignore - intentionally unset for test
+    globalThis.document = undefined;
+    try {
+      expect(byId("missing")).toBeNull();
+    } finally {
+      // @ts-ignore - restore document for other tests
+      globalThis.document = original;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- avoid document access in byId when DOM is unavailable
- add tests for byId defaulting to null without document

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: progress.md, progressPhase3.md)*
- `npx eslint .`
- `npx vitest run` *(fails: Classic Battle cooldown, round resolution, round select; unhandled document ReferenceError)*
- `npx vitest run tests/pages/battleCLI.byId.test.js`
- `npx playwright test` *(fails: Cannot find module playwright/fixtures/commonSetup.js)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: ENETUNREACH connect)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json && echo "❌ Dynamic import in hot path"`
- `grep -RInE "console.(warn|error)(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c47ae1484883269f10aa269f0c8ec7