### PR TITLE
feat: resettable scoreboard initialization

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -46,6 +46,17 @@ sb.showMessage("Ready!");
 sb.updateScore(1, 0);
 ```
 
+### Testing
+
+Call `resetScoreboard()` before reinitializing the default instance to ensure fresh DOM bindings:
+
+```js
+import { initScoreboard, resetScoreboard } from "../src/components/Scoreboard.js";
+
+resetScoreboard();
+initScoreboard(header);
+```
+
 ## Battle Engine
 
 The battle engine exposes a lightweight event emitter for subscribing to game state changes.

--- a/src/components/Scoreboard.js
+++ b/src/components/Scoreboard.js
@@ -170,7 +170,7 @@ export class Scoreboard {
  *
  * @pseudocode
  * 1. If no container is provided, create a headless scoreboard and exit.
- * 2. If a default scoreboard already exists, do nothing.
+ * 2. If a default scoreboard with a view already exists, do nothing.
  * 3. Create a new ScoreboardModel.
  * 4. Create a new ScoreboardView, locating child elements within the container.
  * 5. Set the `aria-live` attribute of the score element to "off".
@@ -187,7 +187,7 @@ export function initScoreboard(container, _controls) {
     defaultScoreboard = new Scoreboard();
     return;
   }
-  if (defaultScoreboard) {
+  if (defaultScoreboard?.view) {
     return;
   }
   const model = new ScoreboardModel();
@@ -327,13 +327,25 @@ export const getState = () =>
   defaultScoreboard?.getState() ?? { score: { player: 0, opponent: 0 } };
 
 /**
+ * Reset the default scoreboard reference.
+ *
+ * @pseudocode
+ * 1. Set `defaultScoreboard` to `null` for a clean slate.
+ *
+ * @returns {void}
+ */
+export const resetScoreboard = () => {
+  defaultScoreboard = null;
+};
+
+/**
  * Destroy the default scoreboard instance.
  *
  * @pseudocode
- * 1. Set `defaultScoreboard` to `null` so helpers no longer forward calls.
+ * 1. Delegate to `resetScoreboard` so helpers no longer forward calls.
  *
  * @returns {void}
  */
 export const destroy = () => {
-  defaultScoreboard = null;
+  resetScoreboard();
 };

--- a/tests/components/Scoreboard.a11y.liveRegions.test.js
+++ b/tests/components/Scoreboard.a11y.liveRegions.test.js
@@ -15,7 +15,10 @@ describe("Scoreboard live region discipline", () => {
 
   it("initializes score display with aria-live=off and does not announce on timer ticks", async () => {
     const header = document.querySelector("header");
-    const { initScoreboard, updateTimer } = await import("../../src/components/Scoreboard.js");
+    const { initScoreboard, updateTimer, resetScoreboard } = await import(
+      "../../src/components/Scoreboard.js"
+    );
+    resetScoreboard();
     initScoreboard(header);
 
     const score = document.getElementById("score-display");

--- a/tests/components/Scoreboard.idempotency.test.js
+++ b/tests/components/Scoreboard.idempotency.test.js
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, expect } from "vitest";
 
 describe("Scoreboard idempotent init and destroy cleanup", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     document.body.innerHTML = "";
     const header = document.createElement("header");
     header.innerHTML = `
@@ -11,6 +11,8 @@ describe("Scoreboard idempotent init and destroy cleanup", () => {
       <p id="score-display" aria-live="off" aria-atomic="true"></p>
     `;
     document.body.appendChild(header);
+    const { resetScoreboard } = await import("../../src/components/Scoreboard.js");
+    resetScoreboard();
   });
 
   it("repeated initScoreboard does not clear existing message", async () => {

--- a/tests/helpers/battleScoreboard.adapter.prd.test.js
+++ b/tests/helpers/battleScoreboard.adapter.prd.test.js
@@ -19,7 +19,8 @@ describe("battleScoreboard PRD adapter", () => {
       <p id="score-display" aria-live="polite" aria-atomic="true"></p>
     `;
     container.appendChild(header);
-    const { initScoreboard } = await import("../../src/components/Scoreboard.js");
+    const { initScoreboard, resetScoreboard } = await import("../../src/components/Scoreboard.js");
+    resetScoreboard();
     initScoreboard(header);
     const mock = await import("./mockScheduler.js");
     setScheduler(mock.createMockScheduler());

--- a/tests/helpers/battleScoreboard.authority.test.js
+++ b/tests/helpers/battleScoreboard.authority.test.js
@@ -18,7 +18,8 @@ describe("battleScoreboard authority + persistence", () => {
       <p id="score-display" aria-live="polite" aria-atomic="true"></p>
     `;
     container.appendChild(header);
-    const { initScoreboard } = await import("../../src/components/Scoreboard.js");
+    const { initScoreboard, resetScoreboard } = await import("../../src/components/Scoreboard.js");
+    resetScoreboard();
     initScoreboard(header);
     const { initBattleScoreboardAdapter } = await import("../../src/helpers/battleScoreboard.js");
     initBattleScoreboardAdapter();

--- a/tests/helpers/battleScoreboard.dom-contract.test.js
+++ b/tests/helpers/battleScoreboard.dom-contract.test.js
@@ -19,7 +19,8 @@ describe("battleScoreboard DOM contract (root data-outcome)", () => {
       <p id="score-display" aria-live="polite" aria-atomic="true"></p>
     `;
     container.appendChild(header);
-    const { initScoreboard } = await import("../../src/components/Scoreboard.js");
+    const { initScoreboard, resetScoreboard } = await import("../../src/components/Scoreboard.js");
+    resetScoreboard();
     initScoreboard(header);
     const { initBattleScoreboardAdapter } = await import("../../src/helpers/battleScoreboard.js");
     initBattleScoreboardAdapter();

--- a/tests/helpers/battleScoreboard.ordering.test.js
+++ b/tests/helpers/battleScoreboard.ordering.test.js
@@ -18,7 +18,8 @@ describe("battleScoreboard out-of-order guards", () => {
       <p id="score-display" aria-live="off" aria-atomic="true"></p>
     `;
     container.appendChild(header);
-    const { initScoreboard } = await import("../../src/components/Scoreboard.js");
+    const { initScoreboard, resetScoreboard } = await import("../../src/components/Scoreboard.js");
+    resetScoreboard();
     initScoreboard(header);
     const { initBattleScoreboardAdapter } = await import("../../src/helpers/battleScoreboard.js");
     initBattleScoreboardAdapter();

--- a/tests/helpers/battleScoreboard.waiting.test.js
+++ b/tests/helpers/battleScoreboard.waiting.test.js
@@ -19,7 +19,8 @@ describe("battleScoreboard waiting fallback", () => {
       <p id="score-display" aria-live="polite" aria-atomic="true"></p>
     `;
     container.appendChild(header);
-    const { initScoreboard } = await import("../../src/components/Scoreboard.js");
+    const { initScoreboard, resetScoreboard } = await import("../../src/components/Scoreboard.js");
+    resetScoreboard();
     initScoreboard(header);
     const mock = await import("./mockScheduler.js");
     setScheduler(mock.createMockScheduler());

--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -62,8 +62,11 @@ describe("classicBattle stalled stat selection recovery", () => {
 
   it("auto-selects after stall timeout", async () => {
     // Initialize scoreboard to ensure messages work
-    const { initScoreboard } = await import("../../../src/components/Scoreboard.js");
+    const { initScoreboard, resetScoreboard } = await import(
+      "../../../src/components/Scoreboard.js"
+    );
     const header = document.querySelector("header");
+    resetScoreboard();
     initScoreboard(header);
 
     const battleMod = await import("../../../src/helpers/classicBattle.js");

--- a/tests/helpers/scoreboard.adapter.test.js
+++ b/tests/helpers/scoreboard.adapter.test.js
@@ -24,7 +24,8 @@ describe("scoreboardAdapter maps display.* events to Scoreboard", () => {
       <p id=\"score-display\" aria-live=\"polite\" aria-atomic=\"true\"></p>
     `;
     container.appendChild(header);
-    const { initScoreboard } = await import("../../src/components/Scoreboard.js");
+    const { initScoreboard, resetScoreboard } = await import("../../src/components/Scoreboard.js");
+    resetScoreboard();
     initScoreboard(header);
     const { initScoreboardAdapter } = await import(
       "../../src/helpers/classicBattle/scoreboardAdapter.js"


### PR DESCRIPTION
## Summary
- allow `initScoreboard` to rebuild when a container is provided after a headless setup
- add `resetScoreboard` helper and document its use
- update tests to reset scoreboard before reinitializing

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: 6 failing tests)*
- `npx playwright test` *(fails: 4 failing tests)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: ENETUNREACH)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json && echo "❌ Dynamic import in hot path"`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c7023bb0e08326affffabd08f67a32