### PR TITLE
Cache next round resolver before cooldown event dispatch

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -708,12 +708,13 @@ async function handleNextRoundExpiration(controls, btn) {
     dispatchReadyDirectly();
   }
 
-  if (typeof controls.resolveReady === "function") {
+  const resolveReadyFn = controls?.resolveReady;
+  if (typeof resolveReadyFn === "function") {
     // Explicitly emit readiness event in addition to resolver for robustness.
     try {
       emitBattleEvent("nextRoundTimerReady");
     } catch {}
-    controls.resolveReady();
+    if (typeof resolveReadyFn === "function") resolveReadyFn();
   }
 }
 


### PR DESCRIPTION
## Task Contract
- inputs: ["src/helpers/classicBattle/roundManager.js", "tests/classicBattle/cooldown.test.js"]
- outputs: ["src/helpers/classicBattle/roundManager.js"]
- success: ["classicBattle schedule/cooldown Vitest suite: PASS"]
- errorMode: ask_on_public_api_change

## Files Changed
- `src/helpers/classicBattle/roundManager.js` — cache the cooldown ready resolver before dispatching the readiness event so the same function reference is invoked even if listeners mutate the controls object.

## Verification
- eslint: PASS (`npx eslint src/helpers/classicBattle/roundManager.js`)
- vitest: 2 passed, 0 failed (`npx vitest run tests/classicBattle/cooldown.test.js`)
- playwright: Not Run (not requested)
- jsdoc: FAIL (baseline issue: `showFatalInitError` missing JSDoc)

## Risk & Follow-Up
- Risk: Low; affects only the cooldown readiness resolver invocation order.
- Follow-Up: None.


------
https://chatgpt.com/codex/tasks/task_e_68cb04c092a0832693307a1fed0533d4