### PR TITLE
Refine round counter handling and share scoreboard parser

### DIFF
--- a/playwright/battle-classic/opponent-reveal.spec.js
+++ b/playwright/battle-classic/opponent-reveal.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
-import selectors from "../../helpers/selectors";
+import selectors from "../helpers/selectors.js";
+import { readScoreboardRound } from "../helpers/roundCounter.js";
 
 test.describe("Classic Battle Opponent Reveal", () => {
   test.describe("Basic Opponent Reveal Functionality", () => {
@@ -99,18 +100,19 @@ test.describe("Classic Battle Opponent Reveal", () => {
       await expect(nextButton).toHaveAttribute("data-next-ready", "true");
 
       const roundCounter = page.locator("#round-counter");
-      const readRoundNumber = async () => {
-        const text = await roundCounter.textContent();
-        const match = text ? text.match(/(\d+)/) : null;
-        return match ? Number(match[1]) : 0;
-      };
+      const readRoundNumber = () => readScoreboardRound(roundCounter);
 
       const beforeNext = await readRoundNumber();
+      expect(
+        beforeNext,
+        "Round counter should show a valid number before advancing."
+      ).not.toBeNull();
+      const beforeNextNumber = /** @type {number} */ (beforeNext);
 
       // Click next round
       await nextButton.click();
 
-      await expect.poll(readRoundNumber).toBeGreaterThanOrEqual(beforeNext);
+      await expect.poll(readRoundNumber).toBeGreaterThanOrEqual(beforeNextNumber);
 
       // Verify round progression
       await expect(roundCounter).toContainText(/Round 2/);

--- a/playwright/battle-classic/smoke.spec.js
+++ b/playwright/battle-classic/smoke.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import selectors from "../../helpers/selectors";
+import selectors from "../helpers/selectors.js";
 
 test.describe("Classic Battle page scaffold", () => {
   test("loads without console errors and has scoreboard nodes", async ({ page }) => {

--- a/playwright/helpers/roundCounter.js
+++ b/playwright/helpers/roundCounter.js
@@ -1,0 +1,31 @@
+const ROUND_PATTERN = /Round\s+(\d+)/i;
+
+/**
+ * Read the scoreboard round number from the provided locator.
+ *
+ * @pseudocode
+ * 1. Read the locator text.
+ * 2. Delegate to the text parser to extract a numeric round.
+ * 3. Return the parsed number or null when unavailable.
+ *
+ * @param {import('@playwright/test').Locator} roundLocator
+ * @returns {Promise<number|null>}
+ */
+export async function readScoreboardRound(roundLocator) {
+  const text = await roundLocator.textContent();
+  return parseScoreboardRound(text);
+}
+
+/**
+ * Parse a scoreboard label for the round number.
+ *
+ * @param {string|null} text
+ * @returns {number|null}
+ */
+export function parseScoreboardRound(text) {
+  if (!text) return null;
+  const match = String(text).match(ROUND_PATTERN);
+  if (!match) return null;
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) ? parsed : null;
+}


### PR DESCRIPTION
## Summary
- tighten `getVisibleRoundNumber` parsing and refactor `updateRoundCounterFromEngine` into clearer helpers with a documented fallback path
- add a Playwright helper to read the scoreboard round and reuse it in the opponent reveal test while asserting the counter is present before advancing
- switch battle classic specs to import local helpers via explicit `.js` paths for ESM compatibility

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: design/productRequirementsDocuments markdown files are not formatted)*
- `npx eslint .`
- `npx vitest run --reporter basic` *(fails: existing timeoutInterrupt.cooldown test expects different ready count)*
- `npx playwright test` *(fails/timeouts: classic battle flows rely on unavailable UI interactions in this environment)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: offline model download ENETUNREACH)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle`
- `grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68cee83054d48326849a1c4595366996