### PR TITLE
Update vector search form submission test

### DIFF
--- a/playwright/vector-search.spec.js
+++ b/playwright/vector-search.spec.js
@@ -244,18 +244,18 @@ test.describe("Vector Search Page", () => {
     });
 
     test("search form prevents default submission", async ({ page }) => {
-      // Monitor for page navigation that would indicate form submission
-      let navigated = false;
-      page.on("framenavigated", () => {
-        navigated = true;
+      page.once("framenavigated", () => {
+        throw new Error("Form submitted");
       });
+
+      const initialUrl = page.url();
 
       await page.getByRole("searchbox").fill("query");
       await page.getByRole("button", { name: /search/i }).click();
 
-      // Wait a bit and ensure no navigation occurred
-      await page.waitForTimeout(500);
-      expect(navigated).toBe(false);
+      await page.evaluate(() => window.vectorSearchResultsPromise);
+
+      await expect(page).toHaveURL(initialUrl);
     });
 
     test("search input handles keyboard submission", async ({ page }) => {


### PR DESCRIPTION
## Summary
- throw an explicit error if the vector search form triggers navigation during submission
- wait for the vectorSearchResultsPromise and assert the URL stays the same to confirm the form prevented navigation

## Testing
- npx playwright test playwright/vector-search.spec.js

## Files Changed
- playwright/vector-search.spec.js

## Risk
- Low; Playwright test adjustments only.


------
https://chatgpt.com/codex/tasks/task_e_68d011fd38348326989cdad5fc38e019