### PR TITLE
Add startCooldown mock to round manager test

### DIFF
--- a/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
+++ b/tests/helpers/classicBattle/cooldownEnter.autoAdvance.test.js
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
   getNextRoundControls: vi.fn(() => null),
-  setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms))
+  setupFallbackTimer: vi.fn((ms, cb) => setTimeout(cb, ms)),
+  startCooldown: vi.fn()
 }));
 vi.mock("../../../src/helpers/timers/computeNextRoundCooldown.js", () => ({
   computeNextRoundCooldown: vi.fn(() => 1)


### PR DESCRIPTION
## Summary
- extend the round manager mock in the cooldown auto-advance test to provide a startCooldown spy
- keep existing mocked exports intact so current assertions still operate the same

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cad2186be48326a1097cc11184986a