### PR TITLE
Preload uiService dynamically in classic battle orchestrator

### DIFF
--- a/src/helpers/classicBattle/orchestrator.js
+++ b/src/helpers/classicBattle/orchestrator.js
@@ -21,7 +21,6 @@ import stateCatalog from "./stateCatalog.js";
 import { dispatchBattleEvent } from "./eventDispatcher.js";
 import { logStateTransition, createComponentLogger } from "./debugLogger.js";
 import { preloadTimerUtils } from "/src/helpers/TimerController.js";
-import "/src/helpers/classicBattle/uiService.js";
 import { initScoreboardAdapter } from "/src/helpers/classicBattle/scoreboardAdapter.js";
 import { createStateManager } from "/src/helpers/classicBattle/stateManager.js";
 
@@ -213,7 +212,7 @@ async function preloadDependencies() {
     await preloadTimerUtils();
   } catch {}
   try {
-    // Side-effect import executed at module load; nothing to do here.
+    await import("./uiService.js");
   } catch {}
   try {
     initScoreboardAdapter();


### PR DESCRIPTION
## Summary
- remove top-level uiService side-effect import
- dynamically preload uiService in `preloadDependencies`
- keep dependency preloading during orchestrator initialization

## Testing
- `npm run check:jsdoc`
- `npx prettier src/helpers/classicBattle/orchestrator.js --check`
- `npx eslint src/helpers/classicBattle/orchestrator.js`
- `npx vitest run` *(interrupted)*
- `npx playwright test` *(interrupted)*
- `npm run check:contrast`
- `npm run rag:validate` *(network unreachable)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json --exclude-dir=node_modules`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json --exclude-dir=node_modules | grep -v "tests/utils/console.js"`

------
https://chatgpt.com/codex/tasks/task_e_68c702401b8c8326ac6386c8a06ec597