### PR TITLE
Ensure ready dedupe skips bus propagation

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -571,8 +571,12 @@ function evaluateMachineReadyPropagation({
   shouldPropagateAfterMachine,
   markMachineHandled
 }) {
+  if (state.dedupeTracked) {
+    markMachineHandled?.();
+    return { propagate: false, requiresPropagation: false };
+  }
   const propagate = state.dispatched && shouldPropagateAfterMachine();
-  const requiresPropagation = state.dispatched && propagate && !state.dedupeTracked;
+  const requiresPropagation = state.dispatched && propagate;
   if (state.dispatched && !propagate) {
     markMachineHandled?.();
   }

--- a/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
@@ -489,17 +489,14 @@ describe("handleNextRoundExpiration orchestrated propagation", () => {
     vi.restoreAllMocks();
   });
 
-  it("dispatches via bus when machine propagation is enabled in orchestrated mode", async () => {
+  it("skips bus propagation when dedupe tracking handles readiness in orchestrated mode", async () => {
     expect(controls).toBeTruthy();
     expect(typeof runtime?.onExpired).toBe("function");
     dispatchReadyViaBusSpy?.mockClear();
     await runtime.onExpired();
     expect(globalDispatchSpy).toHaveBeenCalledTimes(1);
     expect(globalDispatchSpy).toHaveBeenCalledWith("ready");
-    expect(dispatchReadyViaBusSpy).toHaveBeenCalledTimes(1);
-    expect(dispatchReadyViaBusSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ alreadyDispatched: true })
-    );
+    expect(dispatchReadyViaBusSpy).not.toHaveBeenCalled();
     expect(machine.dispatch).toHaveBeenCalledTimes(1);
     expect(machine.dispatch).toHaveBeenCalledWith("ready");
   });


### PR DESCRIPTION
## Summary
- short-circuit machine propagation when dedupe tracking indicates the shared dispatcher already handled the ready event
- update cooldown auto-advance helper test to assert a single ready dispatch and confirm dedupe tracking kicked in
- adjust fallback propagation test expectations so bus dispatch is skipped when readiness was deduped upstream

## Testing
- npx vitest run tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js
- npx vitest run tests/helpers/classicBattle/scheduleNextRound.fallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ceedb4965483268125bc995c2b3c89