### PR TITLE
Handle missing orchestrator machine during cooldown

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -222,8 +222,12 @@ export function startCooldown(_store, scheduler = realScheduler) {
   if (!scheduler || typeof scheduler.setTimeout !== "function") {
     scheduler = realScheduler;
   }
-  const { orchestrated: orchestratedMode, machine: orchestratorMachine } =
-    detectOrchestratorContext();
+  const context = detectOrchestratorContext();
+  let orchestratedMode = context.orchestrated;
+  const orchestratorMachine = context.machine;
+  if (orchestratedMode && !orchestratorMachine) {
+    orchestratedMode = false;
+  }
   logStartCooldown();
   const controls = createNextRoundControls();
   if (orchestratedMode) {


### PR DESCRIPTION
## Summary
- fall back to the non-orchestrated cooldown flow when the orchestrator machine reference is missing
- add coverage to confirm the skip handler still registers when orchestration is active without a machine

## Testing
- npx vitest run tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c9bb39253c83268dafc98f2bf33629