### PR TITLE
Ensure next button readiness uses property toggles

### DIFF
--- a/src/helpers/classicBattle/cooldowns.js
+++ b/src/helpers/classicBattle/cooldowns.js
@@ -87,6 +87,8 @@ export async function initInterRoundCooldown(machine) {
         document.getElementById("next-button") ||
         document.querySelector('[data-role="next-round"]');
       if (b) {
+        b.disabled = false;
+        b.dataset.nextReady = "true";
         b.setAttribute("data-next-ready", "true");
         b.removeAttribute("disabled");
       }
@@ -103,6 +105,8 @@ export async function initInterRoundCooldown(machine) {
   };
 
   const markReady = (btn) => {
+    btn.disabled = false;
+    btn.dataset.nextReady = "true";
     btn.setAttribute("data-next-ready", "true");
     btn.removeAttribute("disabled");
   };


### PR DESCRIPTION
## Summary
- ensure the inter-round cooldown readiness logic writes through button disabled and dataset properties before attribute adjustments
- update both the finish handler and markReady helper to reapply next button readiness consistently

## Testing
- npx vitest run tests/classicBattle/cooldown.test.js

## Risk
- Low risk: DOM readiness toggling only affects cooldown button state

------
https://chatgpt.com/codex/tasks/task_e_68cad72b61908326bea844023188e058