### PR TITLE
Adjust orchestrated cooldown readiness events

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -385,7 +385,13 @@ function setupOrchestratedReady(controls, machine) {
       cleanup();
     });
   }
-  addListener("nextRoundTimerReady", () => finalize());
+  for (const type of [
+    "cooldown.timer.expired",
+    "countdownFinished",
+    "control.countdown.completed"
+  ]) {
+    addListener(type, () => finalize());
+  }
   addListener("battleStateChange", (event) => {
     const next = event?.detail?.to ?? event?.detail;
     if (isOrchestratorReadyState(next)) finalize();


### PR DESCRIPTION
## Summary
- avoid resolving orchestrated cooldown readiness on the initial `nextRoundTimerReady`
- listen for `cooldown.timer.expired`, `countdownFinished`, and `control.countdown.completed` events before settling

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- npx vitest run tests/classicBattle/resolution.test.js
- npx playwright test *(fails: known console error / readiness expectations in this environment)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68c9b1099828832687c345f0bd62c738