### PR TITLE
Re-export updateDebugPanel for dynamic handlers

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -24,7 +24,8 @@ import {
   resolveStatButtonsReady
 } from "./statButtons.js";
 import { guard } from "./guard.js";
-import { updateDebugPanel } from "./debugPanel.js";
+import { updateDebugPanel as updateDebugPanelImpl } from "./debugPanel.js";
+export { updateDebugPanelImpl as updateDebugPanel };
 import { runWhenIdle } from "./idleCallback.js";
 import { getStateSnapshot } from "./battleDebug.js";
 
@@ -867,7 +868,7 @@ export function resetBattleUI() {
   resetNextButton();
   resetQuitButton();
   clearScoreboardAndMessages();
-  updateDebugPanel();
+  updateDebugPanelImpl();
 }
 
 /**

--- a/tests/helpers/classicBattle/roundUI.dynamicUpdateDebugPanel.test.js
+++ b/tests/helpers/classicBattle/roundUI.dynamicUpdateDebugPanel.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const scoreboardMock = {
+  showMessage: vi.fn(),
+  updateScore: vi.fn(),
+  clearMessage: vi.fn(),
+  showTemporaryMessage: vi.fn(),
+  clearTimer: vi.fn(),
+  updateTimer: vi.fn(),
+  showAutoSelect: vi.fn(),
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
+};
+
+vi.mock("../../../src/helpers/setupScoreboard.js", () => scoreboardMock);
+vi.mock("/src/helpers/setupScoreboard.js", () => scoreboardMock);
+vi.mock("../../../src/helpers/showSnackbar.js", () => ({
+  showSnackbar: vi.fn(),
+  updateSnackbar: vi.fn()
+}));
+vi.mock("/src/helpers/showSnackbar.js", () => ({
+  showSnackbar: vi.fn(),
+  updateSnackbar: vi.fn()
+}));
+vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
+  handleReplay: vi.fn(),
+  isOrchestrated: vi.fn(() => false)
+}));
+vi.mock("/src/helpers/classicBattle/roundManager.js", () => ({
+  handleReplay: vi.fn(),
+  isOrchestrated: vi.fn(() => false)
+}));
+vi.mock("../../../src/helpers/timers/computeNextRoundCooldown.js", () => ({
+  computeNextRoundCooldown: vi.fn(() => 3)
+}));
+vi.mock("/src/helpers/timers/computeNextRoundCooldown.js", () => ({
+  computeNextRoundCooldown: vi.fn(() => 3)
+}));
+vi.mock("../../../src/helpers/timers/createRoundTimer.js", () => ({
+  createRoundTimer: vi.fn(() => ({ start: vi.fn() }))
+}));
+vi.mock("/src/helpers/timers/createRoundTimer.js", () => ({
+  createRoundTimer: vi.fn(() => ({ start: vi.fn() }))
+}));
+vi.mock("../../../src/helpers/CooldownRenderer.js", () => ({
+  attachCooldownRenderer: vi.fn()
+}));
+vi.mock("/src/helpers/CooldownRenderer.js", () => ({
+  attachCooldownRenderer: vi.fn()
+}));
+vi.mock("../../../src/helpers/battle/index.js", () => ({
+  resetStatButtons: vi.fn()
+}));
+vi.mock("/src/helpers/battle/index.js", () => ({
+  resetStatButtons: vi.fn()
+}));
+
+const roundResolvedDetail = {
+  store: {},
+  result: { matchEnded: false, message: "", playerScore: 0, opponentScore: 0 }
+};
+
+describe("updateDebugPanel wiring for dynamic handlers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete globalThis.__cbRoundUIDynamicBoundTargets;
+  });
+
+  afterEach(() => {
+    vi.doUnmock("/src/helpers/classicBattle/uiHelpers.js");
+    vi.doUnmock("/src/helpers/classicBattle/debugPanel.js");
+  });
+
+  it("re-exports updateDebugPanel for direct dynamic imports", async () => {
+    const uiHelpers = await import("/src/helpers/classicBattle/uiHelpers.js");
+    const debugPanel = await import("/src/helpers/classicBattle/debugPanel.js");
+    expect(uiHelpers.updateDebugPanel).toBe(debugPanel.updateDebugPanel);
+  });
+
+  it("passes mocked updateDebugPanel to bindRoundUIEventHandlersDynamic", async () => {
+    const fallbackUpdateDebugPanel = vi.fn(() => {
+      throw new Error("fallback updateDebugPanel should not run");
+    });
+    vi.doMock("/src/helpers/classicBattle/debugPanel.js", () => ({
+      updateDebugPanel: fallbackUpdateDebugPanel
+    }));
+    const mockedUpdateDebugPanel = vi.fn();
+    vi.doMock("/src/helpers/classicBattle/uiHelpers.js", async () => {
+      const actual = await vi.importActual("/src/helpers/classicBattle/uiHelpers.js");
+      return {
+        ...actual,
+        updateDebugPanel: mockedUpdateDebugPanel,
+        renderOpponentCard: vi.fn(),
+        disableNextRoundButton: vi.fn(),
+        enableNextRoundButton: vi.fn()
+      };
+    });
+
+    const events = await import("/src/helpers/classicBattle/battleEvents.js");
+    events.__resetBattleEventTarget();
+    const onBattleEventSpy = vi.spyOn(events, "onBattleEvent");
+    const roundUI = await import("/src/helpers/classicBattle/roundUI.js");
+    roundUI.bindRoundUIEventHandlersDynamic();
+    const roundResolvedCall = onBattleEventSpy.mock.calls.find(
+      ([eventName]) => eventName === "roundResolved"
+    );
+    expect(roundResolvedCall?.[1]).toBeTypeOf("function");
+    await roundResolvedCall[1]({ detail: roundResolvedDetail });
+
+    expect(mockedUpdateDebugPanel).toHaveBeenCalled();
+    expect(fallbackUpdateDebugPanel).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- re-export updateDebugPanel from uiHelpers so dynamic imports expose the helper
- adjust resetBattleUI to call the aliased implementation
- add a focused roundUI test verifying dynamic bindings receive updateDebugPanel in real and mocked scenarios

## Testing
- npx vitest run tests/helpers/classicBattle/roundUI.dynamicUpdateDebugPanel.test.js
- npx vitest run tests/helpers/classicBattle/countdownReset.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb2f1260288326a6536590a1e939b4