### PR TITLE
Guard cooldown completion button readiness

### DIFF
--- a/src/helpers/classicBattle/cooldowns.js
+++ b/src/helpers/classicBattle/cooldowns.js
@@ -240,7 +240,13 @@ export function createCooldownCompletion({ machine, timer, button, scheduler }) 
     guard(() => timer?.stop?.());
     guard(() => setSkipHandler(null));
     const target = button || getNextButton();
-    guard(() => markNextButtonReady(target));
+    const isTargetReady =
+      !!target &&
+      target.disabled === false &&
+      (target.dataset?.nextReady === "true" || target.getAttribute("data-next-ready") === "true");
+    if (!isTargetReady) {
+      guard(() => markNextButtonReady(target));
+    }
     for (const evt of [
       "cooldown.timer.expired",
       "nextRoundTimerReady",


### PR DESCRIPTION
## Summary
- add a readiness guard in the cooldown completion handler so it skips redundant updates when the Next button is already ready

## Files Changed
- src/helpers/classicBattle/cooldowns.js

## Testing
- `npx vitest tests/helpers/classicBattle/initInterRoundCooldown.event.test.js`

## Risk
- Low: change is limited to readiness guard logic and covered by existing cooldown tests.

## Task Contract
- Inputs: `src/helpers/classicBattle/cooldowns.js`, `tests/helpers/classicBattle/initInterRoundCooldown.event.test.js`
- Outputs: `src/helpers/classicBattle/cooldowns.js`
- Success: `npx vitest tests/helpers/classicBattle/initInterRoundCooldown.event.test.js`
- Error Mode: `ask_on_public_api_change`


------
https://chatgpt.com/codex/tasks/task_e_68ce87f66ce88326928f47216657f3d0