### PR TITLE
Fix round select modal cleanup listeners

### DIFF
--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -320,16 +320,21 @@ function applyGameModePositioning(modal) {
     if (!isActive) return;
     isActive = false;
     try {
+      backdrop.removeEventListener("close", cleanup);
+    } catch {}
+    try {
       window.removeEventListener("resize", onResize);
       window.removeEventListener("orientationchange", onResize);
-      if (resizeId !== null) {
-        caf(resizeId);
-        resizeId = null;
-      }
     } catch {}
+    if (resizeId !== null) {
+      try {
+        caf(resizeId);
+      } catch {}
+      resizeId = null;
+    }
   };
 
   try {
-    backdrop.addEventListener("close", cleanup, { once: true });
+    backdrop.addEventListener("close", cleanup);
   } catch {}
 }


### PR DESCRIPTION
## Task Contract
```json
{
  "inputs": [
    "src/helpers/classicBattle/roundSelectModal.js",
    "tests/helpers/classicBattle/roundSelectModal.resize.test.js"
  ],
  "outputs": [
    "src/helpers/classicBattle/roundSelectModal.js"
  ],
  "success": [
    "Round select modal detaches close listener on cleanup",
    "Classic battle resize test verifies inset stays at 80px"
  ],
  "errorMode": "ask_on_test_failure"
}
```

## Files Changed
- `src/helpers/classicBattle/roundSelectModal.js`: detach the close event listener manually during cleanup and ensure resize listeners are cleared after the modal closes.

## Verification Summary
- eslint: NOT RUN (not requested)
- vitest: 1 passed, 0 failed (targeted `roundSelectModal.resize.test.js`)
- playwright: NOT RUN (not requested)
- jsdoc: PASS (via pre-commit hook)

## Risk & Follow-Up
- Risk: Low – listener management adjustments limited to modal cleanup.
- Follow-Up: None.


------
https://chatgpt.com/codex/tasks/task_e_68c85386827c8326972c3003f5701090