### PR TITLE
Refine ready dispatch state handling

### DIFF
--- a/src/helpers/classicBattle/roundReadyState.js
+++ b/src/helpers/classicBattle/roundReadyState.js
@@ -1,3 +1,5 @@
+import { resetDispatchHistory } from "./eventDispatcher.js";
+
 /**
  * @summary Track whether the current cooldown already dispatched the "ready" event.
  *
@@ -31,4 +33,18 @@ export function setReadyDispatchedForCurrentCooldown(dispatched) {
  */
 export function hasReadyBeenDispatchedForCurrentCooldown() {
   return readyDispatchedForCurrentCooldown === true;
+}
+
+/**
+ * @summary Reset the readiness dispatch tracking for the upcoming cooldown cycle.
+ *
+ * @pseudocode
+ * 1. Clear the module-level readiness flag so collaborators start from a clean slate.
+ * 2. Reset the shared event dispatcher history for the "ready" event to align dedupe state.
+ *
+ * @returns {void}
+ */
+export function resetReadyDispatchState() {
+  setReadyDispatchedForCurrentCooldown(false);
+  resetDispatchHistory("ready");
 }

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -137,14 +137,19 @@ const ADVANCE_TRANSITIONS = {
  *
  * @param {(() => void)|null} resolveReady - Resolver passed from cooldown controls.
  * @returns {Promise<boolean>} True when the helper dispatched "ready".
- */
 async function dispatchReadyOnce(resolveReady) {
   if (hasReadyBeenDispatchedForCurrentCooldown()) {
     if (typeof resolveReady === "function") resolveReady();
     return false;
   }
   setReadyDispatchedForCurrentCooldown(true);
-  await dispatchBattleEvent("ready");
+  try {
+    await dispatchBattleEvent("ready");
+  } catch (error) {
+    // Reset the flag if dispatch fails to allow retry
+    setReadyDispatchedForCurrentCooldown(false);
+    throw error;
+  }
   if (typeof resolveReady === "function") resolveReady();
   return true;
 }

--- a/tests/helpers/classicBattle/roundReadyState.test.js
+++ b/tests/helpers/classicBattle/roundReadyState.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("roundReadyState", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resets readiness tracking and dispatcher history", async () => {
+    const resetDispatchHistory = vi.fn();
+    vi.doMock("../../../src/helpers/classicBattle/eventDispatcher.js", () => ({
+      resetDispatchHistory
+    }));
+    const mod = await import("../../../src/helpers/classicBattle/roundReadyState.js");
+    mod.setReadyDispatchedForCurrentCooldown(true);
+    expect(mod.hasReadyBeenDispatchedForCurrentCooldown()).toBe(true);
+    mod.resetReadyDispatchState();
+    expect(mod.hasReadyBeenDispatchedForCurrentCooldown()).toBe(false);
+    expect(resetDispatchHistory).toHaveBeenCalledWith("ready");
+  });
+});


### PR DESCRIPTION
## Summary
- add `resetReadyDispatchState` to synchronize round readiness tracking with event dispatcher history
- replace duplicated ready-dispatch guards in timerService with a shared `dispatchReadyOnce` helper
- document machine strategy ordering in roundManager and cover the new reset helper with unit tests

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: repository contains existing formatting violations)*
- npx eslint . *(fails: repository contains existing lint violations in tests)*
- npx vitest run *(aborted due to extremely long runtime; ran focused suites instead)*
- npx vitest run tests/helpers/classicBattle/roundReadyState.test.js tests/helpers/classicBattle/timerService.nextRound.test.js
- npx playwright test *(fails: network access required for assets)*
- npm run check:contrast
- npm run rag:validate *(fails: offline model download blocked by network restrictions)*
- npm run validate:data
- grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle
- grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"

------
https://chatgpt.com/codex/tasks/task_e_68cdd8f2067083268f11747b41ba256e