### PR TITLE
Address dispatcher spy cleanup in fallback tests

### DIFF
--- a/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
@@ -176,7 +176,8 @@ describe("startCooldown ready dispatch discipline", () => {
   let dispatchSpy;
 
   beforeEach(async () => {
-    dispatchSpy = vi.fn().mockResolvedValue(undefined);
+    dispatchSpy = vi.fn();
+    dispatchSpy.mockResolvedValue(undefined);
 
     harness = createClassicBattleHarness({
       mocks: {
@@ -242,7 +243,8 @@ describe("handleNextRoundExpiration immediate readiness", () => {
   let dispatchSpy;
 
   beforeEach(async () => {
-    dispatchSpy = vi.fn().mockResolvedValue(undefined);
+    dispatchSpy = vi.fn();
+    dispatchSpy.mockResolvedValue(undefined);
 
     harness = createClassicBattleHarness({
       mocks: {


### PR DESCRIPTION
## Summary
- split the cooldown fallback test setup to instantiate the dispatch spy with `vi.fn()` before configuring its resolved value, avoiding any stray resets

## Testing
- `npm run check:jsdoc` *(fails: src/helpers/classicBattle/roundStore.js missing JSDoc)*
- `npx prettier . --check` *(fails: unrelated formatting issues in progressCodex.md, roundManager.js, test-traces.json)*
- `npx eslint .` *(fails: existing canonical timer warnings in unrelated tests)*
- `npx vitest run` *(aborted after several minutes without finishing)*
- `npx playwright test` *(fails: existing battle classic specs currently red)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: offline environment prevents model download)*
- `npm run validate:data`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle`
- `grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68d08706d7fc8326a80ec7f2b0e2d29b