### PR TITLE
fix: prevent cooldown double dispatch

### DIFF
--- a/tests/helpers/classicBattle/nextButton.manualClick.test.js
+++ b/tests/helpers/classicBattle/nextButton.manualClick.test.js
@@ -16,9 +16,10 @@ describe("Next button manual click", () => {
     const mod = await import("../../../src/helpers/classicBattle/timerService.js");
     __setStateSnapshot({ state: "cooldown" });
 
+    let spy;
     const readyPromise = new Promise((resolve, reject) => {
       const timer = setTimeout(() => reject(new Error("ready not dispatched")), 50);
-      vi.spyOn(dispatcher, "dispatchBattleEvent").mockImplementation(async (evt) => {
+      spy = vi.spyOn(dispatcher, "dispatchBattleEvent").mockImplementation(async (evt) => {
         if (evt === "ready") {
           clearTimeout(timer);
           resolve();
@@ -28,5 +29,7 @@ describe("Next button manual click", () => {
 
     await mod.onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
     await readyPromise;
+    expect(spy).toHaveBeenCalledWith("ready");
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -91,7 +91,9 @@ describe("timerService next round handling", () => {
     nextButton.click();
     await controls.ready;
     expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
-    // Click advances immediately; fallback may be suppressed
+    // Click advances immediately; no additional dispatch after fallback timer elapses
+    expect(dispatchBattleEvent).toHaveBeenCalledTimes(1);
+    scheduler.tick(5000);
     expect(dispatchBattleEvent).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary
- avoid duplicate `onExpired` scheduling by dropping zero-delay fallback
- clear both scheduler and global fallback timers when skipping cooldown
- assert single ready dispatch in manual skip tests

## Testing
- `npm run rag:validate` *(fails: Network unreachable while loading remote MiniLM model)*
- `npm run validate:data`
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 4 tests failed)*
- `npx playwright test` *(fails: 4 failed, 2 interrupted)*
- `npm run check:contrast`
- `grep -RIn 'await import(' src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json | head -n 20`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=tests/utils/console.js --exclude=client_embeddings.json | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c70244a468832688cdc84f307e3b91