### PR TITLE
Ensure Next button readiness after callbacks

### DIFF
--- a/progress.md
+++ b/progress.md
@@ -172,6 +172,7 @@ Timer implementation meets requirements:
 **Outcome:** Critical P0 bug resolved - game is now fully playable
 
 **Completed Actions:**
+
 1. **✅ Debugged and Fixed Stat Loading Failure**
    - Root cause identified: `clearSkeletonStats()` was clearing real content after `renderStatList()` populated it
    - Fixed by adding `list.dataset.skeleton = "false"` after populating real stats
@@ -181,11 +182,13 @@ Timer implementation meets requirements:
    - `/src/pages/battleCLI/init.js` - Fixed skeleton state management race condition
 
 **Technical Details:**
+
 - **Bug:** Skeleton clearing logic incorrectly identified real content as skeleton data
 - **Fix:** Proper state marking with `data-skeleton="false"` after content population
 - **Impact:** Game progression from unplayable to fully functional
 
 **Validation Results:**
+
 - ✅ Stats list now appears correctly (5 stat elements)
 - ✅ All 12 existing Playwright tests still passing
 - ✅ Proper DOM structure and accessibility maintained
@@ -236,6 +239,7 @@ Timer implementation meets requirements:
 **Outcome:** Perfect synchronization between match length selection and settings UI
 
 **Completed Actions:**
+
 1. **✅ Synced Match Length with Win Target**
    - ✅ Auto-set win target when Quick/Medium/Long selected via `syncWinTargetDropdown()` function
    - ✅ Settings dropdown automatically reflects the choice from round modal
@@ -247,12 +251,14 @@ Timer implementation meets requirements:
    - ✅ Preserves existing responsive behavior for narrow screens
 
 **Technical Implementation:**
+
 - **Added `syncWinTargetDropdown()` function** in `/src/pages/battleCLI/init.js`
 - **Enhanced `startRound()` function** in `/src/helpers/classicBattle/roundSelectModal.js` to call sync after setting win target
 - **Improved header display format** in `/src/pages/battleCLI/dom.js` using bullet separator for compact layout
 - **Created comprehensive test suite** with 4 new tests validating synchronization
 
 **Files Modified:**
+
 - ✅ `/src/pages/battleCLI/init.js` - Added syncWinTargetDropdown() function with proper JSDoc
 - ✅ `/src/helpers/classicBattle/roundSelectModal.js` - Added import and sync call in startRound()
 - ✅ `/src/pages/battleCLI/dom.js` - Updated header format to "R{round} • Target:{target}"
@@ -260,6 +266,7 @@ Timer implementation meets requirements:
 - ✅ `/playwright/round-select-keyboard.spec.js` - Updated tests to match new header format
 
 **Validation Results:**
+
 - ✅ All 4 new synchronization tests passing
 - ✅ All 6 keyboard navigation tests passing (updated for new format)
 - ✅ Settings dropdown shows correct value (5/10/15) after round selection
@@ -267,6 +274,7 @@ Timer implementation meets requirements:
 - ✅ All synchronization bidirectional (round modal ↔ settings dropdown)
 
 **User Experience Impact:**
+
 - **Before:** Selecting "Quick" showed win target dropdown still at 10, causing confusion
 - **After:** Selecting "Quick" immediately updates dropdown to 5, providing clear feedback
 - **Before:** Header showed "Round 0 Target: 5" with character overlap issues

--- a/progressPhase3.md
+++ b/progressPhase3.md
@@ -15,6 +15,7 @@
 ### 1. Win Target Synchronization System
 
 **New Function Added:** `syncWinTargetDropdown()`
+
 ```javascript
 // Location: /src/pages/battleCLI/init.js
 export function syncWinTargetDropdown() {
@@ -43,6 +44,7 @@ export function syncWinTargetDropdown() {
 ```
 
 **Benefits:**
+
 - 40% shorter text reducing overlap risk
 - Maintains all information clarity
 - Uses typography best practices (bullet separator)
@@ -51,18 +53,20 @@ export function syncWinTargetDropdown() {
 ## 📊 Validation Results
 
 ### Test Coverage Added
-| Test Type | Count | Status | Coverage |
-|-----------|-------|--------|----------|
-| **Synchronization Tests** | 4 | ✅ PASS | Quick/Medium/Long selection → dropdown sync |
-| **Keyboard Navigation** | 6 | ✅ PASS | Updated for new header format |
-| **Integration** | 10+ | ✅ PASS | No regressions in existing functionality |
+
+| Test Type                 | Count | Status  | Coverage                                    |
+| ------------------------- | ----- | ------- | ------------------------------------------- |
+| **Synchronization Tests** | 4     | ✅ PASS | Quick/Medium/Long selection → dropdown sync |
+| **Keyboard Navigation**   | 6     | ✅ PASS | Updated for new header format               |
+| **Integration**           | 10+   | ✅ PASS | No regressions in existing functionality    |
 
 ### Synchronization Flow Validated
+
 ```
 1. User selects "Quick" (5 points) from round modal
    ↓
 2. setPointsToWin(5) called → engine state updated
-   ↓  
+   ↓
 3. syncWinTargetDropdown() called → dropdown shows "5"
    ↓
 4. Header updates to "R1 • Target:5"
@@ -73,11 +77,13 @@ export function syncWinTargetDropdown() {
 ## 🎮 User Experience Improvements
 
 ### Before Phase 3
+
 ❌ **Confusing:** Select "Quick" → dropdown still shows "10"  
 ❌ **Unclear:** Text overlap in header reduces readability  
 ❌ **Inconsistent:** UI components showed different values
 
-### After Phase 3  
+### After Phase 3
+
 ✅ **Intuitive:** Select "Quick" → dropdown immediately shows "5"  
 ✅ **Clean:** Compact header format prevents overlap  
 ✅ **Consistent:** All UI components show same win target value
@@ -85,12 +91,14 @@ export function syncWinTargetDropdown() {
 ## 🧪 Quality Assurance
 
 ### Test Categories
+
 - **Unit-level:** Individual function behavior (`syncWinTargetDropdown`)
-- **Integration:** Round modal → settings panel communication  
+- **Integration:** Round modal → settings panel communication
 - **User Journey:** Complete selection → confirmation → display flow
 - **Regression:** Existing functionality preserved
 
 ### Code Quality
+
 - **JSDoc documentation** added for new functions
 - **Error handling** with try/catch blocks
 - **Clean imports** and proper module organization
@@ -98,17 +106,18 @@ export function syncWinTargetDropdown() {
 
 ## 📁 Files Modified
 
-| File | Change Type | Description |
-|------|-------------|-------------|
-| `/src/pages/battleCLI/init.js` | **Added** | `syncWinTargetDropdown()` function with JSDoc |
-| `/src/helpers/classicBattle/roundSelectModal.js` | **Enhanced** | Import + sync call in `startRound()` |
-| `/src/pages/battleCLI/dom.js` | **Optimized** | Compact header format for `updateRoundHeader()` |
-| `/playwright/win-target-sync.spec.js` | **Created** | 4 comprehensive synchronization tests |
-| `/playwright/round-select-keyboard.spec.js` | **Updated** | Tests adapted for new header format |
+| File                                             | Change Type   | Description                                     |
+| ------------------------------------------------ | ------------- | ----------------------------------------------- |
+| `/src/pages/battleCLI/init.js`                   | **Added**     | `syncWinTargetDropdown()` function with JSDoc   |
+| `/src/helpers/classicBattle/roundSelectModal.js` | **Enhanced**  | Import + sync call in `startRound()`            |
+| `/src/pages/battleCLI/dom.js`                    | **Optimized** | Compact header format for `updateRoundHeader()` |
+| `/playwright/win-target-sync.spec.js`            | **Created**   | 4 comprehensive synchronization tests           |
+| `/playwright/round-select-keyboard.spec.js`      | **Updated**   | Tests adapted for new header format             |
 
 ## 🔄 Integration Points
 
 ### Data Flow Architecture
+
 ```
 Round Modal Selection
         ↓
@@ -120,6 +129,7 @@ Round Modal Selection
 ```
 
 ### Error Resilience
+
 - All sync operations wrapped in try/catch
 - Graceful fallbacks if DOM elements missing
 - Non-blocking execution preserves game functionality
@@ -127,8 +137,9 @@ Round Modal Selection
 ## ➡️ Next Phase Ready
 
 Phase 4 (Priority P3) ready to begin:
+
 - Comprehensive testing of all features
-- Accessibility validation at 200% zoom  
+- Accessibility validation at 200% zoom
 - Screen reader announcement verification
 - Retro theme toggle addition
 
@@ -139,6 +150,6 @@ Phase 4 (Priority P3) ready to begin:
 ## 📈 Success Metrics
 
 - **🎯 User Goal Achievement:** 100% - Users can now see immediate feedback
-- **🔧 Technical Robustness:** 100% - All edge cases handled with error handling  
+- **🔧 Technical Robustness:** 100% - All edge cases handled with error handling
 - **🧪 Test Coverage:** 100% - All synchronization paths validated
 - **♿ Accessibility:** Maintained - No degradation in existing accessibility features

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -253,8 +253,7 @@ export function startCooldown(_store, scheduler = realScheduler) {
   const controls = createNextRoundControls();
   const btn = typeof document !== "undefined" ? document.getElementById("next-button") : null;
   if (btn) {
-    btn.disabled = false;
-    btn.dataset.nextReady = "true";
+    markNextReady(btn);
     try {
       emitBattleEvent("nextRoundTimerReady");
     } catch {}
@@ -264,11 +263,12 @@ export function startCooldown(_store, scheduler = realScheduler) {
     try {
       setTimeout(() => {
         const b = document.getElementById("next-button");
-        if (b) {
-          b.disabled = false;
-          b.dataset.nextReady = "true";
-        }
+        markNextReady(b);
       }, 0);
+      setTimeout(() => {
+        const b = document.getElementById("next-button");
+        markNextReady(b);
+      }, 20);
     } catch {}
   }
   const cooldownSeconds = computeNextRoundCooldown();


### PR DESCRIPTION
## Summary
- harden `startCooldown` by re-enabling the Next button twice via `markNextReady`
- cover scenario where late callbacks re-disable Next with targeted unit test
- format progress docs for Prettier compliance

## Testing
- `npm run rag:validate` *(fails: Network unreachable while loading remote MiniLM model)*
- `npm run validate:data`
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run tests/classicBattle/cooldown.test.js`
- `npx playwright test` *(fails: Cannot find module 'playwright/playwright/fixtures/commonSetup.js')*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68c47acdf4cc8326bc3a4b46e70e7522