### PR TITLE
Guard finalizeReadyControls against wrapped resolve recursion

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -664,16 +664,17 @@ function finalizeReadyControls(controls, dispatched) {
   if (!controls) return;
   controls.readyInFlight = false;
   const resolver = typeof controls.resolveReady === "function" ? controls.resolveReady : null;
-  if (!controls.readyDispatched && dispatched && resolver) {
+  const shouldResolveReady = Boolean(dispatched && !controls.readyDispatched && resolver);
+  if (dispatched) {
+    controls.readyDispatched = true;
+  }
+  if (shouldResolveReady) {
     controls.__finalizingReady = true;
     try {
       resolver();
     } finally {
       controls.__finalizingReady = false;
     }
-  }
-  if (dispatched) {
-    controls.readyDispatched = true;
   }
 }
 
@@ -898,3 +899,13 @@ function isOrchestrated() {
     defaultValue: false
   });
 }
+
+/**
+ * @summary Test-only alias for the finalizeReadyControls guard.
+ *
+ * @pseudocode
+ * 1. Return the finalizeReadyControls reference so tests can import the guard logic.
+ *
+ * @returns {typeof finalizeReadyControls} The finalizeReadyControls implementation for tests.
+ */
+export const __testFinalizeReadyControls = finalizeReadyControls;


### PR DESCRIPTION
## Summary
- ensure `finalizeReadyControls` marks controls as dispatched before invoking wrapped ready resolvers to prevent reentry
- document and export a test-only alias for the finalize guard
- add a regression test covering reentrant ready finalization with `createExpirationDispatcher`

## Testing
- npx vitest run tests/roundManager.cooldown-ready.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68ceade61e608326a303355fccd81ff3