### PR TITLE
Adjust ready dispatch fallback semantics

### DIFF
--- a/src/helpers/classicBattle/nextRound/expirationHandlers.js
+++ b/src/helpers/classicBattle/nextRound/expirationHandlers.js
@@ -649,20 +649,16 @@ export async function runReadyDispatchStrategies(params = {}) {
     fallbackAttempted = true;
     if (outcome.dispatched === true) {
       fallbackDispatched = true;
-      dispatched = true;
     }
   };
-  if (!dispatched) {
+  const shouldInvokeFallbackDispatcher = !dispatched && typeof fallbackDispatcher === "function";
+  if (shouldInvokeFallbackDispatcher) {
     const fallbackOutcome = await invokeFallbackDispatcher(fallbackDispatcher);
     registerFallbackOutcome(fallbackOutcome);
-    if (fallbackOutcome?.dispatched) {
-      emitTelemetry?.("handleNextRoundDispatchFallback", true);
-      emitResult(true);
-      return true;
-    }
   }
   const shouldInvokeGlobalFallback =
     !dispatched &&
+    fallbackDispatched !== true &&
     useGlobalFallback === true &&
     typeof globalDispatchBattleEvent === "function" &&
     globalDispatchBattleEvent !== fallbackDispatcher;
@@ -672,10 +668,6 @@ export async function runReadyDispatchStrategies(params = {}) {
   }
   if (fallbackAttempted) {
     emitTelemetry?.("handleNextRoundDispatchFallback", fallbackDispatched);
-    if (fallbackDispatched) {
-      emitResult(true);
-      return true;
-    }
   }
   emitResult(dispatched);
   return dispatched;

--- a/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
+++ b/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
@@ -301,6 +301,20 @@ describe("runReadyDispatchStrategies", () => {
     expect(calls).toEqual(["machine", "bus"]);
     expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchResult", true);
   });
+
+  it("does not report success when only fallback dispatches", async () => {
+    const emit = vi.fn();
+    const fallbackDispatcher = vi.fn(() => true);
+    const result = await runReadyDispatchStrategies({
+      strategies: [() => false],
+      emitTelemetry: emit,
+      fallback: { dispatcher: fallbackDispatcher }
+    });
+    expect(result).toBe(false);
+    expect(fallbackDispatcher).toHaveBeenCalledWith("ready");
+    expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchFallback", true);
+    expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchResult", false);
+  });
 });
 
 describe("updateExpirationUi", () => {


### PR DESCRIPTION
## Summary
- ensure `runReadyDispatchStrategies` no longer marks fallback dispatchers as successful results while continuing to report fallback telemetry
- add regression coverage proving strategies are the only path to a successful ready dispatch result

## Testing
- `npx vitest run tests/helpers/classicBattle/nextRound/expirationHandlers.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d10376cdb8832691f89380e5d8935e