### PR TITLE
Normalize integration harness mock specifiers

### DIFF
--- a/tests/helpers/integrationHarness.test.js
+++ b/tests/helpers/integrationHarness.test.js
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createIntegrationHarness, createMockFactory } from "./integrationHarness.js";
 
+const REPO_ROOT_URL = new URL("../..", import.meta.url);
+
 describe("createMockFactory", () => {
   it("returns function mocks unchanged so they execute as factories", () => {
     const factoryMock = vi.fn();
@@ -35,7 +37,12 @@ describe("createIntegrationHarness mocks", () => {
     const calls = mockRegistrar.mock.calls.slice();
     harness.cleanup();
 
-    expect(calls).toContainEqual(["test/function-module", factoryMock]);
+    const expectedModuleSpecifier = new URL(
+      "test/function-module",
+      REPO_ROOT_URL
+    ).href;
+
+    expect(calls).toContainEqual([expectedModuleSpecifier, factoryMock]);
   });
 
   it("registers value mocks via generated factory wrappers", async () => {
@@ -52,8 +59,12 @@ describe("createIntegrationHarness mocks", () => {
     });
 
     await harness.setup();
+    const expectedModuleSpecifier = new URL(
+      "test/value-module",
+      REPO_ROOT_URL
+    ).href;
     const [, factory] = mockRegistrar.mock.calls.find(
-      ([modulePath]) => modulePath === "test/value-module"
+      ([modulePath]) => modulePath === expectedModuleSpecifier
     );
     harness.cleanup();
 


### PR DESCRIPTION
## Summary
- resolve mock module specifiers to repository-rooted URLs before registering integration harness mocks
- keep existing behavior for bare specifiers while adding path sanitization helpers
- update harness tests to assert normalized specifiers produced by the new resolver

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: progressMock.md formatting pre-existing)*
- `npx eslint .`
- `npx vitest run` *(fails: multiple existing classic battle suites)*
- `CI=1 npx vitest run tests/helpers/integrationHarness.test.js --reporter=basic`
- `npx playwright test --reporter=line` *(fails: numerous pre-existing classic battle UI scenarios)*
- `npm run check:contrast` *(fails/aborted: duplicates playwright failures)*

------
https://chatgpt.com/codex/tasks/task_e_68d136b0300c8326a9f47aac4d701087