### PR TITLE
Ensure Next button readiness after callbacks

### DIFF
--- a/tests/classicBattle/cooldown.test.js
+++ b/tests/classicBattle/cooldown.test.js
@@ -3,6 +3,20 @@ import { resolve } from "node:path";
 import * as timerUtils from "../../src/helpers/timerUtils.js";
 
 describe("Classic Battle inter-round cooldown + Next", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+    [
+      "../../src/helpers/setupScoreboard.js",
+      "../../src/helpers/showSnackbar.js",
+      "../../src/helpers/classicBattle/debugPanel.js",
+      "../../src/helpers/classicBattle/eventDispatcher.js",
+      "../../src/helpers/classicBattle/battleEvents.js",
+      "../../src/helpers/timers/createRoundTimer.js",
+      "../../src/helpers/CooldownRenderer.js",
+      "../../src/helpers/timers/computeNextRoundCooldown.js"
+    ].forEach((m) => vi.doUnmock(m));
+  });
   test("enables Next during cooldown and advances on click", async () => {
     // Make round timer short so resolution happens quickly
     const spy = vi.spyOn(timerUtils, "getDefaultTimer").mockImplementation((cat) => {


### PR DESCRIPTION
## Summary
- restore real timers after fake-timer tests
- reset mocked modules to avoid leaking stubs

## Testing
- `npm run rag:validate` *(fails: ENETUNREACH)*
- `npm run validate:data`
- `npx prettier . --check`
- `npx eslint .`
- `npm run check:jsdoc`
- `npx vitest run tests/classicBattle/cooldown.test.js`
- `npx playwright test` *(fails: 2 failed, 2 interrupted)*
- `npm run check:contrast`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle 2>/dev/null && echo "Found dynamic import in hot path"` *(fails: Found dynamic import in hot path)*
- `grep -RInE "console.(warn|error)(" tests | grep -v "tests/utils/console.js"`

------
https://chatgpt.com/codex/tasks/task_e_68c4806ba7a48326bdb11ba5ce489f6b