### PR TITLE
Refactor round select modal helpers

### DIFF
--- a/auditBattleEngine.md
+++ b/auditBattleEngine.md
@@ -8,6 +8,7 @@ This document provides an audit of the JavaScript files within `src/helpers/clas
 - **Card selection + battle score documentation**: Filled in the remaining `@summary`/`@pseudocode` blocks for exported helpers in `src/helpers/classicBattle/cardSelection.js` and `src/helpers/battle/score.js`, aligning them with the expectations spelled out in `GEMINI.md`.
 - **Card selection data orchestration**: Extracted `loadJudokaData`, `loadGokyoLookup`, `selectOpponentJudoka`, and `renderOpponentPlaceholder` so `drawCards` now coordinates explicit helpers. The smaller helpers accept injected fetchers/containers, which keeps tests deterministic while shrinking the orchestration footprint
 - **Round timer orchestration**: Broke `startTimer` into `resolveRoundTimerDuration`, `primeTimerDisplay`, `configureTimerCallbacks`, and `handleTimerExpiration`, enabling dependency injection for scoreboard/scheduler shims while reducing the orchestration function's complexity.
+- **Round select modal orchestration**: Split `initRoundSelectModal` into helpers that gate autostart/test mode, build the modal, wire buttons/keyboard, and manage tooltip lifecycle, with a new `RoundSelectPositioner` class encapsulating resize/orientation cleanup.
 
 ## General Observations
 


### PR DESCRIPTION
## Summary
- refactor classic battle round select modal into focused helpers for gating, DOM construction, controls, and tooltips
- encapsulate modal positioning logic inside a RoundSelectPositioner lifecycle helper
- document the round select modal remediation in the audit log

## Testing
- npx vitest run tests/helpers/classicBattle/roundSelectModal.test.js tests/helpers/classicBattle/roundSelectModal.positioning.test.js tests/helpers/classicBattle/roundSelectModal.resize.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb0c3b92dc8326b0829fbb43616fb0