### PR TITLE
Improve timer countdown polling in Playwright test

### DIFF
--- a/playwright/battle-classic/timer.spec.js
+++ b/playwright/battle-classic/timer.spec.js
@@ -26,12 +26,19 @@ test.describe("Classic Battle timer", () => {
       const timerLocator = page.getByTestId("next-round-timer");
       await expect(timerLocator).toContainText(/Time Left: \d+s/);
 
-      // Wait for timer to count down and verify it decreases
-      await page.waitForTimeout(1000); // Wait 1 second
-      const timerText1 = await timerLocator.textContent();
+      await page.evaluate(() =>
+        window.__TEST_API?.state?.waitForBattleState?.("waitingForPlayerAction")
+      );
 
-      await page.waitForTimeout(1000); // Wait another second
-      const timerText2 = await timerLocator.textContent();
+      const readTimerText = async () => (await timerLocator.textContent()) ?? "";
+      const waitForTimerUpdate = async (previousText) => {
+        await expect.poll(readTimerText).not.toBe(previousText);
+        return readTimerText();
+      };
+
+      const initialTimerText = await readTimerText();
+      const timerText1 = await waitForTimerUpdate(initialTimerText);
+      const timerText2 = await waitForTimerUpdate(timerText1);
 
       // Timer should have decreased (unless it reached 0)
       if (timerText1 !== "" && timerText2 !== "") {


### PR DESCRIPTION
## Summary
- replace fixed `waitForTimeout` calls in the classic battle timer test with polling to watch the countdown updates
- wait for the battle state to reach `waitingForPlayerAction` before capturing timer text to ensure the timer is running

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- npx vitest run *(fails: command produces extremely large animated output and was aborted)*
- npx playwright test playwright/battle-classic/timer.spec.js
- npx playwright test *(fails: known failures in battle classic opponent reveal / round counter specs)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d01699a8008326b90c519759bb4450