### PR TITLE
Update CLI spec to use Test API timers

### DIFF
--- a/playwright/cli.spec.mjs
+++ b/playwright/cli.spec.mjs
@@ -1,7 +1,10 @@
 import { test, expect } from "@playwright/test";
+
+const buildCliUrl = () =>
+  process.env.CLI_TEST_URL || "http://127.0.0.1:5000/src/pages/battleCLI.html";
+
 test("CLI skeleton and helpers smoke", async ({ page }) => {
-  // Use Playwright's static server (see baseURL/port 5000 in config)
-  await page.goto("/src/pages/battleCLI.html");
+  await page.goto(buildCliUrl());
 
   // stats container present (rows may be skeleton or populated, allow racing init)
   await expect(page.locator("#cli-stats")).toHaveCount(1);
@@ -9,19 +12,23 @@ test("CLI skeleton and helpers smoke", async ({ page }) => {
   const statsCount = await page.locator("#cli-stats .cli-stat").count();
   expect(statsCount).toBeGreaterThan(0);
 
-  // countdown helper exposed on window
-  const hasHelper = await page.waitForFunction(
-    () => !!window.__battleCLIinit && typeof window.__battleCLIinit.setCountdown === "function"
+  // countdown helper exposed via Test API timers
+  await page.waitForFunction(() => typeof window.__TEST_API?.timers?.setCountdown === "function");
+
+  // focus helpers continue to be exposed for keyboard interaction tests
+  await page.waitForFunction(
+    () =>
+      typeof window.__battleCLIinit?.focusStats === "function" &&
+      typeof window.__battleCLIinit?.focusNextHint === "function"
   );
-  expect(Boolean(await hasHelper.jsonValue())).toBe(true);
 
   // set countdown via helper and verify attribute/text
-  await page.evaluate(() => window.__battleCLIinit.setCountdown(12));
+  await page.evaluate(() => window.__TEST_API.timers.setCountdown(12));
   const cd = page.locator("#cli-countdown");
   await expect(cd).toHaveAttribute("data-remaining-time", "12");
   await expect(cd).toHaveText(/12/);
 
-  // focus helpers
+  // focus helpers remain exposed on the legacy helper for keyboard support checks
   await page.evaluate(() => window.__battleCLIinit.focusStats());
   await expect(page.locator("#cli-stats")).toBeFocused();
   await page.evaluate(() => window.__battleCLIinit.focusNextHint());

--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -16,9 +16,7 @@ test.describe("View Judoka screen", () => {
     const btn = page.getByTestId("draw-button");
     await expect(btn).toHaveText(/draw card/i);
 
-    await page.waitForFunction(
-      () => !!window.__TEST_API?.randomJudoka?.setDrawButtonLabel
-    );
+    await page.waitForFunction(() => !!window.__TEST_API?.randomJudoka?.setDrawButtonLabel);
     await page.evaluate(() => {
       window.__TEST_API.randomJudoka.setDrawButtonLabel("Pick a random judoka");
     });


### PR DESCRIPTION
## Summary
- update the CLI smoke test to load the served CLI page (respecting `CLI_TEST_URL`) and drive the countdown through `window.__TEST_API.timers`
- wait for the legacy focus helpers before running keyboard assertions and keep the countdown assertions intact
- format the random judoka Playwright spec to satisfy Prettier

## Testing
- `npx playwright test playwright/cli.spec.mjs`
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run --reporter basic`
- `npx playwright test` *(fails: existing battle classic specs flaky on current baseline)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: model download blocked by offline environment)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle`
- `grep -RInE "console.(warn|error)(" tests --exclude=client_embeddings.json`


------
https://chatgpt.com/codex/tasks/task_e_68d0593758088326997f80f61574a313