### PR TITLE
Ensure battle replay creates new engine instance

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -946,7 +946,7 @@ async function handleReplay(store) {
   try {
     // Reset engine state
     const { createBattleEngine } = await import("../helpers/battleEngineFacade.js");
-    createBattleEngine();
+    createBattleEngine({ forceCreate: true });
 
     // Reset store state
     store.selectionMade = false;


### PR DESCRIPTION
## Summary
- ensure battle replays bootstrap a fresh battle engine instance so round counters reset correctly

## Testing
- npx playwright test playwright/battle-classic/replay.spec.js

## Task Contract
- inputs: ["src/pages/battleClassic.init.js"]
- outputs: ["src/pages/battleClassic.init.js"]
- success: ["npx playwright test playwright/battle-classic/replay.spec.js"]
- errorMode: "standard"

## Files Changed
- src/pages/battleClassic.init.js

## Risk
- Low

## Verification
- npx playwright test playwright/battle-classic/replay.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68cfbe30ba58832680313c043b0497d8