### PR TITLE
Refactor round timer setup into testable helpers

### DIFF
--- a/auditBattleEngine.md
+++ b/auditBattleEngine.md
@@ -6,6 +6,7 @@ This document provides an audit of the JavaScript files within `src/helpers/clas
 
 - **TimerController fallback countdown**: The fallback countdown previously bypassed the injected scheduler, so mocked schedulers could not observe tick scheduling or cancellations. Routing both `setTimeout` and `clearTimeout` calls through the provided scheduler keeps fake timers deterministic and prevents regression tests from missing drift.
 - **Card selection + battle score documentation**: Filled in the remaining `@summary`/`@pseudocode` blocks for exported helpers in `src/helpers/classicBattle/cardSelection.js` and `src/helpers/battle/score.js`, aligning them with the expectations spelled out in `GEMINI.md`.
+- **Round timer orchestration**: Broke `startTimer` into `resolveRoundTimerDuration`, `primeTimerDisplay`, `configureTimerCallbacks`, and `handleTimerExpiration`, enabling dependency injection for scoreboard/scheduler shims while reducing the orchestration function's complexity.
 
 ## General Observations
 


### PR DESCRIPTION
## Summary
- extract `resolveRoundTimerDuration`, `primeTimerDisplay`, `configureTimerCallbacks`, and `handleTimerExpiration` to simplify `startTimer`
- allow dependency injection for scoreboard/event utilities while preserving skip handling and drift fallbacks
- document the timer service refactor in the battle engine audit log

## Testing
- npx vitest run tests/helpers/timerService.test.js tests/helpers/timerService.autoSelect.test.js tests/helpers/timerService.autoSelectDisabled.test.js tests/helpers/classicBattle/timerService.drift.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb06a12fe4832696ebdcc6dd210250