### PR TITLE
Refactor inter-round cooldown helpers

### DIFF
--- a/auditBattleEngine.md
+++ b/auditBattleEngine.md
@@ -8,6 +8,7 @@ This document provides an audit of the JavaScript files within `src/helpers/clas
 - **Card selection + battle score documentation**: Filled in the remaining `@summary`/`@pseudocode` blocks for exported helpers in `src/helpers/classicBattle/cardSelection.js` and `src/helpers/battle/score.js`, aligning them with the expectations spelled out in `GEMINI.md`.
 - **Card selection data orchestration**: Extracted `loadJudokaData`, `loadGokyoLookup`, `selectOpponentJudoka`, and `renderOpponentPlaceholder` so `drawCards` now coordinates explicit helpers. The smaller helpers accept injected fetchers/containers, which keeps tests deterministic while shrinking the orchestration footprint
 - **Round timer orchestration**: Broke `startTimer` into `resolveRoundTimerDuration`, `primeTimerDisplay`, `configureTimerCallbacks`, and `handleTimerExpiration`, enabling dependency injection for scoreboard/scheduler shims while reducing the orchestration function's complexity.
+- **Inter-round cooldown orchestration**: Split `initInterRoundCooldown` into `resolveInterRoundCooldownDuration`, `prepareNextButtonForCooldown`, `setupInterRoundTimer`, and `createCooldownCompletion`. The helpers accept injected schedulers so Vitest fakes advance both engine and fallback timers deterministically.
 - **Round select modal orchestration**: Split `initRoundSelectModal` into helpers that gate autostart/test mode, build the modal, wire buttons/keyboard, and manage tooltip lifecycle, with a new `RoundSelectPositioner` class encapsulating resize/orientation cleanup.
 
 ## General Observations

--- a/tests/helpers/classicBattle/initInterRoundCooldown.event.test.js
+++ b/tests/helpers/classicBattle/initInterRoundCooldown.event.test.js
@@ -50,11 +50,16 @@ function createDisabledSpy(btn) {
 
 describe("initInterRoundCooldown", () => {
   let machine;
+  let scheduler;
   beforeEach(() => {
     emitBattleEvent.mockReset();
     document.body.innerHTML = '<button id="next-button" disabled></button>';
     machine = { dispatch: vi.fn(), getState: () => "cooldown" };
     vi.resetModules();
+    scheduler = {
+      setTimeout: (cb, ms) => setTimeout(cb, ms),
+      clearTimeout: (id) => clearTimeout(id)
+    };
   });
 
   afterEach(() => {
@@ -65,7 +70,7 @@ describe("initInterRoundCooldown", () => {
     const { initInterRoundCooldown } = await import(
       "../../../src/helpers/classicBattle/cooldowns.js"
     );
-    await initInterRoundCooldown(machine);
+    await initInterRoundCooldown(machine, { scheduler });
     const btn = document.getElementById("next-button");
     expect(btn.disabled).toBe(false);
     expect(btn.dataset.nextReady).toBe("true");
@@ -79,7 +84,7 @@ describe("initInterRoundCooldown", () => {
     const { initInterRoundCooldown } = await import(
       "../../../src/helpers/classicBattle/cooldowns.js"
     );
-    await initInterRoundCooldown(machine);
+    await initInterRoundCooldown(machine, { scheduler });
     const btn = document.getElementById("next-button");
     expect(btn.disabled).toBe(false);
     expect(btn.dataset.nextReady).toBe("true");
@@ -93,7 +98,7 @@ describe("initInterRoundCooldown", () => {
     );
     const btn = document.getElementById("next-button");
     const getDisabledSetCount = createDisabledSpy(btn);
-    await initInterRoundCooldown(machine);
+    await initInterRoundCooldown(machine, { scheduler });
     expect(getDisabledSetCount()).toBe(1);
     btn.dataset.nextReady = "";
     await vi.runAllTimersAsync();
@@ -108,7 +113,7 @@ describe("initInterRoundCooldown", () => {
     );
     const btn = document.getElementById("next-button");
     const getDisabledSetCount = createDisabledSpy(btn);
-    await initInterRoundCooldown(machine);
+    await initInterRoundCooldown(machine, { scheduler });
     await vi.runAllTimersAsync();
     expect(getDisabledSetCount()).toBe(1);
   });


### PR DESCRIPTION
## Summary
- extract helper functions for inter-round cooldown duration lookup, button readiness, timer wiring, and completion flow
- allow scheduler injection in cooldown initialization and update vitest coverage to use the new helpers
- document the refactor in the battle engine audit log

## Testing
- npx vitest run tests/helpers/classicBattle/initInterRoundCooldown.event.test.js tests/classicBattle/cooldown.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb1e73ce4c8326a728a8d3e8e0e1a2