### PR TITLE
Refactor PRD reader tests to use component factory

### DIFF
--- a/tests/utils/componentTestUtils.js
+++ b/tests/utils/componentTestUtils.js
@@ -636,6 +636,12 @@ export function createTestPrdReader(docs, parser) {
       getTaskSummary: () => container.querySelector("#task-summary"),
       getNextButtons: () => container.querySelectorAll('[data-nav="next"]'),
       getPrevButtons: () => container.querySelectorAll('[data-nav="prev"]'),
+      getListItems: () => Array.from(container.querySelectorAll("#prd-list li")),
+      getListItem: (index) => {
+        const items = container.querySelectorAll("#prd-list li");
+        return items[index] ?? null;
+      },
+      getWarningBadge: () => container.querySelector(".markdown-warning"),
       navigateNext: () => {
         const nextBtn = container.querySelector('[data-nav="next"]');
         naturalClick(nextBtn);


### PR DESCRIPTION
## Summary
- replace manual DOM markup in PRD reader tests with the shared `createTestPrdReader` factory and clean up after each scenario
- expose additional helpers (list items and warning badge accessors) from the factory to support the updated assertions

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: existing formatting warnings outside the change set)*
- `npx prettier tests/helpers/prdReaderPage.test.js tests/utils/componentTestUtils.js --check`
- `npx eslint .` *(fails with pre-existing canonical timer warnings)*
- `npx vitest run --reporter=basic` *(fails: missing integration harness module in unrelated test file)*
- `npx playwright test` *(fails: known battle-classic flows and hover zoom issues)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68d074850028832693634f73b35e3264