### PR TITLE
Update Vitest timer score update

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -310,11 +310,18 @@ async function beginSelectionTimer(store) {
         } catch (err) {
           console.debug("battleClassic: set autoSelected failed", err);
         }
+        let result;
         try {
-          await computeRoundResult(store, "speed", 5, 3);
+          result = await computeRoundResult(store, "speed", 5, 3);
         } catch (err) {
           console.debug("battleClassic: computeRoundResult (vitest) failed", err);
         }
+        try {
+          const scoreEl = document.getElementById("score-display");
+          if (scoreEl && result) {
+            scoreEl.innerHTML = `<span data-side=\"player\">You: ${Number(result.playerScore) || 0}</span>\n<span data-side=\"opponent\">Opponent: ${Number(result.opponentScore) || 0}</span>`;
+          }
+        } catch {}
         try {
           startCooldown(store);
         } catch (err) {


### PR DESCRIPTION
## Summary
- capture the Vitest countdown expiration result so the round resolver output is available for UI updates
- mirror the existing scoreboard markup update used by the runtime timer path so the score display reflects the computed totals

## Testing
- npm run check:jsdoc
- npx prettier src/pages/battleClassic.init.js --check
- npx prettier . --check *(fails: reports existing formatting issues in Playwright specs)*
- npx eslint . *(fails: same Prettier formatting violations in Playwright specs)*
- npx vitest run *(terminated due to extremely large console output stream)*
- npx playwright test *(terminated; context closed after repeated network errors)*
- npm run check:contrast


------
https://chatgpt.com/codex/tasks/task_e_68c9504fc1708326ad275b7ac0746036