### PR TITLE
Handle refused ready dispatch and add retry test

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -145,7 +145,11 @@ async function dispatchReadyOnce(resolveReady) {
   }
   setReadyDispatchedForCurrentCooldown(true);
   try {
-    await dispatchBattleEvent("ready");
+    const result = await dispatchBattleEvent("ready");
+    if (result === false) {
+      setReadyDispatchedForCurrentCooldown(false);
+      return false;
+    }
   } catch (error) {
     // Reset the flag if dispatch fails to allow retry
     setReadyDispatchedForCurrentCooldown(false);
@@ -181,7 +185,7 @@ export async function advanceWhenReady(btn, resolveReady) {
     } catch {}
   }
   const dispatched = await dispatchReadyOnce(resolveReady);
-  setSkipHandler(null);
+  if (dispatched) setSkipHandler(null);
   if (!dispatched) return;
 }
 

--- a/tests/classicBattle/timer.test.js
+++ b/tests/classicBattle/timer.test.js
@@ -43,4 +43,54 @@ describe("Classic Battle round timer", () => {
       timers.useRealTimers();
     }
   });
+
+  test("retries ready dispatch when initial attempt is refused", async () => {
+    vi.resetModules();
+    const dispatchBattleEventMock = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+
+    vi.doMock("../../src/helpers/classicBattle/eventDispatcher.js", async () => {
+      const actual = await vi.importActual("../../src/helpers/classicBattle/eventDispatcher.js");
+      return {
+        ...actual,
+        dispatchBattleEvent: dispatchBattleEventMock
+      };
+    });
+
+    const skipModule = await import("../../src/helpers/classicBattle/skipHandler.js");
+    const skipSpy = vi.spyOn(skipModule, "setSkipHandler");
+
+    try {
+      const readyState = await import("../../src/helpers/classicBattle/roundReadyState.js");
+      readyState.setReadyDispatchedForCurrentCooldown(false);
+
+      const { advanceWhenReady } = await import("../../src/helpers/classicBattle/timerService.js");
+
+      const resolveReady = vi.fn();
+      const button = { disabled: false, dataset: {} };
+
+      await advanceWhenReady(button, resolveReady);
+
+      expect(dispatchBattleEventMock).toHaveBeenCalledTimes(1);
+      expect(resolveReady).not.toHaveBeenCalled();
+      expect(skipSpy).not.toHaveBeenCalled();
+      expect(readyState.hasReadyBeenDispatchedForCurrentCooldown()).toBe(false);
+
+      skipSpy.mockClear();
+      resolveReady.mockClear();
+      button.disabled = false;
+
+      await advanceWhenReady(button, resolveReady);
+
+      expect(dispatchBattleEventMock).toHaveBeenCalledTimes(2);
+      expect(resolveReady).toHaveBeenCalledTimes(1);
+      expect(skipSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      skipSpy.mockRestore();
+      vi.doUnmock("../../src/helpers/classicBattle/eventDispatcher.js");
+      vi.resetModules();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- reset the round-ready flag when `dispatchBattleEvent("ready")` returns `false` so callers can retry and only clear the skip handler after a successful dispatch
- ensure `advanceWhenReady` respects the new retry behavior and add a regression test covering a refused ready dispatch followed by a retry

## Testing
- `npx vitest run tests/classicBattle/timer.test.js` *(fails: vite import-analysis parse error in src/helpers/classicBattle/testHooks.js, existing syntax issue)*

## Risk
- Low: targeted change to ready dispatch handling with focused unit coverage.

------
https://chatgpt.com/codex/tasks/task_e_68ce7bed75b083268c4b507b08a55393