### PR TITLE
Stub Sentry and provide stat names JSON for Classic Battle

### DIFF
--- a/playwright/battle-classic/smoke.spec.js
+++ b/playwright/battle-classic/smoke.spec.js
@@ -6,6 +6,9 @@ test.describe("Classic Battle page scaffold", () => {
     page.on("console", (msg) => {
       if (msg.type() === "error") errors.push(msg.text() + " at " + msg.location().url);
     });
+    await page.route("https://js-de.sentry-cdn.com/**", (route) =>
+      route.fulfill({ body: "", contentType: "application/javascript" })
+    );
     await page.goto("/src/pages/battleClassic.html");
 
     await expect(page.locator("header #round-message")).toBeVisible();

--- a/src/pages/statNames.json
+++ b/src/pages/statNames.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": 11,
+    "statIndex": 1,
+    "name": "Power",
+    "category": "Judo",
+    "japanese": "パワー",
+    "description": "Power represents a judoka's raw physical strength - stronger judoka can overpower opponents in throws and grip breaks."
+  },
+  {
+    "id": 12,
+    "statIndex": 2,
+    "name": "Speed",
+    "category": "Judo",
+    "japanese": "スピード",
+    "description": "Speed affects how quickly a judoka can attack or react - useful for counterattacks and surprise techniques."
+  },
+  {
+    "id": 13,
+    "statIndex": 3,
+    "name": "Technique",
+    "category": "Judo",
+    "japanese": "テクニック",
+    "description": "Technique measures mastery of judo throws and transitions - high values indicate sharp, precise execution."
+  },
+  {
+    "id": 14,
+    "statIndex": 4,
+    "name": "Kumi-kata",
+    "category": "Judo",
+    "japanese": "組み方",
+    "description": "Kumi-kata is grip fighting - this stat reflects how well a judoka can control grips and deny their opponent's attacks."
+  },
+  {
+    "id": 15,
+    "statIndex": 5,
+    "name": "Ne-waza",
+    "category": "Judo",
+    "japanese": "寝技",
+    "description": "Ne-waza means ground grappling - this stat reflects skill in pins, holds, and other mat techniques."
+  }
+]


### PR DESCRIPTION
## Summary
- provide stat names JSON to satisfy Battle Classic page
- stub external Sentry script in Battle Classic smoke test to eliminate console errors

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test playwright/battle-classic/smoke.spec.js`
- `npx playwright test` *(fails: end-modal.spec.js, replay.spec.js, round-counter.spec.js)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68c7c40c163c8326bc463e4a9fd14dd3