### PR TITLE
Adjust ready dispatch fallback handling

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -830,7 +830,9 @@ async function handleNextRoundExpiration(controls, btn, options = {}) {
     alreadyDispatchedReady:
       options?.alreadyDispatchedReady === true || hasReadyBeenDispatchedForCurrentCooldown(),
     strategies,
-    emitTelemetry
+    emitTelemetry,
+    fallbackDispatcher: options?.dispatchBattleEvent,
+    useGlobalFallback: options?.useGlobalReadyFallback === true
   });
   if (dispatched) {
     setReadyDispatchedForCurrentCooldown(true);


### PR DESCRIPTION
## Summary
- ensure runReadyDispatchStrategies accepts an optional fallback dispatcher and only invokes the global dispatcher when explicitly requested
- wire roundManager to forward the configured dispatcher so tests can rely on mocked implementations

## Testing
- npx vitest run tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
- npx vitest run tests/helpers/classicBattle/scheduleNextRound.fallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0ec3d25908326963f71b595268db4