### PR TITLE
feat: add deterministic round resolve delay

### DIFF
--- a/tests/helpers/classicBattle/roundResolver.resolveRound.test.js
+++ b/tests/helpers/classicBattle/roundResolver.resolveRound.test.js
@@ -26,6 +26,7 @@ describe("resolveRound headless delays", () => {
     const p = mod.resolveRound({}, "power", 1, 2).then(() => {
       resolved = true;
     });
+    await vi.runAllTimersAsync();
     await p;
     expect(resolved).toBe(true);
     setHeadlessMode(false);
@@ -36,9 +37,11 @@ describe("resolveRound headless delays", () => {
     const { setHeadlessMode } = await import("../../../src/helpers/headlessMode.js");
     setHeadlessMode(false);
     let resolved = false;
-    await mod.resolveRound({}, "power", 1, 2).then(() => {
+    const p = mod.resolveRound({}, "power", 1, 2).then(() => {
       resolved = true;
     });
+    await vi.runAllTimersAsync();
+    await p;
     expect(resolved).toBe(true);
   });
 });

--- a/tests/helpers/headlessMode.timing.test.js
+++ b/tests/helpers/headlessMode.timing.test.js
@@ -57,9 +57,11 @@ describe("headless mode timing", () => {
     setHeadlessMode(true);
     let elapsed = -1;
     const start = Date.now();
-    await rrMod.resolveRound({}, "power", 1, 2).then(() => {
+    const p = rrMod.resolveRound({}, "power", 1, 2).then(() => {
       elapsed = Date.now() - start;
     });
+    await vi.runAllTimersAsync();
+    await p;
     expect(elapsed).toBe(0);
     setHeadlessMode(false);
   });
@@ -72,9 +74,11 @@ describe("headless mode timing", () => {
     setHeadlessMode(false);
     let elapsed = -1;
     const start = Date.now();
-    await rrMod.resolveRound({}, "power", 1, 2).then(() => {
+    const p = rrMod.resolveRound({}, "power", 1, 2).then(() => {
       elapsed = Date.now() - start;
     });
+    await vi.runAllTimersAsync();
+    await p;
     expect(elapsed).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- advance fake timers in resolveRound unit tests to avoid hangs
- ensure headless timing specs run timers before assertions

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 4 failed tests)*
- `npx playwright test` *(fails: 11 failed)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: ENETUNREACH)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle 2>/dev/null && echo "Found dynamic import in hot path" && false || true`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c6a2c825588326aab17ebe267fcc60