### PR TITLE
Use live machine state in next-round cooldown preflight

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -684,7 +684,8 @@ async function handleNextRoundExpiration(controls, btn, options = {}) {
           return null;
         }
       }
-      return getter || null;
+      if (getter && typeof getter === "object") return getter;
+      return null;
     };
   })();
   const isCooldownSafeState = (state) => {
@@ -701,12 +702,13 @@ async function handleNextRoundExpiration(controls, btn, options = {}) {
     }
   };
   const shouldResolve = () => {
+    const machineState = readMachineState();
+    if (isCooldownSafeState(machineState)) return true;
     try {
       const snapshotState = getSnapshot()?.state;
       if (isCooldownSafeState(snapshotState)) return true;
     } catch {}
-    const machineState = readMachineState();
-    return isCooldownSafeState(machineState);
+    return false;
   };
   await new Promise((resolve) => {
     if (shouldResolve()) {


### PR DESCRIPTION
## Summary
- call the live classic battle machine getter during the next-round expiration preflight so it can read the newest state
- resolve immediately when the machine is already in cooldown or a subsequent ready state while keeping the existing event-listener fallback

## Testing
- npx prettier src/helpers/classicBattle/roundManager.js --check
- npx eslint src/helpers/classicBattle/roundManager.js

------
https://chatgpt.com/codex/tasks/task_e_68cbc1779444832681dac186a2eb7755