### PR TITLE
Refactor random judoka accessible name test

### DIFF
--- a/playwright/random-judoka.spec.js
+++ b/playwright/random-judoka.spec.js
@@ -16,12 +16,21 @@ test.describe("View Judoka screen", () => {
     const btn = page.getByTestId("draw-button");
     await expect(btn).toHaveText(/draw card/i);
 
-    await page.waitForFunction(() => !!window.__TEST_API?.randomJudoka?.setDrawButtonLabel);
-    await page.evaluate(() => {
-      window.__TEST_API.randomJudoka.setDrawButtonLabel("Pick a random judoka");
-    });
+    await expect(btn).toHaveAccessibleName(/draw a random judoka card/i);
 
-    await expect(page.getByRole("button", { name: /draw a random judoka card/i })).toBeVisible();
+    await btn.click();
+    await expect(btn).toHaveText(/drawing/i);
+    await expect(btn).toHaveAccessibleName(/draw a random judoka card/i);
+
+    await expect(btn).toHaveText(/draw card/i);
+    await expect(btn).toHaveAccessibleName(/draw a random judoka card/i);
+
+    await btn.click();
+    await expect(btn).toHaveText(/drawing/i);
+    await expect(btn).toHaveAccessibleName(/draw a random judoka card/i);
+
+    await expect(btn).toHaveText(/draw card/i);
+    await expect(btn).toHaveAccessibleName(/draw a random judoka card/i);
   });
 
   test("draw card populates container", async ({ page }) => {


### PR DESCRIPTION
## Task Contract
- **Inputs:** `playwright/random-judoka.spec.js`
- **Outputs:** Updated Playwright test coverage for the random judoka draw button.
- **Success Criteria:** The accessible name assertion no longer mutates DOM state and still verifies the label is stable through draw cycles.
- **Failure Modes:** Helper exposure errors, flaky assertions, or DOM writes from the test.

## Summary
- Remove the direct `page.evaluate` call that changed the draw button label from the Playwright spec.
- Assert the draw button’s accessible name using `toHaveAccessibleName` while cycling the button through multiple draw interactions.

## Testing
- `npx playwright test playwright/random-judoka.spec.js`

## Files Changed
- `playwright/random-judoka.spec.js`

## Risk
- Low: test-only change that exercises existing UI interactions.


------
https://chatgpt.com/codex/tasks/task_e_68d0f4303d208326963fdeee1bb96876