### PR TITLE
Fix classic battle resolution timer race

### DIFF
--- a/tests/classicBattle/resolution.test.js
+++ b/tests/classicBattle/resolution.test.js
@@ -48,6 +48,7 @@ describe("Classic Battle round resolution", () => {
 
       vi.useFakeTimers();
       btn.click();
+      await Promise.resolve();
       // If tests use the queued RAF mock, flush any enqueued frames so scheduled work runs.
       if (typeof globalThis.flushRAF === "function") globalThis.flushRAF();
       vi.runAllTimers();


### PR DESCRIPTION
## Summary
- await a microtask after triggering the round-select button click in `tests/classicBattle/resolution.test.js` so the async round-start chain registers timers before fake timers are flushed

## Testing
- `npx vitest run tests/classicBattle/resolution.test.js` *(fails: assertion expects score update, but run now completes without timing out)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2f9e68a4832691e896ce6b9aa1f6