### PR TITLE
Defer cooldown until opponent message min duration

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -377,9 +377,9 @@ function finalizeSelectionReady(store, options = {}) {
   const finalizeRoundReady = () => {
     if (shouldStartCooldown) {
       try {
-        startCooldown(store);
+        triggerCooldownOnce(store, "selectionFinalize");
       } catch (err) {
-        console.debug("battleClassic: startCooldown after selection failed", err);
+        console.debug("battleClassic: triggerCooldownOnce after selection failed", err);
       }
     } else {
       resetCooldownFlag(store);

--- a/tests/helpers/classicBattle/statSelection.failureFallback.test.js
+++ b/tests/helpers/classicBattle/statSelection.failureFallback.test.js
@@ -7,12 +7,15 @@ describe("classicBattle stat selection failure recovery", () => {
   let renderStatButtons;
   let startCooldownMock;
   let handleStatSelectionMock;
+  let showSnackbarMock;
+  let previousMinDuration;
   let originalLocalStorage;
 
   beforeEach(async () => {
     vi.resetModules();
     startCooldownMock = vi.fn();
     handleStatSelectionMock = vi.fn();
+    showSnackbarMock = vi.fn();
 
     vi.doMock(ROUND_MANAGER_PATH, () => ({
       startCooldown: startCooldownMock,
@@ -22,6 +25,15 @@ describe("classicBattle stat selection failure recovery", () => {
     vi.doMock(SELECTION_HANDLER_PATH, () => ({
       handleStatSelection: handleStatSelectionMock,
       getPlayerAndOpponentValues: vi.fn(() => ({ playerVal: 5, opponentVal: 3 }))
+    }));
+
+    vi.doMock("../../../src/helpers/showSnackbar.js", () => ({
+      showSnackbar: (...args) => showSnackbarMock(...args),
+      updateSnackbar: vi.fn()
+    }));
+
+    vi.doMock("../../../src/helpers/i18n.js", () => ({
+      t: (key) => (key === "ui.opponentChoosing" ? "Opponent is choosing…" : key)
     }));
 
     // Install queued RAF mock and allow tests to flush synchronously when needed
@@ -34,6 +46,10 @@ describe("classicBattle stat selection failure recovery", () => {
       setItem: () => {},
       removeItem: () => {}
     };
+
+    const w = globalThis.window || (globalThis.window = {});
+    previousMinDuration = w.__MIN_OPPONENT_MESSAGE_DURATION_MS;
+    w.__MIN_OPPONENT_MESSAGE_DURATION_MS = 200;
 
     ({ renderStatButtons } = await import("../../../src/pages/battleClassic.init.js"));
   });
@@ -48,6 +64,14 @@ describe("classicBattle stat selection failure recovery", () => {
       globalThis.localStorage = originalLocalStorage;
     } else {
       delete globalThis.localStorage;
+    }
+    const w = globalThis.window;
+    if (w) {
+      if (typeof previousMinDuration === "undefined") {
+        delete w.__MIN_OPPONENT_MESSAGE_DURATION_MS;
+      } else {
+        w.__MIN_OPPONENT_MESSAGE_DURATION_MS = previousMinDuration;
+      }
     }
     vi.clearAllMocks();
     vi.resetModules();
@@ -164,5 +188,63 @@ describe("classicBattle stat selection failure recovery", () => {
     const nextBtn = document.getElementById("next-button");
     expect(nextBtn.disabled).toBe(false);
     expect(nextBtn.getAttribute("data-next-ready")).toBe("true");
+  });
+
+  it("keeps opponent choosing message visible before countdown when opponent delay is zero", async () => {
+    vi.useFakeTimers();
+    handleStatSelectionMock.mockResolvedValue({ matchEnded: false });
+
+    document.body.innerHTML = `
+      <div id="score-display"></div>
+      <div id="round-counter"></div>
+      <div id="snackbar-container"></div>
+      <div id="stat-buttons"></div>
+      <div id="next-round-timer"></div>
+      <button id="next-button" data-role="next-round" disabled></button>
+    `;
+
+    const store = {};
+    renderStatButtons(store);
+
+    const btn = document.querySelector("[data-stat]");
+    expect(btn).toBeTruthy();
+
+    const { setOpponentDelay } = await import("../../../src/helpers/classicBattle/snackbar.js");
+    setOpponentDelay(0);
+
+    const minDisplay = 200;
+    const win = globalThis.window || (globalThis.window = {});
+    const previousMin = win.__MIN_OPPONENT_MESSAGE_DURATION_MS;
+    win.__MIN_OPPONENT_MESSAGE_DURATION_MS = minDisplay;
+
+    btn.click();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(showSnackbarMock).toHaveBeenCalledWith("Opponent is choosing…");
+    expect(startCooldownMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(minDisplay - 1);
+    expect(startCooldownMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(startCooldownMock).toHaveBeenCalledTimes(1);
+    const lastMessage = showSnackbarMock.mock.calls.at(-1)?.[0];
+    expect(lastMessage).toBe("Opponent is choosing…");
+    const snackOrder = showSnackbarMock.mock.invocationCallOrder?.[0] ?? 0;
+    const cooldownOrder = startCooldownMock.mock.invocationCallOrder?.[0] ?? Infinity;
+    expect(snackOrder).toBeLessThan(cooldownOrder);
+
+    if (typeof previousMin === "undefined") {
+      delete win.__MIN_OPPONENT_MESSAGE_DURATION_MS;
+    } else {
+      win.__MIN_OPPONENT_MESSAGE_DURATION_MS = previousMin;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- route finalizeSelectionReady through triggerCooldownOnce so cooldown waits out the opponent prompt minimum
- extend statSelection failure tests to stub snackbar/i18n timing and assert zero-delay opponent choice keeps the message until countdown

## Testing
- `npx vitest run tests/helpers/classicBattle/statSelection.failureFallback.test.js`
- `npx vitest run tests/helpers/classicBattle/opponentDelay.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68cfefc458d083269b0c1b2e509b9ec7