### PR TITLE
Add round counter fallback regression coverage

### DIFF
--- a/playwright/battle-classic/cooldown.spec.js
+++ b/playwright/battle-classic/cooldown.spec.js
@@ -56,4 +56,131 @@ test.describe("Classic Battle cooldown + Next", () => {
       await expect(roundCounter).not.toHaveText(/Round\s*3/);
     }, ["log", "info", "warn", "error", "debug"]);
   });
+
+  test("Round counter fallback respects engine state after DOM reversion", async ({ page }) => {
+    await withMutedConsole(async () => {
+      await page.addInitScript(() => {
+        window.__FF_OVERRIDES = { showRoundSelectModal: true };
+      });
+      await page.goto("/src/pages/battleClassic.html");
+
+      const roundCounter = page.getByTestId("round-counter");
+      const statButtonsContainer = page.getByTestId("stat-buttons");
+
+      await expect(page.getByRole("button", { name: "Medium" })).toBeVisible();
+      await page.getByRole("button", { name: "Medium" }).click();
+
+      await expect(statButtonsContainer).toHaveAttribute("data-buttons-ready", "true");
+      await expect(roundCounter).toHaveText(/Round\s*1/);
+
+      const firstStatButton = page.getByTestId("stat-button").first();
+      await expect(firstStatButton).toBeVisible();
+
+      await firstStatButton.click();
+
+      const nextButton = page.getByTestId("next-button");
+      await expect(nextButton).toBeEnabled();
+      await expect(nextButton).toHaveAttribute("data-next-ready", "true");
+
+      const contextBeforeNext = await page.evaluate(() => ({
+        last: window.__lastRoundCounterContext ?? null,
+        previous: window.__previousRoundCounterContext ?? null
+      }));
+
+      let observerInstalled = false;
+      try {
+        await page.evaluate(() => {
+          const counter = document.getElementById("round-counter");
+          if (!counter) throw new Error("round counter element missing");
+          const baselineText = String(counter.textContent ?? "");
+          const baselineHighest = counter.dataset?.highestRound ?? null;
+          let reverted = false;
+          const observer = new MutationObserver(() => {
+            if (reverted || !counter.isConnected) return;
+            const currentText = String(counter.textContent ?? "");
+            const currentHighest = counter.dataset?.highestRound ?? null;
+            if (currentText !== baselineText || currentHighest !== baselineHighest) {
+              reverted = true;
+              counter.textContent = baselineText;
+              if (counter.dataset) {
+                if (baselineHighest !== null) {
+                  counter.dataset.highestRound = baselineHighest;
+                } else {
+                  delete counter.dataset.highestRound;
+                }
+              }
+              observer.disconnect();
+            }
+          });
+          observer.observe(counter, { characterData: true, childList: true, subtree: true });
+          window.__restoreRoundCounterObserver = () => {
+            observer.disconnect();
+            delete window.__restoreRoundCounterObserver;
+          };
+        });
+        observerInstalled = true;
+
+        await nextButton.click();
+
+        await expect(roundCounter).toHaveText(/Round\s*2/);
+        const fallbackSnapshot = await page.evaluate(async () => {
+          const { getRoundsPlayed } = await import("/src/helpers/battleEngineFacade.js");
+          const counter = document.getElementById("round-counter");
+          const text = String(counter?.textContent ?? "");
+          const match = text.match(/Round\s*(\d+)/i);
+          const displayed = match ? Number(match[1]) : NaN;
+          const played = Number(getRoundsPlayed());
+          const expected = Number.isFinite(played) ? played + 1 : NaN;
+          return {
+            displayed,
+            expected,
+            highest: Number(window.__highestDisplayedRound ?? NaN),
+            lastContext: window.__lastRoundCounterContext ?? null,
+            previousContext: window.__previousRoundCounterContext ?? null
+          };
+        });
+        expect(Number.isFinite(fallbackSnapshot.expected)).toBe(true);
+        expect(fallbackSnapshot.displayed).toBe(fallbackSnapshot.expected);
+        expect(fallbackSnapshot.highest).toBe(fallbackSnapshot.expected);
+        expect(fallbackSnapshot.lastContext).toBe(contextBeforeNext.last);
+
+        await page.evaluate(() => window.__restoreRoundCounterObserver?.());
+        observerInstalled = false;
+
+        await page.waitForFunction(() => window.__lastRoundCounterContext === "advance");
+        await page.waitForFunction(
+          (expected) => window.__previousRoundCounterContext === expected,
+          contextBeforeNext.last
+        );
+
+        await expect(nextButton).not.toHaveAttribute("data-next-ready", "true");
+
+        const cycleSnapshot = await page.evaluate(async () => {
+          const { getRoundsPlayed } = await import("/src/helpers/battleEngineFacade.js");
+          const counter = document.getElementById("round-counter");
+          const text = String(counter?.textContent ?? "");
+          const match = text.match(/Round\s*(\d+)/i);
+          const displayed = match ? Number(match[1]) : NaN;
+          const played = Number(getRoundsPlayed());
+          const expected = Number.isFinite(played) ? played + 1 : NaN;
+          return {
+            displayed,
+            expected,
+            highest: Number(window.__highestDisplayedRound ?? NaN),
+            lastContext: window.__lastRoundCounterContext ?? null,
+            previousContext: window.__previousRoundCounterContext ?? null
+          };
+        });
+        expect(Number.isFinite(cycleSnapshot.expected)).toBe(true);
+        expect(cycleSnapshot.displayed).toBe(cycleSnapshot.expected);
+        expect(cycleSnapshot.highest).toBe(cycleSnapshot.expected);
+        expect(cycleSnapshot.lastContext).toBe("advance");
+        expect(cycleSnapshot.previousContext).toBe(contextBeforeNext.last);
+      } finally {
+        if (observerInstalled) {
+          await page.evaluate(() => window.__restoreRoundCounterObserver?.());
+        }
+      }
+    }, ["log", "info", "warn", "error", "debug"]);
+  });
 });


### PR DESCRIPTION
## Summary
- add a Playwright scenario that reverts post-selection round counter DOM changes via a MutationObserver
- verify the Next-button fallback keeps the counter aligned with getRoundsPlayed()+1 and with diagnostic globals
- ensure cleanup by restoring the observer and confirm the engine-driven advance maintains the expected round value

## Testing
- npx playwright test playwright/battle-classic/cooldown.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d00aac153c8326b3685ea012b0091f