### PR TITLE
Address scheduler fallback race conditions

### DIFF
--- a/src/helpers/battle/battleUI.js
+++ b/src/helpers/battle/battleUI.js
@@ -40,17 +40,18 @@ function scheduleImmediate(callback) {
     globalThis.Promise.resolve()
       .then(() => {
         if (cancelled) return;
+        cancelled = true;
         callback();
       })
       .catch(() => {
         if (cancelled) return;
+        cancelled = true;
         callback();
       });
     return () => {
       cancelled = true;
     };
   }
-  if (typeof globalThis?.setTimeout === "function") {
     const timeoutId = globalThis.setTimeout(() => {
       callback();
     }, 0);


### PR DESCRIPTION
## Summary
- tighten `scheduleImmediate` by fixing the microtask cancellation race, adding a Promise-based async fallback, and surfacing a warning when only synchronous execution is available
- refine `resetStatButtons` fallback orchestration to avoid duplicate enables and better document the one-shot guard
- harden the stat button regression test with deterministic task flushing, scheduler state assertions, and reliable global restoration

## Testing
- npx eslint src/helpers/battle/battleUI.js tests/classicBattle/stat-buttons.test.js
- npx vitest run tests/classicBattle/stat-buttons.test.js
- npm run check:jsdoc

------
https://chatgpt.com/codex/tasks/task_e_68cd8e02958483269ab4574d4b0cb52c