### PR TITLE
Guard Next button round counter fallback

### DIFF
--- a/playwright/battle-classic/cooldown.spec.js
+++ b/playwright/battle-classic/cooldown.spec.js
@@ -50,9 +50,10 @@ test.describe("Classic Battle cooldown + Next", () => {
       // Click next button
       await nextButton.click();
 
-      // Check that the round counter has advanced exactly once (no double advance)
-      await expect(roundCounter).toHaveText("Round 2");
-      await expect(roundCounter).not.toHaveText("Round 3");
+      // Immediately after the click, the round counter should remain on Round 2
+      // ensuring no eager fallback increments to Round 3.
+      await expect(roundCounter).toHaveText(/Round\s*2/);
+      await expect(roundCounter).not.toHaveText(/Round\s*3/);
     }, ["log", "info", "warn", "error", "debug"]);
   });
 });

--- a/playwright/battle-classic/round-counter.spec.js
+++ b/playwright/battle-classic/round-counter.spec.js
@@ -12,12 +12,14 @@ test.describe("Classic Battle round counter", () => {
       });
       await page.goto("/src/pages/battleClassic.html");
 
+      const roundCounter = page.locator("#round-counter");
+
       // Start the match via modal (pick medium/10)
       await page.waitForSelector("#round-select-2", { state: "visible" });
       await page.click("#round-select-2");
 
       // Immediately after starting, the round counter should read Round 1
-      await expect(page.locator("#round-counter")).toHaveText(/Round\s*1/);
+      await expect(roundCounter).toHaveText(/Round\s*1/);
 
       // Click a stat to resolve the round
       await page.waitForSelector("#stat-buttons button[data-stat]");
@@ -30,7 +32,8 @@ test.describe("Classic Battle round counter", () => {
 
       // Click Next to start the next round and verify increment to Round 2
       await next.click();
-      await expect(page.locator("#round-counter")).toHaveText(/Round\s*2/);
+      await expect(roundCounter).toHaveText(/Round\s*2/);
+      await expect(roundCounter).not.toHaveText(/Round\s*3/);
       // Timer should be visible again for the new round
       await expect(page.locator("#next-round-timer")).toContainText(/Time Left:/);
     }, ["log", "info", "warn", "error", "debug"]);

--- a/src/helpers/classicBattle/timerService.js
+++ b/src/helpers/classicBattle/timerService.js
@@ -469,7 +469,16 @@ export async function onNextButtonClick(_evt, controls = getNextRoundControls(),
         fallbackTarget = recordedHighest;
       }
 
-      if (Number.isFinite(fallbackTarget) && fallbackTarget >= 1) {
+      const hasLaggingContext =
+        typeof lastContext === "string" && lastContext !== "" && lastContext !== "regular";
+      const displayBehindRecordedHighest =
+        hasRecordedHighest && recordedHighest > displayedRoundBefore;
+
+      if (
+        Number.isFinite(fallbackTarget) &&
+        fallbackTarget >= 1 &&
+        (hasLaggingContext || displayBehindRecordedHighest)
+      ) {
         writeRoundCounter(root, fallbackTarget);
         const nextRecordedHighest = hasRecordedHighest
           ? Math.max(recordedHighest, fallbackTarget)


### PR DESCRIPTION
## Task Contract
```json
{
  "inputs": [
    "src/helpers/classicBattle/timerService.js",
    "playwright/battle-classic/round-counter.spec.js",
    "playwright/battle-classic/cooldown.spec.js"
  ],
  "outputs": [
    "src/helpers/classicBattle/timerService.js",
    "playwright/battle-classic/round-counter.spec.js",
    "playwright/battle-classic/cooldown.spec.js"
  ],
  "success": [
    "npx playwright test playwright/battle-classic/round-counter.spec.js",
    "npx playwright test playwright/battle-classic/cooldown.spec.js"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Summary
- Guard the manual Next button fallback so it only re-renders the round counter when the prior update context signaled lag or diagnostics show the UI is behind.
- Extend the classic battle Playwright suites to assert the counter stays on Round 2 immediately after clicking Next.

## Testing
- `npx playwright test playwright/battle-classic/round-counter.spec.js`
- `npx playwright test playwright/battle-classic/cooldown.spec.js`

## Risks
- Low: limited to fallback guard and accompanying end-to-end assertions for the classic battle flow.


------
https://chatgpt.com/codex/tasks/task_e_68cfe068029083268f6fd348a27dd2f9