### PR TITLE
Fix TimerController fallback scheduler usage

### DIFF
--- a/auditBattleEngine.md
+++ b/auditBattleEngine.md
@@ -2,6 +2,10 @@
 
 This document provides an audit of the JavaScript files within `src/helpers/classicBattle/`, identifying functions that are overly complex or hard to maintain, along with suggestions for improvement and a remediation plan. The assessment focuses on line count (functions >50 lines are a primary concern as per `GEMINI.md`), nesting depth, number of responsibilities, and overall readability.
 
+## Remediation Log
+
+* **TimerController fallback countdown**: The fallback countdown previously bypassed the injected scheduler, so mocked schedulers could not observe tick scheduling or cancellations. Routing both `setTimeout` and `clearTimeout` calls through the provided scheduler keeps fake timers deterministic and prevents regression tests from missing drift.
+
 ## General Observations
 
 * **Orchestration Functions**: Many functions named `init*`, `setup*`, `handle*`, `bind*` tend to be complex because they orchestrate multiple sub-tasks. While some complexity is expected for orchestration, they often exceed reasonable limits.

--- a/src/helpers/TimerController.js
+++ b/src/helpers/TimerController.js
@@ -108,16 +108,16 @@ export class TimerController {
               remaining -= 1;
               if (typeof t === "function") t(remaining);
               if (remaining <= 0) {
-                if (id) clearTimeout(id);
+                if (id) thisScheduler.clearTimeout(id);
                 id = 0;
                 if (typeof e === "function") e();
               } else {
-                id = setTimeout(tick, 1000);
+                id = thisScheduler.setTimeout(tick, 1000);
               }
             };
             return {
               start() {
-                if (id) clearTimeout(id);
+                if (id) thisScheduler.clearTimeout(id);
                 remaining = d;
                 paused = false;
                 if (typeof t === "function") t(remaining);

--- a/tests/helpers/TimerController.fallback.test.js
+++ b/tests/helpers/TimerController.fallback.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+
+const TIMER_UTILS_PATH = "../../src/helpers/timerUtils.js";
+
+describe("TimerController fallback countdown", () => {
+  it("delegates every timeout to the injected scheduler", async () => {
+    vi.resetModules();
+    vi.doMock(TIMER_UTILS_PATH, () => ({
+      getDefaultTimer: vi.fn(async () => 2)
+    }));
+
+    const { TimerController } = await import("../../src/helpers/TimerController.js");
+
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const forbiddenSetTimeout = vi.fn(() => {
+      throw new Error("global setTimeout should not be used by fallback countdown");
+    });
+    const forbiddenClearTimeout = vi.fn(() => {
+      throw new Error("global clearTimeout should not be used by fallback countdown");
+    });
+    globalThis.setTimeout = forbiddenSetTimeout;
+    globalThis.clearTimeout = forbiddenClearTimeout;
+
+    const scheduled = new Map();
+    let nextId = 0;
+    const scheduler = {
+      setTimeout: vi.fn((cb, delay) => {
+        const id = ++nextId;
+        scheduled.set(id, { cb, delay });
+        return id;
+      }),
+      clearTimeout: vi.fn((id) => {
+        scheduled.delete(id);
+      })
+    };
+
+    const controller = new TimerController({
+      scheduler,
+      onSecondTick: () => 0,
+      cancel: () => {}
+    });
+
+    const ticks = [];
+    const onExpired = vi.fn();
+
+    try {
+      await controller.startRound((remaining) => {
+        ticks.push(remaining);
+      }, onExpired, 2);
+
+      expect(scheduler.setTimeout).toHaveBeenCalledTimes(1);
+      expect(scheduler.setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+      expect(forbiddenSetTimeout).not.toHaveBeenCalled();
+
+      const firstEntry = scheduled.entries().next().value;
+      expect(firstEntry).toBeDefined();
+      const [firstId, firstTask] = firstEntry;
+      expect(firstTask.delay).toBe(1000);
+      scheduled.delete(firstId);
+      firstTask.cb();
+
+      expect(ticks).toEqual([2, 1]);
+      expect(scheduler.setTimeout).toHaveBeenCalledTimes(2);
+      expect(forbiddenSetTimeout).not.toHaveBeenCalled();
+
+      const secondEntry = scheduled.entries().next().value;
+      expect(secondEntry).toBeDefined();
+      const [secondId, secondTask] = secondEntry;
+      expect(secondTask.delay).toBe(1000);
+      scheduled.delete(secondId);
+      secondTask.cb();
+
+      expect(ticks).toEqual([2, 1, 0]);
+      expect(scheduler.clearTimeout).toHaveBeenCalledTimes(1);
+      expect(scheduler.clearTimeout).toHaveBeenCalledWith(secondId);
+      expect(forbiddenSetTimeout).not.toHaveBeenCalled();
+      expect(forbiddenClearTimeout).not.toHaveBeenCalled();
+      expect(onExpired).toHaveBeenCalledTimes(1);
+      expect(scheduled.size).toBe(0);
+    } finally {
+      controller.stop();
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+      vi.doUnmock(TIMER_UTILS_PATH);
+      vi.resetModules();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- route the fallback countdown path through the injected scheduler for all timeout operations
- add regression coverage confirming mocked schedulers handle fallback ticks
- document the remediation in the battle engine audit log

## Testing
- npx vitest run tests/helpers/TimerController.drift.test.js tests/helpers/TimerController.fallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ca91396384832689c63ea2fbd327e3