### PR TITLE
Avoid logging warning when machine is unavailable

### DIFF
--- a/src/helpers/classicBattle/eventDispatcher.js
+++ b/src/helpers/classicBattle/eventDispatcher.js
@@ -29,9 +29,8 @@ export async function dispatchBattleEvent(eventName, payload) {
   if (!machine) {
     // Not having a machine is an expected state during early startup
     // (for example when the round selection modal runs before the
-    // orchestrator initializes). Use console.warn so tests that fail
-    // on console.error don't treat this as a hard failure.
-    console.warn("dispatchBattleEvent: no machine available for", eventName);
+    // orchestrator initializes). Return `false` to signal the skipped
+    // dispatch without emitting console noise in production.
     return false;
   }
 


### PR DESCRIPTION
## Summary
- remove the console.warn emitted when dispatchBattleEvent runs without an active machine
- keep the function returning false in that scenario so callers can detect the skip

## Testing
- npx prettier src/helpers/classicBattle/eventDispatcher.js --check
- npx eslint src/helpers/classicBattle/eventDispatcher.js

------
https://chatgpt.com/codex/tasks/task_e_68cac972e61083269cfd330c6f1e760e