### PR TITLE
Track ready dispatch state across cooldowns

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -256,6 +256,9 @@ export async function startRound(store, onRoundStart) {
  */
 let currentNextRound = null;
 
+// Track whether the "ready" event has been dispatched for the current cooldown window.
+let readyDispatchedForCurrentCooldown = false;
+
 /**
  * Schedule the cooldown before the next round and expose controls
  * for the Next button.


### PR DESCRIPTION
## Summary
- add module-level flag tracking whether the current cooldown has dispatched the ready event

## Testing
- npx vitest run tests/classicBattle/cooldown.test.js tests/helpers/classicBattle/scheduleNextRound.test.js tests/helpers/classicBattle/timerService.nextRound.test.js

## Risk
- Low: change introduces a simple module-scoped flag without altering existing control flow


------
https://chatgpt.com/codex/tasks/task_e_68cc450e9ccc83269eff46952013ead1