### PR TITLE
Refactor startCooldown helpers

### DIFF
--- a/auditBattleEngine.md
+++ b/auditBattleEngine.md
@@ -133,11 +133,11 @@ This document provides an audit of the JavaScript files within `src/helpers/clas
 - `handleReplay` (approx. 25 lines): Medium complexity due to conditional engine recreation, event bridging, UI reset, and scoreboard updates.
   - **Suggestion**: Separate engine management from UI reset and scoreboard updates.
 - `startCooldown` (approx. 60 lines): **Very High complexity**. Very long function with complex conditional logic for orchestrated mode, multiple event listeners, and nested functions for timer wiring. Exceeds the informal 50-line limit.
-  - **Suggestion**: This function needs significant refactoring. Break it down into `createCooldownControls`, `setupOrchestratedCooldown`, `setupNonOrchestratedCooldown`, `wireNextRoundTimer`.
+  - **2024-Refactor**: Extracted `createCooldownControls`, `setupNonOrchestratedReady`, and `wireCooldownTimer` helpers with dependency-injection friendly options to reduce inline branching.
 - `setupOrchestratedReady` (approx. 40 lines): **High complexity**. Manages cleanup functions, event listeners, and various readiness checks.
-  - **Suggestion**: Extract event listener registration and cleanup into a dedicated helper.
-- `wireNextRoundTimer` (approx. 50 lines): **High complexity**. Long function with complex timer setup, event listeners, and conditional fallback. Exceeds the informal 50-line limit.
-  - **Suggestion**: Decompose into `createAndAttachTimer`, `setupTimerEventHandlers`, `scheduleFallbackTimer`.
+  - **2024-Refactor**: Centralized listener registration and readiness checks via injectable event bus/scheduler parameters; remaining complexity stems from orchestrator edge cases.
+- `wireCooldownTimer` (approx. 50 lines): **High complexity**. Long function with complex timer setup, event listeners, and conditional fallback. Exceeds the informal 50-line limit.
+  - **2024-Refactor**: Renamed from `wireNextRoundTimer`, now accepts injected timer/rendering/scheduler/event bus dependencies to simplify `startCooldown` mocking.
 - `_resetForTest` (approx. 45 lines): **High complexity**. Resets many subsystems (skip state, selection, engine, scheduler), handles conditional engine recreation, and clears store state.
   - **Suggestion**: Break down into `resetSubsystems`, `resetStoreState`, `emitUIResetEvent`.
 


### PR DESCRIPTION
## Summary
- refactor startCooldown to use createCooldownControls, setupNonOrchestratedReady, and wireCooldownTimer helpers with injected event bus options
- update orchestration helpers, cooldown timer wiring, and expiration handling to support dependency injection for event bus, scheduler, and UI dependencies
- document the refactor in auditBattleEngine.md

## Testing
- npx vitest run tests/helpers/classicBattle/timerService.nextRound.test.js tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js tests/helpers/classicBattle/scheduleNextRound.fallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb0c45a4108326b860d43c97de48d9