### PR TITLE
Add test helper for rendering battle card stats

### DIFF
--- a/src/helpers/classicBattle.js
+++ b/src/helpers/classicBattle.js
@@ -222,7 +222,8 @@ export {
   ensureBindings as __ensureClassicBattleBindings,
   resetBindings as __resetClassicBattleBindings,
   triggerRoundTimeoutNow as __triggerRoundTimeoutNow,
-  triggerStallPromptNow as __triggerStallPromptNow
+  triggerStallPromptNow as __triggerStallPromptNow,
+  setCardStatValuesForTest as __setCardStatValuesForTest
 } from "./classicBattle/testHooks.js";
 
 // PRD Orchestrator API shims

--- a/src/helpers/classicBattle/testHooks.js
+++ b/src/helpers/classicBattle/testHooks.js
@@ -115,9 +115,12 @@ const renderStatsCardForTest = async (target, base, overrides) => {
 
   const card = document.createElement("div");
   card.className = `judoka-card ${rarityClass}`.trim();
-  card.appendChild(statsPanel);
-
-  const container = document.createElement("div");
+  try {
+    container.dataset.cardJson = JSON.stringify(cardData);
+  } catch (error) {
+    console.warn("Failed to serialize card  error);
+    container.dataset.cardJson = JSON.stringify({ id: cardData.id, stats: cardData.stats });
+  }
   container.className = "card-container";
   try {
     container.dataset.cardJson = JSON.stringify(cardData);

--- a/src/helpers/classicBattle/testHooks.js
+++ b/src/helpers/classicBattle/testHooks.js
@@ -136,11 +136,11 @@ const renderStatsCardForTest = async (target, base, overrides) => {
  * Render simplified Classic Battle cards with deterministic stat values for tests.
  *
  * @pseudocode
- * 1. Locate the player and opponent card containers in the DOM.
- * 2. Use `createStatsPanel` to render stat lists for each side with the provided overrides.
- * 3. Replace the existing card markup with the generated panels and return the merged card data.
- *
- * @param {{
+ * @param {object} [config] - Configuration object with player and opponent overrides.
+ * @param {object} [config.player] - Player card overrides including stats.
+ * @param {object} [config.opponent] - Opponent card overrides including stats.
+ * @param {object} [config.player.stats] - Player stat overrides (power, speed, technique, etc.).
+ * @param {object} [config.opponent.stats] - Opponent stat overrides (power, speed, technique, etc.).
  *   player?: { stats?: Partial<Record<string, number>> } & Record<string, unknown>,
  *   opponent?: { stats?: Partial<Record<string, number>> } & Record<string, unknown>
  * }} [config] - Stat overrides and optional card metadata for each side.

--- a/src/helpers/classicBattle/testHooks.js
+++ b/src/helpers/classicBattle/testHooks.js
@@ -91,14 +91,15 @@ const mergeTestCardData = (base, overrides = {}) => {
     ...base.stats,
     ...(statOverrides && typeof statOverrides === "object" ? statOverrides : {})
   };
-  return {
-    ...base,
-    ...cardOverrides,
-    stats: mergedStats
-  };
-};
-
 const renderStatsCardForTest = async (target, base, overrides) => {
+  if (!target) return null;
+  if (!__createStatsPanelPromise) {
+    // Preload during module initialization instead of lazy loading
+    __createStatsPanelPromise = import("/src/components/StatsPanel.js").then(
+      (mod) => mod.createStatsPanel
+    );
+  }
+  const createStatsPanel = await __createStatsPanelPromise;
   if (!target) return null;
   if (!__createStatsPanelPromise) {
     __createStatsPanelPromise = import("/src/components/StatsPanel.js").then(

--- a/tests/helpers/classicBattle/matchEnd.test.js
+++ b/tests/helpers/classicBattle/matchEnd.test.js
@@ -54,10 +54,10 @@ afterEach(() => {
 });
 
 async function playRound(battleMod, store, playerValue, opponentValue) {
-  document.getElementById("player-card").innerHTML =
-    `<ul><li class="stat"><strong>Power</strong> <span>${playerValue}</span></li></ul>`;
-  document.getElementById("opponent-card").innerHTML =
-    `<ul><li class="stat"><strong>Power</strong> <span>${opponentValue}</span></li></ul>`;
+  await battleMod.__setCardStatValuesForTest({
+    player: { stats: { power: playerValue } },
+    opponent: { stats: { power: opponentValue } }
+  });
   store.selectionMade = false;
   const playerVal = battleMod.getCardStatValue(document.getElementById("player-card"), "power");
   const opponentVal = battleMod.getCardStatValue(document.getElementById("opponent-card"), "power");

--- a/tests/helpers/classicBattle/mockSetup.js
+++ b/tests/helpers/classicBattle/mockSetup.js
@@ -37,7 +37,8 @@ vi.mock("../../../src/helpers/dataUtils.js", () => ({
 }));
 
 vi.mock("../../../src/helpers/utils.js", () => ({
-  createGokyoLookup: () => ({})
+  createGokyoLookup: () => ({}),
+  escapeHTML: (value) => String(value)
 }));
 
 vi.mock("../../../src/helpers/featureFlags.js", () => ({


### PR DESCRIPTION
## Summary
- add a `setCardStatValuesForTest` helper that renders lightweight test cards via `StatsPanel`
- expose the helper through the Classic Battle entrypoint and extend the utils mock used in classic battle tests
- update the match end tests to rely on the helper instead of mutating card `innerHTML`

## Testing
- npm run test -- --run tests/helpers/classicBattle/matchEnd.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ce783bb8f4832681b94dfb828f61dd