### PR TITLE
Fix cooldown readiness guard and add regression test

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -641,11 +641,14 @@ async function handleNextRoundExpiration(controls, btn) {
   }
   setSkipHandler(null);
   scoreboard.clearTimer();
-  // Ensure we've reached the cooldown state before advancing.
+  // Ensure we've reached the cooldown state before advancing. If the
+  // machine already moved past cooldown (e.g. into roundStart or
+  // waitingForPlayerAction) resolve immediately so the ready dispatch
+  // still occurs.
   await new Promise((resolve) => {
     try {
       const state = getStateSnapshot().state;
-      if (!state || state === "cooldown") {
+      if (!state || state === "cooldown" || isOrchestratorReadyState(state)) {
         resolve();
         return;
       }


### PR DESCRIPTION
## Summary
- ensure handleNextRoundExpiration resolves immediately once the state machine has moved past cooldown
- add a regression test that drives the snapshot to waitingForPlayerAction before the fallback timer and asserts the ready dispatch

## Testing
- npm run test -- --run tests/helpers/classicBattle/scheduleNextRound.fallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68caa99e5f9c8326a1ebc3e77e8705bc