### PR TITLE
fix: reuse resolve delay for orchestrator fallback

### DIFF
--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -308,11 +308,15 @@ export async function handleStatSelection(store, stat, { playerVal, opponentVal,
       typeof document !== "undefined" &&
       !!(document.body && document.body.dataset && document.body.dataset.battleState);
     if (orchestrated && handledByOrchestrator !== true) {
-      const fallbackDelay = IS_VITEST ? 0 : Math.max(resolveDelay() + 100, 800);
+      const delay = resolveDelay();
+      const fallbackDelay = IS_VITEST ? 0 : Math.max(delay + 100, 800);
       const timeoutId = setTimeout(async () => {
         if (store.playerChoice !== null) {
           try {
-            await resolveRoundDirect(store, stat, playerVal, opponentVal, opts);
+            await resolveRoundDirect(store, stat, playerVal, opponentVal, {
+              ...opts,
+              delayMs: 0
+            });
           } catch {}
           try {
             await dispatchBattleEvent("roundResolved");


### PR DESCRIPTION
## Summary
- reuse computed resolve delay during orchestrator fallback and skip extra wait
- test fallback to ensure resolver invoked with zero delay

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint src/helpers/classicBattle/selectionHandler.js tests/helpers/selectionHandler.test.js`
- `npx vitest run` *(fails: score update, round select)*
- `npx playwright test` *(fails: 11 failed tests)*
- `npm run check:contrast`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c6b01f7a748326834aa322fc571a21