### PR TITLE
Fix cooldown ready dedupe propagation

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -571,8 +571,12 @@ function evaluateMachineReadyPropagation({
   shouldPropagateAfterMachine,
   markMachineHandled
 }) {
+  if (state.dedupeTracked) {
+    markMachineHandled?.();
+    return { propagate: false, requiresPropagation: false };
+  }
   const propagate = state.dispatched && shouldPropagateAfterMachine();
-  const requiresPropagation = state.dispatched && propagate && !state.dedupeTracked;
+  const requiresPropagation = state.dispatched && propagate;
   if (state.dispatched && !propagate) {
     markMachineHandled?.();
   }

--- a/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
+++ b/tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
@@ -135,6 +135,7 @@ describe("timeout → interruptRound → cooldown auto-advance", () => {
         ([eventName]) => eventName === "ready"
       );
       expect(readyCallsAfterFlushing.length).toBe(readyCallsAfterAdvance.length);
+      expect(readyCallsAfterFlushing).toHaveLength(1);
       expect(readyDispatchTracker.events.length).toBe(1);
       expect(readyDispatchTracker.events[0]?.[0]).toBe("ready");
 


### PR DESCRIPTION
## Summary
- stop ready propagation when the machine dispatch recorded dedupe tracking
- recognize already-advanced states when dispatchReadyDirectly consults the shared dispatcher
- tighten the cooldown interrupt unit test to ensure only one ready dispatch occurs

## Testing
- npx vitest run tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
- npx playwright test battle-next-skip.non-orchestrated.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68ceddf6c794832686d528361b76d2bc