### PR TITLE
Ensure Next button honors skip cooldown flag

### DIFF
--- a/src/helpers/classicBattle/testHooks.js
+++ b/src/helpers/classicBattle/testHooks.js
@@ -118,7 +118,7 @@ const renderStatsCardForTest = async (target, base, overrides) => {
   try {
     container.dataset.cardJson = JSON.stringify(cardData);
   } catch (error) {
-    console.warn("Failed to serialize card  error);
+    console.warn("Failed to serialize card", error);
     container.dataset.cardJson = JSON.stringify({ id: cardData.id, stats: cardData.stats });
   }
   container.className = "card-container";

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -228,7 +228,7 @@ export async function cancelTimerOrAdvance(_btn, timer, resolveReady) {
  * `cancelTimerOrAdvance` to stop an active timer / advance when in cooldown.
  *
  * @pseudocode
- * 1. Call `skipRoundCooldownIfEnabled`; return early if it skips.
+ * 1. Ask `skipRoundCooldownIfEnabled` to execute its fast path when available.
  * 2. Emit `countdownFinished` via the battle event bus.
  * 3. Read `controls` (timer and resolveReady) from `getNextRoundControls()` when not supplied.
  * 4. If the Next button element has `data-next-ready="true"`, call `advanceWhenReady`.
@@ -240,7 +240,12 @@ export async function cancelTimerOrAdvance(_btn, timer, resolveReady) {
  * @returns {Promise<void>}
  */
 export async function onNextButtonClick(_evt, controls = getNextRoundControls(), options = {}) {
-  if (skipRoundCooldownIfEnabled()) return;
+  const skipHintConsumed = skipRoundCooldownIfEnabled({
+    onSkip: () => setSkipHandler(null)
+  });
+  if (skipHintConsumed) {
+    timerLogger.debug("skipRoundCooldown hint consumed during Next click");
+  }
   emitBattleEvent("countdownFinished");
   emitBattleEvent("round.start");
   const { timer = null, resolveReady = null } = controls || {};

--- a/src/helpers/classicBattle/uiService.js
+++ b/src/helpers/classicBattle/uiService.js
@@ -172,8 +172,11 @@ function bindUIServiceEventHandlers() {
 
   onBattleEvent("countdownStart", (e) => {
     // If the skip flag is enabled, immediately finish the countdown
-    if (uiHelpers.skipRoundCooldownIfEnabled?.()) {
-      handleCountdownExpired();
+    if (
+      uiHelpers.skipRoundCooldownIfEnabled?.({
+        onSkip: handleCountdownExpired
+      })
+    ) {
       return;
     }
     const { duration, onFinished } = e.detail || {};

--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -1602,7 +1602,16 @@ function handleStatSelectionStalled() {
 }
 
 function handleCountdownStart(e) {
-  if (skipRoundCooldownIfEnabled()) return;
+  if (
+    skipRoundCooldownIfEnabled({
+      onSkip: () => {
+        emitBattleEvent("countdownFinished");
+        emitBattleEvent("round.start");
+      }
+    })
+  ) {
+    return;
+  }
   const ds = typeof document !== "undefined" ? document.body?.dataset : undefined;
   if (ds) ds.battleState = "cooldown";
   // Ensure score line reflects the resolved round before any user interaction

--- a/tests/classicBattle/timer.test.js
+++ b/tests/classicBattle/timer.test.js
@@ -43,4 +43,50 @@ describe("Classic Battle round timer", () => {
       timers.useRealTimers();
     }
   });
+  test("Next button dispatches ready when skip flag is active", async () => {
+    const timers = vi.useFakeTimers();
+    const previousOverrides = typeof window !== "undefined" ? window.__FF_OVERRIDES : undefined;
+    if (typeof window !== "undefined") {
+      window.__FF_OVERRIDES = { ...(previousOverrides || {}), skipRoundCooldown: true };
+    }
+    let readySpy;
+    try {
+      const { createBattleHeader } = await import("../utils/testUtils.js");
+      const header = createBattleHeader();
+      const nextButton = document.createElement("button");
+      nextButton.id = "next-button";
+      document.body.append(header, nextButton);
+
+      const dispatcher = await import("../../src/helpers/classicBattle/eventDispatcher.js");
+      readySpy = vi.spyOn(dispatcher, "dispatchBattleEvent").mockResolvedValue();
+
+      const { __setStateSnapshot } = await import("../../src/helpers/classicBattle/battleDebug.js");
+      __setStateSnapshot({ state: "cooldown" });
+
+      const { onNextButtonClick } = await import("../../src/helpers/classicBattle/timerService.js");
+      const resolveReady = vi.fn();
+      nextButton.dataset.nextReady = "true";
+
+      await onNextButtonClick(
+        new MouseEvent("click"),
+        { timer: null, resolveReady },
+        { root: document }
+      );
+
+      expect(readySpy).toHaveBeenCalledWith("ready");
+      expect(resolveReady).toHaveBeenCalledTimes(1);
+      expect(nextButton.disabled).toBe(true);
+    } finally {
+      if (readySpy) readySpy.mockRestore();
+      if (typeof window !== "undefined") {
+        if (previousOverrides) {
+          window.__FF_OVERRIDES = previousOverrides;
+        } else {
+          delete window.__FF_OVERRIDES;
+        }
+      }
+      document.body.innerHTML = "";
+      timers.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- allow skipRoundCooldownIfEnabled to execute optional fast-path callbacks when the flag is active
- ensure the Next button always emits countdown completion and advances even if skip-round-cooldown is enabled, including CLI/UI services
- extend timer tests to cover the skip flag path for manual Next clicks

## Testing
- `npx vitest run tests/helpers/timerService.onNextButtonClick.test.js tests/classicBattle/timer.test.js` *(fails: vite import analysis hits existing syntax errors in src/helpers/classicBattle/testHooks.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7bf358a48326af3b433ebfdb4eab