### PR TITLE
Handle fallback readiness dispatch tracking

### DIFF
--- a/src/helpers/classicBattle/nextRound/expirationHandlers.js
+++ b/src/helpers/classicBattle/nextRound/expirationHandlers.js
@@ -626,7 +626,7 @@ export async function dispatchReadyDirectly(params) {
  * @param {(type: string) => any} [params.fallback.dispatcher]
  * @param {boolean} [params.fallback.useGlobal]
  *   When `true`, invoke the shared global dispatcher after strategies fail.
- * @returns {Promise<boolean>}
+ * @returns {Promise<{ dispatched: boolean, fallbackDispatched: boolean }>}
  */
 export async function runReadyDispatchStrategies(params = {}) {
   const { alreadyDispatchedReady = false, strategies = [], emitTelemetry, fallback = {} } = params;
@@ -639,9 +639,10 @@ export async function runReadyDispatchStrategies(params = {}) {
   };
   if (alreadyDispatchedReady) {
     emitResult(true);
-    return true;
+    return { dispatched: true, fallbackDispatched: false };
   }
   let dispatched = false;
+  let fallbackDispatched = false;
   const interpretResult = (value) => {
     if (value && typeof value === "object" && value !== null && !Array.isArray(value)) {
       const hasDispatchedProp = "dispatched" in value;
@@ -672,12 +673,11 @@ export async function runReadyDispatchStrategies(params = {}) {
         });
         if (!propagate) {
           emitResult(true);
-          return true;
+          return { dispatched: true, fallbackDispatched: false };
         }
       }
     } catch {}
   }
-  let fallbackDispatched = false;
   let fallbackAttempted = false;
   const invokeFallbackDispatcher = async (dispatcher) => {
     if (typeof dispatcher !== "function") {
@@ -720,7 +720,7 @@ export async function runReadyDispatchStrategies(params = {}) {
     emitTelemetry?.("handleNextRoundDispatchFallback", fallbackDispatched);
   }
   emitResult(dispatched);
-  return dispatched;
+  return { dispatched, fallbackDispatched };
 }
 
 /**

--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -826,7 +826,7 @@ async function handleNextRoundExpiration(controls, btn, options = {}) {
     getDebugBag,
     orchestrated
   });
-  const dispatched = await runReadyDispatchStrategies({
+  const { dispatched, fallbackDispatched } = await runReadyDispatchStrategies({
     alreadyDispatchedReady:
       options?.alreadyDispatchedReady === true || hasReadyBeenDispatchedForCurrentCooldown(),
     strategies,
@@ -836,8 +836,10 @@ async function handleNextRoundExpiration(controls, btn, options = {}) {
       useGlobal: options?.useGlobalReadyFallback === true
     }
   });
-  if (dispatched) {
+  if (dispatched || fallbackDispatched) {
     setReadyDispatchedForCurrentCooldown(true);
+  }
+  if (dispatched) {
     safeRound(
       "handleNextRoundExpiration.traceDispatched",
       () => appendReadyTrace("handleNextRoundExpiration.dispatched", { dispatched: true }),

--- a/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
+++ b/tests/helpers/classicBattle/nextRound/expirationHandlers.test.js
@@ -267,7 +267,7 @@ describe("runReadyDispatchStrategies", () => {
       ],
       emitTelemetry: emit
     });
-    expect(result).toBe(true);
+    expect(result).toEqual({ dispatched: true, fallbackDispatched: false });
     expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchResult", true);
   });
 
@@ -277,7 +277,7 @@ describe("runReadyDispatchStrategies", () => {
       strategies: [() => false, () => false],
       emitTelemetry: emit
     });
-    expect(result).toBe(false);
+    expect(result).toEqual({ dispatched: false, fallbackDispatched: false });
     expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchResult", false);
   });
 
@@ -297,8 +297,21 @@ describe("runReadyDispatchStrategies", () => {
       ],
       emitTelemetry: emit
     });
-    expect(result).toBe(true);
+    expect(result).toEqual({ dispatched: true, fallbackDispatched: false });
     expect(calls).toEqual(["machine", "bus"]);
+    expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchResult", true);
+  });
+
+  it("surfaces prior readiness when already dispatched", async () => {
+    const emit = vi.fn();
+    const strategies = [vi.fn()];
+    const result = await runReadyDispatchStrategies({
+      alreadyDispatchedReady: true,
+      strategies,
+      emitTelemetry: emit
+    });
+    expect(strategies[0]).not.toHaveBeenCalled();
+    expect(result).toEqual({ dispatched: true, fallbackDispatched: false });
     expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchResult", true);
   });
 
@@ -310,7 +323,7 @@ describe("runReadyDispatchStrategies", () => {
       emitTelemetry: emit,
       fallback: { dispatcher: fallbackDispatcher }
     });
-    expect(result).toBe(false);
+    expect(result).toEqual({ dispatched: false, fallbackDispatched: true });
     expect(fallbackDispatcher).toHaveBeenCalledWith("ready");
     expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchFallback", true);
     expect(emit).toHaveBeenCalledWith("handleNextRoundDispatchResult", false);


### PR DESCRIPTION
## Summary
- surface fallback dispatch outcomes from runReadyDispatchStrategies so callers can detect fallback success without altering telemetry semantics
- ensure roundManager marks readiness state when only fallback dispatchers fire during cooldown expiration
- update and extend classic battle readiness tests to cover the new return shape and fallback readiness flag behavior

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: progressMock.md, src/pages/prdViewer.html, tests/helpers/classicBattle/scheduleNextRound.fallback.test.js)*
- npx eslint .
- npx vitest run *(fails: numerous pre-existing classic battle suites and settings page tests)*
- npx vitest run tests/helpers/classicBattle/scheduleNextRound.fallback.test.js -t "fallback readiness flag discipline"
- npx playwright test *(fails: pre-existing classic battle end modal and opponent reveal specs)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d15cc3f5888326bd428a7fe65bc60f