### PR TITLE
Normalize integration harness mock specifiers

### DIFF
--- a/tests/helpers/integrationHarness.js
+++ b/tests/helpers/integrationHarness.js
@@ -7,14 +7,21 @@
  * @module tests/helpers/integrationHarness
  */
 
+import { sep as PATH_SEPARATOR } from "node:path";
 import { pathToFileURL } from "node:url";
 import { vi } from "vitest";
 import { useCanonicalTimers } from "../setup/fakeTimers.js";
 import installRAFMock from "./rafMock.js";
 
-const REPO_ROOT_URL = new URL("../..", import.meta.url);
+const REPO_ROOT_URL = pathToFileURL(
+  `${process.cwd()}${process.cwd().endsWith(PATH_SEPARATOR) ? "" : PATH_SEPARATOR}`
+);
 const WINDOWS_DRIVE_PATH_PATTERN = /^[a-zA-Z]:[\\/]/;
 const URL_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
+
+const CLASSIC_BATTLE_SNACKBAR_MODULE = resolveMockModuleSpecifier(
+  "../../../src/helpers/showSnackbar.js"
+);
 
 /**
  * Resolves mock module specifiers to repository-rooted URLs for consistent mock registration.
@@ -354,7 +361,7 @@ export function createClassicBattleHarness(customConfig = {}) {
     },
     mocks: {
       // Mock only true externalities, not internal modules
-      "../../../src/helpers/showSnackbar.js": () => ({
+      [CLASSIC_BATTLE_SNACKBAR_MODULE]: () => ({
         showSnackbar: vi.fn(),
         updateSnackbar: vi.fn()
       }),

--- a/tests/helpers/integrationHarness.test.js
+++ b/tests/helpers/integrationHarness.test.js
@@ -103,6 +103,17 @@ describe("createIntegrationHarness mocks", () => {
     expect(registeredPath).toBe(new URL("etc/passwd", REPO_ROOT_URL).href);
   });
 
+  it("normalizes deep relative module paths before registering mocks", async () => {
+    const deepRelativePath = "../../../src/helpers/classicBattle/eventDispatcher.js";
+    const { registeredPath, mockRegistrar } = await getRegisteredModuleSpecifier(deepRelativePath);
+
+    const expectedSpecifier = new URL("src/helpers/classicBattle/eventDispatcher.js", REPO_ROOT_URL)
+      .href;
+
+    expect(registeredPath).toBe(expectedSpecifier);
+    expect(mockRegistrar).toHaveBeenCalledWith(expectedSpecifier, expect.any(Function));
+  });
+
   it("normalizes Windows-style traversal attempts", async () => {
     const { registeredPath } = await getRegisteredModuleSpecifier("..\\\\..\\\\evil/module.js");
 


### PR DESCRIPTION
## Summary
- resolve integration harness mock keys against the repository root and reuse a shared helper for classic battle snackbar mocks
- extend integration harness tests to cover deep relative paths and specifier normalization expectations
- align the classic battle fallback tests with the normalized module specifiers and updated readiness spies

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: repository has pre-existing formatting issues in progressMock.md and src/pages/prdViewer.html)*
- npx prettier tests/helpers/integrationHarness.js tests/helpers/integrationHarness.test.js tests/helpers/classicBattle/scheduleNextRound.fallback.test.js --check
- npx eslint .
- npx vitest run *(fails: multiple suites unrelated to this change already failing)*
- npx vitest run tests/helpers/classicBattle/scheduleNextRound.fallback.test.js
- npx playwright test *(fails: existing end-to-end suites currently red)*
- npm run check:contrast
- npm run rag:validate *(fails: ENETUNREACH while contacting remote resources)*
- npm run validate:data
- grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json
- grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"

------
https://chatgpt.com/codex/tasks/task_e_68d14647ac508326b3dd1e16b1ab6b7a