### PR TITLE
Use Test API timer control in opponent reveal timer test

### DIFF
--- a/playwright/battle-classic/opponent-reveal.spec.js
+++ b/playwright/battle-classic/opponent-reveal.spec.js
@@ -504,8 +504,18 @@ test.describe("Classic Battle Opponent Reveal", () => {
           setOpponentDelay(100);
         });
 
-        // Don't click any stat - let timer expire
-        await page.waitForTimeout(3500); // Wait for timer to expire
+        // Don't click any stat - let timer expire, then fast-forward via Test API
+        await page.waitForFunction(
+          () => typeof window.__TEST_API?.state?.waitForBattleState === "function"
+        );
+
+        await page.evaluate(() =>
+          window.__TEST_API.state.waitForBattleState("waitingForPlayerAction")
+        );
+
+        await page.evaluate(() =>
+          window.__TEST_API.timers.expireSelectionTimer()
+        );
 
         // Should auto-select and resolve
         await expect(page.locator("#score-display")).toContainText(/You:\s*\d/);


### PR DESCRIPTION
## Summary
- remove the hard-coded wait in the opponent reveal timer test
- wait for the stat selection state and expire the timer via the in-page Test API to trigger auto-selection

## Testing
- npx playwright test playwright/battle-classic/opponent-reveal.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d0351493a48326863216b344bb4c57