### PR TITLE
Fix timerService JSDoc termination

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -137,6 +137,7 @@ const ADVANCE_TRANSITIONS = {
  *
  * @param {(() => void)|null} resolveReady - Resolver passed from cooldown controls.
  * @returns {Promise<boolean>} True when the helper dispatched "ready".
+ */
 async function dispatchReadyOnce(resolveReady) {
   if (hasReadyBeenDispatchedForCurrentCooldown()) {
     if (typeof resolveReady === "function") resolveReady();
@@ -154,23 +155,6 @@ async function dispatchReadyOnce(resolveReady) {
   return true;
 }
 
-/**
- * Advance to the next round when the Next button is marked ready.
- *
- * This helper disables the Next button, ensures the battle state machine
- * reaches the `cooldown` state if necessary, dispatches the `ready` event,
- * and resolves the ready promise used by tests.
- *
- * @pseudocode
- * 1. Disable the Next button and clear the `data-next-ready` attribute.
- * 2. If the machine is not in `cooldown`, dispatch an `interrupt` to reach it.
- * 3. Dispatch `ready` to advance to the next round and call `resolveReady`.
- * 4. Clear any skip handler to prevent late skips affecting the new round.
- *
- * @param {HTMLButtonElement} btn - Next button element.
- * @param {(() => void)|null} resolveReady - Resolver for the ready promise.
- * @returns {Promise<void>}
- */
 /**
  * Advance to the next round when the cooldown is ready.
  *


### PR DESCRIPTION
## Task Contract
- **Inputs:** `src/helpers/classicBattle/timerService.js`
- **Outputs:** `src/helpers/classicBattle/timerService.js`
- **Success Criteria:** `dispatchReadyOnce` defined in module scope, no stray duplicate docs, vitest ReferenceError resolved
- **Error Mode:** report test or lint failures encountered during verification

## Files Changed
- `src/helpers/classicBattle/timerService.js`: closed the `dispatchReadyOnce` JSDoc block and removed the duplicate `advanceWhenReady` documentation so the helper is declared in module scope with a single doc comment.

## Verification
- eslint: PASS (`npx eslint src/helpers/classicBattle/timerService.js`)
- vitest: 17 passed, 3 failed (`npx vitest run tests/helpers/classicBattle/scheduleNextRound.test.js tests/helpers/classicBattle/timerService.nextRound.test.js tests/helpers/classicBattle/statDoubleClick.test.js tests/helpers/classicBattle/drawNextRound.test.js`) — failures are assertion mismatches; the ReferenceError is resolved.
- playwright: not run (not requested)
- jsdoc: PASS (`npm run check:jsdoc`)

## Risk & Follow-Up
- **Risk:** Low; documentation-only edits that restore existing helper visibility.
- **Follow-Up:** Investigate the remaining vitest assertion failures in `scheduleNextRound` to confirm dedupe expectations.


------
https://chatgpt.com/codex/tasks/task_e_68ce4c0f27388326975bd257c5098245