### PR TITLE
Fix browse test hook cleanup and card wiring

### DIFF
--- a/src/helpers/browse/testHooks.js
+++ b/src/helpers/browse/testHooks.js
@@ -90,11 +90,17 @@ async function addTestCard(judoka) {
   const existing = new Set(container.children);
   const { ready } = appendCards(container, [judoka], state.gokyoLookup);
   await ready;
-  addHoverZoomMarkers(container);
+
+  let hasNewNodes = false;
   for (const node of container.children) {
     if (!existing.has(node)) {
       state.addedNodes.add(node);
+      hasNewNodes = true;
     }
+  }
+
+  if (hasNewNodes) {
+    addHoverZoomMarkers();
   }
 }
 
@@ -109,13 +115,17 @@ async function addTestCard(judoka) {
 function resetState() {
   enableHoverAnimations();
   for (const node of state.addedNodes) {
+    if (!node?.parentElement) continue;
     try {
-      node?.parentElement?.removeChild(node);
+      node.parentElement.removeChild(node);
     } catch (error) {
-      // Only ignore errors for nodes that are already removed
-      if (error?.name !== "NotFoundError" && !error?.message?.includes("not a child")) {
-        console.warn("Error removing test node during cleanup:", error);
+      if (
+        error?.name === "NotFoundError" ||
+        error?.message?.includes("not a child")
+      ) {
+        continue;
       }
+      throw error;
     }
   }
   state.addedNodes.clear();


### PR DESCRIPTION
## Summary
- re-run hover zoom wiring only when new browse cards are appended and track them for cleanup
- guard browse test reset against already-removed nodes while clearing hover animation overrides

## Testing
- node --check src/helpers/browse/testHooks.js
- npx vitest run tests/helpers/browseJudokaPage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ce87eaf03c8326b2d1f4c30a253885