### PR TITLE
Track and cancel selection timer

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -324,7 +324,7 @@ async function beginSelectionTimer(store) {
       console.debug("battleClassic: computeRoundResult (timer) failed", err);
     }
     return Promise.resolve();
-  });
+  }, store);
   // Fail-safe: if for any reason the expiration callback path is interrupted,
   // ensure the round resolves and Next becomes ready shortly after the expected
   // duration. This keeps E2E deterministic even when optional adapters are missing.


### PR DESCRIPTION
## Summary
- Return timer controls from `startTimer` for external management
- Track and clear active selection timers and failsafe timeouts on the Classic Battle page
- Ensure `cleanupTimers` halts the selection timer via global hook
- Pass battle store to `startTimer` to avoid double auto-select when cleaning up timers

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: roundSelectModal responsive test)*
- `npx playwright test` *(fails: Classic Battle opponent reveal/stat selection/timer clearing scenarios)*
- `npm run check:contrast`
- `grep -RIn "await import\(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json 2>/dev/null || echo "No dynamic imports found"`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js" || echo "No unsilenced console found"`


------
https://chatgpt.com/codex/tasks/task_e_68c7d14c9eac8326bfd1f90ca41f8fb0