### PR TITLE
Prevent fallback ready dispatch after manual cooldown resolve

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -673,6 +673,26 @@ function wireNextRoundTimer(controls, btn, cooldownSeconds, scheduler) {
   let fallbackId;
   /** @type {ReturnType<typeof setTimeout>|null|undefined} */
   let schedulerFallbackId;
+  const originalResolveReady =
+    typeof controls.resolveReady === "function" ? controls.resolveReady : null;
+  if (originalResolveReady) {
+    controls.resolveReady = function wrappedResolveReady(...args) {
+      if (fallbackId) {
+        clearTimeout(fallbackId);
+        fallbackId = null;
+      }
+      try {
+        if (schedulerFallbackId) {
+          scheduler.clearTimeout?.(schedulerFallbackId);
+        }
+      } catch {}
+      schedulerFallbackId = null;
+      if (!expired) {
+        expired = true;
+      }
+      return originalResolveReady.apply(this, args);
+    };
+  }
   const onExpired = () => {
     if (expired) return;
     expired = true;


### PR DESCRIPTION
## Summary
- wrap the cooldown resolveReady hook so manual resolution cancels fallback timers and marks the timer as expired
- add unit coverage confirming manual resolution does not trigger additional ready dispatches from fallback timers

## Testing
- npx vitest run tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c9cd314d988326911d1d9df2170274