### PR TITLE
refactor: share win target dropdown helper

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -20,6 +20,8 @@ import { getStateSnapshot } from "./battleDebug.js";
 import { setupFallbackTimer } from "./timerService.js";
 import { createEventBus } from "./eventBusUtils.js";
 
+export { setupFallbackTimer } from "./timerService.js";
+
 const READY_TRACE_KEY = "nextRoundReadyTrace";
 
 function resetReadyTrace() {

--- a/src/helpers/classicBattle/roundSelectModal.js
+++ b/src/helpers/classicBattle/roundSelectModal.js
@@ -12,7 +12,7 @@ import { rafDebounce } from "../../utils/rafUtils.js";
 import { logEvent } from "../telemetry.js";
 import { t } from "../i18n.js";
 import rounds from "../../data/battleRounds.js";
-import { syncWinTargetDropdown } from "../../pages/battleCLI/init.js";
+import { syncWinTargetDropdown } from "./winTargetSync.js";
 
 /**
  * Check if the URL requests an automatic start.

--- a/src/helpers/classicBattle/winTargetSync.js
+++ b/src/helpers/classicBattle/winTargetSync.js
@@ -1,0 +1,93 @@
+import { getPointsToWin } from "../battleEngineFacade.js";
+
+/**
+ * Safely retrieve an element by id.
+ *
+ * @param {string} id - Element id to lookup.
+ * @returns {HTMLElement | null}
+ */
+function byId(id) {
+  try {
+    return typeof document === "undefined" ? null : document.getElementById(id);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the current round number from the CLI root element.
+ *
+ * @returns {number} The round stored on the CLI dataset, or 0 when unavailable.
+ */
+function getCurrentRoundNumber() {
+  try {
+    const root = byId("cli-root");
+    const value = Number(root?.dataset?.round);
+    return Number.isFinite(value) ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Update CLI header metadata to reflect the provided round and target.
+ *
+ * @param {number} round - Current round number.
+ * @param {number} target - Points required to win the match.
+ * @returns {void}
+ */
+function updateRoundHeader(round, target) {
+  try {
+    const header = byId("cli-round");
+    if (header) {
+      header.textContent = `Round ${round} Target: ${target}`;
+    }
+  } catch {}
+
+  try {
+    const root = byId("cli-root");
+    if (root) {
+      root.dataset.round = String(round);
+      root.dataset.target = String(target);
+    }
+  } catch {}
+}
+
+/**
+ * Read the points-to-win value from the battle engine facade.
+ *
+ * @returns {number | null} The configured target or null when unavailable.
+ */
+function readPointsToWin() {
+  try {
+    const value = Number(getPointsToWin());
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Synchronise the win target dropdown with the battle engine setting.
+ *
+ * @pseudocode
+ * 1. Lookup `#points-select`; exit when missing.
+ * 2. Read the current points-to-win from the battle engine.
+ * 3. When valid, set the dropdown value to match.
+ * 4. Refresh the CLI header metadata using the stored round number.
+ *
+ * @returns {void}
+ */
+export function syncWinTargetDropdown() {
+  try {
+    const select = byId("points-select");
+    if (!select) return;
+
+    const currentTarget = readPointsToWin();
+    if (typeof currentTarget !== "number" || !Number.isFinite(currentTarget)) return;
+
+    select.value = String(currentTarget);
+    const round = getCurrentRoundNumber();
+    updateRoundHeader(round, currentTarget);
+  } catch {}
+}

--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -46,6 +46,7 @@ import { exposeTestAPI } from "../../helpers/testApi.js";
 // Phase 2: Shared Scoreboard imports for dual-write
 import { setupScoreboard } from "../../helpers/setupScoreboard.js";
 import { initBattleScoreboardAdapter } from "../../helpers/battleScoreboard.js";
+export { syncWinTargetDropdown } from "../../helpers/classicBattle/winTargetSync.js";
 // Phase 4: Removed redundant scoreboardShowMessage, updateScore, updateTimer, updateRoundCounter imports
 // These are now handled by the shared Scoreboard adapter
 import state, { resolveEscapeHandled, getEscapeHandledPromise } from "./state.js";
@@ -1236,29 +1237,6 @@ function renderHiddenPlayerStats(judoka) {
  *    c. If confirmed: save, apply, and reset without starting.
  *    d. Otherwise revert to previous value.
  */
-/**
- * Update the win target dropdown to reflect the current engine value.
- *
- * @pseudocode
- * 1. Get the current points to win from the engine
- * 2. Find the points-select dropdown element
- * 3. Update its value to match the engine setting
- * 4. Update the round header to show the new target
- *
- * @returns {void}
- */
-export function syncWinTargetDropdown() {
-  try {
-    const select = byId("points-select");
-    const currentTarget = engineFacade.getPointsToWin?.();
-    if (select && currentTarget) {
-      select.value = String(currentTarget);
-      const round = Number(byId("cli-root")?.dataset.round || 0);
-      updateRoundHeader(round, currentTarget);
-    }
-  } catch {}
-}
-
 /**
  * Restore, persist, and handle changes to the points-to-win selector.
  *

--- a/tests/helpers/classicBattle/roundSelectModal.positioning.test.js
+++ b/tests/helpers/classicBattle/roundSelectModal.positioning.test.js
@@ -33,7 +33,7 @@ describe("roundSelectModal positioning and skinning", () => {
     backdrop.className = "modal-backdrop";
     mockModalReturning(backdrop);
 
-    vi.doMock("../../../src/pages/battleCLI/init.js", () => ({
+    vi.doMock("../../../src/helpers/classicBattle/winTargetSync.js", () => ({
       syncWinTargetDropdown: vi.fn()
     }));
 
@@ -66,7 +66,7 @@ describe("roundSelectModal positioning and skinning", () => {
     backdrop.className = "modal-backdrop";
     mockModalReturning(backdrop);
 
-    vi.doMock("../../../src/pages/battleCLI/init.js", () => ({
+    vi.doMock("../../../src/helpers/classicBattle/winTargetSync.js", () => ({
       syncWinTargetDropdown: vi.fn()
     }));
 


### PR DESCRIPTION
## Summary
- extract the win target dropdown synchronisation helper into `src/helpers/classicBattle/winTargetSync.js`
- update the CLI entrypoint to re-export the shared helper and expose `setupFallbackTimer` so round manager imports stay valid
- switch the round select modal and its tests to consume the new helper module

## Testing
- `npx eslint src/helpers/classicBattle/winTargetSync.js src/helpers/classicBattle/roundSelectModal.js src/pages/battleCLI/init.js src/helpers/classicBattle/roundManager.js tests/helpers/classicBattle/roundSelectModal.positioning.test.js`
- `npx playwright test playwright/battle-classic/round-select.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68cc27bd2dec8326a9e61cd1b9b8c557