### PR TITLE
feat: prompt stat selection

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -25,6 +25,7 @@ import { initScoreboardAdapter } from "../helpers/classicBattle/scoreboardAdapte
 import { bridgeEngineEvents } from "../helpers/classicBattle/engineBridge.js";
 import { initFeatureFlags } from "../helpers/featureFlags.js";
 import { exposeTestAPI } from "../helpers/testApi.js";
+import { showSelectionPrompt } from "../helpers/classicBattle/snackbar.js";
 import { removeBackdrops, enableNextRoundButton } from "../helpers/classicBattle/uiHelpers.js";
 
 // Store the active selection timer for cleanup when stat selection occurs
@@ -397,6 +398,11 @@ async function startRoundCycle(store) {
     renderStatButtons(store);
   } catch (err) {
     console.debug("battleClassic: renderStatButtons failed", err);
+  }
+  try {
+    showSelectionPrompt();
+  } catch (err) {
+    console.debug("battleClassic: showSelectionPrompt failed", err);
   }
   try {
     await beginSelectionTimer(store);


### PR DESCRIPTION
## Summary
- emit stat selection prompt in Classic Battle round cycle

## Testing
- `npm run rag:validate` *(fails: ENETUNREACH)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle && echo "❌ Dynamic import in hot path"`
- `grep -RInE "console.(warn|error)(" tests | grep -v "tests/utils/console.js"`
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: some tests failing)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68c7b8be4a0c8326a991fce96e502dac