### PR TITLE
Fix orchestrated ready dispatch ordering

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -496,7 +496,8 @@ function prepareCooldownContext(options, emitTelemetry) {
  * @pseudocode
  * 1. Detect whether a custom dispatcher exists and configure bus dispatch options.
  * 2. Create a guarded helper for the machine strategy so it is registered once.
- * 3. When orchestrated, register the machine first so orchestration observes the event before fallbacks.
+ * 3. When orchestrated without a custom dispatcher override, register the machine first so orchestration observes the event
+ *    before fallbacks.
  * 4. Append custom dispatcher and bus strategies, then add the machine strategy again if not already present so manual flows
  *    still dispatch through the machine when earlier strategies short circuit.
  * 5. Return the assembled strategy list for `runReadyDispatchStrategies`.
@@ -538,7 +539,7 @@ function createReadyDispatchStrategies({
     strategies.push(machineStrategy);
     machineStrategyAdded = true;
   };
-  if (orchestrated) {
+  if (orchestrated && !hasCustomDispatcher) {
     addMachineStrategy();
   }
   if (hasCustomDispatcher) {

--- a/tests/roundManager.cooldown-ready.spec.js
+++ b/tests/roundManager.cooldown-ready.spec.js
@@ -88,12 +88,15 @@ test("roundManager - cooldown expiry: observe ready dispatch count (baseline)", 
     getClassicBattleMachine: () => machine
   });
 
+  // Ensure no immediate machine dispatch occurs before async work resolves.
+  expect(machine.dispatch).not.toHaveBeenCalled();
+
   // Allow microtasks to settle
   await new Promise((r) => setTimeout(r, 0));
 
   // In this scenario the injected dispatcher handled the event, so machine.dispatch should not be called
-  const callsA = machine.dispatch.mock ? machine.dispatch.mock.calls.length : 0;
-  expect(callsA).toBe(0);
+  expect(machine.dispatch).not.toHaveBeenCalled();
+  expect(dispatchBattleEventSpy).toHaveBeenCalledTimes(1);
 
   // Inspect trace (accept any of several markers; ordering can vary by timing)
   const traceA = globalThis.__classicBattleDebugRead?.("nextRoundReadyTrace") || [];


### PR DESCRIPTION
## Summary
- gate the initial machine strategy registration behind the absence of a dispatcher override so custom handlers stay ahead of the machine
- extend the cooldown ready regression test to assert injected dispatchers prevent any machine dispatches

## Testing
- npx vitest run tests/roundManager.cooldown-ready.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68ce5046b2d8832685ecbb8bd3734a62