### PR TITLE
Ensure ready promise resolves when dispatch is skipped

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -144,11 +144,12 @@ async function dispatchReadyOnce(resolveReady) {
     return false;
   }
   setReadyDispatchedForCurrentCooldown(true);
+  let dispatched = true;
   try {
     const result = await dispatchBattleEvent("ready");
     if (result === false) {
+      dispatched = false;
       setReadyDispatchedForCurrentCooldown(false);
-      return false;
     }
   } catch (error) {
     // Reset the flag if dispatch fails to allow retry
@@ -156,7 +157,7 @@ async function dispatchReadyOnce(resolveReady) {
     throw error;
   }
   if (typeof resolveReady === "function") resolveReady();
-  return true;
+  return dispatched;
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure `dispatchReadyOnce` still resolves cooldown controls when the ready dispatch returns `false`
- keep the cooldown ready dedupe flag consistent so retries stay possible
- add cooldown coverage asserting the ready promise settles without an active machine

## Testing
- npx vitest tests/classicBattle/cooldown.test.js
- npx eslint src/helpers/classicBattle/timerService.js tests/classicBattle/cooldown.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ce8b44a94c832686dee968946767f7