### PR TITLE
Refactor card selection data flow helpers

### DIFF
--- a/auditBattleEngine.md
+++ b/auditBattleEngine.md
@@ -6,6 +6,7 @@ This document provides an audit of the JavaScript files within `src/helpers/clas
 
 - **TimerController fallback countdown**: The fallback countdown previously bypassed the injected scheduler, so mocked schedulers could not observe tick scheduling or cancellations. Routing both `setTimeout` and `clearTimeout` calls through the provided scheduler keeps fake timers deterministic and prevents regression tests from missing drift.
 - **Card selection + battle score documentation**: Filled in the remaining `@summary`/`@pseudocode` blocks for exported helpers in `src/helpers/classicBattle/cardSelection.js` and `src/helpers/battle/score.js`, aligning them with the expectations spelled out in `GEMINI.md`.
+- **Card selection data orchestration**: Extracted `loadJudokaData`, `loadGokyoLookup`, `selectOpponentJudoka`, and `renderOpponentPlaceholder` so `drawCards` now coordinates explicit helpers. The smaller helpers accept injected fetchers/containers, which keeps tests deterministic while shrinking the orchestration footprint.
 
 ## General Observations
 

--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -89,92 +89,204 @@ function showLoadError(error) {
  * @summary Fetch and cache the judoka dataset needed for card selection.
  *
  * @pseudocode
- * 1. If `judokaData` already exists, return it as an array (or an empty array when invalid).
- * 2. Otherwise fetch `judoka.json`, cache the array, and return the data.
- * 3. On failure, surface the load error to the UI and resolve with an empty array.
+ * 1. If cached data exists, return it as an array (or an empty array when invalid).
+ * 2. Otherwise invoke the provided fetcher for `judoka.json` and cache the result.
+ * 3. Surface errors via `onError` and resolve with an empty array so the caller can recover.
  *
+ * @param {{fetcher?: (path: string) => Promise<any>, onError?: (error: any) => void}} [options]
  * @returns {Promise<object[]>}
  */
-async function ensureJudokaData() {
+export async function loadJudokaData({ fetcher = fetchJson, onError = showLoadError } = {}) {
   if (judokaData) return Array.isArray(judokaData) ? judokaData : [];
   try {
-    judokaData = await fetchJson(`${DATA_DIR}judoka.json`);
+    judokaData = await fetcher(`${DATA_DIR}judoka.json`);
     return Array.isArray(judokaData) ? judokaData : [];
   } catch (error) {
-    showLoadError(error);
+    try {
+      onError?.(error);
+    } catch {}
     return [];
   }
 }
 
-async function ensureGokyoLookup() {
+/**
+ * @summary Ensure the gokyo lookup is available and return it.
+ *
+ * @pseudocode
+ * 1. Reuse cached lookup when present.
+ * 2. Otherwise fetch `gokyo.json`, create the lookup via the provided factory, and cache it.
+ * 3. Surface errors via `onError` and return an empty lookup so callers can continue deterministically.
+ *
+ * @param {{fetcher?: (path: string) => Promise<any>, lookupFactory?: (data: any) => any, onError?: (error: any) => void}} [options]
+ * @returns {Promise<object>}
+ */
+export async function loadGokyoLookup({
+  fetcher = fetchJson,
+  lookupFactory = createGokyoLookup,
+  onError = showLoadError
+} = {}) {
   if (gokyoLookup) return gokyoLookup;
   try {
-    const gokyoData = await fetchJson(`${DATA_DIR}gokyo.json`);
-    gokyoLookup = createGokyoLookup(gokyoData);
+    const gokyoData = await fetcher(`${DATA_DIR}gokyo.json`);
+    gokyoLookup = lookupFactory(gokyoData);
     return gokyoLookup;
   } catch (error) {
-    showLoadError(error);
-    return createGokyoLookup([]);
+    try {
+      onError?.(error);
+    } catch {}
+    return lookupFactory([]);
   }
 }
 
-function pickOpponent(available, playerJudoka) {
-  let compJudoka = getRandomJudoka(available);
-  if (!playerJudoka) return compJudoka;
-  let attempts = 0;
-  const maxAttempts = Math.max(available.length || 0, 5);
-  while (compJudoka.id === playerJudoka.id && attempts < maxAttempts) {
-    compJudoka = getRandomJudoka(available);
-    attempts += 1;
+/**
+ * @summary Select an opponent judoka distinct from the player when possible.
+ *
+ * @pseudocode
+ * 1. Attempt to pick a random judoka from `availableJudoka` using `randomJudoka`.
+ * 2. Retry while the selection matches `playerJudoka` (bounded by pool size).
+ * 3. When selection fails, fall back to `fallbackProvider` and log via `qaLogger`.
+ *
+ * @param {{
+ *   availableJudoka?: object[],
+ *   playerJudoka?: object|null,
+ *   randomJudoka?: (pool: object[]) => object|null,
+ *   fallbackProvider?: () => Promise<object>,
+ *   qaLogger?: (message: string) => void
+ * }} [options]
+ * @returns {Promise<object|null>}
+ */
+export async function selectOpponentJudoka({
+  availableJudoka = [],
+  playerJudoka = null,
+  randomJudoka = getRandomJudoka,
+  fallbackProvider = getFallbackJudoka,
+  qaLogger = qaInfo
+} = {}) {
+  const pool = Array.isArray(availableJudoka) ? availableJudoka : [];
+  const pickRandom = () => {
+    if (typeof randomJudoka !== "function") return null;
+    try {
+      return randomJudoka(pool) || null;
+    } catch {
+      return null;
+    }
+  };
+
+  let selection = pickRandom();
+  if (playerJudoka) {
+    let attempts = 0;
+    const maxAttempts = Math.max(pool.length || 0, 5);
+    while (selection?.id === playerJudoka.id && attempts < maxAttempts) {
+      selection = pickRandom();
+      attempts += 1;
+    }
   }
-  return compJudoka;
+
+  if (selection) return selection;
+
+  if (typeof fallbackProvider === "function") {
+    try {
+      const fallback = await fallbackProvider();
+      if (fallback && typeof qaLogger === "function") {
+        try {
+          qaLogger("Using fallback judoka for opponent");
+        } catch {}
+      }
+      return fallback || null;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
 }
 
-async function renderOpponentPlaceholder(container, placeholder, enableInspector) {
+/**
+ * @summary Render the opponent placeholder card while preserving debug UI.
+ *
+ * @pseudocode
+ * 1. Resolve the placeholder judoka from explicit input, dataset, opponent, or fallback provider.
+ * 2. Instantiate a `JudokaCard` via the provided factory and ensure it renders an HTMLElement.
+ * 3. Replace the container contents (preserving debug panel) and attach lazy portrait observers when supported.
+ *
+ * @param {{
+ *   container?: HTMLElement|null,
+ *   allJudoka?: object[],
+ *   opponentJudoka?: object|null,
+ *   placeholderJudoka?: object|null,
+ *   lookup?: object|null,
+ *   enableInspector?: boolean,
+ *   fallbackProvider?: () => Promise<object>,
+ *   qaLogger?: (message: string) => void,
+ *   cardFactory?: (judoka: object, lookup: object|null, options: {useObscuredStats: boolean, enableInspector: boolean}) => { render?: () => Promise<HTMLElement>|HTMLElement },
+ *   lazyPortraitSetup?: (cardEl: HTMLElement) => void
+ * }} [options]
+ * @returns {Promise<void>}
+ */
+export async function renderOpponentPlaceholder({
+  container,
+  allJudoka = [],
+  opponentJudoka = null,
+  placeholderJudoka = null,
+  lookup = gokyoLookup,
+  enableInspector = false,
+  fallbackProvider = getFallbackJudoka,
+  qaLogger = qaInfo,
+  cardFactory = (judoka, lookupArg, options) => new JudokaCard(judoka, lookupArg, options),
+  lazyPortraitSetup = setupLazyPortraits
+} = {}) {
   if (!container) return;
 
-  // Preserve the debug panel across placeholder re-renders
   const debugPanel = container.querySelector("#debug-panel");
+  const dataset = Array.isArray(allJudoka) ? allJudoka : [];
 
-  // Ensure we have a valid judoka object; fall back to the built-in
-  // placeholder when data failed to load or is empty.
-  let target = placeholder;
-  // Do not pre-validate fields here; tests may provide a minimal object.
-  // Only fall back when no placeholder was provided at all.
-  if (!target) {
+  let target = placeholderJudoka;
+  if (!target) target = dataset.find((j) => j && j.id === 1) || null;
+  if (!target && opponentJudoka) target = opponentJudoka;
+
+  if (!target && typeof fallbackProvider === "function") {
     try {
-      target = await getFallbackJudoka();
-      qaInfo("Using fallback judoka for opponent placeholder");
+      target = await fallbackProvider();
+      if (target && typeof qaLogger === "function") {
+        try {
+          qaLogger("Using fallback judoka for opponent placeholder");
+        } catch {}
+      }
     } catch {
-      // If even the fallback cannot be retrieved, bail silently.
       return;
     }
   }
 
+  if (!target) return;
+
   try {
-    const judokaCard = new JudokaCard(target, gokyoLookup, {
+    const cardCreator =
+      typeof cardFactory === "function"
+        ? cardFactory
+        : (judoka, lookupArg, options) => new JudokaCard(judoka, lookupArg, options);
+    const cardInstance = cardCreator(target, lookup ?? gokyoLookup, {
       useObscuredStats: true,
       enableInspector
     });
-    if (typeof judokaCard.render === "function") {
-      const card = await judokaCard.render();
-      if (!(card && typeof card === "object" && card.nodeType === 1)) {
-        console.error("JudokaCard did not render an HTMLElement");
-        return;
-      }
-      container.innerHTML = "";
-      if (debugPanel) container.appendChild(debugPanel);
-      container.appendChild(card);
-      // Defer lazy portrait setup when unsupported (e.g., JSDOM)
-      if (typeof IntersectionObserver !== "undefined") {
-        try {
-          setupLazyPortraits(card);
-        } catch {}
-      }
+
+    if (!cardInstance || typeof cardInstance.render !== "function") return;
+
+    const rendered = await cardInstance.render();
+    if (!(rendered && typeof rendered === "object" && rendered.nodeType === 1)) {
+      console.error("JudokaCard did not render an HTMLElement");
+      return;
+    }
+
+    container.innerHTML = "";
+    if (debugPanel) container.appendChild(debugPanel);
+    container.appendChild(rendered);
+
+    if (typeof IntersectionObserver !== "undefined" && typeof lazyPortraitSetup === "function") {
+      try {
+        lazyPortraitSetup(rendered);
+      } catch {}
     }
   } catch (error) {
-    // Swallow constructor/render errors to avoid breaking round start; the
-    // timer and selection can proceed even if the placeholder fails.
     console.debug("Error rendering JudokaCard placeholder:", error);
   }
 }
@@ -183,82 +295,99 @@ async function renderOpponentPlaceholder(container, placeholder, enableInspector
  * @summary Load card data, generate the player card, select an opponent, and render an obscured placeholder.
  *
  * @pseudocode
- * 1. Ensure judoka and gokyo datasets are loaded (fetch if missing).
- * 2. Filter out hidden judoka and generate a random player card (skip rendering when no container exists).
- * 3. Pick an opponent that doesn't match the player when possible, falling back to the built-in placeholder.
- * 4. Render an opponent placeholder card with obscured stats and preserve any debug panel.
- * 5. Return the selected player and opponent judoka objects.
+ * 1. Load judoka and gokyo datasets using injectable helpers for deterministic testing.
+ * 2. Generate the player card while capturing the selected judoka.
+ * 3. Select an opponent judoka and remember it for subsequent reads.
+ * 4. Render the opponent placeholder card with preserved debug panel state.
  *
+ * @param {{
+ *   judokaLoader?: typeof loadJudokaData,
+ *   gokyoLoader?: typeof loadGokyoLookup,
+ *   fetcher?: (path: string) => Promise<any>,
+ *   lookupFactory?: (data: any) => any,
+ *   playerContainer?: HTMLElement|null,
+ *   opponentContainer?: HTMLElement|null,
+ *   containerProvider?: (id: string) => HTMLElement|null,
+ *   cardGenerator?: typeof generateRandomCard,
+ *   randomJudoka?: typeof getRandomJudoka,
+ *   placeholderRenderer?: typeof renderOpponentPlaceholder,
+ *   fallbackProvider?: typeof getFallbackJudoka,
+ *   loadSettingsFn?: typeof loadSettings,
+ *   inspectorFlagReader?: () => boolean,
+ *   qaLogger?: (message: string) => void,
+ *   cardFactory?: (judoka: object, lookup: object|null, options: {useObscuredStats: boolean, enableInspector: boolean}) => any,
+ *   lazyPortraitSetup?: (cardEl: HTMLElement) => void
+ * }} [options]
  * @returns {Promise<{playerJudoka: object|null, opponentJudoka: object|null}>}
  */
-export async function drawCards() {
-  // Always attempt to load both datasets so retries re-fetch both.
-  const allJudoka = await ensureJudokaData();
-  const available = allJudoka.filter((j) => !j.isHidden);
+export async function drawCards(options = {}) {
+  const {
+    judokaLoader = loadJudokaData,
+    gokyoLoader = loadGokyoLookup,
+    fetcher = fetchJson,
+    lookupFactory = createGokyoLookup,
+    playerContainer = options.containerProvider?.("player-card") ??
+      options.playerContainer ??
+      document.getElementById("player-card"),
+    opponentContainer = options.containerProvider?.("opponent-card") ??
+      options.opponentContainer ??
+      document.getElementById("opponent-card"),
+    cardGenerator = generateRandomCard,
+    randomJudoka = getRandomJudoka,
+    placeholderRenderer = renderOpponentPlaceholder,
+    fallbackProvider = getFallbackJudoka,
+    loadSettingsFn = loadSettings,
+    inspectorFlagReader = () => isEnabled("enableCardInspector"),
+    qaLogger = qaInfo,
+    cardFactory,
+    lazyPortraitSetup
+  } = options;
 
-  const lookup = await ensureGokyoLookup();
-  // If lookup failed completely, bail out; judoka may be empty but we can still proceed.
+  const allJudoka = await judokaLoader({ fetcher, onError: showLoadError });
+  const available = allJudoka.filter((j) => !j?.isHidden);
+  const lookup = await gokyoLoader({ fetcher, lookupFactory, onError: showLoadError });
   if (!lookup) return { playerJudoka: null, opponentJudoka: null };
 
-  const playerContainer = document.getElementById("player-card");
-  const opponentContainer = document.getElementById("opponent-card");
-
   try {
-    await loadSettings();
+    await loadSettingsFn();
   } catch {}
-  const enableInspector = isEnabled("enableCardInspector");
+  const enableInspector = !!inspectorFlagReader();
 
   let playerJudoka = null;
   const skipRender = !playerContainer;
-  await generateRandomCard(
+  await cardGenerator(
     available,
     null,
     playerContainer,
     false,
-    (j) => {
-      playerJudoka = j;
+    (judoka) => {
+      playerJudoka = judoka;
     },
     { enableInspector, skipRender }
   );
 
-  // Pick an opponent safely; fall back to the built-in judoka when selection fails
-  let compJudoka;
-  try {
-    compJudoka = pickOpponent(available, playerJudoka);
-  } catch {
-    try {
-      compJudoka = await getFallbackJudoka();
-      qaInfo("Using fallback judoka for opponent");
-    } catch {
-      compJudoka = null;
-    }
-  }
-  // Keep the selected opponent even if it is a minimal object.
-  // Only fall back when opponent selection failed entirely.
-  if (!compJudoka) {
-    try {
-      compJudoka = await getFallbackJudoka();
-      qaInfo("Using fallback judoka for opponent");
-    } catch {
-      compJudoka = null;
-    }
-  }
-  opponentJudoka = compJudoka;
+  const opponent = await selectOpponentJudoka({
+    availableJudoka: available,
+    playerJudoka,
+    randomJudoka,
+    fallbackProvider,
+    qaLogger
+  });
+  opponentJudoka = opponent;
 
-  // Choose a placeholder based on a stable ID (1) or the opponent.
-  // Do not validate here to allow minimal objects during tests.
-  let placeholder = allJudoka.find((j) => j.id === 1) || compJudoka;
-  if (!placeholder) {
-    try {
-      placeholder = await getFallbackJudoka();
-      qaInfo("Using fallback judoka for opponent placeholder");
-    } catch {
-      placeholder = null;
-    }
-  }
-  await renderOpponentPlaceholder(opponentContainer, placeholder, enableInspector);
+  await placeholderRenderer({
+    container: opponentContainer,
+    allJudoka,
+    opponentJudoka: opponent,
+    lookup,
+    enableInspector,
+    fallbackProvider,
+    qaLogger,
+    cardFactory,
+    lazyPortraitSetup
+  });
 
-  return { playerJudoka, opponentJudoka };
+  return { playerJudoka, opponentJudoka: opponent };
 }
 
 /**
@@ -301,13 +430,13 @@ export function getGokyoLookup() {
  * @summary Ensure the gokyo lookup exists and return it.
  *
  * @pseudocode
- * 1. Invoke `ensureGokyoLookup()` to reuse the cached lookup or fetch and create it when missing.
+ * 1. Invoke `loadGokyoLookup()` to reuse the cached lookup or fetch and create it when missing.
  * 2. Return the resulting lookup object (never `null`, possibly empty).
  *
  * @returns {Promise<Object>}
  */
 export async function getOrLoadGokyoLookup() {
-  return await ensureGokyoLookup();
+  return await loadGokyoLookup();
 }
 
 /**


### PR DESCRIPTION
## Summary
- add loadJudokaData and loadGokyoLookup helpers so fetchers can be injected for deterministic tests
- extract selectOpponentJudoka and renderOpponentPlaceholder and have drawCards orchestrate their work with minimal inline logic
- document the refactor in auditBattleEngine.md remediation log

## Testing
- npx vitest run tests/helpers/classicBattle/cardSelection.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb06cc950c83269e09d6980bc02006