### PR TITLE
Add browse test hooks for hover zoom tests

### DIFF
--- a/playwright/hover-zoom.spec.js
+++ b/playwright/hover-zoom.spec.js
@@ -1,5 +1,24 @@
 import { test, expect } from "./fixtures/commonSetup.js";
 
+async function callBrowseHook(page, name, ...args) {
+  await page.waitForFunction(
+    (hookName) => typeof window.__testHooks?.browse?.[hookName] === "function",
+    name
+  );
+  return page.evaluate(
+    ([hookName, params]) => window.__testHooks?.browse?.[hookName]?.(...params),
+    [name, args]
+  );
+}
+
+async function resetBrowseHooks(page) {
+  await page.evaluate(() => window.__testHooks?.browse?.reset?.());
+}
+
+test.afterEach(async ({ page }) => {
+  await resetBrowseHooks(page);
+});
+
 test.describe("Hover Zoom Functionality", () => {
   test.describe("Basic Hover Interactions", () => {
     test("judoka card enlarges on hover", async ({ page }) => {
@@ -45,9 +64,7 @@ test.describe("Hover Zoom Functionality", () => {
       await page.waitForSelector(".judoka-card", { timeout: 10000 });
 
       // Disable animations for deterministic testing
-      await page.evaluate(() => {
-        document.body.setAttribute("data-test-disable-animations", "true");
-      });
+      await callBrowseHook(page, "disableHoverAnimations");
 
       const cards = page.locator(".judoka-card");
 
@@ -131,12 +148,9 @@ test.describe("Hover Zoom Functionality", () => {
     });
 
     test("handles test disable animations attribute", async ({ page }) => {
-      await page.addInitScript(() => {
-        document.body.setAttribute("data-test-disable-animations", "true");
-      });
-
       await page.goto("/src/pages/browseJudoka.html", { waitUntil: "networkidle" });
       await page.waitForSelector(".judoka-card", { timeout: 10000 });
+      await callBrowseHook(page, "disableHoverAnimations");
 
       const firstCard = page.locator(".judoka-card").first();
 
@@ -247,12 +261,22 @@ test.describe("Hover Zoom Functionality", () => {
       await page.goto("/src/pages/browseJudoka.html", { waitUntil: "networkidle" });
       await page.waitForSelector(".judoka-card", { timeout: 10000 });
 
-      // Add a new card dynamically
-      await page.evaluate(() => {
-        const newCard = document.createElement("div");
-        newCard.className = "judoka-card";
-        newCard.textContent = "Dynamic Card";
-        document.querySelector(".card-carousel")?.appendChild(newCard);
+      // Add a new card dynamically via the production card factory
+      await callBrowseHook(page, "addCard", {
+        firstname: "Dynamic",
+        surname: "Card",
+        country: "Testland",
+        countryCode: "jp",
+        stats: {
+          power: 1,
+          speed: 1,
+          technique: 1,
+          kumikata: 1,
+          newaza: 1
+        },
+        weightClass: "60kg",
+        signatureMoveId: 1,
+        rarity: "common"
       });
 
       const dynamicCard = page.locator(".judoka-card").last();
@@ -261,8 +285,8 @@ test.describe("Hover Zoom Functionality", () => {
       await expect(dynamicCard).toBeVisible();
 
       // The dynamic card won't have hover zoom markers since they were added after initialization
-      // This is expected behavior - we just verify the card exists and is visible
-      await expect(dynamicCard).toHaveText("Dynamic Card");
+      // This is expected behavior - we just verify the card exists and exposes the expected aria label
+      await expect(dynamicCard).toHaveAttribute("aria-label", /Dynamic Card/);
     });
 
     test("handles missing DOM elements gracefully", async ({ page }) => {

--- a/src/helpers/browse/testHooks.js
+++ b/src/helpers/browse/testHooks.js
@@ -1,0 +1,154 @@
+import { appendCards } from "../carousel/index.js";
+import { createGokyoLookup } from "../utils.js";
+import { addHoverZoomMarkers } from "../setupHoverZoom.js";
+
+const state = {
+  container: null,
+  gokyoData: [],
+  gokyoLookup: {},
+  addedNodes: new Set(),
+  animationsDisabled: false,
+  previousAnimationValue: null
+};
+
+function ensureBrowseHookContainer() {
+  if (typeof window === "undefined") return;
+  window.__testHooks = window.__testHooks || {};
+  window.__testHooks.browse = Object.assign(window.__testHooks.browse || {}, {
+    disableHoverAnimations,
+    enableHoverAnimations,
+    addCard: addTestCard,
+    reset: resetState
+  });
+}
+
+/**
+ * Disable hover animations on the browse page for deterministic testing.
+ *
+ * @pseudocode
+ * 1. Exit early when `document.body` is unavailable.
+ * 2. If animations are already disabled, skip further work.
+ * 3. Remember the previous value of `data-test-disable-animations` (if any).
+ * 4. Set `data-test-disable-animations="true"` on `<body>`.
+ * 5. Mark animations as disabled in local state so they can be restored.
+ *
+ * @returns {void}
+ */
+function disableHoverAnimations() {
+  if (typeof document === "undefined") return;
+  const body = document.body;
+  if (!body || state.animationsDisabled) return;
+  state.previousAnimationValue = body.hasAttribute("data-test-disable-animations")
+    ? body.getAttribute("data-test-disable-animations")
+    : null;
+  body.setAttribute("data-test-disable-animations", "true");
+  state.animationsDisabled = true;
+}
+
+/**
+ * Restore hover animations on the browse page after tests mutate them.
+ *
+ * @pseudocode
+ * 1. Exit early when `<body>` is missing or animations were not disabled.
+ * 2. If the body previously lacked the attribute, remove it; otherwise restore the prior value.
+ * 3. Clear saved attribute state and mark animations as enabled.
+ *
+ * @returns {void}
+ */
+function enableHoverAnimations() {
+  if (typeof document === "undefined") return;
+  const body = document.body;
+  if (!body || !state.animationsDisabled) return;
+  if (state.previousAnimationValue === null) {
+    body.removeAttribute("data-test-disable-animations");
+  } else {
+    body.setAttribute("data-test-disable-animations", state.previousAnimationValue);
+  }
+  state.previousAnimationValue = null;
+  state.animationsDisabled = false;
+}
+
+/**
+ * Append a new judoka card using the production carousel pipeline.
+ *
+ * @pseudocode
+ * 1. Ensure a carousel container has been registered; throw when missing.
+ * 2. Record existing direct children of the container so new nodes can be identified later.
+ * 3. Run `appendCards(container, [judoka], gokyoLookup)` to build the DOM using real factories.
+ * 4. Await the resulting `ready` promise.
+ * 5. Re-run `addHoverZoomMarkers()` so the new card gets hover listeners.
+ * 6. Track any newly appended nodes so they can be removed during cleanup.
+ *
+ * @param {import("../types.js").Judoka} judoka - Judoka data used to create the card.
+ * @returns {Promise<void>} Resolves when the card has been generated and listeners attached.
+ */
+async function addTestCard(judoka) {
+  if (!state.container) {
+    throw new Error("Browse carousel is not ready for test cards.");
+  }
+  const container = state.container;
+  const existing = new Set(container.children);
+  const { ready } = appendCards(container, [judoka], state.gokyoLookup);
+  await ready;
+  addHoverZoomMarkers();
+  for (const node of container.children) {
+    if (!existing.has(node)) {
+      state.addedNodes.add(node);
+    }
+  }
+}
+
+/**
+ * Remove cards added through the test hook and restore animation state.
+ *
+ * @pseudocode
+ * 1. Re-enable hover animations if they were disabled.
+ * 2. Remove any nodes tracked in `addedNodes` that are still attached to the DOM.
+ * 3. Clear the `addedNodes` set to avoid leaking references across renders.
+ *
+ * @returns {void}
+ */
+function resetState() {
+  enableHoverAnimations();
+  for (const node of state.addedNodes) {
+    try {
+      node?.parentElement?.removeChild(node);
+    } catch {}
+  }
+  state.addedNodes.clear();
+}
+
+/**
+ * Update carousel references so the browse test hooks operate on the latest render.
+ *
+ * @pseudocode
+ * 1. Store the provided container and gokyo data in local state.
+ * 2. Pre-compute the gokyo lookup when data exists to match production behavior.
+ * 3. Clear any tracked nodes so stale references do not affect later resets.
+ * 4. Ensure global test hooks are attached to `window.__testHooks.browse`.
+ *
+ * @param {HTMLElement|null} container - Carousel container element.
+ * @param {import("../types.js").GokyoEntry[]|undefined} gokyoData - Raw gokyo list.
+ * @returns {void}
+ */
+export function updateBrowseTestHooksContext({ container, gokyoData }) {
+  state.container = container || null;
+  state.gokyoData = Array.isArray(gokyoData) ? gokyoData : [];
+  state.gokyoLookup = state.gokyoData.length ? createGokyoLookup(state.gokyoData) : {};
+  state.addedNodes.clear();
+  ensureBrowseHookContainer();
+}
+
+/**
+ * Reset browse-specific test hooks and remove any injected state.
+ *
+ * @pseudocode
+ * 1. Delegate to `resetState()` so animations and injected cards are cleared.
+ *
+ * @returns {void}
+ */
+export function resetBrowseTestHooks() {
+  resetState();
+}
+
+ensureBrowseHookContainer();

--- a/src/helpers/browseJudokaPage.js
+++ b/src/helpers/browseJudokaPage.js
@@ -10,6 +10,10 @@ import { setupButtonEffects } from "./buttonEffects.js";
 import { setupCountryToggle } from "./browse/setupCountryToggle.js";
 import { setupCountryFilter } from "./browse/setupCountryFilter.js";
 import { addHoverZoomMarkers } from "./setupHoverZoom.js";
+import {
+  resetBrowseTestHooks,
+  updateBrowseTestHooksContext
+} from "./browse/testHooks.js";
 
 let resolveBrowseReady;
 export const browseJudokaReadyPromise =
@@ -59,6 +63,7 @@ export function setupLayoutToggle(layoutBtn, panel) {
  * @returns {Promise<void>} A promise that resolves when the page setup is complete.
  */
 export async function setupBrowseJudokaPage() {
+  resetBrowseTestHooks();
   const carouselContainer = document.getElementById("carousel-container");
   if (!carouselContainer) {
     console.error("Carousel container not found. Cannot set up browse Judoka page.");
@@ -132,6 +137,7 @@ export async function setupBrowseJudokaPage() {
 
     setupButtonEffects();
     addHoverZoomMarkers();
+    updateBrowseTestHooksContext({ container: containerEl || null, gokyoData });
   }
 
   async function init() {


### PR DESCRIPTION
## Summary
- add a browse page test helper that exposes hover animation toggles and card factory access
- integrate the new hooks into the browse Judoka page setup so test state stays isolated
- update the hover zoom Playwright spec to rely on the helper instead of manual DOM mutations

## Testing
- npx playwright test playwright/hover-zoom.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68ce7855ea888326a8699441136b9682