### PR TITLE
Use global state manager in cooldown integration test

### DIFF
--- a/tests/integration/roundManager.cooldown-integration.spec.js
+++ b/tests/integration/roundManager.cooldown-integration.spec.js
@@ -5,6 +5,7 @@ import {
   _resetForTest
 } from "../../src/helpers/classicBattle/roundManager.js";
 import * as eventDispatcher from "../../src/helpers/classicBattle/eventDispatcher.js";
+import { createGlobalStateManager } from "./roundManagerTestUtils.js";
 
 function createScoreboardStub() {
   return {
@@ -26,19 +27,17 @@ function createSnackbarStub() {
 }
 
 test("integration: startCooldown drives readiness flow with fake timers", async () => {
+  const globalStateManager = createGlobalStateManager();
   const timers = vi.useFakeTimers();
   const store = createBattleStore();
   const dispatchSpy = vi.spyOn(eventDispatcher, "dispatchBattleEvent").mockResolvedValue(true);
 
-  const previousDebugMap = window.__classicBattleDebugMap;
-  const previousStartCount = globalThis.__startCooldownCount;
-  const previousInvoked = window.__startCooldownInvoked;
-  const previousCooldownOverride = window.__NEXT_ROUND_COOLDOWN_MS;
-
-  window.__classicBattleDebugMap = new Map();
-  globalThis.__startCooldownCount = 0;
-  window.__startCooldownInvoked = false;
-  window.__NEXT_ROUND_COOLDOWN_MS = 1000;
+  globalStateManager.setup({
+    __classicBattleDebugMap: new Map(),
+    __startCooldownCount: 0,
+    __startCooldownInvoked: false,
+    __NEXT_ROUND_COOLDOWN_MS: 1000
+  });
 
   document.body.innerHTML = "";
   delete document.body.dataset?.battleState;
@@ -88,25 +87,6 @@ test("integration: startCooldown drives readiness flow with fake timers", async 
     try {
       _resetForTest(store);
     } catch {}
-    if (typeof previousCooldownOverride === "undefined") {
-      delete window.__NEXT_ROUND_COOLDOWN_MS;
-    } else {
-      window.__NEXT_ROUND_COOLDOWN_MS = previousCooldownOverride;
-    }
-    if (typeof previousDebugMap === "undefined") {
-      delete window.__classicBattleDebugMap;
-    } else {
-      window.__classicBattleDebugMap = previousDebugMap;
-    }
-    if (typeof previousStartCount === "undefined") {
-      delete globalThis.__startCooldownCount;
-    } else {
-      globalThis.__startCooldownCount = previousStartCount;
-    }
-    if (typeof previousInvoked === "undefined") {
-      delete window.__startCooldownInvoked;
-    } else {
-      window.__startCooldownInvoked = previousInvoked;
-    }
+    globalStateManager.restore();
   }
 });


### PR DESCRIPTION
## Summary
- import the shared global state manager helper into the cooldown integration test
- configure test globals through the manager setup instead of manual snapshots
- restore globals with the manager to simplify cleanup logic

## Testing
- npx vitest run tests/integration/roundManager.cooldown-integration.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d0055f21288326bc535ae05ceaf911