### PR TITLE
Guard skip handler teardown for Node

### DIFF
--- a/src/helpers/classicBattle/skipHandler.js
+++ b/src/helpers/classicBattle/skipHandler.js
@@ -84,5 +84,7 @@ export function skipCurrentPhase() {
 export function resetSkipState() {
   skipHandler = null;
   pendingSkip = false;
-  window.dispatchEvent(new CustomEvent("skip-handler-change", { detail: { active: false } }));
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent("skip-handler-change", { detail: { active: false } }));
+  }
 }


### PR DESCRIPTION
## Summary
- prevent `resetSkipState` from throwing in Node by guarding `window.dispatchEvent`

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint src/helpers/classicBattle/skipHandler.js`
- `npx vitest run` *(fails: expected true to be false in tests/classicBattle/cooldown.test.js, expected 'You: 0 Opponent: 0' to match /You:\s*1/, expected undefined to be '15', expected 'power' to be null)*
- `npx playwright test`
- `npm run check:contrast`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c6911fc08883269f190631fc4fce05