### PR TITLE
Refine classic battle listener initialization

### DIFF
--- a/src/helpers/classicBattle/promises.js
+++ b/src/helpers/classicBattle/promises.js
@@ -117,17 +117,6 @@ export function resetBattlePromises() {
   roundResolvedPromise = setupPromise("roundResolvedPromise", "roundResolved")();
 }
 
-// Initialize on module load once per worker to avoid accumulating listeners
-try {
-  const FLAG = "__classicBattlePromisesBound";
-  if (!globalThis[FLAG]) {
-    resetBattlePromises();
-    globalThis[FLAG] = true;
-  }
-} catch {
-  resetBattlePromises();
-}
-
 // Return the latest promise instance for each awaitable, using the window-scoped
 // reference maintained by setupPromise(). This avoids races where a module-level
 // Promise was already resolved before the test started awaiting it.

--- a/src/helpers/classicBattle/testHooks.js
+++ b/src/helpers/classicBattle/testHooks.js
@@ -71,8 +71,36 @@ export async function ensureBindings(opts = {}) {
   const force = !!opts.force;
   // Bind round UI listeners once per worker to avoid duplicate handlers.
   if (!__uiBound) {
-    await import("/src/helpers/classicBattle/roundUI.js");
+    const ui = await import("/src/helpers/classicBattle/roundUI.js");
+    if (typeof ui.bindRoundUIEventHandlersOnce === "function") {
+      ui.bindRoundUIEventHandlersOnce();
+    } else if (typeof ui.bindRoundUIEventHandlers === "function") {
+      ui.bindRoundUIEventHandlers();
+    }
+    let uiService;
+    try {
+      uiService = await import("/src/helpers/classicBattle/uiService.js");
+      if (typeof uiService.bindUIServiceEventHandlersOnce === "function") {
+        uiService.bindUIServiceEventHandlersOnce();
+      }
+    } catch {}
     __uiBound = true;
+    if (force) {
+      try {
+        __resetBattleEventTarget();
+      } catch {}
+      if (typeof ui.bindRoundUIEventHandlersDynamic === "function")
+        ui.bindRoundUIEventHandlersDynamic();
+      try {
+        uiService = uiService || (await import("/src/helpers/classicBattle/uiService.js"));
+        if (typeof uiService.bindUIServiceEventHandlersOnce === "function") {
+          uiService.bindUIServiceEventHandlersOnce();
+        }
+      } catch {}
+      const eventHandlers = await import("/src/helpers/classicBattle/uiEventHandlers.js");
+      if (typeof eventHandlers.bindUIHelperEventHandlersDynamic === "function")
+        eventHandlers.bindUIHelperEventHandlersDynamic();
+    }
   } else if (force) {
     // Reset the event bus and bind dynamic handlers to honor vi.mocks.
     try {
@@ -81,6 +109,12 @@ export async function ensureBindings(opts = {}) {
     const ui = await import("/src/helpers/classicBattle/roundUI.js");
     if (typeof ui.bindRoundUIEventHandlersDynamic === "function")
       ui.bindRoundUIEventHandlersDynamic();
+    try {
+      const uiService = await import("/src/helpers/classicBattle/uiService.js");
+      if (typeof uiService.bindUIServiceEventHandlersOnce === "function") {
+        uiService.bindUIServiceEventHandlersOnce();
+      }
+    } catch {}
     const eventHandlers = await import("/src/helpers/classicBattle/uiEventHandlers.js");
     if (typeof eventHandlers.bindUIHelperEventHandlersDynamic === "function")
       eventHandlers.bindUIHelperEventHandlersDynamic();

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -210,14 +210,26 @@ function bindUIServiceEventHandlers() {
   });
 }
 
-// Bind per EventTarget instance; if tests reset the bus, we rebind.
-try {
-  const KEY = "__classicBattleUIServiceBoundTarget";
-  const current = getBattleEventTarget();
-  if (globalThis[KEY] !== current) {
+/**
+ * Bind UI service handlers once per battle event target.
+ *
+ * Mirrors the previous module-level binding behavior but defers execution
+ * until explicitly invoked so tests can control when listeners register.
+ *
+ * @returns {void}
+ */
+export function bindUIServiceEventHandlersOnce() {
+  let shouldBind = true;
+  try {
+    const KEY = "__cbUiServiceBoundTargets";
+    const target = getBattleEventTarget();
+    if (target) {
+      const set = (globalThis[KEY] ||= new WeakSet());
+      if (set.has(target)) shouldBind = false;
+      else set.add(target);
+    }
+  } catch {}
+  if (shouldBind) {
     bindUIServiceEventHandlers();
-    globalThis[KEY] = current;
   }
-} catch {
-  bindUIServiceEventHandlers();
 }


### PR DESCRIPTION
## Summary
- defer classic battle round UI listener registration until explicitly requested and guard the UI service preload
- remove module-load side effects from the classic battle promises and UI service helpers while adding per-target binders
- ensure the classic battle test hook initializes both static and dynamic binders appropriately, including UI service wiring when forced

## Testing
- `npx vitest run tests/helpers/classicBattleBindings.idempotent.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ce523b63148326b895aa122b01f06e