### PR TITLE
Refactor stat selection handler orchestration

### DIFF
--- a/auditBattleEngine.md
+++ b/auditBattleEngine.md
@@ -165,6 +165,7 @@ This document provides an audit of the JavaScript files within `src/helpers/clas
   - **Suggestion**: Separate test-specific DOM cleanup into a test utility.
 - `handleStatSelection` (approx. 70 lines): **Very High complexity**. Very long function with many responsibilities: validation, store update, timer cleanup, event emission, orchestrator dispatch, fallback resolution, and UI updates. Exceeds the informal 50-line limit.
   - **Suggestion**: This function is a prime candidate for significant refactoring. Break down into `validateAndApplySelection`, `cleanupAndEmitSelection`, `resolveRoundViaOrchestratorOrDirectly`, `updateUIAfterResolution`.
+  - **2024-Refactor**: Extracted `validateAndApplySelection`, `dispatchStatSelected`, `resolveWithFallback`, and `syncResultDisplay` helpers so `handleStatSelection` now orchestrates the flow.
 
 ### `src/helpers/classicBattle/setupUIBindings.js`
 

--- a/tests/helpers/classicBattle/debugPanel.test.js
+++ b/tests/helpers/classicBattle/debugPanel.test.js
@@ -32,7 +32,11 @@ vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
 }));
 vi.mock("../../../src/helpers/battle/index.js", () => ({ showResult: vi.fn() }));
 vi.mock("../../../src/helpers/classicBattle/selectionHandler.js", () => ({
-  handleStatSelection: vi.fn()
+  handleStatSelection: vi.fn(),
+  validateAndApplySelection: vi.fn(),
+  dispatchStatSelected: vi.fn(),
+  resolveWithFallback: vi.fn(),
+  syncResultDisplay: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
   getNextRoundControls: vi.fn(),

--- a/tests/helpers/classicBattle/mocks.js
+++ b/tests/helpers/classicBattle/mocks.js
@@ -60,7 +60,11 @@ export function mockRoundManager() {
 
 export function mockSelectionHandler() {
   vi.doMock("../../../src/helpers/classicBattle/selectionHandler.js", () => ({
-    handleStatSelection: vi.fn()
+    handleStatSelection: vi.fn(),
+    validateAndApplySelection: vi.fn(),
+    dispatchStatSelected: vi.fn(),
+    resolveWithFallback: vi.fn(),
+    syncResultDisplay: vi.fn()
   }));
 }
 

--- a/tests/helpers/classicBattle/roundUI.handlers.test.js
+++ b/tests/helpers/classicBattle/roundUI.handlers.test.js
@@ -36,7 +36,11 @@ vi.mock("../../../src/helpers/classicBattle/timerService.js", () => ({
   handleStatSelectionTimeout: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/selectionHandler.js", () => ({
-  handleStatSelection: vi.fn()
+  handleStatSelection: vi.fn(),
+  validateAndApplySelection: vi.fn(),
+  dispatchStatSelected: vi.fn(),
+  resolveWithFallback: vi.fn(),
+  syncResultDisplay: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/cardStatUtils.js", () => ({
   getCardStatValue: () => 0


### PR DESCRIPTION
## Summary
- extract helper functions in `selectionHandler` to handle validation, dispatch, fallback, and DOM sync flows
- update classic battle test mocks to expose the new helpers
- document the refactor in `auditBattleEngine.md`

## Testing
- npx vitest run tests/helpers/classicBattle/handleStatSelection.machine.test.js tests/helpers/classicBattle/race.statSelected.startup.test.js


------
https://chatgpt.com/codex/tasks/task_e_68caf46f1c3883269c7ff15284df6ecc