### PR TITLE
Refactor classic battle resolution test to use helpers and events

### DIFF
--- a/tests/helpers/classicBattle/battleEvents.js
+++ b/tests/helpers/classicBattle/battleEvents.js
@@ -1,0 +1,30 @@
+import { onBattleEvent, offBattleEvent } from "../../../src/helpers/classicBattle/battleEvents.js";
+
+/**
+ * Wait for a single classic battle event and resolve with the dispatched detail.
+ *
+ * @pseudocode
+ * 1. Register an event listener for the provided event name.
+ * 2. Start a timeout that rejects if the event does not fire in time.
+ * 3. On event, clear the timeout, remove the listener, and resolve with the event detail.
+ *
+ * @param {string} eventName - Battle event to listen for once.
+ * @param {number} [timeout=3000] - Maximum time to wait in milliseconds.
+ * @returns {Promise<CustomEvent>} Resolves with the captured event.
+ */
+export function waitForBattleEventOnce(eventName, timeout = 3000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      offBattleEvent(eventName, handler);
+      reject(new Error(`timeout waiting for ${eventName}`));
+    }, timeout);
+
+    const handler = (event) => {
+      clearTimeout(timer);
+      offBattleEvent(eventName, handler);
+      resolve(event);
+    };
+
+    onBattleEvent(eventName, handler);
+  });
+}

--- a/tests/helpers/classicBattle/realDom.js
+++ b/tests/helpers/classicBattle/realDom.js
@@ -1,0 +1,79 @@
+import { vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import * as timerUtils from "../../../src/helpers/timerUtils.js";
+
+/**
+ * Render the real Classic Battle HTML into the document element.
+ *
+ * @pseudocode
+ * 1. Resolve the battleClassic.html path from the repo root.
+ * 2. Read the HTML into a string.
+ * 3. Assign the markup to document.documentElement.innerHTML.
+ * 4. Return a cleanup callback that clears the innerHTML when invoked.
+ *
+ * @returns {() => void} Cleanup function that clears the rendered DOM.
+ */
+export function renderClassicBattlePage() {
+  const file = resolve(process.cwd(), "src/pages/battleClassic.html");
+  const html = readFileSync(file, "utf-8");
+  document.documentElement.innerHTML = html;
+  return () => {
+    document.documentElement.innerHTML = "";
+  };
+}
+
+/**
+ * Initialize the Classic Battle page script after the DOM is rendered.
+ *
+ * @pseudocode
+ * 1. Dynamically import the battleClassic.init module.
+ * 2. If the module exposes an init function, await its execution.
+ * 3. Return the imported module for callers needing extra hooks.
+ *
+ * @returns {Promise<object>} Imported module for additional introspection.
+ */
+export async function initClassicBattlePage() {
+  const mod = await import("../../../src/pages/battleClassic.init.js");
+  if (typeof mod.init === "function") {
+    await mod.init();
+  }
+  return mod;
+}
+
+/**
+ * Convenience helper that renders the HTML and runs the page initializer.
+ *
+ * @pseudocode
+ * 1. Render the battleClassic markup using renderClassicBattlePage().
+ * 2. Await initClassicBattlePage() so scripts bind to the DOM.
+ * 3. Return the cleanup callback alongside the imported module.
+ *
+ * @returns {Promise<{ cleanup: () => void, module: object }>} Cleanup handle and module reference.
+ */
+export async function bootstrapClassicBattlePage() {
+  const cleanup = renderClassicBattlePage();
+  const module = await initClassicBattlePage();
+  return { cleanup, module };
+}
+
+/**
+ * Mock the default timer values so the round timer resolves quickly in tests.
+ *
+ * @pseudocode
+ * 1. Spy on timerUtils.getDefaultTimer.
+ * 2. When the requested category is "roundTimer", return the injected duration.
+ * 3. Otherwise return the fallback duration for non-round timers.
+ * 4. Expose the spy so callers can restore the original implementation.
+ *
+ * @param {number} roundTimerSeconds - Duration to use for the round timer category.
+ * @param {number} [fallbackSeconds=3] - Duration to use for all other timers.
+ * @returns {import("vitest").MockInstance} Spy instance for restoration.
+ */
+export function mockRoundTimerDuration(roundTimerSeconds, fallbackSeconds = 3) {
+  return vi
+    .spyOn(timerUtils, "getDefaultTimer")
+    .mockImplementation((category) =>
+      category === "roundTimer" ? roundTimerSeconds : fallbackSeconds
+    );
+}


### PR DESCRIPTION
## Summary
- add helpers to render the real Classic Battle DOM and to await battle events in tests
- refactor the classic battle resolution test to use the new helpers and verify state via events and engine data instead of DOM text
- ensure score assertions rely on the scoreboard model and engine scores after auto-select resolves

## Testing
- npx vitest run tests/classicBattle/resolution.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c95af547b08326886007903928d972