### PR TITLE
Handle stat selection failure cooldown

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -423,6 +423,59 @@ function renderStatButtons(store) {
         }
       } catch (err) {
         console.debug("battleClassic: stat selection handler failed", err);
+        let cooldownStarted = false;
+        try {
+          cooldownStarted = triggerCooldownOnce(store, "statSelectionFailed");
+        } catch (cooldownErr) {
+          console.debug(
+            "battleClassic: triggerCooldownOnce after selection failure failed",
+            cooldownErr
+          );
+        }
+        try {
+          resetCooldownFlag(store);
+        } catch {}
+        try {
+          enableNextRoundButton();
+        } catch (enableErr) {
+          console.debug(
+            "battleClassic: enableNextRoundButton after selection failure failed",
+            enableErr
+          );
+        }
+        let nextBtn = null;
+        try {
+          nextBtn =
+            document.getElementById("next-button") ||
+            document.querySelector('[data-role="next-round"]');
+        } catch {}
+        if (nextBtn) {
+          try {
+            nextBtn.disabled = false;
+            nextBtn.removeAttribute("disabled");
+          } catch {}
+          try {
+            nextBtn.setAttribute("data-next-ready", "true");
+            if (nextBtn.dataset) nextBtn.dataset.nextReady = "true";
+          } catch {}
+          try {
+            setTimeout(() => {
+              try {
+                nextBtn.disabled = false;
+                nextBtn.removeAttribute("disabled");
+                nextBtn.setAttribute("data-next-ready", "true");
+                if (nextBtn.dataset) nextBtn.dataset.nextReady = "true";
+              } catch {}
+            }, 0);
+          } catch {}
+          try {
+            console.debug("battleClassic: next button enabled after selection failure", {
+              disabled: nextBtn.disabled,
+              attr: nextBtn.getAttribute("data-next-ready"),
+              cooldownStarted
+            });
+          } catch {}
+        }
       }
 
       if (!selectionResolved) return;

--- a/tests/helpers/classicBattle/statSelection.failureFallback.test.js
+++ b/tests/helpers/classicBattle/statSelection.failureFallback.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("classicBattle stat selection failure recovery", () => {
+  const ROUND_MANAGER_PATH = "../../../src/helpers/classicBattle/roundManager.js";
+  const SELECTION_HANDLER_PATH = "../../../src/helpers/classicBattle/selectionHandler.js";
+  let renderStatButtons;
+  let startCooldownMock;
+  let handleStatSelectionMock;
+  let originalRequestAnimationFrame;
+  let originalLocalStorage;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    startCooldownMock = vi.fn();
+    handleStatSelectionMock = vi.fn();
+
+    vi.doMock(ROUND_MANAGER_PATH, () => ({
+      startCooldown: startCooldownMock,
+      createBattleStore: vi.fn(() => ({ __uiCooldownStarted: false }))
+    }));
+
+    vi.doMock(SELECTION_HANDLER_PATH, () => ({
+      handleStatSelection: handleStatSelectionMock
+    }));
+
+    originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = (cb) => {
+      if (typeof cb === "function") {
+        cb();
+      }
+      return 1;
+    };
+
+    originalLocalStorage = globalThis.localStorage;
+    globalThis.localStorage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {}
+    };
+
+    ({ renderStatButtons } = await import("../../../src/pages/battleClassic.init.js"));
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    if (originalRequestAnimationFrame) {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    } else {
+      delete globalThis.requestAnimationFrame;
+    }
+    if (originalLocalStorage) {
+      globalThis.localStorage = originalLocalStorage;
+    } else {
+      delete globalThis.localStorage;
+    }
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("starts cooldown and marks Next ready when selection handler rejects", async () => {
+    handleStatSelectionMock.mockRejectedValue(new Error("stat selection failed"));
+
+    document.body.innerHTML = `
+      <div id="stat-buttons"></div>
+      <button id="next-button" data-role="next-round" disabled></button>
+    `;
+
+    const store = {};
+    renderStatButtons(store);
+
+    const btn = document.querySelector("[data-stat]");
+    expect(btn).toBeTruthy();
+
+    btn.click();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(startCooldownMock).toHaveBeenCalledTimes(1);
+    expect(startCooldownMock).toHaveBeenCalledWith(store);
+    expect(store.__uiCooldownStarted).toBe(false);
+
+    const nextBtn = document.getElementById("next-button");
+    expect(nextBtn.disabled).toBe(false);
+    expect(nextBtn.getAttribute("data-next-ready")).toBe("true");
+    expect(nextBtn.dataset.nextReady).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary
- start the cooldown and re-enable the Next button when classic battle stat selection rejects
- reset the one-shot cooldown flag after failure so the UI remains responsive
- add a regression test that stubs handleStatSelection to reject and verifies cooldown + button readiness recovery

## Testing
- npm run check:jsdoc
- npx prettier src/pages/battleClassic.init.js tests/helpers/classicBattle/statSelection.failureFallback.test.js --check
- npx eslint .
- npx vitest run tests/helpers/classicBattle/statSelection.failureFallback.test.js
- npx vitest run *(fails: cancelled after long runtime)*
- npx playwright test *(fails: cancelled after long runtime)*
- npm run check:contrast


------
https://chatgpt.com/codex/tasks/task_e_68ceedc59e848326a899b4387f278541