### PR TITLE
Adjust resolution test to activate fake timers before starting round timer

### DIFF
--- a/tests/classicBattle/resolution.test.js
+++ b/tests/classicBattle/resolution.test.js
@@ -39,9 +39,9 @@ describe("Classic Battle round resolution", () => {
           loop();
         });
       const btn = await waitForBtn();
-      btn.click();
 
       vi.useFakeTimers();
+      btn.click();
       vi.advanceTimersByTime(1200);
       await roundResolvedPromise;
 


### PR DESCRIPTION
## Summary
- move the fake timer activation ahead of the action that starts the round timer in the classic battle resolution test

## Testing
- npx vitest run tests/classicBattle/resolution.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8537da5e08326a767004fbcabfc83