### PR TITLE
Cache classic battle machine for dispatch

### DIFF
--- a/src/helpers/classicBattle/eventDispatcher.js
+++ b/src/helpers/classicBattle/eventDispatcher.js
@@ -211,26 +211,20 @@ export async function dispatchBattleEvent(eventName, payload) {
       exposeDebugState("dispatch_globalGetterType", typeof globalGetter);
     } catch {}
   } catch {}
+  const machineSourceType = typeof machineSource;
+  let machine = null;
+  if (machineSourceType === "function") {
+    machine = machineSource();
+  } else if (machineSource) {
+    machine = machineSource;
+  }
   try {
-    exposeDebugState("dispatch_machineSourceType", typeof machineSource);
+    exposeDebugState("dispatch_machineSourceType", machineSourceType);
   } catch {}
   try {
-    if (typeof machineSource === "function") {
-      let invoked = null;
-      try {
-        invoked = machineSource();
-      } catch {}
-      try {
-        exposeDebugState("dispatch_machineSourceInvokedType", typeof invoked);
-      } catch {}
-    } else {
-      try {
-        exposeDebugState("dispatch_machineSourceInvokedType", typeof machineSource);
-      } catch {}
-    }
+    const invokedType = machineSourceType === "function" ? typeof machine : machineSourceType;
+    exposeDebugState("dispatch_machineSourceInvokedType", invokedType);
   } catch {}
-
-  const machine = typeof machineSource === "function" ? machineSource() : machineSource || null;
   try {
     exposeDebugState("dispatchMachineAvailable", !!machine);
   } catch {}

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -410,6 +410,12 @@ export function bindRoundUIEventHandlers() {
  * encountered again the function exits early, mirroring the previous module-
  * level behavior without performing work eagerly on import.
  *
+ * @pseudocode
+ * 1. Optimistically schedule lazy UI service preload to match default path.
+ * 2. Read the global WeakSet keyed by the battle event target.
+ * 3. If the current target already exists in the set, skip binding.
+ * 4. Otherwise add the target and invoke the shared binding routine.
+ *
  * @returns {void}
  */
 export function bindRoundUIEventHandlersOnce() {

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -216,6 +216,12 @@ function bindUIServiceEventHandlers() {
  * Mirrors the previous module-level binding behavior but defers execution
  * until explicitly invoked so tests can control when listeners register.
  *
+ * @pseudocode
+ * 1. Assume binding should occur; fetch the shared battle event target.
+ * 2. Look up (or create) the WeakSet tracking bound targets.
+ * 3. If the target is already tracked, skip binding.
+ * 4. Otherwise add the target and delegate to `bindUIServiceEventHandlers`.
+ *
  * @returns {void}
  */
 export function bindUIServiceEventHandlersOnce() {

--- a/tests/classicBattle/eventDispatcher.machineGetter.test.js
+++ b/tests/classicBattle/eventDispatcher.machineGetter.test.js
@@ -1,0 +1,77 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+import { withMutedConsole } from "../utils/console.js";
+
+describe("Classic Battle dispatchBattleEvent getter caching", () => {
+  let originalDebugReader;
+  let stdoutSpy;
+  let dispatchBattleEvent;
+  let resetDispatchHistory;
+
+  beforeEach(async () => {
+    ({ dispatchBattleEvent, resetDispatchHistory } = await import(
+      "../../src/helpers/classicBattle/eventDispatcher.js"
+    ));
+    vi.useFakeTimers();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    originalDebugReader = globalThis.__classicBattleDebugRead;
+  });
+
+  afterEach(async () => {
+    vi.advanceTimersByTime(100);
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+    stdoutSpy.mockRestore();
+    resetDispatchHistory();
+    if (originalDebugReader) {
+      globalThis.__classicBattleDebugRead = originalDebugReader;
+    } else {
+      delete globalThis.__classicBattleDebugRead;
+    }
+    vi.resetModules();
+  });
+
+  it("caches the getter result and continues to dedupe rapid ready events", async () => {
+    const dispatchSpies = [];
+    const machineGetter = vi.fn(() => {
+      const dispatch = vi.fn(async () => "dispatched");
+      dispatchSpies.push(dispatch);
+      return {
+        dispatch,
+        getState: vi.fn(() => "cooldown")
+      };
+    });
+
+    globalThis.__classicBattleDebugRead = (token) => {
+      if (token === "getClassicBattleMachine") {
+        return machineGetter;
+      }
+      return undefined;
+    };
+
+    await withMutedConsole(async () => {
+      const firstResult = await dispatchBattleEvent("ready");
+      expect(firstResult).toBe("dispatched");
+    }, ["error", "warn", "log"]);
+
+    expect(machineGetter).toHaveBeenCalledTimes(1);
+    expect(dispatchSpies).toHaveLength(1);
+    expect(dispatchSpies[0]).toHaveBeenCalledTimes(1);
+
+    resetDispatchHistory();
+    const stableMachine = {
+      dispatch: vi.fn(async () => "dispatched"),
+      getState: vi.fn(() => "cooldown")
+    };
+    machineGetter.mockImplementation(() => stableMachine);
+
+    await withMutedConsole(async () => {
+      const firstReady = await dispatchBattleEvent("ready");
+      expect(firstReady).toBe("dispatched");
+
+      const secondReady = await dispatchBattleEvent("ready");
+      expect(secondReady).toBe(true);
+    }, ["error", "warn", "log"]);
+
+    expect(stableMachine.dispatch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- cache the classic battle machine getter result so instrumentation and dispatch use the same instance
- document the once-per-target binding helpers with pseudocode for jsdoc compliance
- add a regression test covering getter caching and ready-event dedupe behaviour

## Testing
- npm run check:jsdoc
- npx prettier tests/classicBattle/eventDispatcher.machineGetter.test.js src/helpers/classicBattle/eventDispatcher.js --check
- npx eslint .
- npx vitest run --reporter=dot
- npx vitest run tests/classicBattle/eventDispatcher.machineGetter.test.js
- npx playwright test
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68ce6c5a94ec8326b72d15fc90e1453a