### PR TITLE
Ensure cooldown readiness resolves after dispatch failures

### DIFF
--- a/tests/classicBattle/timer.test.js
+++ b/tests/classicBattle/timer.test.js
@@ -165,7 +165,7 @@ describe("Classic Battle round timer", () => {
       await advanceWhenReady(button, resolveReady);
 
       expect(dispatchBattleEventMock).toHaveBeenCalledTimes(1);
-      expect(resolveReady).not.toHaveBeenCalled();
+      expect(resolveReady).toHaveBeenCalledTimes(1);
       expect(skipSpy).not.toHaveBeenCalled();
       expect(button.disabled).toBe(false);
       expect(button.dataset.nextReady).toBe("");
@@ -208,7 +208,7 @@ describe("Classic Battle round timer", () => {
       await advanceWhenReady(button, resolveReady);
 
       expect(dispatchBattleEventMock).toHaveBeenCalledTimes(1);
-      expect(resolveReady).not.toHaveBeenCalled();
+      expect(resolveReady).toHaveBeenCalledTimes(1);
       expect(skipSpy).not.toHaveBeenCalled();
       expect(button.disabled).toBe(false);
       expect(button.dataset.nextReady).toBe("");
@@ -221,7 +221,7 @@ describe("Classic Battle round timer", () => {
       await advanceWhenReady(button, resolveReady);
 
       expect(dispatchBattleEventMock).toHaveBeenCalledTimes(2);
-      expect(resolveReady).not.toHaveBeenCalled();
+      expect(resolveReady).toHaveBeenCalledTimes(1);
       expect(skipSpy).not.toHaveBeenCalled();
       expect(button.disabled).toBe(false);
       expect(button.dataset.nextReady).toBe("");


### PR DESCRIPTION
## Summary
- ensure the cooldown ready dispatcher always resolves its callback while resetting the retry flag when dispatchBattleEvent fails or rejects
- guard advanceWhenReady so it restores the Next button state if the ready dispatch throws before bubbling the error
- extend the cooldown and timer specs to cover false/throw outcomes and confirm readiness promises settle for those paths

## Testing
- npx vitest run tests/classicBattle/cooldown.test.js
- npx vitest run tests/classicBattle/timer.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cea1df621883268295dc532e79ad0e