### PR TITLE
Dispose classic battle orchestrator before resetting modules

### DIFF
--- a/tests/helpers/classicBattle/utils.js
+++ b/tests/helpers/classicBattle/utils.js
@@ -6,6 +6,7 @@ if (typeof console !== "undefined") {
 console.log("[TEST DEBUG] top-level utils.js");
 import { vi } from "vitest";
 import { createBattleHeader, createBattleCardContainers } from "../../utils/testUtils.js";
+import { disposeClassicBattleOrchestrator } from "../../../src/helpers/classicBattle/orchestrator.js";
 
 /**
  * @pseudocode
@@ -22,6 +23,7 @@ import { createBattleHeader, createBattleCardContainers } from "../../utils/test
  *   - expose timerSpy, mocks, and currentFlags
  */
 export function setupClassicBattleDom() {
+  disposeClassicBattleOrchestrator();
   vi.resetModules();
   document.body.innerHTML = "";
   const { playerCard, opponentCard } = createBattleCardContainers();


### PR DESCRIPTION
## Summary
- import `disposeClassicBattleOrchestrator` in the classic battle test DOM helper
- clear any cached orchestrator instance before `vi.resetModules()` when rebuilding the test DOM

## Testing
- `npx vitest run tests/helpers/classicBattle/scheduleNextRound.test.js tests/helpers/classicBattle/scheduleNextRound.fallback.test.js` *(fails: scheduleNextRound specs still time out)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19afa22c8326a34ff6a7123c7da8