### PR TITLE
Add shared Battle CLI DOM scaffold for unit tests

### DIFF
--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -155,8 +155,209 @@ try {
 const statDisplayNames = {};
 let cachedStatDefs = null;
 
+const CLI_DOM_TEMPLATE = `
+  <div class="terminal-title-bar">bash — JU-DO-KON</div>
+  <a href="#cli-main" class="skip-link">Skip to main content</a>
+  <div id="cli-root" class="cli-root" data-round="0" data-target="0" data-test="cli-root">
+    <header id="cli-header" class="cli-header" role="banner">
+      <div class="cli-title">
+        <a href="../../index.html" data-testid="home-link" aria-label="Return to home">Home</a>
+        &nbsp;|&nbsp; Classic Battle (CLI)
+        <span id="battle-state-badge" data-flag="battleStateBadge" class="state-badge" style="display: none">State: —</span>
+      </div>
+      <div class="cli-status" aria-live="polite" aria-atomic="true">
+        <div id="cli-round">Round 0 Target: 10</div>
+        <div
+          id="cli-score"
+          data-score-player="0"
+          data-score-opponent="0"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          You: 0 Opponent: 0
+        </div>
+      </div>
+      <div class="standard-scoreboard-nodes" style="display: none" aria-hidden="true">
+        <p id="next-round-timer" aria-atomic="true" role="status"></p>
+        <p id="round-counter" aria-atomic="true">Round 0</p>
+        <p id="score-display" aria-live="off" aria-atomic="true">You: 0 Opponent: 0</p>
+      </div>
+    </header>
+    <main id="cli-main" class="cli-main" role="main">
+      <section aria-label="Round Status" class="cli-block">
+        <div id="round-message" role="status" aria-live="polite" aria-atomic="true"></div>
+        <div id="cli-countdown" role="status" aria-live="polite" data-remaining-time="0"></div>
+      </section>
+      <div class="ascii-sep">────────────────────────</div>
+      <section aria-label="Match Settings" class="cli-block cli-settings">
+        <div class="cli-settings-header d-flex align-items-center justify-content-between">
+          <div class="fw-600">Match Settings</div>
+          <div>
+            <button
+              id="cli-settings-toggle"
+              data-testid="settings-button"
+              aria-expanded="true"
+              aria-controls="cli-settings-body"
+              class="button-reset"
+            >
+              Settings ▾
+            </button>
+          </div>
+        </div>
+        <div id="cli-settings-body">
+          <div class="cli-settings-row">
+            <label for="points-select">Win target:</label>
+            <select id="points-select" aria-label="Points to win" data-tooltip-id="settings.pointsToWin">
+              <option value="5">5</option>
+              <option value="10" selected>10</option>
+              <option value="15">15</option>
+            </select>
+          </div>
+          <div class="cli-settings-row">
+            <label for="verbose-toggle">Verbose:</label>
+            <input
+              id="verbose-toggle"
+              type="checkbox"
+              aria-label="Toggle verbose logging"
+              data-flag="cliVerbose"
+            />
+          </div>
+          <div class="cli-settings-row">
+            <label for="seed-input">Seed:</label>
+            <div class="d-flex flex-col">
+              <input
+                id="seed-input"
+                type="number"
+                inputmode="numeric"
+                aria-label="Deterministic seed (optional)"
+                aria-describedby="seed-error"
+                class="seed-input"
+              />
+              <div id="seed-error" class="seed-error"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <div class="ascii-sep">────────────────────────</div>
+      <section aria-label="Stat Selection" class="cli-block">
+        <div
+          id="cli-stats"
+          role="listbox"
+          tabindex="0"
+          aria-label="Select a stat with number keys 1–5"
+          aria-busy="true"
+          data-skeleton="true"
+        >
+          <div class="cli-stat skeleton" role="presentation" style="display: flex; min-height: 44px">(1) ─────────────── ─</div>
+          <div class="cli-stat skeleton" role="presentation" style="display: flex; min-height: 44px">(2) ─────────────── ─</div>
+          <div class="cli-stat skeleton" role="presentation" style="display: flex; min-height: 44px">(3) ─────────────── ─</div>
+          <div class="cli-stat skeleton" role="presentation" style="display: flex; min-height: 44px">(4) ─────────────── ─</div>
+          <div class="cli-stat skeleton" role="presentation" style="display: flex; min-height: 44px">(5) ─────────────── ─</div>
+        </div>
+      </section>
+      <div class="ascii-sep">────────────────────────</div>
+      <section aria-label="Shortcuts" id="cli-shortcuts" class="cli-block cli-settings" data-flag="cliShortcuts" hidden>
+        <div class="cli-settings-header d-flex align-items-center justify-content-between">
+          <div class="fw-600">Shortcuts</div>
+          <div>
+            <button
+              id="cli-shortcuts-close"
+              aria-label="Close help"
+              aria-controls="cli-shortcuts-body"
+              aria-expanded="false"
+              class="button-reset"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+        <div id="cli-shortcuts-body">
+          <ul id="cli-help">
+            <li>[1–5] Select Stat</li>
+            <li>[Enter]/[Space] Next</li>
+            <li>[Q] Quit</li>
+            <li>[H] Toggle Help</li>
+          </ul>
+        </div>
+      </section>
+      <div class="ascii-sep">────────────────────────</div>
+      <section aria-label="Verbose Log" id="cli-verbose-section" class="cli-block" data-flag="cliVerbose" hidden>
+        <pre id="cli-verbose-log" aria-atomic="false" class="pre-wrap"></pre>
+      </section>
+      <div id="cli-prompt" role="status" aria-label="Command prompt">
+        &gt; <span id="cli-cursor" aria-hidden="true">▌</span>
+      </div>
+    </main>
+    <footer class="cli-footer" role="contentinfo">
+      <div id="cli-controls-hint" aria-hidden="true">[1–5] Stats · [Enter/Space] Next · [H] Help · [Q] Quit</div>
+      <div id="snackbar-container" role="status" aria-live="polite"></div>
+    </footer>
+    <div id="player-card" style="display: none"></div>
+    <div id="opponent-card" style="display: none"></div>
+    <div id="modal-container"></div>
+  </div>
+`;
+
+/**
+ * Ensure the CLI DOM scaffold exists for tests.
+ *
+ * @summary Reset the document body to the production Battle CLI structure when needed.
+ * @param {{ reset?: boolean }} [options]
+ * @returns {HTMLElement | null}
+ * @pseudocode
+ * if document undefined → return null
+ * if !reset and #cli-root exists → return it
+ * build a template container with CLI_DOM_TEMPLATE
+ * replace document.body children with the template fragment
+ * clear body class & dataset
+ * reveal standard scoreboard nodes to match post-init state
+ * ensure countdown has remainingTime dataset
+ * return #cli-root element
+ */
+function ensureCliDomForTest({ reset = false } = {}) {
+  if (typeof document === "undefined") return null;
+
+  const existing = document.getElementById("cli-root");
+  if (existing && !reset) {
+    return existing;
+  }
+
+  const body = document.body;
+  if (!body) return null;
+
+  const container = document.createElement("div");
+  container.innerHTML = CLI_DOM_TEMPLATE;
+  const fragment = document.createDocumentFragment();
+  while (container.firstChild) {
+    fragment.appendChild(container.firstChild);
+  }
+
+  body.replaceChildren(fragment);
+  body.className = "";
+  try {
+    const keys = Object.keys(body.dataset || {});
+    for (const key of keys) {
+      delete body.dataset[key];
+    }
+  } catch {}
+
+  const standardNodes = document.querySelector(".standard-scoreboard-nodes");
+  if (standardNodes) {
+    standardNodes.style.display = "block";
+    standardNodes.removeAttribute("aria-hidden");
+  }
+
+  const countdown = document.getElementById("cli-countdown");
+  if (countdown && !countdown.dataset.remainingTime) {
+    countdown.dataset.remainingTime = "0";
+  }
+
+  return document.getElementById("cli-root");
+}
+
 // Test hooks to access internal timer state
 export const __test = {
+  ensureCliDomForTest,
   setCooldownTimers(timer, interval) {
     cooldownTimer = timer;
     cooldownInterval = interval;

--- a/tests/pages/battleCLI.handlers.test.js
+++ b/tests/pages/battleCLI.handlers.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import statNamesData from "../../src/data/statNames.js";
 
 let cleanupSetAutoContinue;
@@ -70,20 +70,12 @@ async function loadHandlers({ autoSelect = false, skipCooldown = false } = {}) {
 async function setupHandlers(options) {
   const result = await loadHandlers(options);
   cleanupSetAutoContinue = result.setAutoContinue;
+  result.handlers.ensureCliDomForTest({ reset: true });
   await result.handlers.renderStatList();
   return result;
 }
 
 describe("battleCLI event handlers", () => {
-  beforeEach(() => {
-    document.body.innerHTML =
-      '<div id="cli-stats"></div>' +
-      '<ul id="cli-help"></ul>' +
-      '<div id="round-message"></div>' +
-      '<div id="snackbar-container"></div>' +
-      '<main id="cli-main"></main>' +
-      '<pre id="cli-verbose-log"></pre>';
-  });
   afterEach(() => {
     document.body.innerHTML = "";
     delete window.__TEST__;
@@ -147,10 +139,9 @@ describe("battleCLI event handlers", () => {
   it("captures remaining selection time when paused", async () => {
     vi.useFakeTimers();
     const { handlers } = await setupHandlers();
-    const countdown = document.createElement("div");
-    countdown.id = "cli-countdown";
+    const countdown = document.getElementById("cli-countdown");
     countdown.dataset.remainingTime = "5";
-    document.body.appendChild(countdown);
+    countdown.setAttribute("data-remaining-time", "5");
     handlers.setSelectionTimers(
       setTimeout(() => {}, 5000),
       setInterval(() => {}, 1000)
@@ -165,11 +156,11 @@ describe("battleCLI event handlers", () => {
   it("captures remaining cooldown time when paused", async () => {
     vi.useFakeTimers();
     const { handlers } = await setupHandlers();
-    const bar = document.getElementById("snackbar-container");
-    const snack = document.createElement("div");
-    snack.className = "snackbar";
-    snack.textContent = "Next round in: 7";
-    bar.appendChild(snack);
+    handlers.handleCountdownStart({ detail: { duration: 7 } });
+    const { cooldownTimer: originalTimer, cooldownInterval: originalInterval } =
+      handlers.getCooldownTimers();
+    clearTimeout(originalTimer);
+    clearInterval(originalInterval);
     handlers.setCooldownTimers(
       setTimeout(() => {}, 7000),
       setInterval(() => {}, 1000)
@@ -184,19 +175,18 @@ describe("battleCLI event handlers", () => {
   it("preserves remaining time when paused twice", async () => {
     vi.useFakeTimers();
     const { handlers } = await setupHandlers();
-    const countdown = document.createElement("div");
-    countdown.id = "cli-countdown";
+    const countdown = document.getElementById("cli-countdown");
     countdown.dataset.remainingTime = "5";
-    document.body.appendChild(countdown);
+    countdown.setAttribute("data-remaining-time", "5");
     handlers.setSelectionTimers(
       setTimeout(() => {}, 5000),
       setInterval(() => {}, 1000)
     );
-    const bar = document.getElementById("snackbar-container");
-    const snack = document.createElement("div");
-    snack.className = "snackbar";
-    snack.textContent = "Next round in: 7";
-    bar.appendChild(snack);
+    handlers.handleCountdownStart({ detail: { duration: 7 } });
+    const { cooldownTimer: originalTimer, cooldownInterval: originalInterval } =
+      handlers.getCooldownTimers();
+    clearTimeout(originalTimer);
+    clearInterval(originalInterval);
     handlers.setCooldownTimers(
       setTimeout(() => {}, 7000),
       setInterval(() => {}, 1000)
@@ -353,10 +343,11 @@ describe("battleCLI event handlers", () => {
       setTimeout(() => {}, 0),
       setInterval(() => {}, 100)
     );
-    const bar = document.createElement("div");
-    bar.className = "snackbar";
-    bar.textContent = "Next round in: 3";
-    document.getElementById("snackbar-container").appendChild(bar);
+    handlers.handleCountdownStart({ detail: { duration: 3 } });
+    const { cooldownTimer: originalTimer, cooldownInterval: originalInterval } =
+      handlers.getCooldownTimers();
+    clearTimeout(originalTimer);
+    clearInterval(originalInterval);
     handlers.onClickAdvance({ target: document.body });
     expect(mockDispatch).toHaveBeenCalledWith("ready");
     expect(handlers.getCooldownTimers()).toEqual({

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -35,15 +35,7 @@ describe("battleCLI onKeyDown", () => {
       battleCLI: __test,
       getEscapeHandledPromise
     } = await import("../../src/pages/index.js"));
-    document.body.innerHTML = `
-      <div id="cli-root">
-        <div id="cli-main"></div>
-      </div>
-      <div id="cli-shortcuts" hidden><button id="cli-shortcuts-close"></button></div>
-      <div id="cli-countdown" aria-live="polite"></div>
-      <div id="snackbar-container"></div>
-      <div id="modal-container"></div>
-    `;
+    __test.ensureCliDomForTest({ reset: true });
     document.body.className = "";
     document.body.dataset.battleState = "";
   });
@@ -112,13 +104,13 @@ describe("battleCLI onKeyDown", () => {
   });
 
   it("routes arrow keys to stat list navigation", async () => {
-    const list = document.createElement("ul");
-    list.id = "cli-stats";
-    const li = document.createElement("li");
-    list.appendChild(li);
-    document.getElementById("cli-main").appendChild(list);
-    li.tabIndex = -1;
-    li.focus();
+    const list = document.getElementById("cli-stats");
+    list.innerHTML = "";
+    const item = document.createElement("div");
+    item.className = "cli-stat";
+    item.tabIndex = -1;
+    list.appendChild(item);
+    item.focus();
     const battleHandlers = await import("../../src/pages/battleCLI/battleHandlers.js");
     const spy = vi.spyOn(battleHandlers, "handleStatListArrowKey");
     onKeyDown(new KeyboardEvent("keydown", { key: "ArrowDown" }));

--- a/tests/pages/battleCLI.scoreboard.test.js
+++ b/tests/pages/battleCLI.scoreboard.test.js
@@ -60,8 +60,7 @@ describe("battleCLI scoreboard", () => {
 
   it("updates after player win", async () => {
     const handlers = await loadHandlers({ playerScore: 1, opponentScore: 0 });
-    document.body.innerHTML =
-      '<div id="round-message"></div><div id="cli-score" data-score-player="0" data-score-opponent="0">You: 0 Opponent: 0</div>';
+    handlers.ensureCliDomForTest({ reset: true });
     handlers.handleRoundResolved({ detail: { result: { message: "Win" } } });
     const el = document.getElementById("cli-score");
     expect(el.dataset.scorePlayer).toBe("1");
@@ -70,8 +69,11 @@ describe("battleCLI scoreboard", () => {
 
   it("updates after player loss", async () => {
     const handlers = await loadHandlers({ playerScore: 0, opponentScore: 1 });
-    document.body.innerHTML =
-      '<div id="round-message"></div><div id="cli-score" data-score-player="2" data-score-opponent="2">You: 2 Opponent: 2</div>';
+    handlers.ensureCliDomForTest({ reset: true });
+    const scoreEl = document.getElementById("cli-score");
+    scoreEl.dataset.scorePlayer = "2";
+    scoreEl.dataset.scoreOpponent = "2";
+    scoreEl.textContent = "You: 2 Opponent: 2";
     handlers.handleRoundResolved({ detail: { result: { message: "Loss" } } });
     const el = document.getElementById("cli-score");
     expect(el.dataset.scorePlayer).toBe("0");
@@ -80,8 +82,11 @@ describe("battleCLI scoreboard", () => {
 
   it("updates after draw", async () => {
     const handlers = await loadHandlers({ playerScore: 0, opponentScore: 0 });
-    document.body.innerHTML =
-      '<div id="round-message"></div><div id="cli-score" data-score-player="5" data-score-opponent="6">You: 5 Opponent: 6</div>';
+    handlers.ensureCliDomForTest({ reset: true });
+    const scoreEl = document.getElementById("cli-score");
+    scoreEl.dataset.scorePlayer = "5";
+    scoreEl.dataset.scoreOpponent = "6";
+    scoreEl.textContent = "You: 5 Opponent: 6";
     handlers.handleRoundResolved({ detail: { result: { message: "Draw" } } });
     const el = document.getElementById("cli-score");
     expect(el.dataset.scorePlayer).toBe("0");

--- a/tests/pages/utils/loadBattleCLI.js
+++ b/tests/pages/utils/loadBattleCLI.js
@@ -34,30 +34,6 @@ export async function loadBattleCLI(options = {}) {
     mockBattleEngine = true
   } = options;
 
-  const baseHtml = `
-    <div id="cli-root"></div>
-    <main id="cli-main"></main>
-    <div id="cli-round"></div>
-    <div id="cli-stats" tabindex="0"></div>
-    <div id="cli-help"></div>
-    <select id="points-select">
-      <option value="5">5</option>
-      <option value="10">10</option>
-      <option value="15">15</option>
-    </select>
-    <section id="cli-verbose-section" hidden>
-      <pre id="cli-verbose-log"></pre>
-    </section>
-    <input id="verbose-toggle" type="checkbox" />
-    <div id="cli-shortcuts" hidden><button id="cli-shortcuts-close"></button><div id="cli-shortcuts-body"></div></div>
-    <span id="battle-state-badge"></span>
-    <div id="round-message"></div>
-    <div id="cli-countdown"></div>
-    <div id="cli-score" data-score-player="0" data-score-opponent="0"></div>
-    <div id="snackbar-container"></div>
-    <div id="cli-controls-hint" aria-hidden="true"></div>
-  `;
-  document.body.innerHTML = baseHtml + html;
   window.__TEST__ = true;
   if (url) {
     vi.stubGlobal("location", new URL(url));
@@ -178,7 +154,12 @@ export async function loadBattleCLI(options = {}) {
   }
 
   const mod = await import("../../../src/pages/index.js");
-  return mod.battleCLI;
+  const cli = mod.battleCLI;
+  cli.ensureCliDomForTest({ reset: true });
+  if (html) {
+    document.body.insertAdjacentHTML("beforeend", html);
+  }
+  return cli;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add the production CLI DOM scaffold to `battleCLI.__test.ensureCliDomForTest` so tests can rebuild the page structure deterministically
- refactor the Battle CLI unit tests and helpers to invoke the shared scaffold (directly or via `loadBattleCLI`) instead of crafting ad-hoc DOM fragments
- update countdown- and scoreboard-related specs to rely on real handlers for snackbar/countdown nodes rather than hand-built elements

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- npx vitest run *(fails in existing classic battle cooldown suites; see log)*
- npx playwright test *(fails/timeouts in existing battle classic flows; run aborted after failure summary)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68ce88379ff48326bf915e56e40d2516