### PR TITLE
fix: clear timer via DOM fallback in selection handler

### DIFF
--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -200,7 +200,10 @@ async function emitSelectionEvent(store, stat, playerVal, opponentVal, opts) {
   try {
     if (IS_VITEST) {
       try {
-        scoreboard.clearTimer();
+        // Direct DOM fallback to clear timer display when scoreboard adapter is absent
+        const timer = document.getElementById("next-round-timer");
+        if (timer) timer.textContent = "";
+        scoreboard.clearTimer?.();
       } catch {}
       try {
         const msg = document.getElementById("round-message");


### PR DESCRIPTION
## Summary
- clear next-round timer directly in DOM when running under Vitest
- optionally call `scoreboard.clearTimer` with optional chaining and mention DOM fallback

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: event dispatch errors)*
- `npx playwright test` *(fails: 3 failed, 2 interrupted)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: network unreachable)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json`
- `grep -RInE "console.(warn|error)(" tests --exclude=client_embeddings.json --exclude=tests/utils/console.js`
- `npm test tests/helpers/selectionHandler.test.js`

## Risk
- Low: change affects test-mode timer clearing with DOM fallback and optional scoreboard call.


------
https://chatgpt.com/codex/tasks/task_e_68c70f9f7b148326a77bdabd78d7d014