### PR TITLE
Default battle state badge to Lobby

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -839,7 +839,8 @@ export function setBattleStateBadgeEnabled(enable) {
   badge.hidden = false;
   badge.removeAttribute("hidden");
   console.debug("Setting badge visible, after:", badge.hidden, badge.hasAttribute("hidden"));
-  updateBattleStateBadge(getStateSnapshot().state);
+  const state = getStateSnapshot().state ?? "Lobby";
+  updateBattleStateBadge(state);
 }
 
 /**


### PR DESCRIPTION
## Summary
- default battle state badge text to Lobby when state snapshot is missing

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: interrupted)*
- `npx playwright test` *(fails: 4 failed, 1 interrupted)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: network unreachable)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json 2>/dev/null`
- `grep -RInE "console.(warn|error)(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`

## Risk
- dynamic import check reported existing uses in classic battle modules
- vitest and playwright suites currently failing
- rag:validate requires network or local model


------
https://chatgpt.com/codex/tasks/task_e_68c68ed09bd08326abc76d3f54d436b1