### PR TITLE
Use round manager constant in fallback test

### DIFF
--- a/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
+++ b/tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
@@ -149,9 +149,7 @@ describe("startCooldown fallback timer", () => {
 
   it("resolves ready when dispatcher reports false and enables button", async () => {
     dispatchSpy.mockImplementation(() => false);
-    const { startCooldown } = await harness.importModule(
-      "/workspaces/judokon/src/helpers/classicBattle/roundManager.js"
-    );
+    const { startCooldown } = await harness.importModule(ROUND_MANAGER_MODULE);
     const btn = document.querySelector('[data-role="next-round"]');
     btn.disabled = true;
     const controls = startCooldown({}, scheduler);


### PR DESCRIPTION
## Summary
- switch the fallback test to import the round manager module via the existing constant

## Testing
- npm run check:jsdoc *(fails: known missing JSDoc for roundStore)*
- npx prettier tests/helpers/classicBattle/scheduleNextRound.fallback.test.js --check
- npx eslint tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
- npx vitest run *(terminated after prolonged progress output)*

------
https://chatgpt.com/codex/tasks/task_e_68d0eacd3a7483268af6f0a75f0b49ec