### PR TITLE
Ensure battleCLI page bootstraps without extra script

### DIFF
--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -662,7 +662,6 @@
       <div id="opponent-card" style="display: none"></div>
       <div id="modal-container"></div>
       <script type="module" src="../pages/battleCLI.init.js"></script>
-      <script type="module" src="../pages/battleCLI.js"></script>
     </div>
   </body>
 </html>

--- a/src/pages/battleCLI.init.js
+++ b/src/pages/battleCLI.init.js
@@ -94,6 +94,27 @@ function initSettingsCollapse() {
   });
 }
 
+function loadBattleCLIModule() {
+  if (typeof window === "undefined") return null;
+
+  const existingPromise = window.__battleCLIinit?.loadPromise;
+  if (existingPromise) return existingPromise;
+
+  const cliRoot = byId("cli-root");
+  if (!cliRoot) return null;
+
+  const loadPromise = import("./battleCLI/init.js").catch((error) => {
+    console.error("Failed to load Classic Battle CLI module:", error);
+    return null;
+  });
+
+  try {
+    window.__battleCLIinit = Object.assign(window.__battleCLIinit || {}, { loadPromise });
+  } catch {}
+
+  return loadPromise;
+}
+
 function init() {
   renderSkeletonStats(5);
   initSettingsCollapse();
@@ -153,6 +174,8 @@ function init() {
       return true;
     };
   } catch {}
+
+  loadBattleCLIModule();
 }
 
 // Expose helpers as early as possible so tests can see them even if init hasn't run yet.


### PR DESCRIPTION
## Summary
- remove the extra battleCLI.js script tag so the CLI page only loads battleCLI.init.js
- update battleCLI.init.js to lazy-load the full Classic Battle CLI module and store the load promise for reuse

## Testing
- npm run check:contrast
- npx playwright test *(fails: playwright/battle-classic/round-counter.spec.js expects Round 2 after Next, observed Round 1)*
- npx playwright test playwright/battle-classic/round-counter.spec.js *(fails: same expectation as above)*

------
https://chatgpt.com/codex/tasks/task_e_68c855ea08cc83268fc2e27318af884b