### PR TITLE
Add random Judoka draw button test hook

### DIFF
--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -16,9 +16,11 @@ test.describe("View Judoka screen", () => {
     const btn = page.getByTestId("draw-button");
     await expect(btn).toHaveText(/draw card/i);
 
+    await page.waitForFunction(
+      () => !!window.__TEST_API?.randomJudoka?.setDrawButtonLabel
+    );
     await page.evaluate(() => {
-      const button = document.querySelector('[data-testid="draw-button"]');
-      button.textContent = "Pick a random judoka";
+      window.__TEST_API.randomJudoka.setDrawButtonLabel("Pick a random judoka");
     });
 
     await expect(page.getByRole("button", { name: /draw a random judoka card/i })).toBeVisible();

--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -149,6 +149,16 @@ export function createDrawButton() {
   return drawButton;
 }
 
+function updateDrawButtonLabel(drawButton, text) {
+  if (!drawButton) return;
+  const label = drawButton.querySelector?.(".button-label");
+  if (label) {
+    label.textContent = text;
+  } else {
+    drawButton.textContent = text;
+  }
+}
+
 function showError(msg) {
   let errorEl = document.getElementById("draw-error-message");
   if (!errorEl) {
@@ -221,15 +231,10 @@ async function displayCard({
       settle();
       return;
     }
-    const label = drawButton.querySelector(".button-label");
     drawButton.disabled = true;
     drawButton.setAttribute("aria-disabled", "true");
     drawButton.classList.add("is-loading");
-    if (label) {
-      label.textContent = "Drawing…";
-    } else {
-      drawButton.textContent = "Drawing…";
-    }
+    updateDrawButtonLabel(drawButton, "Drawing…");
     drawButton.setAttribute("aria-busy", "true");
     const errorEl = document.getElementById("draw-error-message");
     if (errorEl) errorEl.textContent = "";
@@ -238,11 +243,7 @@ async function displayCard({
       drawButton.disabled = false;
       drawButton.removeAttribute("aria-disabled");
       drawButton.classList.remove("is-loading");
-      if (label) {
-        label.textContent = "Draw Card!";
-      } else {
-        drawButton.textContent = "Draw Card!";
-      }
+      updateDrawButtonLabel(drawButton, "Draw Card!");
       drawButton.removeAttribute("aria-busy");
       settle();
     }
@@ -330,6 +331,18 @@ export async function setupRandomJudokaPage() {
   const cardSection = document.querySelector(".card-section");
   const drawButton = createDrawButton();
   cardSection.appendChild(drawButton);
+
+  if (typeof window !== "undefined") {
+    const testApi =
+      typeof window.__TEST_API === "object" && window.__TEST_API !== null
+        ? window.__TEST_API
+        : (window.__TEST_API = {});
+    const randomJudokaApi = testApi.randomJudoka || (testApi.randomJudoka = {});
+    randomJudokaApi.setDrawButtonLabel = (labelText) => {
+      if (typeof labelText !== "string") return;
+      updateDrawButtonLabel(drawButton, labelText);
+    };
+  }
 
   const onSelect = (j) => addToHistory(historyManager, historyList, j);
 


### PR DESCRIPTION
## Summary
- expose a random Judoka test helper that updates the draw button label using the existing rendering logic
- update the random Judoka Playwright spec to call the helper before re-running the accessible-name assertion

## Testing
- npx playwright test playwright/random-judoka.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d04f0127e483269ef7bd78e6b485e7