### PR TITLE
Fix classic battle scaffold stat button handlers

### DIFF
--- a/tests/classicBattle/page-scaffold.test.js
+++ b/tests/classicBattle/page-scaffold.test.js
@@ -337,10 +337,21 @@ vi.mock("../../src/helpers/classicBattle/uiHelpers.js", () => {
     const nativeClick =
       typeof HTMLElement !== "undefined" ? HTMLElement.prototype.click : undefined;
 
+    let detachHandlers = null;
+
     const attachHandlers = () => {
+      if (detachHandlers) return;
+      const detachFns = [];
+
       buttons.forEach((btn) => {
-        let assignedClick;
+        if (!(btn instanceof HTMLElement)) return;
+
+        let assignedClick = typeof btn.onclick === "function" ? btn.onclick : null;
         let runningFromProxy = false;
+
+        const setAssignedClick = (value) => {
+          assignedClick = typeof value === "function" ? value : null;
+        };
 
         const runSelection = async (event) => {
           event?.preventDefault?.();
@@ -360,11 +371,12 @@ vi.mock("../../src/helpers/classicBattle/uiHelpers.js", () => {
         };
 
         const proxyClick = async (event) => {
+          if (btn.disabled) return undefined;
           runningFromProxy = true;
           try {
             await runSelection(event);
             if (assignedClick) {
-              return assignedClick(event);
+              return assignedClick.call(btn, event);
             }
             if (nativeClick) {
               return nativeClick.call(btn);
@@ -374,6 +386,54 @@ vi.mock("../../src/helpers/classicBattle/uiHelpers.js", () => {
             runningFromProxy = false;
           }
         };
+
+        const listener = (event) => {
+          if (runningFromProxy) return;
+          void proxyClick(event);
+        };
+
+        const descriptor = {
+          configurable: true,
+          enumerable: true,
+          get() {
+            return assignedClick;
+          },
+          set(value) {
+            setAssignedClick(value);
+          }
+        };
+
+        try {
+          Object.defineProperty(btn, "onclick", descriptor);
+        } catch {
+          setAssignedClick(btn.onclick);
+        }
+
+        btn.addEventListener("click", listener);
+
+        detachFns.push(() => {
+          btn.removeEventListener("click", listener);
+          try {
+            delete btn.onclick;
+          } catch {}
+          if (assignedClick) {
+            try {
+              btn.onclick = assignedClick;
+            } catch {}
+          }
+        });
+      });
+
+      detachHandlers = () => {
+        while (detachFns.length > 0) {
+          const fn = detachFns.pop();
+          try {
+            fn();
+          } catch {}
+        }
+        detachHandlers = null;
+      };
+    };
 
     if (containers.length === 0 || buttons.length === 0) {
       const enable = vi.fn(() => {
@@ -394,9 +454,11 @@ vi.mock("../../src/helpers/classicBattle/uiHelpers.js", () => {
     const disable = vi.fn(() => {
       setButtonsDisabled(buttons, true);
       readyState.setPending();
+      detachHandlers?.();
     });
 
     const enable = vi.fn(() => {
+      attachHandlers();
       setButtonsDisabled(buttons, false);
       readyState.resolve();
     });


### PR DESCRIPTION
## Summary
- rebuild the mock `initStatButtons` helper so button handlers are attached with cleanup and restored onclick tracking
- ensure disabling clears listeners and enabling wires them back up before resolving readiness

## Testing
- `npx vitest run tests/classicBattle/page-scaffold.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ce52541dc883268f319234a396b3c3