### PR TITLE
Add scoreboard readiness hook for RoundStore integration tests

### DIFF
--- a/src/helpers/classicBattle/roundStore.js
+++ b/src/helpers/classicBattle/roundStore.js
@@ -243,11 +243,11 @@ class RoundStore {
    */
   wireIntoScoreboardAdapter() {
     if (!isEnabled("roundStore")) {
-      return; // Feature flag disabled, use legacy event system
+      return Promise.resolve(); // Feature flag disabled, use legacy event system
     }
 
     // Import scoreboard adapter dynamically to avoid circular dependencies
-    import("../setupScoreboard.js")
+    return import("../setupScoreboard.js")
       .then(({ updateRoundCounter }) => {
         // Subscribe to round number changes
         this.onRoundNumberChange((newNumber) => {
@@ -284,6 +284,13 @@ class RoundStore {
   }
 }
 
-// Export singleton instance
+/**
+ * Singleton round store instance for classic battles.
+ *
+ * @pseudocode
+ * 1. Create a RoundStore and reuse it across imports.
+ *
+ * @type {RoundStore}
+ */
 export const roundStore = new RoundStore();
 export default roundStore;

--- a/tests/unit/roundStore-integration.test.js
+++ b/tests/unit/roundStore-integration.test.js
@@ -8,7 +8,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { roundStore } from "../../src/helpers/classicBattle/roundStore.js";
 import {
   initScoreboardAdapter,
-  disposeScoreboardAdapter
+  disposeScoreboardAdapter,
+  whenScoreboardReady
 } from "../../src/helpers/classicBattle/scoreboardAdapter.js";
 
 // Mock the feature flags module
@@ -90,8 +91,8 @@ describe("RoundStore Feature Flag Integration", () => {
       // Should have called isEnabled to check flag
       expect(mockIsEnabled).toHaveBeenCalledWith("roundStore");
 
-      // Wait for dynamic import to complete
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Wait for async wiring to complete deterministically
+      await whenScoreboardReady();
 
       // RoundStore should now have scoreboard callback
       expect(typeof roundStore.callbacks.onRoundNumberChange).toBe("function");
@@ -100,8 +101,8 @@ describe("RoundStore Feature Flag Integration", () => {
     it("should update scoreboard when round number changes", async () => {
       initScoreboardAdapter();
 
-      // Wait for dynamic import
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Wait for wiring to resolve
+      await whenScoreboardReady();
 
       // Set round number - should call updateRoundCounter
       roundStore.setRoundNumber(3);
@@ -115,8 +116,8 @@ describe("RoundStore Feature Flag Integration", () => {
 
       initScoreboardAdapter();
 
-      // Wait for dynamic import
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Wait for wiring promise to resolve
+      await whenScoreboardReady();
 
       // Should have called updateRoundCounter with initial value
       expect(mockUpdateRoundCounter).toHaveBeenCalledWith(2);
@@ -129,8 +130,8 @@ describe("RoundStore Feature Flag Integration", () => {
 
       initScoreboardAdapter();
 
-      // Wait for dynamic import
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Wait for wiring promise to resolve
+      await whenScoreboardReady();
 
       // This should not throw, errors should be caught internally
       expect(() => roundStore.setRoundNumber(1)).not.toThrow();
@@ -143,8 +144,8 @@ describe("RoundStore Feature Flag Integration", () => {
 
       initScoreboardAdapter();
 
-      // Wait for wiring
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Wait for deterministic wiring hook
+      await whenScoreboardReady();
 
       // Verify callback is set
       expect(typeof roundStore.callbacks.onRoundNumberChange).toBe("function");


### PR DESCRIPTION
## Summary
- expose a `whenScoreboardReady` helper from the scoreboard adapter to share the async wiring promise and reset it on dispose
- ensure `roundStore.wireIntoScoreboardAdapter` returns a promise and document the singleton export
- update the RoundStore integration tests to await the readiness hook instead of timer-based sleeps

## Testing
- npx eslint src/helpers/classicBattle/scoreboardAdapter.js src/helpers/classicBattle/roundStore.js tests/unit/roundStore-integration.test.js
- npx vitest run tests/unit/roundStore-integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0ecd656fc8326ace2692df4f27945