### PR TITLE
Ensure orchestrator cooldown dispatch drives machine

### DIFF
--- a/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
+++ b/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
@@ -216,8 +216,14 @@ describe("dispatchReadyDirectly", () => {
       emitTelemetry: emit
     });
     expect(result).toEqual({ dispatched: true, dedupeTracked: true });
+    expect(mocked).toHaveBeenCalledTimes(1);
     expect(mocked).toHaveBeenCalledWith("ready");
+    expect(mocked.mock.results[0]?.value).toBeTruthy();
+    expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledWith("ready");
+    expect(dispatch.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mocked.mock.invocationCallOrder[0]
+    );
     expect(emit).toHaveBeenCalledWith("handleNextRound_dispatchReadyDirectly_result", true);
   });
 

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -250,6 +250,7 @@ describe("timerService next round handling", () => {
       cb();
       return null;
     });
+    dispatchBattleEvent.mockReturnValueOnce(true);
     const roundMod = await import("../../../src/helpers/classicBattle/roundManager.js");
     try {
       const controls = roundMod.startCooldown({}, scheduler, {
@@ -259,6 +260,8 @@ describe("timerService next round handling", () => {
       });
       await expect(controls.ready).resolves.toBeUndefined();
       expect(setupFallbackTimer).toHaveBeenCalled();
+      expect(dispatchBattleEvent).toHaveBeenCalledWith("ready");
+      expect(dispatchBattleEvent).toHaveBeenCalledTimes(1);
       expect(machine.dispatch).toHaveBeenCalledWith("ready");
       expect(machine.dispatch).toHaveBeenCalledTimes(1);
       expect(getStateSnapshot).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- ensure the direct ready dispatcher always invokes the machine after a shared dispatcher success so cooldown recovery drives state transitions
- tighten classic battle tests to assert both shared and machine dispatchers fire once when cooldown cleanup runs

## Testing
- `npx vitest run tests/helpers/classicBattle/nextRound/expirationHandlers.test.js`
- `npx vitest run tests/helpers/classicBattle/timerService.nextRound.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68cebd42c1848326ac0ae49e77ba98a8