### PR TITLE
Improve round cycle tracking payload and logging

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -152,18 +152,52 @@ function recordRoundCycleTrigger(source) {
   }
 }
 
-function trackRoundCycleEvent(type, info = {}) {
+function trackRoundCycleEvent(type, info = {}, eventDetail) {
   if (typeof window === "undefined") return;
+
+  const sanitizeDetailValue = (value) => {
+    if (value === null) return null;
+    const valueType = typeof value;
+    return valueType === "string" || valueType === "number" || valueType === "boolean"
+      ? value
+      : undefined;
+  };
+
+  const detailSnapshot =
+    eventDetail && typeof eventDetail === "object"
+      ? {
+          source: sanitizeDetailValue(eventDetail?.source),
+          via: sanitizeDetailValue(eventDetail?.via)
+        }
+      : undefined;
+
+  const historyEntry = {
+    type: type || "unknown",
+    timestamp: getCurrentTimestamp(),
+    ...info
+  };
+
+  if (detailSnapshot) {
+    historyEntry.payload = detailSnapshot;
+  }
+
   try {
     if (!Array.isArray(window.__roundCycleHistory)) {
       window.__roundCycleHistory = [];
     }
-    window.__roundCycleHistory.push({
-      type: type || "unknown",
-      timestamp: getCurrentTimestamp(),
-      ...info
-    });
-  } catch {}
+    window.__roundCycleHistory.push(historyEntry);
+  } catch (error) {
+    try {
+      if (typeof console !== "undefined" && typeof console.debug === "function") {
+        console.debug("battleClassic: failed to push to window.__roundCycleHistory", {
+          type: historyEntry.type,
+          info,
+          payload: historyEntry.payload,
+          error
+        });
+      }
+    } catch {}
+  }
 }
 
 function handleCooldownError(store, reason, err) {
@@ -1469,12 +1503,12 @@ async function init() {
           if (hasManualStamp && Number.isFinite(elapsedSinceManual)) {
             eventInfo.sinceManualStartMs = elapsedSinceManual;
           }
-          trackRoundCycleEvent(eventType, eventInfo);
+          trackRoundCycleEvent(eventType, eventInfo, eventDetail);
           if (skipDueToManual) {
             return;
           }
         } else {
-          trackRoundCycleEvent(eventType, { manualRoundStart });
+          trackRoundCycleEvent(eventType, { manualRoundStart }, eventDetail);
         }
 
         try {


### PR DESCRIPTION
## Summary
- sanitize and persist select event detail fields alongside round cycle history entries while logging push failures
- forward battle event detail objects from `startIfNotEnded` so manual-start and ready events retain their origin context

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- CI=1 npx vitest run
- CI=1 npx playwright test *(fails: opponent reveal scenarios expect “Opponent is choosing” snackbar but received countdown text)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d0202e63388326895c15a88f686515