### PR TITLE
Optimize ready bus dispatch short-circuit

### DIFF
--- a/src/helpers/classicBattle/nextRound/expirationHandlers.js
+++ b/src/helpers/classicBattle/nextRound/expirationHandlers.js
@@ -320,18 +320,17 @@ export function createMachineStateInspector(params) {
  * @returns {Promise<boolean>}
  */
 export async function dispatchReadyViaBus(options = {}) {
+  if (options.alreadyDispatched === true) {
+    return true;
+  }
   const dispatchers = [];
-  const candidate = options.dispatchBattleEvent;
   const skipCandidate = options.skipCandidate === true;
-  const alreadyDispatched = options.alreadyDispatched === true;
+  const candidate = options.dispatchBattleEvent;
   if (!skipCandidate && typeof candidate === "function") {
     dispatchers.push(candidate);
   }
   if (typeof globalDispatchBattleEvent === "function" && globalDispatchBattleEvent !== candidate) {
     dispatchers.push(globalDispatchBattleEvent);
-  }
-  if (alreadyDispatched) {
-    return true;
   }
   for (const dispatcher of dispatchers) {
     try {


### PR DESCRIPTION
## Summary
- short-circuit `dispatchReadyViaBus` when `alreadyDispatched` is true so we avoid touching any dispatcher candidates

## Testing
- npx vitest run tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
- npx vitest run --reporter=basic
- npx playwright test --reporter=line > /tmp/playwright.log 2>&1 *(fails: 1 existing test `playwright/cli-flows-improved.spec.mjs:315`)*
- npm run check:jsdoc
- npx eslint .
- npx prettier src/helpers/classicBattle/nextRound/expirationHandlers.js --check
- npx prettier . --check --log-level warn *(fails: 3 pre-existing design documents)*
- npm run check:contrast
- npm run rag:validate > /tmp/rag_validate.log 2>&1 *(network fallback messages, command exited 0)*
- npm run validate:data

------
https://chatgpt.com/codex/tasks/task_e_68cf05842b6c8326ac69b430c180e3f3