### PR TITLE
Prevent round counter regression

### DIFF
--- a/playwright/battle-classic/opponent-reveal.spec.js
+++ b/playwright/battle-classic/opponent-reveal.spec.js
@@ -96,11 +96,22 @@ test.describe("Classic Battle Opponent Reveal", () => {
       await expect(nextButton).toBeEnabled();
       await expect(nextButton).toHaveAttribute("data-next-ready", "true");
 
+      const roundCounter = page.locator("#round-counter");
+      const readRoundNumber = async () => {
+        const text = await roundCounter.textContent();
+        const match = text ? text.match(/(\d+)/) : null;
+        return match ? Number(match[1]) : 0;
+      };
+
+      const beforeNext = await readRoundNumber();
+
       // Click next round
       await nextButton.click();
 
+      await expect.poll(readRoundNumber).toBeGreaterThanOrEqual(beforeNext);
+
       // Verify round progression
-      await expect(page.locator("#round-counter")).toContainText(/Round 2/);
+      await expect(roundCounter).toContainText(/Round 2/);
 
       // Second round should work the same way
       const secondStat = page.locator("#stat-buttons button[data-stat]").nth(1);


### PR DESCRIPTION
## Summary
- derive the current scoreboard round before consuming engine data so the UI never regresses when the engine lags
- extend the opponent reveal battle-flow test to ensure an immediate Next click never decreases the round counter

## Testing
- npx playwright test playwright/battle-classic/opponent-reveal.spec.js *(fails: modal selectors never became visible in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cedbc9adbc8326a082c07420367e40