### PR TITLE
Use resolved path for classic battle round manager tests

### DIFF
--- a/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
@@ -1,3 +1,5 @@
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, resolve } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createTimerNodes } from "./domUtils.js";
 import { createMockScheduler } from "../mockScheduler.js";
@@ -5,6 +7,11 @@ import { createClassicBattleHarness } from "../integrationHarness.js";
 import { resetDispatchHistory } from "../../../src/helpers/classicBattle/eventDispatcher.js";
 
 const READY_EVENT = "ready";
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, "../../..");
+const ROUND_MANAGER_MODULE = pathToFileURL(
+  resolve(REPO_ROOT, "src/helpers/classicBattle/roundManager.js")
+).href;
 
 /**
  * Create a dispatcher mock that replays candidate dispatchers before falling
@@ -119,9 +126,7 @@ describe("startCooldown fallback timer", () => {
   });
 
   it("resolves ready after fallback timer and enables button", async () => {
-    const { startCooldown } = await harness.importModule(
-      "/workspaces/judokon/src/helpers/classicBattle/roundManager.js"
-    );
+    const { startCooldown } = await harness.importModule(ROUND_MANAGER_MODULE);
     const btn = document.querySelector('[data-role="next-round"]');
     btn.disabled = true;
     const controls = startCooldown({}, scheduler);
@@ -178,9 +183,7 @@ describe("startCooldown ready dispatch discipline", () => {
     const { mockCreateRoundTimer } = await import("../roundTimerMock.js");
     mockCreateRoundTimer({ scheduled: false, ticks: [], expire: true });
 
-    const { startCooldown } = await harness.importModule(
-      "/workspaces/judokon/src/helpers/classicBattle/roundManager.js"
-    );
+    const { startCooldown } = await harness.importModule(ROUND_MANAGER_MODULE);
     const controls = startCooldown({}, scheduler);
     scheduler.tick(0);
     await controls.ready;
@@ -193,9 +196,7 @@ describe("startCooldown ready dispatch discipline", () => {
     const { mockCreateRoundTimer } = await import("../roundTimerMock.js");
     mockCreateRoundTimer({ scheduled: false, ticks: [], expire: false });
 
-    const { startCooldown } = await harness.importModule(
-      "/workspaces/judokon/src/helpers/classicBattle/roundManager.js"
-    );
+    const { startCooldown } = await harness.importModule(ROUND_MANAGER_MODULE);
     const controls = startCooldown({}, scheduler);
     scheduler.tick(0);
     scheduler.tick(20);
@@ -245,9 +246,7 @@ describe("handleNextRoundExpiration immediate readiness", () => {
     const { mockCreateRoundTimer } = await import("../roundTimerMock.js");
     mockCreateRoundTimer({ scheduled: false, ticks: [], expire: true });
 
-    const { startCooldown } = await harness.importModule(
-      "/workspaces/judokon/src/helpers/classicBattle/roundManager.js"
-    );
+    const { startCooldown } = await harness.importModule(ROUND_MANAGER_MODULE);
     const controls = startCooldown({}, scheduler);
     expect(controls).toBeTruthy();
     expect(typeof controls?.ready).toBe("object");
@@ -263,9 +262,7 @@ describe("handleNextRoundExpiration immediate readiness", () => {
     const { mockCreateRoundTimer } = await import("../roundTimerMock.js");
     mockCreateRoundTimer({ scheduled: false, ticks: [], expire: true });
 
-    const { startCooldown } = await harness.importModule(
-      "/workspaces/judokon/src/helpers/classicBattle/roundManager.js"
-    );
+    const { startCooldown } = await harness.importModule(ROUND_MANAGER_MODULE);
     const controls = startCooldown({}, scheduler);
     expect(controls).toBeTruthy();
     expect(typeof controls?.ready).toBe("object");
@@ -312,9 +309,7 @@ describe("bus propagation and deduplication", () => {
     const { mockCreateRoundTimer } = await import("../roundTimerMock.js");
     mockCreateRoundTimer({ scheduled: false, ticks: [], expire: true });
 
-    const { startCooldown } = await harness.importModule(
-      "/workspaces/judokon/src/helpers/classicBattle/roundManager.js"
-    );
+    const { startCooldown } = await harness.importModule(ROUND_MANAGER_MODULE);
     controls = startCooldown({}, createMockScheduler(), {
       dispatchReadyViaBus: dispatchReadyViaBusSpy
     });


### PR DESCRIPTION
## Summary
- compute the classic battle round manager module path relative to the repository root using Node path helpers
- reuse the shared specifier across the fallback schedule tests instead of the hard-coded `/workspaces/...` path

## Testing
- `npx vitest run tests/helpers/classicBattle/scheduleNextRound.fallback.test.js` *(fails: existing timeouts in startCooldown readiness cases)*

## Task Contract
- **Inputs:** `tests/helpers/classicBattle/scheduleNextRound.fallback.test.js`, repository root location, vitest harness.
- **Outputs:** updated test imports that derive the round manager module path relative to `import.meta.url` and reuse a shared constant.
- **Success Criteria:** the test suite loads `roundManager.js` via the computed specifier and the targeted Vitest run completes.
- **Failure Modes:** mis-resolved path causing module import errors or regressions in classic battle readiness tests.

## Files Changed
- tests/helpers/classicBattle/scheduleNextRound.fallback.test.js

## Risk
- Low: adjustments are confined to test path resolution logic.


------
https://chatgpt.com/codex/tasks/task_e_68d081c3692c8326a099d511ae3b22e9