### PR TITLE
test: strengthen classic battle quit flow

### DIFF
--- a/tests/classicBattle/quit-flow.test.js
+++ b/tests/classicBattle/quit-flow.test.js
@@ -1,11 +1,31 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { afterEach, vi } from "vitest";
 
 describe("Classic Battle quit flow", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test("clicking Quit opens confirmation modal", async () => {
     const file = resolve(process.cwd(), "src/pages/battleClassic.html");
     const html = readFileSync(file, "utf-8");
     document.documentElement.innerHTML = html;
+
+    const battleEngine = await import("../../src/helpers/battleEngineFacade.js");
+    const navUtils = await import("../../src/helpers/navUtils.js");
+    const eventDispatcher = await import("../../src/helpers/classicBattle/eventDispatcher.js");
+    const eventBus = await import("../../src/helpers/classicBattle/eventBus.js");
+    const battleUI = await import("../../src/helpers/battle/index.js");
+
+    vi.spyOn(battleEngine, "quitMatch").mockReturnValue({ outcome: "quit" });
+    const showResultSpy = vi.spyOn(battleUI, "showResult").mockImplementation(() => {});
+    const dispatchedEvents = [];
+    vi.spyOn(eventDispatcher, "dispatchBattleEvent").mockImplementation(async (eventName) => {
+      dispatchedEvents.push(eventName);
+    });
+    vi.spyOn(eventBus, "getBattleState").mockReturnValue("interruptMatch");
+    const navigateSpy = vi.spyOn(navUtils, "navigateToHome").mockImplementation(() => {});
 
     const { initClassicBattleTest } = await import("../helpers/initClassicBattleTest.js");
     await initClassicBattleTest({ afterMock: true });
@@ -21,5 +41,32 @@ describe("Classic Battle quit flow", () => {
 
     const confirmBtn = await window.quitConfirmButtonPromise;
     expect(confirmBtn).toBeTruthy();
+
+    const title = document.getElementById("quit-modal-title");
+    expect(title?.textContent).toBe("Quit the match?");
+    const desc = document.getElementById("quit-modal-desc");
+    expect(desc?.textContent).toBe("Your progress will be lost.");
+    const cancelBtn = document.getElementById("cancel-quit-button");
+    expect(cancelBtn?.textContent).toBe("Cancel");
+    expect(confirmBtn.textContent).toBe("Quit");
+
+    const modal = confirmBtn.closest(".modal");
+    expect(modal).toBeTruthy();
+    expect(modal?.getAttribute("role")).toBe("dialog");
+    expect(modal?.getAttribute("aria-modal")).toBe("true");
+    expect(modal?.getAttribute("aria-labelledby")).toBe("quit-modal-title");
+    expect(modal?.getAttribute("aria-describedby")).toBe("quit-modal-desc");
+
+    expect(document.activeElement?.id).toBe("cancel-quit-button");
+
+    confirmBtn.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(showResultSpy).toHaveBeenCalledWith("You quit the match. You lose!");
+    expect(dispatchedEvents).toEqual(["interrupt", "toLobby"]);
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    expect(document.activeElement?.id).toBe("quit-button");
+    expect(confirmBtn.isConnected).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- stub navigation, engine, and dispatcher dependencies to interact with the quit modal in the Classic Battle page test
- assert modal copy, accessibility wiring, and focus movement when the quit dialog opens
- verify confirm-handling side effects including event dispatches, result messaging, focus restoration, and teardown

## Testing
- npx vitest run tests/classicBattle/quit-flow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c960d21c488326b22584620db79324