### PR TITLE
Refactor CLI flows tests to use battle test API waits

### DIFF
--- a/playwright/helpers/battleStateHelper.js
+++ b/playwright/helpers/battleStateHelper.js
@@ -3,58 +3,123 @@
  */
 
 /**
- * Wait for battle state using Test API instead of DOM polling
+ * Wait for the Playwright Test API bootstrap to be available on the page.
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {object} options - Options object
+ * @param {number} options.timeout - Timeout in ms (default: 10_000)
+ * @returns {Promise<void>}
+ */
+export async function waitForTestApi(page, options = {}) {
+  const { timeout = 10_000 } = options;
+
+  await page.waitForFunction(
+    () => {
+      try {
+        return typeof window !== "undefined" && typeof window.__TEST_API !== "undefined";
+      } catch {
+        return false;
+      }
+    },
+    { timeout }
+  );
+}
+
+/**
+ * Wait for battle initialization using the Test API when available.
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {object} options - Options object
+ * @param {number} options.timeout - Timeout in ms (default: 10_000)
+ * @param {boolean} options.allowFallback - Allow DOM fallback if Test API unavailable (default: true)
+ * @returns {Promise<void>}
+ */
+export async function waitForBattleReady(page, options = {}) {
+  const { timeout = 10_000, allowFallback = true } = options;
+
+  await waitForTestApi(page, { timeout });
+
+  const readyViaApi = await page.evaluate(
+    ({ waitTimeout }) => {
+      try {
+        const initApi = window.__TEST_API?.init;
+        if (initApi && typeof initApi.waitForBattleReady === "function") {
+          return initApi.waitForBattleReady.call(initApi, waitTimeout);
+        }
+      } catch {}
+      return null;
+    },
+    { waitTimeout: timeout }
+  );
+
+  if (readyViaApi === true) {
+    return;
+  }
+
+  if (readyViaApi === false && !allowFallback) {
+    throw new Error("Timed out waiting for battle readiness via Test API");
+  }
+
+  if (readyViaApi === false || readyViaApi === null) {
+    if (!allowFallback) {
+      throw new Error("Test API waitForBattleReady unavailable and fallback disabled");
+    }
+
+    await page.waitForFunction(
+      () => {
+        try {
+          return (
+            typeof window.__TEST_API?.init?.isBattleReady === "function" &&
+            window.__TEST_API.init.isBattleReady()
+          );
+        } catch {
+          return false;
+        }
+      },
+      { timeout }
+    );
+  }
+}
+
+/**
+ * Wait for battle state using Test API instead of DOM polling.
  * @param {import('@playwright/test').Page} page - Playwright page object
  * @param {string} expectedState - The state to wait for
  * @param {object} options - Options object
- * @param {number} options.timeout - Timeout in ms (default: 5000)
+ * @param {number} options.timeout - Timeout in ms (default: 5_000)
  * @param {boolean} options.allowFallback - Allow DOM fallback if Test API unavailable (default: true)
  * @returns {Promise<void>}
  */
 export async function waitForBattleState(page, expectedState, options = {}) {
-  const { timeout = 5000, allowFallback = true } = options;
+  const { timeout = 5_000, allowFallback = true } = options;
 
-  // First check if Test API is available
-  const hasTestAPI = await page.evaluate(() => {
-    return (
-      typeof window.__TEST_API !== "undefined" &&
-      window.__TEST_API.state &&
-      typeof window.__TEST_API.state.getBattleState === "function"
-    );
-  });
+  await waitForTestApi(page, { timeout });
 
-  if (hasTestAPI) {
-    // console.log(`⚡ Using Test API to wait for state: ${expectedState}`);
-    // Use Test API for fast, direct state checking
-    try {
-      await page.waitForFunction(
-        (state) => {
-          const currentState = window.__TEST_API.state.getBattleState();
-          return currentState === state;
-        },
-        expectedState,
-        { timeout }
-      );
-      return;
-    } catch (error) {
-      // console.log(
-      //   `⚠️ Test API state check failed, current state:`,
-      //   await page.evaluate(() => {
-      //     return window.__TEST_API.state.getBattleState();
-      //   })
-      // );
-      if (!allowFallback) {
-        throw error;
-      }
-    }
+  const apiResult = await page.evaluate(
+    ({ state, waitTimeout }) => {
+      try {
+        const stateApi = window.__TEST_API?.state;
+        if (stateApi && typeof stateApi.waitForBattleState === "function") {
+          return stateApi.waitForBattleState.call(stateApi, state, waitTimeout);
+        }
+      } catch {}
+      return null;
+    },
+    { state: expectedState, waitTimeout: timeout }
+  );
+
+  if (apiResult === true) {
+    return;
   }
 
-  if (allowFallback) {
-    // console.log(`🔄 Falling back to DOM polling for state: ${expectedState}`);
-    // Fallback to DOM polling if Test API unavailable or failed
+  if (apiResult === false && !allowFallback) {
+    throw new Error(`Timed out waiting for battle state "${expectedState}" via Test API`);
+  }
+
+  if (apiResult === false || apiResult === null) {
+    if (!allowFallback) {
+      throw new Error(`Test API waitForBattleState unavailable for "${expectedState}"`);
+    }
+
     await page.waitForSelector(`[data-battle-state="${expectedState}"]`, { timeout });
-  } else {
-    throw new Error(`Test API not available and fallback disabled for state: ${expectedState}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- update the CLI Playwright specs to rely on the Test API handshake helpers instead of inlined waitForFunction polling
- ensure both suites wait for battle readiness/state transitions via the shared battleStateHelper using the battle Test API
- extend battleStateHelper with waitForTestApi/waitForBattleReady that prefer the Test API and only fall back to DOM polling when needed

## Testing
- npx playwright test cli-flows.spec.mjs cli-flows-improved.spec.mjs
- npx eslint playwright/cli-flows.spec.mjs playwright/cli-flows-improved.spec.mjs playwright/helpers/battleStateHelper.js

------
https://chatgpt.com/codex/tasks/task_e_68d068f7206c83269831a70d2eec0439