### PR TITLE
Refine non-orchestrated cooldown test helpers

### DIFF
--- a/src/helpers/testApi.js
+++ b/src/helpers/testApi.js
@@ -132,6 +132,47 @@ const stateApi = {
 
       check();
     });
+  },
+
+  /**
+   * Wait for the Next button to be marked ready and enabled.
+   * @param {number} timeout - Timeout in milliseconds
+   * @returns {Promise<boolean>} Resolves true when ready, false on timeout
+   */
+  async waitForNextButtonReady(timeout = 5000) {
+    return new Promise((resolve) => {
+      const startTime = Date.now();
+
+      const check = () => {
+        try {
+          const nextButton =
+            document.getElementById("next-button") ||
+            document.querySelector("[data-role='next-round']");
+          const ariaDisabled =
+            typeof nextButton?.getAttribute === "function"
+              ? nextButton.getAttribute("aria-disabled")
+              : null;
+          if (
+            nextButton &&
+            nextButton.dataset?.nextReady === "true" &&
+            nextButton.disabled !== true &&
+            ariaDisabled !== "true"
+          ) {
+            resolve(true);
+            return;
+          }
+        } catch {}
+
+        if (Date.now() - startTime > timeout) {
+          resolve(false);
+          return;
+        }
+
+        setTimeout(check, 50);
+      };
+
+      check();
+    });
   }
 };
 


### PR DESCRIPTION
## Summary
- update the non-orchestrated cooldown Playwright spec to wait on shared helpers and Test API promises instead of manual DOM polling
- extend the Playwright waits helper to fall back to dataset flags or the exposed Test API when battleReadyPromise is absent, and let waitForBattleState read machine/debug data
- add a waitForNextButtonReady helper to the Test API so specs can assert the Next button deterministically

## Testing
- npx prettier playwright/battle-next-skip.non-orchestrated.spec.js playwright/fixtures/waits.js src/helpers/testApi.js --check
- npx eslint playwright/battle-next-skip.non-orchestrated.spec.js playwright/fixtures/waits.js src/helpers/testApi.js
- npx playwright test playwright/battle-next-skip.non-orchestrated.spec.js
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d06e41a1408326bd456e735c9a38c3