### PR TITLE
Await navigation handler in quit flow test

### DIFF
--- a/tests/classicBattle/quit-flow.test.js
+++ b/tests/classicBattle/quit-flow.test.js
@@ -25,7 +25,12 @@ describe("Classic Battle quit flow", () => {
       dispatchedEvents.push(eventName);
     });
     vi.spyOn(eventBus, "getBattleState").mockReturnValue("interruptMatch");
-    const navigateSpy = vi.spyOn(navUtils, "navigateToHome").mockImplementation(() => {});
+    const navigateSpy = vi.spyOn(navUtils, "navigateToHome");
+    const navComplete = new Promise((resolve) => {
+      navigateSpy.mockImplementation(() => {
+        resolve();
+      });
+    });
 
     const { initClassicBattleTest } = await import("../helpers/initClassicBattleTest.js");
     await initClassicBattleTest({ afterMock: true });
@@ -60,8 +65,7 @@ describe("Classic Battle quit flow", () => {
     expect(document.activeElement?.id).toBe("cancel-quit-button");
 
     confirmBtn.click();
-    await Promise.resolve();
-    await Promise.resolve();
+    await navComplete;
 
     expect(showResultSpy).toHaveBeenCalledWith("You quit the match. You lose!");
     expect(dispatchedEvents).toEqual(["interrupt", "toLobby"]);


### PR DESCRIPTION
## Summary
- replace ad-hoc Promise.resolve calls with a deterministic navigation completion promise
- await the navigation handler after confirming quit so post-click assertions execute after navigation

## Testing
- npx vitest run tests/classicBattle/quit-flow.test.js

## Files
- tests/classicBattle/quit-flow.test.js

## Risk
- Low risk: test-only change


------
https://chatgpt.com/codex/tasks/task_e_68d05f36b84083269e3c2f32c13e9519