### PR TITLE
Prevent Next fallback from double advancing round

### DIFF
--- a/playwright/battle-classic/cooldown.spec.js
+++ b/playwright/battle-classic/cooldown.spec.js
@@ -9,12 +9,14 @@ test.describe("Classic Battle cooldown + Next", () => {
       });
       await page.goto("/src/pages/battleClassic.html");
 
+      const roundCounter = page.getByTestId("round-counter");
+
       // Start the match via modal (pick medium/10)
       await expect(page.getByRole("button", { name: "Medium" })).toBeVisible();
       await page.getByRole("button", { name: "Medium" }).click();
 
       // Before the first round, the counter is 1
-      await expect(page.getByTestId("round-counter")).toHaveText("Round 1");
+      await expect(roundCounter).toHaveText("Round 1");
 
       // Click a stat to complete the round
       await expect(page.getByTestId("stat-button").first()).toBeVisible();
@@ -25,11 +27,30 @@ test.describe("Classic Battle cooldown + Next", () => {
       await expect(nextButton).toBeEnabled();
       await expect(nextButton).toHaveAttribute("data-next-ready", "true");
 
+      // Simulate an engine-driven update that already advanced the round.
+      await page.evaluate(() => {
+        const counter = document.getElementById("round-counter");
+        if (!counter) return;
+        counter.textContent = "Round 2";
+        if (counter.dataset) {
+          counter.dataset.highestRound = "2";
+        }
+        const lastContext =
+          typeof window.__lastRoundCounterContext === "string"
+            ? window.__lastRoundCounterContext
+            : null;
+        window.__highestDisplayedRound = 2;
+        window.__previousRoundCounterContext = lastContext;
+        window.__lastRoundCounterContext = "advance";
+      });
+      await expect(roundCounter).toHaveText("Round 2");
+
       // Click next button
       await nextButton.click();
 
       // Check that the round counter has advanced
-      await expect(page.getByTestId("round-counter")).toHaveText("Round 2");
+      await expect(roundCounter).toHaveText("Round 2");
+      await expect.poll(async () => roundCounter.textContent()).toBe("Round 2");
     }, ["log", "info", "warn", "error", "debug"]);
   });
 });


### PR DESCRIPTION
## Summary
- clamp the Next-button fallback counter using the tracked highest round and cooldown context
- persist the bounded highest round metadata when the manual fallback runs
- extend the Playwright cooldown spec to guard against double-advancing after a single Next click

## Testing
- npx eslint src/helpers/classicBattle/timerService.js playwright/battle-classic/cooldown.spec.js
- npx playwright test playwright/battle-classic/cooldown.spec.js

## Risks
- Low: touches the manual Next-button fallback path and related regression test.

------
https://chatgpt.com/codex/tasks/task_e_68cfcdfef2648326a321d2864f6ff5b5