### PR TITLE
Fix integration harness mock factory behavior

### DIFF
--- a/tests/helpers/integrationHarness.js
+++ b/tests/helpers/integrationHarness.js
@@ -87,7 +87,9 @@ export function createIntegrationHarness(config = {}) {
 
     // Apply selective mocks for externalities only
     for (const [modulePath, mockImpl] of Object.entries(mocks)) {
-      vi.doMock(modulePath, () => mockImpl);
+      const mockFactory = typeof mockImpl === "function" ? mockImpl : () => mockImpl;
+
+      vi.doMock(modulePath, mockFactory);
     }
 
     // Inject fixtures into global scope or modules as needed


### PR DESCRIPTION
## Summary
- update the integration test harness to pass function mocks directly to `vi.doMock`
- ensure non-function mocks continue to be wrapped in a factory for Vitest

## Testing
- npm run check:jsdoc *(fails: existing missing JSDoc for roundStore)*
- npx prettier . --check
- npx eslint .
- CI=1 npx vitest run --reporter=json *(fails: classic battle schedule fallback tests report missing module/dispatch expectations)*
- CI=1 npx playwright test *(fails: classic battle E2E scenarios report score/DOM expectations)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d0e4deee4883268601056a6ebfa381