### PR TITLE
Refactor next round expiration handling

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -706,6 +706,22 @@ function markNextReady(btn) {
   );
 }
 
+/**
+ * Handle the expiration of the next round cooldown timer.
+ *
+ * @param {object} controls - Cooldown controls object
+ * @param {HTMLButtonElement|null|undefined} btn - Next button element
+ * @param {object} [options={}] - Configuration options
+ * @returns {Promise<boolean>} True if ready event was successfully dispatched
+ * @pseudocode
+ * 1. Set up telemetry emitter for debugging and instrumentation
+ * 2. Check if ready dispatch is already in flight, exit early if so
+ * 3. Create machine reader and state inspector for cooldown detection
+ * 4. Wait for machine to reach cooldown state before proceeding
+ * 5. Update UI elements to indicate readiness
+ * 6. Execute dispatch strategies in sequence until one succeeds
+ * 7. Update controls state and return dispatch result
+ */
 async function handleNextRoundExpiration(controls, btn, options = {}) {
   if (typeof window !== "undefined") window.__NEXT_ROUND_EXPIRED = true;
   const debugExpose =
@@ -810,8 +826,8 @@ async function handleNextRoundExpiration(controls, btn, options = {}) {
 
   const busStrategyOptions =
     typeof options.dispatchBattleEvent === "function"
-      ? {}
-      : { dispatchBattleEvent: options.dispatchBattleEvent };
+      ? { dispatchBattleEvent: options.dispatchBattleEvent }
+      : {};
   const strategies = [
     () =>
       dispatchReadyWithOptions({

--- a/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
+++ b/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
@@ -24,7 +24,13 @@ import {
 } from "../../../../src/helpers/classicBattle/nextRound/expirationHandlers.js";
 import { dispatchBattleEvent } from "../../../../src/helpers/classicBattle/eventDispatcher.js";
 
-const getMockedDispatch = () => /** @type {ReturnType<typeof vi.fn>} */ (dispatchBattleEvent);
+const getMockedDispatch = () => {
+  const mock = /** @type {ReturnType<typeof vi.fn>} */ (dispatchBattleEvent);
+  if (!mock?.mock) {
+    throw new Error("dispatchBattleEvent is not properly mocked");
+  }
+  return mock;
+};
 
 describe("createExpirationTelemetryEmitter", () => {
   it("emits to all targets and stores values in debug bag", () => {


### PR DESCRIPTION
## Summary
- create a nextRound/expirationHandlers module that owns machine inspection, telemetry, dispatch, and UI helpers for cooldown expiration
- rewrite handleNextRoundExpiration to compose the extracted helpers with explicit dependency injection
- add targeted unit coverage validating each helper’s success and failure paths
- align telemetry, waiting, and dispatch helpers with reviewer feedback (consistent error handling, race-condition fix, streamlined UI updates, corrected bus strategy logic, stronger test mocks, and JSDoc coverage)

## Testing
- npm run check:jsdoc *(fails: existing project-wide missing JSDoc entries)*
- npx prettier . --check
- npx eslint .
- npx vitest run *(fails: baseline test failures unrelated to this change)*
- npx playwright test *(fails: baseline Playwright failures and network issues)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68cd4d9964c08326bf3f7b0d0a6b69d0