### PR TITLE
Track machine readiness propagation for bus

### DIFF
--- a/src/helpers/classicBattle/nextRound/expirationHandlers.js
+++ b/src/helpers/classicBattle/nextRound/expirationHandlers.js
@@ -437,7 +437,11 @@ export async function dispatchReadyDirectly(params) {
           return recordSuccess(true);
         }
         const machineStateBeforeDispatch = readMachineState();
-        if (machineStateBeforeDispatch && machineStateBeforeDispatch !== "cooldown" && machineStateBeforeDispatch !== "roundOver") {
+        if (
+          machineStateBeforeDispatch &&
+          machineStateBeforeDispatch !== "cooldown" &&
+          machineStateBeforeDispatch !== "roundOver"
+        ) {
           return recordSuccess(true);
         }
         try {


### PR DESCRIPTION
## Summary
- persist machine dispatch state, dedupe tracking, and propagation needs so bus dispatch can short-circuit correctly
- pass bus dispatch the new readiness state and extend orchestrated fallback tests to cover machine-only propagation
- format the expiration handler helper after running Prettier

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- npx vitest run tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
- npx playwright test *(fails: classic battle cooldown/opponent reveal specs timeout)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68cec6a304e883269694cf579f85feef