### PR TITLE
Fix classic battle resolution test describe

### DIFF
--- a/tests/classicBattle/resolution.test.js
+++ b/tests/classicBattle/resolution.test.js
@@ -8,7 +8,7 @@ import { resetFallbackScores } from "../../src/helpers/api/battleUI.js";
 import { setTestMode } from "../../src/helpers/testModeUtils.js";
 import { createBattleEngine } from "../../src/helpers/battleEngineFacade.js";
 
-describe.configure({ environment: "jsdom" })("Classic Battle round resolution", () => {
+describe("Classic Battle round resolution", () => {
   test("score updates after auto-select on expiry", async () => {
     // Ensure deterministic test mode and engine state
     setTestMode({ enabled: true, seed: 1 });


### PR DESCRIPTION
## Task Contract
- **Inputs**: `tests/classicBattle/resolution.test.js`
- **Outputs**: `tests/classicBattle/resolution.test.js`
- **Success**: `npm test` executes without the previous TypeError; jsdom environment explicitly configured.
- **Error Mode**: Ask on blocker

## Files Changed
- `tests/classicBattle/resolution.test.js`: Replace the `describe.configure` wrapper with a plain `describe` call while keeping the file-level jsdom directive to avoid runtime errors when running the suite.

## Verification
- eslint: Not Run (not requested)
- vitest: PASS (`npm test`)
- playwright: Not Run (not requested)
- jsdoc: PASS (`npm run check:jsdoc`)

## Risk & Follow-Up
- **Risk**: Low – test harness change only.
- **Follow-Up**: None.


------
https://chatgpt.com/codex/tasks/task_e_68c95f0ab2c08326a744f0ab4368f183