### PR TITLE
Address error handling review feedback

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,7 +47,10 @@ export default defineConfig([
     }
   },
   {
-    files: ["src/helpers/classicBattle/roundManager.js"],
+    // Enforce no-empty catch blocks for the round manager and utilities; remaining
+    // classic battle modules will be migrated incrementally to avoid destabilizing
+    // legacy scaffolding that still relies on empty catch placeholders.
+    files: ["src/helpers/classicBattle/roundManager.js", "src/helpers/classicBattle/utils/**/*.js"],
     rules: {
       "no-empty": ["error", { allowEmptyCatch: false }]
     }

--- a/src/helpers/classicBattle/utils/errorHandling.js
+++ b/src/helpers/classicBattle/utils/errorHandling.js
@@ -5,7 +5,7 @@ const DEFAULT_SCOPE = "classicBattle";
 const ERROR_HISTORY_KEY = "classicBattleErrors";
 const ERROR_HISTORY_LIMIT = 25;
 const ENV = typeof process !== "undefined" && process.env ? process.env : {};
-const IS_PRODUCTION = ENV.NODE_ENV === "production";
+const IS_PRODUCTION = String(ENV.NODE_ENV || "").toLowerCase() === "production";
 
 function isPromiseLike(value) {
   return !!value && typeof value === "object" && typeof value.then === "function";
@@ -51,9 +51,10 @@ function pushDebugEntry(entry, context) {
   }
   if (typeof globalThis !== "undefined") {
     const bagKey = "__CLASSIC_BATTLE_ERROR_LOG";
-    const bag = Array.isArray(globalThis[bagKey]) ? globalThis[bagKey] : [];
-    bag.push(entry);
-    globalThis[bagKey] = bag.slice(-ERROR_HISTORY_LIMIT);
+    const existingLog = Array.isArray(globalThis[bagKey]) ? globalThis[bagKey] : [];
+    const trimmed = existingLog.slice(-ERROR_HISTORY_LIMIT + 1);
+    trimmed.push(entry);
+    globalThis[bagKey] = trimmed;
   }
 }
 


### PR DESCRIPTION
## Summary
- tighten the error handling helper by hardening production detection and bounding the global debug log buffer
- streamline classic battle round manager fallbacks, inline the machine state normalizer, ensure debug traces use safeRound, and rethrow production reset failures
- add broader error-handling tests including async paths, fallback failures, and history limits while isolating NODE_ENV per run
- broaden the no-empty catch lint rule to cover classic battle utilities with documentation for the phased rollout

## Testing
- npx prettier src/helpers/classicBattle/roundManager.js src/helpers/classicBattle/utils/errorHandling.js tests/helpers/classicBattle/roundManager.errorHandling.test.js --check
- npx eslint .
- npx vitest run tests/helpers/classicBattle/roundManager.errorHandling.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cd81e8cef483268f94dbe71b130aca