### PR TITLE
Add shared Classic Battle DOM harness for orchestrator tests

### DIFF
--- a/tests/helpers/classicBattle/createTestBattleDom.js
+++ b/tests/helpers/classicBattle/createTestBattleDom.js
@@ -1,0 +1,60 @@
+import { vi } from "vitest";
+import { setupClassicBattleDom } from "./utils.js";
+import { domStateListener } from "../../../src/helpers/classicBattle/stateTransitionListeners.js";
+
+/**
+ * @summary Build a Classic Battle DOM harness with state synchronization.
+ * @returns {Promise<{
+ *   timerSpy: import("vitest").FakeTimers,
+ *   fetchJsonMock: import("vitest").Mock,
+ *   generateRandomCardMock: import("vitest").Mock,
+ *   getRandomJudokaMock: import("vitest").Mock,
+ *   renderMock: import("vitest").Mock,
+ *   currentFlags: Record<string, any>,
+ *   dispatchBattleState: (detail: {from?: string|null, to: string|null, event?: string|null}) => {
+ *     from?: string|null,
+ *     to: string|null,
+ *     event?: string|null
+ *   },
+ *   cleanup: () => void
+ * }>} Harness helpers for Classic Battle tests.
+ * @pseudocode
+ * create harness
+ *   - run setupClassicBattleDom to prepare core nodes and mocks
+ *   - import the real battleEvents module with vi.importActual
+ *   - reset the event target for isolation and register domStateListener
+ * expose helpers
+ *   - dispatchBattleState(detail): dispatch CustomEvent via shared target
+ *   - cleanup(): remove domStateListener listener
+ */
+export async function createTestBattleDom() {
+  const env = setupClassicBattleDom();
+  const battleEvents = await vi.importActual("../../../src/helpers/classicBattle/battleEvents.js");
+
+  if (typeof battleEvents.__resetBattleEventTarget === "function") {
+    battleEvents.__resetBattleEventTarget();
+  }
+
+  const target = battleEvents.getBattleEventTarget();
+  battleEvents.onBattleEvent("battleStateChange", domStateListener);
+
+  const dispatchBattleState = (detail) => {
+    const eventDetail = {
+      from: detail?.from ?? null,
+      to: detail?.to ?? null,
+      event: detail?.event ?? null
+    };
+    target.dispatchEvent(new CustomEvent("battleStateChange", { detail: eventDetail }));
+    return eventDetail;
+  };
+
+  const cleanup = () => {
+    battleEvents.offBattleEvent("battleStateChange", domStateListener);
+  };
+
+  return {
+    ...env,
+    dispatchBattleState,
+    cleanup
+  };
+}

--- a/tests/helpers/orchestratorHandlers.computeOutcome.test.js
+++ b/tests/helpers/orchestratorHandlers.computeOutcome.test.js
@@ -1,8 +1,10 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTestBattleDom } from "./classicBattle/createTestBattleDom.js";
 let debugHooks;
 
 let store;
+let cleanupBattleDom;
 beforeEach(async () => {
   vi.resetModules();
   debugHooks = await import("../../src/helpers/classicBattle/debugHooks.js");
@@ -14,6 +16,11 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  if (cleanupBattleDom) {
+    cleanupBattleDom();
+    cleanupBattleDom = undefined;
+  }
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -34,8 +41,9 @@ describe("computeAndDispatchOutcome", () => {
 
     const mod = await import("../../src/helpers/classicBattle/orchestratorHandlers.js");
 
-    document.body.innerHTML = '<div id="player-card"></div><div id="opponent-card"></div>';
-    document.body.dataset.battleState = "roundDecision";
+    const { cleanup, dispatchBattleState } = await createTestBattleDom();
+    cleanupBattleDom = cleanup;
+    dispatchBattleState({ from: "waitingForPlayerAction", to: "roundDecision" });
     debugHooks.exposeDebugState("roundDebug", {});
 
     const store = { playerChoice: "strength" };
@@ -46,7 +54,6 @@ describe("computeAndDispatchOutcome", () => {
 
     expect(machine.dispatch).toHaveBeenCalledWith("outcome=winPlayer");
     expect(machine.dispatch).toHaveBeenCalledWith("continue");
-    vi.useRealTimers();
   });
 
   it("waits for user input when autoContinue is disabled", async () => {
@@ -66,8 +73,9 @@ describe("computeAndDispatchOutcome", () => {
     const mod = await import("../../src/helpers/classicBattle/orchestratorHandlers.js");
     mod.setAutoContinue(false);
 
-    document.body.innerHTML = '<div id="player-card"></div><div id="opponent-card"></div>';
-    document.body.dataset.battleState = "roundDecision";
+    const { cleanup, dispatchBattleState } = await createTestBattleDom();
+    cleanupBattleDom = cleanup;
+    dispatchBattleState({ from: "waitingForPlayerAction", to: "roundDecision" });
     debugHooks.exposeDebugState("roundDebug", {});
 
     const store = { playerChoice: "strength" };
@@ -78,7 +86,6 @@ describe("computeAndDispatchOutcome", () => {
 
     expect(machine.dispatch).toHaveBeenCalledWith("outcome=winPlayer");
     expect(machine.dispatch).not.toHaveBeenCalledWith("continue");
-    vi.useRealTimers();
   });
 
   it("dispatches interrupt when no outcome is produced", async () => {
@@ -96,8 +103,9 @@ describe("computeAndDispatchOutcome", () => {
 
     const mod = await import("../../src/helpers/classicBattle/orchestratorHandlers.js");
 
-    document.body.innerHTML = '<div id="player-card"></div><div id="opponent-card"></div>';
-    document.body.dataset.battleState = "roundDecision";
+    const { cleanup, dispatchBattleState } = await createTestBattleDom();
+    cleanupBattleDom = cleanup;
+    dispatchBattleState({ from: "waitingForPlayerAction", to: "roundDecision" });
     debugHooks.exposeDebugState("roundDebug", {});
 
     const store = { playerChoice: "strength" };


### PR DESCRIPTION
## Summary
- add a Classic Battle DOM harness that composes `setupClassicBattleDom` with the real `domStateListener`
- refactor `orchestratorHandlers.computeOutcome` tests to rely on the harness and dispatch `battleStateChange`

## Testing
- npx vitest run tests/helpers/orchestratorHandlers.computeOutcome.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ce8b22cb5083268aa0649690df8b90