### PR TITLE
Refactor round UI event handlers for dependency injection

### DIFF
--- a/auditBattleEngine.md
+++ b/auditBattleEngine.md
@@ -9,6 +9,7 @@ This document provides an audit of the JavaScript files within `src/helpers/clas
 - **Card selection data orchestration**: Extracted `loadJudokaData`, `loadGokyoLookup`, `selectOpponentJudoka`, and `renderOpponentPlaceholder` so `drawCards` now coordinates explicit helpers. The smaller helpers accept injected fetchers/containers, which keeps tests deterministic while shrinking the orchestration footprint
 - **Round timer orchestration**: Broke `startTimer` into `resolveRoundTimerDuration`, `primeTimerDisplay`, `configureTimerCallbacks`, and `handleTimerExpiration`, enabling dependency injection for scoreboard/scheduler shims while reducing the orchestration function's complexity.
 - **Round select modal orchestration**: Split `initRoundSelectModal` into helpers that gate autostart/test mode, build the modal, wire buttons/keyboard, and manage tooltip lifecycle, with a new `RoundSelectPositioner` class encapsulating resize/orientation cleanup.
+- **Round UI handler extraction**: Moved `roundStarted`, `statSelected`, and `roundResolved` listeners into injectable helpers shared by the static and dynamic bindings, and centralized the dynamic preloading/promise silencing into a `createPreloader` utility so tests can assert side effects without deep nesting.
 
 ## General Observations
 


### PR DESCRIPTION
## Summary
- extract the roundStarted, statSelected, and roundResolved event handlers into injectable helpers used by both static and dynamic bindings
- introduce a shared preloader that centralizes promise silencing while wiring dynamically loaded dependencies
- document the handler refactor in auditBattleEngine.md

## Testing
- npx vitest run tests/helpers/classicBattle/roundUI.handlers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb1e7c23ac832689d327566bbd9f60