### PR TITLE
Ensure opponent snackbar persists before cooldown

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -62,10 +62,18 @@ const POST_SELECTION_READY_DELAY_MS = 48;
  */
 const OPPONENT_MESSAGE_BUFFER_MS = 150;
 
+/**
+ * Minimum amount of time the opponent choosing message should remain visible
+ * before transitioning into the next-round countdown state.
+ */
+const MIN_OPPONENT_MESSAGE_DURATION_MS = 250;
+
 const BASE_SELECTION_READY_DELAY_MS = Math.max(
   POST_SELECTION_READY_DELAY_MS,
   OPPONENT_MESSAGE_BUFFER_MS
 );
+
+let lastOpponentPromptTimestamp = 0;
 
 function computeSelectionReadyDelay() {
   let delayForReady = BASE_SELECTION_READY_DELAY_MS;
@@ -75,7 +83,7 @@ function computeSelectionReadyDelay() {
       delayForReady = Math.max(delayForReady, opponentDelay + OPPONENT_MESSAGE_BUFFER_MS);
     }
   } catch {}
-  return delayForReady;
+  return Math.max(delayForReady, MIN_OPPONENT_MESSAGE_DURATION_MS);
 }
 
 const COOLDOWN_FLAG = "__uiCooldownStarted";
@@ -132,21 +140,54 @@ function markCooldownStarted(store) {
 
 function triggerCooldownOnce(store, reason) {
   if (!markCooldownStarted(store)) return false;
-  try {
-    startCooldown(store);
-    return true;
-  } catch (err) {
+  const invokeStartCooldown = () => {
     try {
-      store[COOLDOWN_FLAG] = false;
+      startCooldown(store);
+      return true;
+    } catch (err) {
+      try {
+        store[COOLDOWN_FLAG] = false;
+      } catch {}
+      try {
+        console.debug("battleClassic: startCooldown manual trigger failed", {
+          reason: reason || "unknown",
+          error: err
+        });
+      } catch {}
+      return false;
+    }
+  };
+
+  const scheduleStartCooldown = (delayMs) => {
+    const runner = () => {
+      invokeStartCooldown();
+    };
+    try {
+      if (typeof window !== "undefined" && typeof window.setTimeout === "function") {
+        window.setTimeout(runner, delayMs);
+        return true;
+      }
     } catch {}
     try {
-      console.debug("battleClassic: startCooldown manual trigger failed", {
-        reason: reason || "unknown",
-        error: err
-      });
+      setTimeout(runner, delayMs);
+      return true;
     } catch {}
     return false;
-  }
+  };
+
+  try {
+    const now =
+      typeof performance !== "undefined" && typeof performance.now === "function"
+        ? performance.now()
+        : Date.now();
+    const elapsed = now - (lastOpponentPromptTimestamp || 0);
+    const remaining = Math.max(0, MIN_OPPONENT_MESSAGE_DURATION_MS - elapsed);
+    if (remaining > 0 && scheduleStartCooldown(remaining)) {
+      return true;
+    }
+  } catch {}
+
+  return invokeStartCooldown();
 }
 
 function getNextRoundButton() {
@@ -244,6 +285,15 @@ function prepareUiBeforeSelection() {
   }
   try {
     showSnackbar(t("ui.opponentChoosing"));
+    try {
+      const now =
+        typeof performance !== "undefined" && typeof performance.now === "function"
+          ? performance.now()
+          : Date.now();
+      lastOpponentPromptTimestamp = now;
+    } catch {
+      lastOpponentPromptTimestamp = Date.now();
+    }
   } catch {}
   return delayOverride;
 }


### PR DESCRIPTION
## Summary
- enforce a minimum opponent message display window by tracking when the snackbar was shown and delaying cooldown start until 250ms have elapsed
- clamp `computeSelectionReadyDelay` so small opponent delays still respect the minimum duration

## Testing
- npx playwright test playwright/battle-classic/opponent-reveal.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68cfd7fa375c83269023ea1d7a5e11ac