### PR TITLE
Resolve integration harness mocks and stabilize classic battle tests

### DIFF
--- a/playwright/battle-classic/end-modal.spec.js
+++ b/playwright/battle-classic/end-modal.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from "../fixtures/commonSetup.js";
 import { withMutedConsole } from "../../tests/utils/console.js";
+import { selectWinningStat } from "../helpers/classicBattleActions.js";
 
 async function waitForScoreDisplay(page, timeout = 10000) {
   await page.waitForFunction(
@@ -37,7 +38,7 @@ test.describe("Classic Battle End Game Flow", () => {
 
         // Start match
         await page.click("#round-select-2");
-        await page.click("#stat-buttons button[data-stat]");
+        await selectWinningStat(page);
 
         // Verify match completion
         await expect(page.locator("#score-display")).toContainText(/You:\s*1/);
@@ -66,7 +67,7 @@ test.describe("Classic Battle End Game Flow", () => {
 
         // Start and complete match
         await page.click("#round-select-2");
-        await page.click("#stat-buttons button[data-stat]");
+        await selectWinningStat(page);
 
         // Verify score display shows completion
         const scoreDisplay = page.locator("#score-display");
@@ -101,7 +102,7 @@ test.describe("Classic Battle End Game Flow", () => {
         });
 
         await page.click("#round-select-2");
-        await page.click("#stat-buttons button[data-stat]");
+        await selectWinningStat(page);
 
         // Verify match ended
         await expect(page.locator("#score-display")).toContainText(/You:\s*1/);
@@ -139,7 +140,7 @@ test.describe("Classic Battle End Game Flow", () => {
         });
 
         await page.click("#round-select-2");
-        await page.click("#stat-buttons button[data-stat]");
+        await selectWinningStat(page);
 
         await waitForScoreDisplay(page);
         expect(errors.length).toBe(0);
@@ -171,7 +172,7 @@ test.describe("Classic Battle End Game Flow", () => {
         });
 
         await page.click("#round-select-2");
-        await page.click("#stat-buttons button[data-stat]");
+        await selectWinningStat(page);
 
         // Verify score display is clear and readable
         const scoreDisplay = page.locator("#score-display");
@@ -202,7 +203,7 @@ test.describe("Classic Battle End Game Flow", () => {
         });
 
         await page.click("#round-select-2");
-        await page.click("#stat-buttons button[data-stat]");
+        await selectWinningStat(page);
 
         // Verify match completed
         await expect(page.locator("#score-display")).toContainText(/You:\s*1/);
@@ -240,7 +241,7 @@ test.describe("Classic Battle End Game Flow", () => {
         });
 
         await page.click("#round-select-2");
-        await page.click("#stat-buttons button[data-stat]");
+        await selectWinningStat(page);
 
         await waitForScoreDisplay(page);
         expect(errors.length).toBe(0);
@@ -267,7 +268,7 @@ test.describe("Classic Battle End Game Flow", () => {
 
         // Complete first match
         await page.click("#round-select-2");
-        await page.click("#stat-buttons button[data-stat]");
+        await selectWinningStat(page);
         await expect(page.locator("#score-display")).toContainText(/You:\s*1/);
 
         // Verify page remains functional after match completion

--- a/playwright/battle-classic/opponent-reveal.spec.js
+++ b/playwright/battle-classic/opponent-reveal.spec.js
@@ -2,6 +2,15 @@ import { test, expect } from "@playwright/test";
 import selectors from "../helpers/selectors.js";
 import { readScoreboardRound } from "../helpers/roundCounter.js";
 import { withMutedConsole } from "../../tests/utils/console.js";
+import { selectWinningStat } from "../helpers/classicBattleActions.js";
+
+async function chooseStatByIndex(page, index) {
+  const statKey = await page.evaluate((idx) => {
+    const buttons = Array.from(document.querySelectorAll("#stat-buttons button[data-stat]"));
+    return buttons[idx]?.getAttribute("data-stat") || null;
+  }, index);
+  await selectWinningStat(page, { statKey: statKey ?? undefined });
+}
 
 test.describe("Classic Battle Opponent Reveal", () => {
   test.describe("Basic Opponent Reveal Functionality", () => {
@@ -28,8 +37,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
         });
 
         // Click the first stat (player 0)
-        const firstStat = page.locator(selectors.statButton(0)).first();
-        await firstStat.click();
+        await selectWinningStat(page);
 
         // Expect the snackbar to show opponent choosing soon
         const snack = page.locator(selectors.snackbarContainer());
@@ -60,8 +68,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
           setOpponentDelay(1);
         });
 
-        const firstStat = page.locator(selectors.statButton(0)).first();
-        await firstStat.click();
+        await selectWinningStat(page);
 
         // Should still show opponent choosing briefly
         const snackbar = page.locator(selectors.snackbarContainer());
@@ -118,8 +125,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
         });
 
         // First round
-        const firstStat = page.locator(selectors.statButton(0)).first();
-        await firstStat.click();
+        await selectWinningStat(page);
 
         // Verify battle flow continues (snackbar shows various states)
 
@@ -217,8 +223,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
         });
 
         // Second round should work the same way
-        const secondStat = page.locator(selectors.statButton(0)).nth(1);
-        await secondStat.click();
+        await chooseStatByIndex(page, 1);
 
         // Should resolve second round
         await expect(page.locator("#score-display")).toContainText(/You:\s*\d/);
@@ -243,8 +248,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
           setOpponentDelay(10);
         });
 
-        const firstStat = page.locator("#stat-buttons button[data-stat]").first();
-        await firstStat.click();
+        await selectWinningStat(page);
 
         // Should still show message briefly
         const snackbar = page.locator(selectors.snackbarContainer());
@@ -271,8 +275,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
           setOpponentDelay(500);
         });
 
-        const firstStat = page.locator(selectors.statButton(0)).first();
-        await firstStat.click();
+        await selectWinningStat(page);
 
         // Should show message for longer period
         const snackbar = page.locator(selectors.snackbarContainer());
@@ -302,7 +305,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
 
         // Click multiple stats rapidly
         const stats = page.locator("#stat-buttons button[data-stat]");
-        await stats.first().click();
+        await chooseStatByIndex(page, 0);
         await stats.nth(1).click(); // Should be ignored
 
         // Should still resolve properly despite rapid clicks
@@ -325,8 +328,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
           setOpponentDelay(200);
         });
 
-        const firstStat = page.locator("#stat-buttons button[data-stat]").first();
-        await firstStat.click();
+        await selectWinningStat(page);
 
         // Navigate away during opponent reveal
         await page.goto("/index.html");
@@ -360,8 +362,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
           setOpponentDelay(50);
         });
 
-        const firstStat = page.locator("#stat-buttons button[data-stat]").first();
-        await firstStat.click();
+        await selectWinningStat(page);
 
         // Should still resolve even without snackbar
         await expect(page.locator("#score-display")).toContainText(/You:\s*\d/);
@@ -387,8 +388,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
         });
 
         // First round
-        const firstStat = page.locator("#stat-buttons button[data-stat]").first();
-        await firstStat.click();
+        await selectWinningStat(page);
 
         // Wait for first round to complete
         await expect(page.locator("#next-button")).toBeEnabled();
@@ -399,8 +399,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
           .poll(() => readScoreboardRound(page.locator("#round-counter")))
           .toBeGreaterThanOrEqual(2);
 
-        const secondStat = page.locator("#stat-buttons button[data-stat]").nth(1);
-        await secondStat.click();
+        await chooseStatByIndex(page, 1);
 
         // Should resolve second round
         await expect(page.locator("#score-display")).toContainText(/You:\s*\d/);
@@ -428,8 +427,7 @@ test.describe("Classic Battle Opponent Reveal", () => {
           setOpponentDelay(50);
         });
 
-        const firstStat = page.locator("#stat-buttons button[data-stat]").first();
-        await firstStat.click();
+        await selectWinningStat(page);
 
         const snackbar = page.locator("#snackbar-container");
         await expect(snackbar).toContainText(/Opponent is choosing/i);

--- a/playwright/battle-classic/replay.spec.js
+++ b/playwright/battle-classic/replay.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from "../fixtures/commonSetup.js";
 import selectors from "../../playwright/helpers/selectors";
 import { withMutedConsole } from "../../tests/utils/console.js";
+import { selectWinningStat } from "../helpers/classicBattleActions.js";
 
 test.describe("Classic Battle replay", () => {
   test("Replay resets scoreboard after match end", async ({ page }) => {
@@ -21,12 +22,14 @@ test.describe("Classic Battle replay", () => {
 
       // Start match
       await page.click("#round-select-2");
-      await page.locator(selectors.statButton(0)).first().click();
+      await selectWinningStat(page);
       await expect(page.locator(selectors.scoreDisplay())).toContainText(/You:\s*1/);
 
       // Click Replay and assert round counter resets
       await page.getByTestId("replay-button").click();
-      await expect(page.locator(selectors.roundCounter())).toHaveText("Round 1");
+      await expect
+        .poll(async () => (await page.locator(selectors.roundCounter()).textContent())?.trim())
+        .toMatch(/Round\s*1/);
     }, ["log", "info", "warn", "error", "debug"]);
   });
 });

--- a/playwright/battle-classic/round-counter.spec.js
+++ b/playwright/battle-classic/round-counter.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { withMutedConsole } from "../../tests/utils/console.js";
+import { selectWinningStat } from "../helpers/classicBattleActions.js";
 
 test.describe("Classic Battle round counter", () => {
   test("shows Round 1 after start and increments after Next", async ({ page }) => {
@@ -23,7 +24,7 @@ test.describe("Classic Battle round counter", () => {
 
       // Click a stat to resolve the round
       await page.waitForSelector("#stat-buttons button[data-stat]");
-      await page.click("#stat-buttons button[data-stat]");
+      await selectWinningStat(page);
 
       // Wait for cooldown to start and Next to be ready
       const next = page.locator("#next-button");
@@ -57,7 +58,7 @@ test.describe("Classic Battle round counter", () => {
       await expect(roundCounter).toHaveText(/Round\s*1/);
 
       await page.waitForSelector("#stat-buttons button[data-stat]");
-      await page.click("#stat-buttons button[data-stat]");
+      await selectWinningStat(page);
 
       const next = page.locator("#next-button");
       await expect(next).toBeEnabled();

--- a/playwright/battle-classic/timer-clearing.spec.js
+++ b/playwright/battle-classic/timer-clearing.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import selectors from "../../playwright/helpers/selectors";
 import { withMutedConsole } from "../../tests/utils/console.js";
+import { selectWinningStat } from "../helpers/classicBattleActions.js";
 
 test.describe("Classic Battle timer clearing", () => {
   test("score is updated immediately when stat selection is made", async ({ page }) => {
@@ -25,7 +26,7 @@ test.describe("Classic Battle timer clearing", () => {
       await expect(timerLocator).toHaveText(/Time Left: \d+s/);
 
       // Click stat button
-      await buttons.first().click();
+      await selectWinningStat(page);
 
       // Score should be updated
       const score = page.locator(selectors.scoreDisplay());

--- a/playwright/helpers/classicBattleActions.js
+++ b/playwright/helpers/classicBattleActions.js
@@ -1,0 +1,83 @@
+import selectors from "./selectors.js";
+
+/**
+ * Choose a stat button for the player that guarantees a win for deterministic tests.
+ *
+ * @pseudocode
+ * wait until the battle store exposes current judoka stats
+ * determine the stat with the largest player-vs-opponent delta
+ * if no positive delta exists, boost the player's stat above the opponent's
+ * click the resolved stat button for the player
+ * return the stat key so callers can perform follow-up assertions
+ *
+ * @param {import("@playwright/test").Page} page - Active Playwright page.
+ * @param {{ playerIndex?: number }} [options] - Player index (defaults to 0 for the user).
+ * @returns {Promise<string>} Resolves with the selected stat key.
+ */
+export async function selectWinningStat(page, { playerIndex = 0, statKey: preferredStat } = {}) {
+  await waitForBattleStats(page);
+
+  const statKey = await page.evaluate(resolveWinningStatInPage, {
+    statKey: preferredStat
+  });
+
+  if (!statKey) {
+    throw new Error("Unable to determine a winning stat for the current round.");
+  }
+
+  const button = page.locator(selectors.statButton(playerIndex, statKey)).first();
+  await button.waitFor({ state: "visible" });
+  await button.click();
+
+  return statKey;
+}
+
+async function waitForBattleStats(page) {
+  await page.waitForFunction(() => {
+    const store = window.battleStore;
+    const player = store?.currentPlayerJudoka;
+    const opponent = store?.currentOpponentJudoka;
+    return Boolean(player?.stats && opponent?.stats);
+  });
+}
+
+function resolveWinningStatInPage({ statKey } = {}) {
+  const store = window.battleStore;
+  const playerStats = { ...(store?.currentPlayerJudoka?.stats || {}) };
+  const opponentStats = store?.currentOpponentJudoka?.stats || {};
+  const statKeys = Object.keys(playerStats);
+  if (statKeys.length === 0) {
+    return null;
+  }
+
+  const deltaFor = (key) => {
+    const playerValue = Number(playerStats[key]);
+    const opponentValue = Number(opponentStats[key]);
+    const safePlayer = Number.isFinite(playerValue) ? playerValue : 0;
+    const safeOpponent = Number.isFinite(opponentValue) ? opponentValue : 0;
+    return safePlayer - safeOpponent;
+  };
+
+  const normalizedKey = statKey && statKeys.includes(statKey) ? statKey : null;
+  const bestKey = normalizedKey
+    ? normalizedKey
+    : statKeys.reduce((currentBest, key, index) => {
+        if (index === 0) {
+          return key;
+        }
+        return deltaFor(key) > deltaFor(currentBest) ? key : currentBest;
+      }, statKeys[0]);
+
+  if (!bestKey) {
+    return null;
+  }
+
+  if (deltaFor(bestKey) <= 0) {
+    const opponentValue = Number(opponentStats[bestKey]) || 0;
+    if (store?.currentPlayerJudoka?.stats) {
+      store.currentPlayerJudoka.stats[bestKey] = opponentValue + 1;
+    }
+  }
+
+  return bestKey;
+}

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -373,6 +373,11 @@ export function startCooldown(_store, scheduler, overrides = {}) {
   });
   startTimerWithDiagnostics(runtime, cooldownSeconds);
   scheduleCooldownFallbacks({ runtime, cooldownSeconds, onExpired });
+  safeRound(
+    "startCooldown.exposeRuntime",
+    () => exposeDebugState("currentNextRoundRuntime", runtime),
+    { suppressInProduction: true }
+  );
   const session = createNextRoundSession({
     controls,
     runtime,

--- a/tests/helpers/integrationHarness.test.js
+++ b/tests/helpers/integrationHarness.test.js
@@ -1,6 +1,13 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
 import { describe, expect, it, vi } from "vitest";
 
 import { createIntegrationHarness, createMockFactory } from "./integrationHarness.js";
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, "..", "..");
+const toRepoPath = (specifier) => resolve(REPO_ROOT, specifier);
 
 describe("createMockFactory", () => {
   it("returns function mocks unchanged so they execute as factories", () => {
@@ -34,8 +41,14 @@ describe("createIntegrationHarness mocks", () => {
     await harness.setup();
     const calls = mockRegistrar.mock.calls.slice();
     harness.cleanup();
+    const resolvedUrl = pathToFileURL(toRepoPath("test/function-module")).href;
 
-    expect(calls).toContainEqual(["test/function-module", factoryMock]);
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        [resolvedUrl, expect.any(Function)],
+        ["test/function-module", factoryMock]
+      ])
+    );
   });
 
   it("registers value mocks via generated factory wrappers", async () => {


### PR DESCRIPTION
## Task Contract
- **Inputs**: Integration harness mock resolution requirements and flaky classic battle test scenarios outlined in the task description.
- **Outputs**: Revised harness mock registration that resolves module specifiers, deterministic classic battle Playwright helpers/tests, and supporting unit/debug updates.
- **Success**: Integration harness registers mocks via repository-root specifiers without breaking existing callers, Vitest/Playwright suites for classic battle flows pass deterministically, and debug state exposes the active runtime for tests.
- **Error Handling**: Surface rag:validate network failures (ENETUNREACH) so the check can be rerun once connectivity to the model CDN is restored.

## Files Changed
- `tests/helpers/integrationHarness.js`: Resolve mock specifiers against the repo root, sanitize escaped paths, and merge real exports when mocks omit keys so both resolved and original specifiers register correctly.【F:tests/helpers/integrationHarness.js†L10-L194】
- `tests/helpers/integrationHarness.test.js`: Update expectations to assert dual registration (resolved URL + original spec) using repo-root resolution helpers.【F:tests/helpers/integrationHarness.test.js†L1-L75】
- `tests/helpers/classicBattle/scheduleNextRound.fallback.test.js`: Rework bus propagation coverage to exercise `dispatchReadyDirectly/dispatchReadyViaBus` with spies while cleaning up debug state between runs.【F:tests/helpers/classicBattle/scheduleNextRound.fallback.test.js†L305-L367】
- `src/helpers/classicBattle/roundManager.js`: Expose `currentNextRoundRuntime` via `exposeDebugState` to support the new fallback tests.【F:src/helpers/classicBattle/roundManager.js†L360-L403】
- `playwright/helpers/classicBattleActions.js`: Introduce a deterministic stat-selection helper that boosts player stats when needed and keeps functions within 50-line guidance.【F:playwright/helpers/classicBattleActions.js†L1-L83】
- `playwright/battle-classic/end-modal.spec.js`: Replace direct stat clicks with the deterministic helper to stabilize win-dependent assertions.【F:playwright/battle-classic/end-modal.spec.js†L1-L107】
- `playwright/battle-classic/opponent-reveal.spec.js`: Adopt the helper (including indexed selection utility) so reveal scenarios resolve predictably.【F:playwright/battle-classic/opponent-reveal.spec.js†L1-L204】
- `playwright/battle-classic/replay.spec.js`, `round-counter.spec.js`, `timer-clearing.spec.js`: Reuse the deterministic helper across remaining classic battle Playwright specs for consistent victories.【F:playwright/battle-classic/replay.spec.js†L1-L34】【F:playwright/battle-classic/round-counter.spec.js†L1-L105】【F:playwright/battle-classic/timer-clearing.spec.js†L1-L36】

## Verification Summary
- `npm run check:jsdoc`: PASS
- `npx prettier . --check`: PASS
- `npx eslint .`: PASS (existing warnings only)
- `npx vitest run`: PASS (306 files / 1,292 tests)
- `npx playwright test`: PASS (182 tests)
- `npm run check:contrast`: PASS
- `npm run validate:data`: PASS
- `npm run rag:validate`: FAIL — ENETUNREACH while fetching MiniLM model; rerun when network access to CDN is available.

## Risk & Follow-Up
- **Risk**: Low-to-medium — exposing debug state and wrapping mocks touches core testing infrastructure; unexpected module resolution edge cases or runtime exposure leaks could surface in downstream suites.
- **Follow-Up**: Rerun `npm run rag:validate` once outbound network access is restored to hydrate the MiniLM model locally; monitor for any additional Playwright specs still relying on nondeterministic stat clicks.

------
https://chatgpt.com/codex/tasks/task_e_68d10fce6b948326852d773fd1a533db