### PR TITLE
Fix error history limit trimming

### DIFF
--- a/src/helpers/classicBattle/utils/errorHandling.js
+++ b/src/helpers/classicBattle/utils/errorHandling.js
@@ -37,8 +37,8 @@ function pushDebugEntry(entry, context) {
   const key = context?.debugKey || ERROR_HISTORY_KEY;
   try {
     const existing = readDebugState(key);
-    const history = Array.isArray(existing) ? existing.slice(-ERROR_HISTORY_LIMIT + 1) : [];
-    history.push(entry);
+    const baseHistory = Array.isArray(existing) ? existing : [];
+    const history = baseHistory.concat(entry).slice(-ERROR_HISTORY_LIMIT);
     exposeDebugState(key, history);
   } catch (debugError) {
     if (!IS_PRODUCTION) {
@@ -52,8 +52,7 @@ function pushDebugEntry(entry, context) {
   if (typeof globalThis !== "undefined") {
     const bagKey = "__CLASSIC_BATTLE_ERROR_LOG";
     const existingLog = Array.isArray(globalThis[bagKey]) ? globalThis[bagKey] : [];
-    const trimmed = existingLog.slice(-ERROR_HISTORY_LIMIT + 1);
-    trimmed.push(entry);
+    const trimmed = existingLog.concat(entry).slice(-ERROR_HISTORY_LIMIT);
     globalThis[bagKey] = trimmed;
   }
 }

--- a/tests/helpers/classicBattle/roundManager.errorHandling.test.js
+++ b/tests/helpers/classicBattle/roundManager.errorHandling.test.js
@@ -135,13 +135,15 @@ describe("roundManager error handling integration", () => {
     }
 
     const entries = readDebugState("classicBattleErrors") || [];
-    expect(entries.length).toBeLessThanOrEqual(25);
+    expect(entries.length).toBe(25);
+    expect(entries.at(0)?.operation).toBe("limit-15");
     expect(entries.at(-1)?.operation).toBe("limit-39");
 
     if (typeof globalThis !== "undefined") {
       const bag = globalThis.__CLASSIC_BATTLE_ERROR_LOG;
       expect(Array.isArray(bag)).toBe(true);
       expect(bag.length).toBe(entries.length);
+      expect(bag.at(0)?.operation).toBe("limit-15");
       expect(bag.at(-1)?.operation).toBe("limit-39");
     }
   });


### PR DESCRIPTION
## Summary
- tighten the error handling helper by hardening production detection and bounding the global debug log buffer
- streamline classic battle round manager fallbacks, inline the machine state normalizer, ensure debug traces use safeRound, and rethrow production reset failures
- add broader error-handling tests including async paths, fallback failures, and history limits while isolating NODE_ENV per run
- broaden the no-empty catch lint rule to cover classic battle utilities with documentation for the phased rollout
- fix the error history trimming to retain the full limit and extend the limit test to assert boundary behavior for both debug channels

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: progressBug.md, test-traces.json pre-existing formatting issues)*
- npx prettier src/helpers/classicBattle/utils/errorHandling.js tests/helpers/classicBattle/roundManager.errorHandling.test.js --check
- npx eslint .
- npx vitest run tests/helpers/classicBattle/roundManager.errorHandling.test.js
- npx playwright test *(fails: classic battle flows expect next-button to enable; see battle-classic specs)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68cd85ea6a7c83268d0faa2873e2cf98