### PR TITLE
Update RAG chunk count references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ npm run rag:validate
 
 ## 🧠 RAG (Retrieval-Augmented Generation) Policy
 
-This project contains a high-performance vector database with 16,000+ indexed chunks covering documentation, code standards, and game rules. RAG queries return results in ~2 seconds with 62.5% accuracy for finding correct sources.
+This project contains a high-performance vector database with over 2,300 indexed chunks (2,328 currently) covering documentation, code standards, and game rules. RAG queries return results in ~2 seconds with 62.5% accuracy for finding correct sources.
 
 **See also**: [Quick Reference Cards](#-quick-reference-cards) | [docs/rag-system.md](./docs/rag-system.md) for complete usage guide
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -146,7 +146,7 @@ npm run rag:validate
 
 ## 🧠 RAG (Retrieval-Augmented Generation) Policy
 
-This project contains a high-performance vector database with 16,000+ indexed chunks covering documentation, code standards, and game rules. RAG queries return results in ~2 seconds with 62.5% accuracy for finding correct sources.
+This project contains a high-performance vector database with over 2,300 indexed chunks (2,328 currently) covering documentation, code standards, and game rules. RAG queries return results in ~2 seconds with 62.5% accuracy for finding correct sources.
 
 **See also**: [Quick Reference Cards](#-quick-reference-cards) | [docs/rag-system.md](./docs/rag-system.md) for complete usage guide
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ For complete API documentation, event schemas, and component usage, see **[docs/
 
 ## 🔎 Using the Vector RAG System
 
-The project includes a high-performance vector RAG system with 16,000+ indexed chunks covering documentation, code standards, and game rules. Before scanning the repo for answers, use the [`queryRag`](./src/helpers/queryRag.js) helper:
+The project includes a high-performance vector RAG system with over 2,300 indexed chunks (2,328 currently) covering documentation, code standards, and game rules. Before scanning the repo for answers, use the [`queryRag`](./src/helpers/queryRag.js) helper:
 
 ```javascript
 import queryRag from "./src/helpers/queryRag.js";

--- a/design/agentWorkflows/ragUsageGuide.md
+++ b/design/agentWorkflows/ragUsageGuide.md
@@ -6,7 +6,7 @@
 
 - **⚡ Speed:** 2-second queries vs 30+ seconds of code exploration
 - **🎯 Accuracy:** 62.5% success rate for finding correct sources
-- **🧠 Context:** Access to 16,000+ indexed chunks
+- **🧠 Context:** Access to over 2,300 indexed chunks (2,328 currently)
 - **📚 Coverage:** Design docs, PRDs, implementation patterns, and test examples
 
 ## ⚡ Quick Decision Tree

--- a/design/productRequirementsDocuments/prdAIAgentWorkflows.md
+++ b/design/productRequirementsDocuments/prdAIAgentWorkflows.md
@@ -18,7 +18,7 @@ AI agents working with the JU-DO-KON! project lack unified workflows and optimiz
 - **Accuracy**: Maintain 62.5%+ success rate for finding correct sources through optimized queries
 - **Consistency**: Establish standardized workflows for common agent tasks and interactions
 - **Quality**: Ensure AI-generated content meets project standards for documentation and code
-- **Knowledge Leverage**: Enable full utilization of the 16,000+ indexed chunks in the vector database
+- **Knowledge Leverage**: Enable full utilization of over 2,300 indexed chunks (2,328 currently) in the vector database
 - **Workflow Optimization**: Provide clear decision trees and patterns for different query types
 
 ---

--- a/docs/rag-system.md
+++ b/docs/rag-system.md
@@ -4,7 +4,7 @@ This document provides comprehensive guidance on using the JU-DO-KON! vector RAG
 
 ## Overview
 
-Before scanning the repo for answers, call [`queryRag`](../src/helpers/queryRag.js) with a natural-language question to pull relevant context from the embeddings database containing 16,000+ indexed chunks covering documentation, code standards, and game rules.
+Before scanning the repo for answers, call [`queryRag`](../src/helpers/queryRag.js) with a natural-language question to pull relevant context from the embeddings database containing over 2,300 indexed chunks (2,328 currently) covering documentation, code standards, and game rules.
 
 ## Basic Usage
 


### PR DESCRIPTION
## Summary
- update RAG documentation and agent guides to note over 2,300 indexed chunks (2,328 currently) instead of the outdated 16,000+ figure
- reviewed nearby text to keep the speed and accuracy messaging natural after the count change

## Testing
- npm run check:jsdoc

------
https://chatgpt.com/codex/tasks/task_e_68c9a61598588326ba9fc7b666b1a08d