### PR TITLE
Add pseudocode docs for evaluateMachineReadyPropagation

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -565,6 +565,12 @@ function handleReadyDispatchEarlyExit({ context, controls, emitTelemetry, getDeb
  * machine can finalize the dispatch without bus propagation.
  * @returns {{ propagate: boolean, requiresPropagation: boolean }} Propagation
  * metadata describing follow-up actions.
+ *
+ * @pseudocode
+ * 1. If deduplication tracking is active, mark machine as handled and skip propagation
+ * 2. Otherwise evaluate propagation requirements based on dispatch state and strategy
+ * 3. Mark machine as handled when dispatch succeeded but propagation is disabled
+ * 4. Return propagation flags for downstream decision making
  */
 function evaluateMachineReadyPropagation({
   state,


### PR DESCRIPTION
## Summary
- add @pseudocode guidance to the evaluateMachineReadyPropagation JSDoc to document the dedupe short-circuit flow

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: formatting issues already present in design/productRequirementsDocuments)*
- npx eslint .
- CI=1 NO_COLOR=1 npx vitest run tests/helpers/classicBattle/timeoutInterrupt.cooldown.test.js tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
- CI=1 npx playwright test *(terminated due to long-running suite/output constraints)*
- npm run check:contrast
- npm run validate:data
- grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle
- grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"


------
https://chatgpt.com/codex/tasks/task_e_68cef41213708326860c135b9be51529