### PR TITLE
Track and cancel selection timer

### DIFF
--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -146,7 +146,8 @@ function applySelectionToStore(store, stat, playerVal, opponentVal) {
  * stall timeouts so they cannot fire after the player has made a selection.
  *
  * @pseudocode
- * 1. Call engine `stopTimer()` to pause/stop the round countdown.
+ * 1. Call engine `stopTimer()` to pause/stop the round countdown and invoke
+ *    `window.__battleClassicStopSelectionTimer` if available.
  * 2. Clear `store.statTimeoutId` and `store.autoSelectId` via `clearTimeout`.
  * 3. Null out the stored ids so subsequent cleanup calls are safe.
  *
@@ -156,6 +157,11 @@ function applySelectionToStore(store, stat, playerVal, opponentVal) {
 export function cleanupTimers(store) {
   try {
     stopTimer();
+  } catch {}
+  try {
+    if (typeof window !== "undefined" && window.__battleClassicStopSelectionTimer) {
+      window.__battleClassicStopSelectionTimer();
+    }
   } catch {}
   try {
     clearTimeout(store.statTimeoutId);
@@ -208,12 +214,6 @@ async function emitSelectionEvent(store, stat, playerVal, opponentVal, opts) {
       try {
         const msg = document.getElementById("round-message");
         if (msg) msg.textContent = "";
-      } catch {}
-      // Stop the active selection timer created in battleClassic.init.js
-      try {
-        if (typeof window !== "undefined" && window.__battleClassicStopSelectionTimer) {
-          window.__battleClassicStopSelectionTimer();
-        }
       } catch {}
       // Snackbar display is handled elsewhere based on resolution path
     }

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -203,7 +203,7 @@ export async function onNextButtonClick(_evt, controls = getNextRoundControls(),
  * @param {(stat: string, opts?: { delayOpponentMessage?: boolean }) => Promise<void>} onExpiredSelect
  * - Callback to handle stat auto-selection.
  * @param {{selectionMade?: boolean}|null} [store=null] - Battle state store.
- * @returns {Promise<void>} Resolves when the timer begins.
+ * @returns {Promise<ReturnType<typeof createRoundTimer>>} Resolves with timer controls.
  */
 export async function startTimer(onExpiredSelect, store = null) {
   let duration = 30;
@@ -327,6 +327,7 @@ export async function startTimer(onExpiredSelect, store = null) {
 
   timer.start(duration);
   restore();
+  return timer;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Return timer controls from `startTimer` for external management
- Track and clear active selection timers and failsafe timeouts on the Classic Battle page
- Ensure `cleanupTimers` halts the selection timer via global hook

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: Classic Battle timer clearing, stat selection, smoke, and end-modal scenarios)*
- `npm run check:contrast`
- `grep -RIn "await import\(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json 2>/dev/null || echo "No dynamic imports found"`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js" || echo "No unsilenced console found"`


------
https://chatgpt.com/codex/tasks/task_e_68c7c3f61ec48326ac8b11868a9dd2c6