### PR TITLE
Define preload service caches

### DIFF
--- a/src/helpers/classicBattle/preloadService.js
+++ b/src/helpers/classicBattle/preloadService.js
@@ -1,5 +1,8 @@
 import { runWhenIdle } from "./idleCallback.js";
 
+const cachedModules = new Map();
+const preloadPromises = new Map();
+
 /**
  * Preload service for lazy loading heavy modules during idle time.
  *


### PR DESCRIPTION
## Summary
- initialize preload service module caches at definition time to avoid undefined map references

## Testing
- npx vitest run tests/helpers/classicBattle/scheduleNextRound.test.js *(fails: ReferenceError readyDispatchedForCurrentCooldown is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3ebc258c8326854165db8b1d71eb