### PR TITLE
fix: restore static uiService import in classic battle orchestrator

### DIFF
--- a/src/helpers/classicBattle/orchestrator.js
+++ b/src/helpers/classicBattle/orchestrator.js
@@ -23,6 +23,7 @@ import { logStateTransition, createComponentLogger } from "./debugLogger.js";
 import { preloadTimerUtils } from "/src/helpers/TimerController.js";
 import { initScoreboardAdapter } from "/src/helpers/classicBattle/scoreboardAdapter.js";
 import { createStateManager } from "/src/helpers/classicBattle/stateManager.js";
+import "./uiService.js";
 
 const orchestratorLogger = createComponentLogger("Orchestrator");
 
@@ -201,18 +202,14 @@ function emitResolution(event) {
  *
  * @pseudocode
  * 1. Await `preloadTimerUtils`.
- * 2. Dynamically import `./uiService.js`.
- * 3. Initialize `initScoreboardAdapter`.
- * 4. Swallow errors from each step.
+ * 2. Initialize `initScoreboardAdapter`.
+ * 3. Swallow errors from each step.
  *
  * @returns {Promise<void>} resolves when best-effort preloads finish.
  */
 async function preloadDependencies() {
   try {
     await preloadTimerUtils();
-  } catch {}
-  try {
-    await import("./uiService.js");
   } catch {}
   try {
     initScoreboardAdapter();

--- a/tests/helpers/classicBattle/orchestrator.init.test.js
+++ b/tests/helpers/classicBattle/orchestrator.init.test.js
@@ -29,9 +29,7 @@ describe("classic battle orchestrator init preloads", () => {
       throw new Error("fail");
     });
     vi.doMock(`${testPath}/TimerController.js`, () => ({ preloadTimerUtils }));
-    vi.doMock(`${testPath}/classicBattle/uiService.js`, () => {
-      throw new Error("fail");
-    });
+    vi.doMock(`${testPath}/classicBattle/uiService.js`, () => ({}));
     vi.doMock(`${testPath}/classicBattle/scoreboardAdapter.js`, () => ({
       initScoreboardAdapter
     }));


### PR DESCRIPTION
## Summary
- statically import uiService in classic battle orchestrator
- remove dynamic uiService preload and update tests

## Testing
- `npm run check:jsdoc` *(fails: Functions missing or with incomplete JSDoc blocks)*
- `npx prettier . --check`
- `npx eslint .` *(warn: tests/classicBattle/cooldown.test.js - 'timerUtils' is defined but never used)*
- `npx vitest run` *(fails: 3 failing tests)*
- `npx playwright test` *(fails: 5 failing tests)*
- `npm run check:contrast`
- `npm run rag:validate` *(network unreachable)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json --exclude-dir=node_modules`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json --exclude-dir=node_modules | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68c707366630832685022b041ba14dce