### PR TITLE
Reset points-to-win target in opponent reveal cleanup test

### DIFF
--- a/playwright/battle-classic/opponent-reveal.spec.js
+++ b/playwright/battle-classic/opponent-reveal.spec.js
@@ -419,6 +419,11 @@ test.describe("Classic Battle Opponent Reveal", () => {
         await page.click("#round-select-1");
 
         await page.evaluate(async () => {
+          const { setPointsToWin } = await import("/src/helpers/battleEngineFacade.js");
+          setPointsToWin(1);
+        });
+
+        await page.evaluate(async () => {
           const { setOpponentDelay } = await import("/src/helpers/classicBattle/snackbar.js");
           setOpponentDelay(50);
         });


### PR DESCRIPTION
## Task Contract
```json
{
  "inputs": ["playwright/battle-classic/opponent-reveal.spec.js"],
  "outputs": ["playwright/battle-classic/opponent-reveal.spec.js"],
  "success": ["npx playwright test playwright/battle-classic/opponent-reveal.spec.js"],
  "errorMode": "fail_on_error"
}
```

## Summary
- Force the points-to-win target back to one before stat selection in the opponent reveal cleanup test so cooldown expectations remain valid at match end.

## Files Changed
- playwright/battle-classic/opponent-reveal.spec.js

## Verification
- npx playwright test playwright/battle-classic/opponent-reveal.spec.js

## Risk
- Low: adjustment only touches Playwright test setup and does not affect production code.


------
https://chatgpt.com/codex/tasks/task_e_68cfc816adc48326b082e9d554ae9403