### PR TITLE
Emit countdownFinished before round start

### DIFF
--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -17,6 +17,7 @@ let activeCountdown = null;
 function handleCountdownExpired() {
   setSkipHandler(null);
   activeCountdown = null;
+  battleEvents.emitBattleEvent("countdownFinished");
   battleEvents.emitBattleEvent("round.start");
 }
 

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -476,13 +476,15 @@ describe("classicBattle startCooldown", () => {
 
     await vi.runAllTimersAsync();
     await Promise.resolve();
-
     const events = emitSpy.mock.calls.map(([eventName]) => eventName);
     const countdownIndex = events.lastIndexOf("countdownFinished");
     const roundStartIndex = events.lastIndexOf("round.start");
     expect(countdownIndex).toBeGreaterThan(-1);
     expect(roundStartIndex).toBeGreaterThan(-1);
     expect(countdownIndex).toBeLessThan(roundStartIndex);
+    // Verify both events were actually emitted
+    expect(events).toContain("countdownFinished");
+    expect(events).toContain("round.start");
     expect(onFinished).toHaveBeenCalled();
   });
 

--- a/tests/helpers/classicBattle/scheduleNextRound.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.test.js
@@ -444,13 +444,46 @@ describe("classicBattle startCooldown", () => {
     await battleEventsMod.emitBattleEvent("countdownStart", { duration: 3 });
     await Promise.resolve();
 
+    const events = emitSpy.mock.calls.map(([eventName]) => eventName);
+
     if (enabled) {
       expect(attachCooldownRenderer).not.toHaveBeenCalled();
-      expect(emitSpy).toHaveBeenCalledWith("countdownFinished");
+      const countdownIndex = events.indexOf("countdownFinished");
+      const roundStartIndex = events.indexOf("round.start");
+      expect(countdownIndex).toBeGreaterThan(-1);
+      expect(roundStartIndex).toBeGreaterThan(-1);
+      expect(countdownIndex).toBeLessThan(roundStartIndex);
     } else {
       expect(attachCooldownRenderer).toHaveBeenCalled();
       expect(emitSpy).toHaveBeenCalledTimes(1);
     }
+  });
+
+  it("emits countdownFinished before round.start when countdown expires", async () => {
+    vi.resetModules();
+    currentFlags.skipRoundCooldown = { enabled: false };
+    applyMockSetup({ currentFlags });
+
+    const battleEventsMod = await import("../../../src/helpers/classicBattle/battleEvents.js");
+    battleEventsMod.__resetBattleEventTarget();
+    const emitSpy = vi.spyOn(battleEventsMod, "emitBattleEvent");
+    const uiService = await import("../../../src/helpers/classicBattle/uiService.js");
+    uiService.bindUIServiceEventHandlersOnce();
+
+    const onFinished = vi.fn();
+    await battleEventsMod.emitBattleEvent("countdownStart", { duration: 2, onFinished });
+    await Promise.resolve();
+
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    const events = emitSpy.mock.calls.map(([eventName]) => eventName);
+    const countdownIndex = events.lastIndexOf("countdownFinished");
+    const roundStartIndex = events.lastIndexOf("round.start");
+    expect(countdownIndex).toBeGreaterThan(-1);
+    expect(roundStartIndex).toBeGreaterThan(-1);
+    expect(countdownIndex).toBeLessThan(roundStartIndex);
+    expect(onFinished).toHaveBeenCalled();
   });
 
   it("schedules a 1s minimum cooldown in test mode", async () => {


### PR DESCRIPTION
## Summary
- emit the countdownFinished event before round.start so both skip and natural expiry share the same signals
- extend the countdown skip test to assert the emission order and add a new countdown completion test

## Testing
- npm run check:jsdoc
- CI=1 npx prettier . --check *(fails: formatting issues in existing files)*
- npx eslint . *(fails: existing prettier/style warnings in unrelated files)*
- npx vitest run *(terminated due to extremely long run time/output)*

------
https://chatgpt.com/codex/tasks/task_e_68ce74d7b12c83269f028fe58a6e3f07