### PR TITLE
Enable next round button after cooldown in tests

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -26,7 +26,7 @@ import { initScoreboardAdapter } from "../helpers/classicBattle/scoreboardAdapte
 import { bridgeEngineEvents } from "../helpers/classicBattle/engineBridge.js";
 import { initFeatureFlags } from "../helpers/featureFlags.js";
 import { exposeTestAPI } from "../helpers/testApi.js";
-import { removeBackdrops } from "../helpers/classicBattle/uiHelpers.js";
+import { removeBackdrops, enableNextRoundButton } from "../helpers/classicBattle/uiHelpers.js";
 
 // Store the active selection timer for cleanup when stat selection occurs
 let activeSelectionTimer = null;
@@ -173,12 +173,8 @@ function renderStatButtons(store) {
             timerEl.textContent = "";
           }
 
-          // Enable next button
-          const nextBtn = document.getElementById("next-button");
-          if (nextBtn) {
-            nextBtn.disabled = false;
-            nextBtn.setAttribute("data-next-ready", "true");
-          }
+          startCooldown(store);
+          enableNextRoundButton();
           if (typeof window !== "undefined" && window.__battleClassicStopSelectionTimer) {
             try {
               window.__battleClassicStopSelectionTimer();
@@ -186,7 +182,6 @@ function renderStatButtons(store) {
               console.debug("battleClassic: cancel selection timer failed", err);
             }
           }
-          startCooldown(store);
           return;
         }
 


### PR DESCRIPTION
## Summary
- import enableNextRoundButton for battleClassic page
- ensure Vitest stat-button path starts cooldown before enabling Next

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run tests/classicBattle/stat-buttons.test.js`
- `npx vitest run` *(fails: cooldown, resolution, round-select tests)*
- `npx playwright test` *(fails: 11 tests)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: ENETUNREACH)*
- `npm run validate:data`
- `grep -RIn 'await import(' src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle 2>/dev/null` *(found matches)*
- `grep -RInE "console.(warn|error)(" tests | grep -v "tests/utils/console.js"`

------
https://chatgpt.com/codex/tasks/task_e_68c6be3fa2208326b9304604e5b70cc5