### PR TITLE
Use battle event promise for round selection test

### DIFF
--- a/tests/classicBattle/round-select.test.js
+++ b/tests/classicBattle/round-select.test.js
@@ -8,35 +8,24 @@ describe("Classic Battle round select modal", () => {
     const html = readFileSync(file, "utf-8");
     document.documentElement.innerHTML = html;
 
-    // Load page init (will be updated to wire modal) and start
-    const mod = await import("../../src/pages/battleClassic.init.js");
-    if (typeof mod.init === "function") mod.init();
+    const { initClassicBattleTest } = await import("../helpers/initClassicBattleTest.js");
+    await initClassicBattleTest({ afterMock: true });
 
-    // Expect modal to render with round-select buttons
-    const btnLong = await new Promise((resolveBtn) => {
-      const tryFind = () => {
-        const el = document.getElementById("round-select-3");
-        if (el) return resolveBtn(el);
-        setTimeout(tryFind, 0);
-      };
-      tryFind();
-    });
+    const mod = await import("../../src/pages/battleClassic.init.js");
+    await mod.init?.();
+
+    const { getRoundPromptPromise } = await import("../../src/helpers/classicBattle.js");
+    const roundPrompt = getRoundPromptPromise();
+
+    const btnLong = document.getElementById("round-select-3");
     expect(btnLong).toBeTruthy();
 
-    const { onBattleEvent } = await import("../../src/helpers/classicBattle/battleEvents.js");
-
-    const started = new Promise((resolve) => onBattleEvent("startClicked", resolve));
-
-    // Click the "Long" (15) option
     btnLong.click();
 
-    await started;
+    await roundPrompt;
 
-    // Assert engine pointsToWin updated
     const { getPointsToWin } = await import("../../src/helpers/battleEngineFacade.js");
     expect(getPointsToWin()).toBe(15);
-
-    // Assert page reflects target for testing via data attribute
     expect(document.body.dataset.target).toBe("15");
   });
 });


### PR DESCRIPTION
## Summary
- refactor round select test to initialize classic battle helpers
- await round prompt event before asserting battle engine state

## Testing
- `npm run check:jsdoc`
- `npx prettier tests/classicBattle/round-select.test.js --check`
- `npx eslint tests/classicBattle/round-select.test.js`
- `npx vitest run` *(fails: Test timed out; selectionHandler assertion failed)*
- `npx playwright test` *(fails: 1 failed, 1 interrupted)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: network unreachable while loading model)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle 2>/dev/null && echo "Found dynamic import in hot path" && exit 1 || true`
- `grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js" && echo "Unsilenced console found" && exit 1 || true`


------
https://chatgpt.com/codex/tasks/task_e_68c70d7a5c648326bd393ee1c4095ea6