### PR TITLE
feat: fetch stat definitions from JSON in battle CLI

### DIFF
--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -17,6 +17,7 @@ import { onBattleEvent, emitBattleEvent } from "../../helpers/classicBattle/batt
 import { STATS } from "../../helpers/BattleEngine.js";
 import * as engineFacade from "../../helpers/battleEngineFacade.js";
 import statNamesData from "../../data/statNames.js";
+import { fetchJson } from "../../helpers/dataUtils.js";
 import { createModal } from "../../components/Modal.js";
 import { createButton } from "../../components/Button.js";
 import {
@@ -1014,15 +1015,24 @@ export function handleStatListArrowKey(key) {
  * Load stat definitions once and return them.
  *
  * @pseudocode
- * 1. If the cache is empty, try dynamic fetch of `statNames.json`.
- * 2. Fallback to bundled module data when fetch fails or returns empty.
+ * 1. If no cache, attempt to fetch `statNames.json` via `fetchJson`.
+ * 2. On failure or empty result, fall back to local `statNamesData`.
  * 3. Return the cached definitions array or an empty array.
  *
  * @returns {Promise<Array>} Cached stat definition objects.
  */
 async function loadStatDefs() {
   if (!cachedStatDefs) {
-    cachedStatDefs = statNamesData;
+    try {
+      const fetched = await fetchJson("statNames.json");
+      if (Array.isArray(fetched) && fetched.length) {
+        cachedStatDefs = fetched;
+      } else {
+        cachedStatDefs = statNamesData;
+      }
+    } catch {
+      cachedStatDefs = statNamesData;
+    }
   }
   return Array.isArray(cachedStatDefs) ? cachedStatDefs : [];
 }


### PR DESCRIPTION
## Summary
- fetch stat definitions via `fetchJson('statNames.json')` with caching and fallback
- keep CLI stat rendering using fetched definitions so tests can inject custom stats

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or incomplete JSDoc blocks)*
- `npx prettier src/pages/battleCLI/init.js --check`
- `npx eslint src/pages/battleCLI/init.js`
- `npx vitest run --reporter basic` *(fails: 4 failed tests)*
- `npx playwright test` *(fails: 2 failed, 1 interrupted)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: connect ENETUNREACH)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle 2>/dev/null`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`

------
https://chatgpt.com/codex/tasks/task_e_68c70235961083269606c79a15ebb711