### PR TITLE
Restore legacy CLI scoreboard markup

### DIFF
--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -506,6 +506,18 @@
           >
         </div>
         <!-- header title + status only; controls moved into main.settings for less prominence -->
+        <div class="cli-status" aria-live="polite" aria-atomic="true">
+          <div id="cli-round">Round 0 Target: 10</div>
+          <div
+            id="cli-score"
+            data-score-player="0"
+            data-score-opponent="0"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            You: 0 Opponent: 0
+          </div>
+        </div>
 
         <!-- Standard Scoreboard DOM nodes (Phase 1: hidden, for future shared component) -->
         <div class="standard-scoreboard-nodes" style="display: none" aria-hidden="true">


### PR DESCRIPTION
## Summary
- restore the legacy CLI round and score nodes in the battle CLI header so helper utilities find them alongside the new scoreboard markup

## Testing
- npx vitest tests/pages/battleCLI.standardDOM.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb04bc1f748326b617d2ccc13d6798