### PR TITLE
Restore countdownFinished emission when skipping cooldown

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -222,10 +222,10 @@ export async function cancelTimerOrAdvance(_btn, timer, resolveReady) {
 /**
  * Click handler for the Next button.
  *
- * Unconditionally skips the inter-round cooldown by emitting
- * `countdownFinished`, then delegates to `advanceWhenReady` when the button is
- * marked ready or to `cancelTimerOrAdvance` to stop an active timer / advance
- * when in cooldown.
+ * Unconditionally skips the inter-round cooldown by emitting the legacy
+ * `countdownFinished` event (and the newer `round.start` signal), then
+ * delegates to `advanceWhenReady` when the button is marked ready or to
+ * `cancelTimerOrAdvance` to stop an active timer / advance when in cooldown.
  *
  * @pseudocode
  * 1. Call `skipRoundCooldownIfEnabled`; return early if it skips.
@@ -241,6 +241,7 @@ export async function cancelTimerOrAdvance(_btn, timer, resolveReady) {
  */
 export async function onNextButtonClick(_evt, controls = getNextRoundControls(), options = {}) {
   if (skipRoundCooldownIfEnabled()) return;
+  emitBattleEvent("countdownFinished");
   emitBattleEvent("round.start");
   const { timer = null, resolveReady = null } = controls || {};
   const root = options.root || document;

--- a/tests/helpers/classicBattle/nextButton.countdownFinished.test.js
+++ b/tests/helpers/classicBattle/nextButton.countdownFinished.test.js
@@ -37,13 +37,15 @@ describe("Next button countdownFinished", () => {
   it("emits countdownFinished when button exists", async () => {
     document.body.innerHTML = '<button id="next-button" data-role="next-round"></button>';
     await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
-    expect(emitBattleEvent).toHaveBeenCalledTimes(1);
-    expect(emitBattleEvent).toHaveBeenCalledWith("countdownFinished");
+    expect(emitBattleEvent).toHaveBeenCalledTimes(2);
+    expect(emitBattleEvent).toHaveBeenNthCalledWith(1, "countdownFinished");
+    expect(emitBattleEvent).toHaveBeenNthCalledWith(2, "round.start");
   });
 
   it("emits countdownFinished when button missing", async () => {
     await onNextButtonClick(new MouseEvent("click"), { timer: null, resolveReady: null });
-    expect(emitBattleEvent).toHaveBeenCalledTimes(1);
-    expect(emitBattleEvent).toHaveBeenCalledWith("countdownFinished");
+    expect(emitBattleEvent).toHaveBeenCalledTimes(2);
+    expect(emitBattleEvent).toHaveBeenNthCalledWith(1, "countdownFinished");
+    expect(emitBattleEvent).toHaveBeenNthCalledWith(2, "round.start");
   });
 });

--- a/tests/helpers/timerService.onNextButtonClick.test.js
+++ b/tests/helpers/timerService.onNextButtonClick.test.js
@@ -52,7 +52,8 @@ describe("onNextButtonClick", () => {
     const events = await import("../../src/helpers/classicBattle/battleEvents.js");
     expect(btn.disabled).toBe(true);
     expect(btn.dataset.nextReady).toBeUndefined();
-    expect(events.emitBattleEvent).toHaveBeenCalledWith("countdownFinished");
+    expect(events.emitBattleEvent).toHaveBeenNthCalledWith(1, "countdownFinished");
+    expect(events.emitBattleEvent).toHaveBeenNthCalledWith(2, "round.start");
     expect(events.emitBattleEvent).toHaveBeenCalledBefore(dispatcher.dispatchBattleEvent);
     expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
     expect(resolveReady).toHaveBeenCalledTimes(1);
@@ -73,7 +74,8 @@ describe("onNextButtonClick", () => {
     const dispatcher = await import("../../src/helpers/classicBattle/eventDispatcher.js");
     const events = await import("../../src/helpers/classicBattle/battleEvents.js");
     expect(stop).toHaveBeenCalledTimes(1);
-    expect(events.emitBattleEvent).toHaveBeenCalledWith("countdownFinished");
+    expect(events.emitBattleEvent).toHaveBeenNthCalledWith(1, "countdownFinished");
+    expect(events.emitBattleEvent).toHaveBeenNthCalledWith(2, "round.start");
     expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
   });
 
@@ -91,7 +93,8 @@ describe("onNextButtonClick", () => {
     });
     const dispatcher = await import("../../src/helpers/classicBattle/eventDispatcher.js");
     const events = await import("../../src/helpers/classicBattle/battleEvents.js");
-    expect(events.emitBattleEvent).toHaveBeenCalledWith("countdownFinished");
+    expect(events.emitBattleEvent).toHaveBeenNthCalledWith(1, "countdownFinished");
+    expect(events.emitBattleEvent).toHaveBeenNthCalledWith(2, "round.start");
     expect(dispatcher.dispatchBattleEvent).toHaveBeenCalledWith("ready");
     expect(resolveReady2).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary
- emit the legacy `countdownFinished` event from the Next button handler while still publishing `round.start`
- adjust the Next-button unit tests to cover both emitted events and maintain ordering expectations

## Testing
- npx vitest run tests/helpers/timerService.onNextButtonClick.test.js tests/helpers/classicBattle/nextButton.countdownFinished.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ce725ed5d88326af65177ab57e8159