### PR TITLE
Set round target dataset in startRound

### DIFF
--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -48,6 +48,9 @@ function persistRoundAndLog(value) {
 
 async function startRound(value, onStart, emitEvents) {
   setPointsToWin(value);
+  try {
+    document.body.dataset.target = String(value);
+  } catch {}
   // Sync the settings dropdown to reflect the new win target
   try {
     syncWinTargetDropdown();

--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -1,7 +1,6 @@
 import { setupScoreboard, updateScore, updateRoundCounter } from "../helpers/setupScoreboard.js";
 import {
   createBattleEngine,
-  getPointsToWin,
   STATS,
   on as onEngine,
   getRoundsPlayed
@@ -558,15 +557,11 @@ async function init() {
     try {
       await initRoundSelectModal(async () => {
         try {
-          const pts = getPointsToWin();
-          document.body.dataset.target = String(pts);
-          try {
-            if (typeof process !== "undefined" && process.env && process.env.VITEST) {
-              console.debug(
-                `[test] battleClassic.init onStart set body.dataset.target=${document.body.dataset.target}`
-              );
-            }
-          } catch {}
+          if (typeof process !== "undefined" && process.env && process.env.VITEST) {
+            console.debug(
+              `[test] battleClassic.init onStart set body.dataset.target=${document.body.dataset.target}`
+            );
+          }
         } catch {}
         // Reflect state change in badge
         try {


### PR DESCRIPTION
## Summary
- set `document.body.dataset.target` when starting a round
- remove redundant dataset target update in classic battle init

## Testing
- `rg "await import\\(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --glob '!client_embeddings.json' | wc -l`
- `rg -n "console\.(warn|error)\(" tests --glob '!client_embeddings.json' | rg -v "tests/utils/console.js" | wc -l`
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68c6dbe033888326bb8e6f33a5b1e9eb