### PR TITLE
Improve CLI stat sizing test stability

### DIFF
--- a/playwright/cli-layout-assessment.spec.js
+++ b/playwright/cli-layout-assessment.spec.js
@@ -31,12 +31,14 @@ test.describe("CLI Layout Assessment - Desktop Focused", () => {
     const stats = page.locator(".cli-stat");
     const statCount = await stats.count();
 
-    if (statCount > 0) {
-      // Test first stat row height
-      const firstStat = stats.first();
-      const statBox = await firstStat.boundingBox();
-      expect(statBox.height).toBeGreaterThanOrEqual(44);
-    }
+    expect(statCount, "Expected at least one CLI stat to be rendered").toBeGreaterThan(0);
+
+    // Test first stat row height
+    const firstStat = stats.first();
+    await expect(firstStat).toBeVisible();
+    const statBox = await firstStat.boundingBox();
+    expect(statBox, "Bounding box should be available once stat is visible").not.toBeNull();
+    expect(statBox.height).toBeGreaterThanOrEqual(44);
 
     // Container should be visible and meet minimum height
     const statsContainer = page.locator("#cli-stats");


### PR DESCRIPTION
## Summary
- wait for the first CLI stat to be rendered and visible before capturing its size
- assert a bounding box is returned before enforcing the 44px minimum height requirement

## Testing
- npm run check:jsdoc
- npx prettier playwright/cli-layout-assessment.spec.js --check
- npx eslint playwright/cli-layout-assessment.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68cf0ebaaca483269cef81243d7a6c14