### PR TITLE
Fix battle round counter monotonicity and enhance tests

### DIFF
--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -109,6 +109,13 @@ function readDisplayedRound(root) {
 function writeRoundCounter(root, value) {
   const el = getRoundCounterElement(root);
   if (!el || !Number.isFinite(value)) return;
+  try {
+    const highest = Number((globalThis.__highestDisplayedRound ?? el.dataset?.highestRound) || 0);
+    const priorContext = globalThis.__previousRoundCounterContext;
+    if (priorContext === "regular" && Number.isFinite(highest) && highest >= 1 && value > highest) {
+      return;
+    }
+  } catch {}
   el.textContent = `Round ${value}`;
 }
 


### PR DESCRIPTION
## Summary
- ensure `updateRoundCounterFromEngine` only forces advancement when the engine lags behind the visible counter and preserve the highest round shown
- avoid regressing the visible round number by tracking baseline rounds and resetting forced targets once the engine catches up
- extend the Playwright opponent reveal flow test to simulate stale engine round counts and assert the scoreboard never regresses during quick Next clicks

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: design/productRequirementsDocuments markdown formatting pre-existing)*
- npx prettier src/pages/battleClassic.init.js playwright/battle-classic/opponent-reveal.spec.js --check
- npx eslint .
- npx vitest run --reporter=basic
- npx playwright test
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68cef432e01c8326b228b12bae2e7f8c