### PR TITLE
Ensure cooldown starts immediately after stat selection failure

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -193,7 +193,9 @@ function triggerCooldownOnce(store, reason) {
   if (!markCooldownStarted(store)) return false;
 
   const remaining = calculateRemainingOpponentMessageTime();
-  if (remaining > 0 && scheduleDelayedCooldown(remaining, store, reason)) {
+  const shouldForceImmediate = reason === "statSelectionFailed";
+
+  if (!shouldForceImmediate && remaining > 0 && scheduleDelayedCooldown(remaining, store, reason)) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- force the battle UI cooldown trigger to bypass scheduled delays when a stat selection failure occurs so `startCooldown` executes immediately
- reset fake timers in the failure recovery test harness and add coverage that verifies the cooldown mock fires without advancing timers

## Testing
- `npx vitest run tests/helpers/classicBattle/statSelection.failureFallback.test.js`

## Files Changed
- src/pages/battleClassic.init.js
- tests/helpers/classicBattle/statSelection.failureFallback.test.js

## Task Contract
```json
{
  "inputs": [
    "src/pages/battleClassic.init.js",
    "tests/helpers/classicBattle/statSelection.failureFallback.test.js"
  ],
  "outputs": [
    "src/pages/battleClassic.init.js",
    "tests/helpers/classicBattle/statSelection.failureFallback.test.js"
  ],
  "success": [
    "vitest: PASS"
  ],
  "errorMode": "ask_on_public_api_change"
}
```

## Risk
- Low: changes are isolated to the stat selection failure recovery path and accompanying unit tests.


------
https://chatgpt.com/codex/tasks/task_e_68cfe6e9e18c832694851c6c223f0506