### PR TITLE
Trigger ready dispatch when manually resolving cooldown

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -940,7 +940,8 @@ function createReadyDispatchStrategies({
     busStrategyOptions.eventBus = bus;
   }
   const hasCustomDispatcher =
-    typeof options.dispatchBattleEvent === "function" && options.dispatchBattleEvent !== dispatchBattleEvent;
+    typeof options.dispatchBattleEvent === "function" &&
+    options.dispatchBattleEvent !== dispatchBattleEvent;
   const strategies = [];
   if (hasCustomDispatcher) {
     strategies.push(() => {
@@ -1110,7 +1111,9 @@ function wireCooldownTimer(controls, btn, cooldownSeconds, scheduler, overrides 
       if (!expired) {
         expired = true;
       }
-      return originalResolveReady.apply(this, args);
+      const finalizeResult = finalizeExpiration();
+      const originalResult = originalResolveReady.apply(this, args);
+      return finalizeResult ?? originalResult;
     };
   }
   let finalizePromise = null;

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -1113,7 +1113,11 @@ function wireCooldownTimer(controls, btn, cooldownSeconds, scheduler, overrides 
       }
       const finalizeResult = finalizeExpiration();
       const originalResult = originalResolveReady.apply(this, args);
-      return finalizeResult ?? originalResult;
+      // Ensure we await the finalize result if it's a promise
+      if (finalizeResult && typeof finalizeResult.then === 'function') {
+        return finalizeResult.then(() => originalResult);
+      }
+      return originalResult;
     };
   }
   let finalizePromise = null;

--- a/tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js
+++ b/tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js
@@ -141,8 +141,11 @@ describe("skip handler clears fallback timer", () => {
     await eventDispatcher.dispatchBattleEvent("ready");
     expect(eventDispatcher.dispatchBattleEvent).toHaveBeenCalledTimes(1);
     const readyPromise = controls.ready;
-    controls.resolveReady?.();
+    const resolvePromise = controls.resolveReady?.();
+    await resolvePromise;
     await readyPromise;
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenCalledTimes(2);
+    expect(eventDispatcher.dispatchBattleEvent).toHaveBeenNthCalledWith(2, "ready");
     await Promise.resolve();
     await vi.advanceTimersByTimeAsync(50);
     scheduler.tick(50);


### PR DESCRIPTION
## Summary
- call the cooldown expiration finalizer when resolveReady clears timers so the "ready" dispatch logic runs immediately
- ensure resolveReady returns the finalizer promise to support awaiting manual completions
- extend the cooldown skip handler test to await resolveReady and assert exactly one additional ready dispatch occurs

## Testing
- npm run check:jsdoc
- npx eslint .
- npx prettier . --check *(fails: pre-existing formatting issues in progressBug.md and test-traces.json)*
- npx vitest run *(aborted: suite output is extremely verbose and could not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9a7f242483269c98ad21587dd906