### PR TITLE
Refactor cooldown test to use battle test API

### DIFF
--- a/src/helpers/testApi.js
+++ b/src/helpers/testApi.js
@@ -192,6 +192,83 @@ const stateApi = {
 
       check();
     });
+  },
+
+  /**
+   * Simulate an external script reverting the round counter display.
+   *
+   * @param {{
+   *   round?: number|null,
+   *   text?: string|null,
+   *   highestRound?: number|null
+   * }} [options]
+   * @returns {{
+   *   success: boolean,
+   *   previousText: string|null,
+   *   previousHighest: string|null,
+   *   appliedText: string|null,
+   *   appliedHighest: string|null,
+   *   reason?: string
+   * }} Snapshot describing the interference effect.
+   */
+  simulateRoundCounterInterference(options = {}) {
+    const { round = null, text = null, highestRound = null } = options || {};
+
+    try {
+      const counter = document.getElementById("round-counter");
+      if (!counter) {
+        return {
+          success: false,
+          previousText: null,
+          previousHighest: null,
+          appliedText: null,
+          appliedHighest: null,
+          reason: "round-counter-missing"
+        };
+      }
+
+      const previousText = String(counter.textContent ?? "");
+      const previousHighest = counter.dataset?.highestRound ?? null;
+
+      let appliedText = null;
+      if (typeof text === "string") {
+        appliedText = text;
+      } else if (Number.isFinite(Number(round)) && Number(round) > 0) {
+        appliedText = `Round ${Number(round)}`;
+      }
+
+      if (appliedText !== null) {
+        counter.textContent = appliedText;
+      }
+
+      let appliedHighest = null;
+      const numericHighest = Number(highestRound);
+      if (Number.isFinite(numericHighest) && numericHighest > 0) {
+        appliedHighest = String(numericHighest);
+        if (counter.dataset) {
+          counter.dataset.highestRound = appliedHighest;
+        }
+      } else if (counter.dataset && "highestRound" in counter.dataset) {
+        delete counter.dataset.highestRound;
+      }
+
+      return {
+        success: true,
+        previousText,
+        previousHighest,
+        appliedText,
+        appliedHighest
+      };
+    } catch (error) {
+      return {
+        success: false,
+        previousText: null,
+        previousHighest: null,
+        appliedText: null,
+        appliedHighest: null,
+        reason: error instanceof Error ? error.message : String(error)
+      };
+    }
   }
 };
 


### PR DESCRIPTION
## Task Contract
- **Inputs:** Existing Playwright cooldown tests and test API utilities for the Classic Battle flow.
- **Outputs:** Refactored Playwright coverage that advances rounds via the public test API and a helper that safely simulates round-counter interference.
- **Success Criteria:** Cooldown scenarios exercise natural interactions, rely on `__TEST_API` diagnostics/timers, and avoid DOM mutation hacks while still asserting recovery from interference.
- **Error Handling:** Surface failures through Playwright expectations/Test API polling; throw descriptive errors if required helpers are unavailable.

## Files Changed
- **playwright/battle-classic/cooldown.spec.js:** Replace manual DOM tweaking with Test API waits/diagnostics and controlled interference simulation.
- **src/helpers/testApi.js:** Provide `state.simulateRoundCounterInterference` to emulate external round counter edits for Playwright regression coverage.

## Verification Summary
- **eslint:** PASS
- **vitest:** 1285 passed, 6 failed (scheduleNextRound fallback readiness expectations)
- **playwright:** FAIL (4 failures in battle-classic end-modal/timer-clearing specs)
- **jsdoc:** PASS

## Risk & Follow-Up
- Medium risk: new Test API surface and Playwright logic rely on runtime hooks; additional unit coverage for `simulateRoundCounterInterference` is recommended to guard behavior. Investigate the existing Vitest fallback readiness and Playwright end-modal score expectations, which currently fail without additional deterministic battle setup.


------
https://chatgpt.com/codex/tasks/task_e_68d103b4962083268f8317c9cad8442b