### PR TITLE
test: cover svg fallback via fixture

### DIFF
--- a/playwright/fixtures/svg-fallback.html
+++ b/playwright/fixtures/svg-fallback.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>SVG fallback fixture</title>
+  </head>
+  <body>
+    <img id="broken-icon" alt="Broken icon" data-src="./missing-icon.svg" />
+    <script type="module">
+      import { applySvgFallback } from "../../src/helpers/svgFallback.js";
+
+      const brokenIcon = document.getElementById("broken-icon");
+      brokenIcon.src = brokenIcon.dataset.src;
+      applySvgFallback("../../src/assets/images/judokonLogoSmall.png");
+    </script>
+  </body>
+</html>

--- a/playwright/homepage.spec.js
+++ b/playwright/homepage.spec.js
@@ -51,23 +51,10 @@ test.describe("Homepage", () => {
   });
 
   test("fallback icon applied on load failure", async ({ page }) => {
-    await page.addInitScript(() => {
-      window.brokenIconInsertedPromise = new Promise((resolve) => {
-        document.addEventListener("DOMContentLoaded", () => {
-          const img = document.createElement("img");
-          img.id = "broken-icon";
-          img.src = "./missing-icon.svg";
-          img.alt = "Broken icon";
-          document.body.appendChild(img);
-          resolve();
-        });
-      });
-    });
-
-    await page.goto("/index.html");
-    await page.evaluate(() => window.brokenIconInsertedPromise);
+    await page.goto("/playwright/fixtures/svg-fallback.html");
 
     const icon = page.locator("#broken-icon");
+    await expect(icon).toBeVisible();
     await expect.poll(() => icon.getAttribute("src")).toContain("judokonLogoSmall.png");
     await expect(icon).toHaveClass(/svg-fallback/);
   });


### PR DESCRIPTION
## Summary
- add a dedicated svg fallback HTML fixture that loads the shared helper and points at a missing icon
- update the homepage Playwright test to rely on the fixture rather than injecting markup and keep the fallback assertions

## Testing
- npx playwright test playwright/homepage.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d068f285988326bbb15c5fee595fb1