### PR TITLE
Ensure orchestrated ready dispatch propagates to bus

### DIFF
--- a/src/helpers/classicBattle/nextRound/expirationHandlers.js
+++ b/src/helpers/classicBattle/nextRound/expirationHandlers.js
@@ -411,11 +411,15 @@ export async function runReadyDispatchStrategies(params = {}) {
   }
   let dispatched = false;
   const interpretResult = (value) => {
-    if (value && typeof value === "object" && ("dispatched" in value || "propagate" in value)) {
-      return {
-        dispatched: value.dispatched === true,
-        propagate: value.propagate === true
-      };
+    if (value && typeof value === "object" && value !== null && !Array.isArray(value)) {
+      const hasDispatchedProp = "dispatched" in value;
+      const hasPropagateProp = "propagate" in value;
+      if (hasDispatchedProp || hasPropagateProp) {
+        return {
+          dispatched: value.dispatched === true,
+          propagate: value.propagate === true
+        };
+      }
     }
     return { dispatched: value === true, propagate: false };
   };

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -521,9 +521,14 @@ function createReadyDispatchStrategies({
     typeof options.dispatchBattleEvent === "function" &&
     options.dispatchBattleEvent !== dispatchBattleEvent;
   const shouldShortCircuitReadyDispatch = () => hasReadyBeenDispatchedForCurrentCooldown();
-  const machineStrategy = () => {
+  const shouldPropagateAfterMachine = orchestrated && !hasCustomDispatcher;
+  const machineStrategy = async () => {
     if (shouldShortCircuitReadyDispatch()) return true;
-    return dispatchReadyDirectly({ machineReader, emitTelemetry });
+    const dispatched = await dispatchReadyDirectly({ machineReader, emitTelemetry });
+    if (dispatched && shouldPropagateAfterMachine) {
+      return { dispatched: true, propagate: true };
+    }
+    return dispatched;
   };
   const strategies = [];
   let machineStrategyAdded = false;

--- a/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
+++ b/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
@@ -242,6 +242,27 @@ describe("runReadyDispatchStrategies", () => {
     expect(result).toBe(false);
     expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchResult", false);
   });
+
+  it("allows later strategies to run when a step requests propagation", async () => {
+    const emit = vi.fn();
+    const calls = [];
+    const result = await runReadyDispatchStrategies({
+      strategies: [
+        () => {
+          calls.push("machine");
+          return { dispatched: true, propagate: true };
+        },
+        () => {
+          calls.push("bus");
+          return true;
+        }
+      ],
+      emitTelemetry: emit
+    });
+    expect(result).toBe(true);
+    expect(calls).toEqual(["machine", "bus"]);
+    expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchResult", true);
+  });
 });
 
 describe("updateExpirationUi", () => {

--- a/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
+++ b/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
@@ -128,6 +128,7 @@ describe("timeout → interruptRound → cooldown auto-advance", () => {
       const readyDispatchesDuringAdvance =
         readyCallsAfterAdvance.length - readyCallsBeforeAdvance.length;
       expect(readyDispatchesDuringAdvance).toBe(1);
+      expect(readyCallsAfterAdvance).toHaveLength(1);
       // Ensure no additional ready dispatches occur after flushing remaining timers
       await vi.runOnlyPendingTimersAsync();
       const readyCallsAfterFlushing = dispatchBattleEvent.mock.calls.filter(


### PR DESCRIPTION
## Summary
- let orchestrated machine-ready dispatch request propagation so the event bus still fires once
- teach the ready strategy runner to honor propagation requests while keeping overall dispatch telemetry accurate
- extend classic battle tests to cover propagation logic and assert a single ready event is dispatched during cooldown auto-advance

## Testing
- npx vitest run tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
- npx vitest run tests/helpers/classicBattle/nextRound/expirationHandlers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ce69c90eb88326bc644081ff0f8332