### PR TITLE
Refactor next round expiration handling

### DIFF
--- a/src/helpers/classicBattle/nextRound/expirationHandlers.js
+++ b/src/helpers/classicBattle/nextRound/expirationHandlers.js
@@ -1,0 +1,328 @@
+import { dispatchBattleEvent as globalDispatchBattleEvent } from "../eventDispatcher.js";
+import { readDebugState as globalReadDebugState } from "../debugHooks.js";
+
+/**
+ * Create a telemetry emitter for next-round expiration instrumentation.
+ *
+ * @param {object} [targets]
+ * @param {(key: string, value: any) => void} [targets.exposeDebugState]
+ * @param {(key: string, value: any) => void} [targets.debugExpose]
+ * @param {() => Record<string, any>|null} [targets.getDebugBag]
+ * @returns {{ emit: (key: string, value: any) => void, getDebugBag: () => Record<string, any>|null }}
+ */
+export function createExpirationTelemetryEmitter(targets = {}) {
+  const { exposeDebugState, debugExpose, getDebugBag } = targets;
+  const emit = (key, value) => {
+    try {
+      if (typeof exposeDebugState === "function") exposeDebugState(key, value);
+    } catch {}
+    if (typeof getDebugBag === "function") {
+      try {
+        const bag = getDebugBag();
+        if (bag && typeof bag === "object") {
+          bag[key] = value;
+        }
+      } catch {}
+    }
+    try {
+      if (typeof debugExpose === "function") debugExpose(key, value);
+    } catch {}
+  };
+  const safeGetDebugBag = () => {
+    if (typeof getDebugBag !== "function") return null;
+    try {
+      const bag = getDebugBag();
+      return bag && typeof bag === "object" ? bag : null;
+    } catch {
+      return null;
+    }
+  };
+  return { emit, getDebugBag: safeGetDebugBag };
+}
+
+/**
+ * Create a machine reader that surfaces orchestrator state for expiration logic.
+ *
+ * @param {object} [options]
+ * @param {() => any} [options.getClassicBattleMachine]
+ * @param {object} [dependencies]
+ * @param {(key: string, value: any) => void} [dependencies.emitTelemetry]
+ * @param {(key: string) => any} [dependencies.readDebugState]
+ * @param {(key: string) => any} [dependencies.debugRead]
+ * @returns {() => any}
+ */
+export function createMachineReader(options = {}, dependencies = {}) {
+  const { getClassicBattleMachine } = options;
+  const { emitTelemetry, readDebugState, debugRead } = dependencies;
+  const readDebug = typeof readDebugState === "function" ? readDebugState : globalReadDebugState;
+  const globalReader = typeof debugRead === "function" ? debugRead : undefined;
+  if (typeof getClassicBattleMachine === "function") {
+    return () => {
+      try {
+        const machine = getClassicBattleMachine();
+        emitTelemetry?.("handleNextRoundMachineGetterOverride", machine);
+        return machine;
+      } catch {
+        return null;
+      }
+    };
+  }
+  return () => {
+    let getter = null;
+    try {
+      getter = readDebug?.("getClassicBattleMachine");
+    } catch {}
+    if (!getter && typeof globalReader === "function") {
+      try {
+        getter = globalReader("getClassicBattleMachine");
+      } catch {}
+    }
+    emitTelemetry?.("handleNextRoundMachineGetter", {
+      sourceReadDebug: typeof getter,
+      hasGlobal: typeof globalReader === "function"
+    });
+    let result = null;
+    if (typeof getter === "function") {
+      try {
+        result = getter();
+      } catch {
+        result = null;
+      }
+    } else if (getter && typeof getter === "object") {
+      result = getter;
+    }
+    emitTelemetry?.("handleNextRoundMachineGetterResult", result);
+    return result;
+  };
+}
+
+/**
+ * Build helpers that read machine state and await cooldown readiness.
+ *
+ * @param {object} params
+ * @param {() => any} params.machineReader
+ * @param {() => any} [params.getSnapshot]
+ * @param {(machine: any) => string|null} params.getMachineState
+ * @param {(state: string|null) => boolean} params.isCooldownState
+ * @param {(key: string, value: any) => void} [params.emitTelemetry]
+ * @returns {{ machineState: string|null, snapshotState: string|null, shouldResolve: () => boolean, waitForCooldown: (eventBus: any) => Promise<void> }}
+ */
+export function createMachineStateInspector(params) {
+  const { machineReader, getSnapshot, getMachineState, isCooldownState, emitTelemetry } = params;
+  const safeGetState = () => {
+    try {
+      return getMachineState(machineReader?.());
+    } catch {
+      emitTelemetry?.("handleNextRoundMachineReadError", true);
+      return null;
+    }
+  };
+  const safeGetSnapshot = () => {
+    if (typeof getSnapshot !== "function") return null;
+    try {
+      const snapshot = getSnapshot();
+      return snapshot && typeof snapshot === "object" ? (snapshot.state ?? null) : null;
+    } catch {
+      return null;
+    }
+  };
+  const machineState = safeGetState();
+  emitTelemetry?.("handleNextRoundMachineState", machineState ?? null);
+  const snapshotState = safeGetSnapshot();
+  emitTelemetry?.("handleNextRoundSnapshotState", snapshotState);
+  const shouldResolve = () => {
+    const state = safeGetState();
+    if (isCooldownState(state)) return true;
+    const snapshot = safeGetSnapshot();
+    if (isCooldownState(snapshot)) return true;
+    return false;
+  };
+  const waitForCooldown = async (eventBus) => {
+    if (shouldResolve()) {
+      emitTelemetry?.("handleNextRoundMachineStateAfterWait", safeGetState() ?? null);
+      return;
+    }
+    await new Promise((resolve) => {
+      const handler = () => {
+        if (!shouldResolve()) return;
+        try {
+          eventBus?.off?.("battleStateChange", handler);
+        } catch {}
+        resolve();
+      };
+      eventBus?.on?.("battleStateChange", handler);
+    });
+    emitTelemetry?.("handleNextRoundMachineStateAfterWait", safeGetState() ?? null);
+  };
+  return { machineState, snapshotState, shouldResolve, waitForCooldown };
+}
+
+/**
+ * Dispatch the ready event via available battle event dispatchers.
+ *
+ * @param {object} [options]
+ * @param {(type: string) => any} [options.dispatchBattleEvent]
+ * @returns {Promise<boolean>}
+ */
+export async function dispatchReadyViaBus(options = {}) {
+  const dispatchers = [];
+  const candidate = options.dispatchBattleEvent;
+  if (typeof candidate === "function") {
+    dispatchers.push(candidate);
+  }
+  if (typeof globalDispatchBattleEvent === "function" && globalDispatchBattleEvent !== candidate) {
+    dispatchers.push(globalDispatchBattleEvent);
+  }
+  for (const dispatcher of dispatchers) {
+    try {
+      const result = dispatcher("ready");
+      const resolved = await Promise.resolve(result);
+      if (resolved !== false) {
+        return true;
+      }
+    } catch {}
+  }
+  return false;
+}
+
+/**
+ * Attempt to dispatch the ready event with a provided dispatcher.
+ *
+ * @param {object} params
+ * @param {(type: string) => any} params.dispatchBattleEvent
+ * @param {(key: string, value: any) => void} [params.emitTelemetry]
+ * @param {() => Record<string, any>|null} [params.getDebugBag]
+ * @returns {Promise<boolean>}
+ */
+export async function dispatchReadyWithOptions(params) {
+  const { dispatchBattleEvent, emitTelemetry, getDebugBag } = params;
+  if (typeof dispatchBattleEvent !== "function") return false;
+  const info = {
+    hasFn: true,
+    name: dispatchBattleEvent.name || null,
+    toStringLen:
+      typeof dispatchBattleEvent.toString === "function" ? dispatchBattleEvent.toString().length : 0
+  };
+  emitTelemetry?.("handleNextRound_dispatchViaOptions_info", info);
+  const bag = getDebugBag?.();
+  if (bag) {
+    bag.handleNextRound_dispatchViaOptions_info = info;
+    bag.handleNextRound_dispatchViaOptions_count =
+      (bag.handleNextRound_dispatchViaOptions_count || 0) + 1;
+  }
+  try {
+    const result = dispatchBattleEvent("ready");
+    const resolved = await Promise.resolve(result);
+    const dispatched = resolved !== false;
+    emitTelemetry?.("handleNextRound_dispatchViaOptions_result", dispatched);
+    if (bag) {
+      bag.handleNextRound_dispatchViaOptions_result = { dispatched };
+    }
+    return dispatched;
+  } catch (error) {
+    const payload = {
+      message: error && error.message ? error.message : String(error)
+    };
+    emitTelemetry?.("handleNextRound_dispatchViaOptions_error", payload);
+    if (bag) {
+      bag.handleNextRound_dispatchViaOptions_error = payload;
+    }
+    return false;
+  }
+}
+
+/**
+ * Directly dispatch the ready event via the state machine when available.
+ *
+ * @param {object} params
+ * @param {() => any} params.machineReader
+ * @param {(key: string, value: any) => void} [params.emitTelemetry]
+ * @returns {Promise<boolean>}
+ */
+export async function dispatchReadyDirectly(params) {
+  const { machineReader, emitTelemetry } = params;
+  let machine = null;
+  try {
+    machine = machineReader?.();
+  } catch {}
+  const info = {
+    machineExists: !!machine,
+    hasDispatch: typeof machine?.dispatch === "function"
+  };
+  emitTelemetry?.("handleNextRound_dispatchReadyDirectly_info", info);
+  if (!info.hasDispatch) return false;
+  try {
+    const result = machine.dispatch("ready");
+    await Promise.resolve(result);
+    emitTelemetry?.("handleNextRound_dispatchReadyDirectly_result", true);
+    return true;
+  } catch (error) {
+    const payload = error && error.message ? error.message : String(error);
+    emitTelemetry?.("handleNextRound_dispatchReadyDirectly_error", payload);
+    return false;
+  }
+}
+
+/**
+ * Sequentially execute dispatch strategies until one succeeds.
+ *
+ * @param {object} params
+ * @param {boolean} [params.alreadyDispatchedReady]
+ * @param {Array<() => Promise<boolean>|boolean>} [params.strategies]
+ * @param {(key: string, value: any) => void} [params.emitTelemetry]
+ * @returns {Promise<boolean>}
+ */
+export async function runReadyDispatchStrategies(params = {}) {
+  const { alreadyDispatchedReady = false, strategies = [], emitTelemetry } = params;
+  if (alreadyDispatchedReady) {
+    emitTelemetry?.("handleNextRoundDispatchResult", true);
+    return true;
+  }
+  for (const strategy of strategies) {
+    if (typeof strategy !== "function") continue;
+    try {
+      const result = await Promise.resolve(strategy());
+      if (result) {
+        emitTelemetry?.("handleNextRoundDispatchResult", true);
+        return true;
+      }
+    } catch {}
+  }
+  emitTelemetry?.("handleNextRoundDispatchResult", false);
+  return false;
+}
+
+/**
+ * Update DOM/UI affordances after the cooldown expires.
+ *
+ * @param {object} params
+ * @param {() => boolean} params.isOrchestrated
+ * @param {(btn: HTMLButtonElement|null|undefined) => void} params.markReady
+ * @param {HTMLButtonElement|null|undefined} params.button
+ * @param {Document|null|undefined} [params.documentRef]
+ * @param {() => Promise<void>|void} [params.updateDebugPanel]
+ * @returns {Promise<void>}
+ */
+export async function updateExpirationUi(params) {
+  const { isOrchestrated, markReady, button, documentRef, updateDebugPanel } = params;
+  const orchestrated = typeof isOrchestrated === "function" && isOrchestrated();
+  if (!orchestrated) {
+    let target = button || null;
+    try {
+      if (!target && documentRef) {
+        target = documentRef.getElementById?.("next-button") || null;
+      } else if (documentRef) {
+        const liveBtn = documentRef.getElementById?.("next-button");
+        if (liveBtn) target = liveBtn;
+      }
+    } catch {}
+    try {
+      markReady?.(target);
+    } catch {}
+  }
+  if (typeof updateDebugPanel === "function") {
+    try {
+      await updateDebugPanel();
+    } catch {}
+  }
+}

--- a/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
+++ b/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../src/helpers/classicBattle/eventDispatcher.js", () => {
+  const dispatchBattleEvent = vi.fn(() => true);
+  return {
+    dispatchBattleEvent,
+    resetDispatchHistory: vi.fn()
+  };
+});
+
+vi.mock("../../../../src/helpers/classicBattle/debugHooks.js", () => ({
+  readDebugState: vi.fn(() => undefined)
+}));
+
+import {
+  createExpirationTelemetryEmitter,
+  createMachineReader,
+  createMachineStateInspector,
+  dispatchReadyDirectly,
+  dispatchReadyViaBus,
+  dispatchReadyWithOptions,
+  runReadyDispatchStrategies,
+  updateExpirationUi
+} from "../../../../src/helpers/classicBattle/nextRound/expirationHandlers.js";
+import { dispatchBattleEvent } from "../../../../src/helpers/classicBattle/eventDispatcher.js";
+
+const getMockedDispatch = () => /** @type {ReturnType<typeof vi.fn>} */ (dispatchBattleEvent);
+
+describe("createExpirationTelemetryEmitter", () => {
+  it("emits to all targets and stores values in debug bag", () => {
+    const expose = vi.fn();
+    const debugExpose = vi.fn();
+    const bag = {};
+    const { emit, getDebugBag } = createExpirationTelemetryEmitter({
+      exposeDebugState: expose,
+      debugExpose,
+      getDebugBag: () => bag
+    });
+    emit("testKey", { value: 42 });
+    expect(expose).toHaveBeenCalledWith("testKey", { value: 42 });
+    expect(debugExpose).toHaveBeenCalledWith("testKey", { value: 42 });
+    expect(bag.testKey).toEqual({ value: 42 });
+    expect(getDebugBag()).toBe(bag);
+  });
+});
+
+describe("createMachineReader", () => {
+  it("prefers override getter and reports telemetry", () => {
+    const emit = vi.fn();
+    const machine = { state: "cooldown" };
+    const reader = createMachineReader(
+      { getClassicBattleMachine: () => machine },
+      { emitTelemetry: emit }
+    );
+    expect(reader()).toBe(machine);
+    expect(emit).toHaveBeenCalledWith("handleNextRoundMachineGetterOverride", machine);
+  });
+
+  it("falls back to debug state getter", () => {
+    const emit = vi.fn();
+    const getter = vi.fn(() => ({ state: "roundOver" }));
+    const reader = createMachineReader(
+      {},
+      {
+        emitTelemetry: emit,
+        readDebugState: vi.fn(() => getter)
+      }
+    );
+    expect(reader()).toEqual({ state: "roundOver" });
+    expect(getter).toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledWith("handleNextRoundMachineGetterResult", { state: "roundOver" });
+  });
+});
+
+describe("createMachineStateInspector", () => {
+  it("resolves immediately when machine already cooled down", async () => {
+    const emit = vi.fn();
+    const machineReader = () => ({ getState: () => "cooldown" });
+    const inspector = createMachineStateInspector({
+      machineReader,
+      getSnapshot: () => ({ state: "intro" }),
+      getMachineState: (machine) => machine?.getState?.() ?? null,
+      isCooldownState: (state) => state === "cooldown",
+      emitTelemetry: emit
+    });
+    await inspector.waitForCooldown({
+      on: vi.fn(),
+      off: vi.fn()
+    });
+    expect(emit).toHaveBeenCalledWith("handleNextRoundMachineStateAfterWait", "cooldown");
+  });
+
+  it("waits for bus notification when not yet ready", async () => {
+    const emit = vi.fn();
+    let state = "intro";
+    const machineReader = () => ({ getState: () => state });
+    const handlers = new Set();
+    const inspector = createMachineStateInspector({
+      machineReader,
+      getSnapshot: () => ({ state }),
+      getMachineState: (machine) => machine?.getState?.() ?? null,
+      isCooldownState: (value) => value === "cooldown",
+      emitTelemetry: emit
+    });
+    const bus = {
+      on: vi.fn((event, handler) => {
+        if (event === "battleStateChange") handlers.add(handler);
+      }),
+      off: vi.fn((event, handler) => {
+        if (event === "battleStateChange") handlers.delete(handler);
+      })
+    };
+    const waitPromise = inspector.waitForCooldown(bus);
+    state = "cooldown";
+    handlers.forEach((handler) => handler());
+    await waitPromise;
+    expect(bus.off).toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledWith("handleNextRoundMachineStateAfterWait", "cooldown");
+  });
+
+  it("records telemetry when machine read fails", () => {
+    const emit = vi.fn();
+    const inspector = createMachineStateInspector({
+      machineReader: () => {
+        throw new Error("no machine");
+      },
+      getSnapshot: () => null,
+      getMachineState: () => {
+        throw new Error("boom");
+      },
+      isCooldownState: () => false,
+      emitTelemetry: emit
+    });
+    inspector.shouldResolve();
+    expect(emit).toHaveBeenCalledWith("handleNextRoundMachineReadError", true);
+  });
+});
+
+describe("dispatchReadyWithOptions", () => {
+  it("returns true when dispatcher resolves truthy", async () => {
+    const emit = vi.fn();
+    const bag = {};
+    const result = await dispatchReadyWithOptions({
+      dispatchBattleEvent: vi.fn(() => "ok"),
+      emitTelemetry: emit,
+      getDebugBag: () => bag
+    });
+    expect(result).toBe(true);
+    expect(emit).toHaveBeenCalledWith("handleNextRound_dispatchViaOptions_result", true);
+    expect(bag.handleNextRound_dispatchViaOptions_result).toEqual({ dispatched: true });
+  });
+
+  it("returns false when dispatcher rejects", async () => {
+    const emit = vi.fn();
+    const error = new Error("nope");
+    const result = await dispatchReadyWithOptions({
+      dispatchBattleEvent: vi.fn(() => {
+        throw error;
+      }),
+      emitTelemetry: emit,
+      getDebugBag: () => ({})
+    });
+    expect(result).toBe(false);
+    expect(emit).toHaveBeenCalledWith("handleNextRound_dispatchViaOptions_error", {
+      message: error.message
+    });
+  });
+});
+
+describe("dispatchReadyViaBus", () => {
+  it("uses injected dispatcher when provided", async () => {
+    const dispatcher = vi.fn(() => true);
+    const result = await dispatchReadyViaBus({ dispatchBattleEvent: dispatcher });
+    expect(result).toBe(true);
+    expect(dispatcher).toHaveBeenCalledWith("ready");
+  });
+
+  it("falls back to global dispatcher when override missing", async () => {
+    const mocked = getMockedDispatch();
+    mocked.mockReturnValueOnce(true);
+    const result = await dispatchReadyViaBus();
+    expect(result).toBe(true);
+    expect(mocked).toHaveBeenCalledWith("ready");
+  });
+});
+
+describe("dispatchReadyDirectly", () => {
+  it("invokes machine dispatch when available", async () => {
+    const emit = vi.fn();
+    const dispatch = vi.fn(() => "done");
+    const result = await dispatchReadyDirectly({
+      machineReader: () => ({ dispatch }),
+      emitTelemetry: emit
+    });
+    expect(result).toBe(true);
+    expect(dispatch).toHaveBeenCalledWith("ready");
+    expect(emit).toHaveBeenCalledWith("handleNextRound_dispatchReadyDirectly_result", true);
+  });
+
+  it("returns false when dispatch missing", async () => {
+    const emit = vi.fn();
+    const result = await dispatchReadyDirectly({ machineReader: () => ({}), emitTelemetry: emit });
+    expect(result).toBe(false);
+    expect(emit).toHaveBeenCalledWith("handleNextRound_dispatchReadyDirectly_info", {
+      machineExists: true,
+      hasDispatch: false
+    });
+  });
+});
+
+describe("runReadyDispatchStrategies", () => {
+  it("short-circuits once a strategy succeeds", async () => {
+    const emit = vi.fn();
+    const result = await runReadyDispatchStrategies({
+      strategies: [
+        () => false,
+        () => true,
+        () => {
+          throw new Error("should not run");
+        }
+      ],
+      emitTelemetry: emit
+    });
+    expect(result).toBe(true);
+    expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchResult", true);
+  });
+
+  it("reports failure when all strategies fail", async () => {
+    const emit = vi.fn();
+    const result = await runReadyDispatchStrategies({
+      strategies: [() => false, () => false],
+      emitTelemetry: emit
+    });
+    expect(result).toBe(false);
+    expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchResult", false);
+  });
+});
+
+describe("updateExpirationUi", () => {
+  it("marks DOM when orchestration inactive", async () => {
+    const markReady = vi.fn();
+    const button = { id: "btn" };
+    const documentRef = { getElementById: vi.fn(() => button) };
+    await updateExpirationUi({
+      isOrchestrated: () => false,
+      markReady,
+      button,
+      documentRef
+    });
+    expect(markReady).toHaveBeenCalledWith(button);
+  });
+
+  it("skips DOM updates when orchestrated and still updates debug panel", async () => {
+    const markReady = vi.fn();
+    const updatePanel = vi.fn();
+    await updateExpirationUi({
+      isOrchestrated: () => true,
+      markReady,
+      button: null,
+      documentRef: null,
+      updateDebugPanel: updatePanel
+    });
+    expect(markReady).not.toHaveBeenCalled();
+    expect(updatePanel).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- create a nextRound/expirationHandlers module that owns machine inspection, telemetry, dispatch, and UI helpers for cooldown expiration
- rewrite handleNextRoundExpiration to compose the extracted helpers with explicit dependency injection
- add targeted unit coverage validating each helper’s success and failure paths

## Testing
- npx vitest run tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
- npx eslint src/helpers/classicBattle/nextRound/expirationHandlers.js tests/helpers/classicBattle/nextRound/expirationHandlers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cd120a9a188326943b7b6a4b65d4da