### PR TITLE
Add legacy settings form exports

### DIFF
--- a/progressBug.md
+++ b/progressBug.md
@@ -435,13 +435,14 @@ Hypotheses / next experiments:
 Immediate next action (planned):
 
 1. Mark debugging todo (in the plan) as in-progress and run targeted experiments on `page-scaffold.test.js`:
-  - Advance multiple frames after `roundEnded`.
-  - Await a microtask tick before/after advancing frames.
-  - Log scoreboard mock call details and event emission timing to inspect ordering.
+
+- Advance multiple frames after `roundEnded`.
+- Await a microtask tick before/after advancing frames.
+- Log scoreboard mock call details and event emission timing to inspect ordering.
+
 2. If the issue stems from module mock rebinding, adjust the test harness to ensure `bridgeengineevents()` binds to the mocked engine facade used by the test spies.
 
 Once the failing test is fixed, resume migrating remaining tests that still use the legacy RAF helper and update this document with outcomes.
-
 
 ---
 

--- a/src/helpers/settingsFormUtils.js
+++ b/src/helpers/settingsFormUtils.js
@@ -1,0 +1,58 @@
+/**
+ * @file Legacy settings form utilities entry point.
+ *
+ * @description
+ * Maintains backwards compatibility for modules that previously imported
+ * from `src/helpers/settingsFormUtils.js` by re-exporting the consolidated
+ * utilities from their modular locations.
+ */
+
+import { renderGameModeSwitches as baseRenderGameModeSwitches } from "./settings/gameModeSwitches.js";
+import { renderFeatureFlagSwitches as baseRenderFeatureFlagSwitches } from "./settings/featureFlagSwitches.js";
+
+/**
+ * Legacy alias for {@link baseRenderGameModeSwitches}.
+ *
+ * @pseudocode
+ * 1. Invoke {@link baseRenderGameModeSwitches} with the provided arguments.
+ * 2. Return the promise from the underlying implementation.
+ *
+ * @param {HTMLElement} container - DOM element that will receive toggle controls.
+ * @param {Array<Object>} gameModes - Array of game mode definitions.
+ * @param {() => Object} getCurrentSettings - Getter for the current settings snapshot.
+ * @param {(key: string, value: any, onError?: Function) => Promise} handleUpdate - Persist callback for setting updates.
+ * @returns {ReturnType<typeof baseRenderGameModeSwitches>} A promise that resolves when rendering side effects complete.
+ */
+export function renderGameModeSwitches(container, gameModes, getCurrentSettings, handleUpdate) {
+  return baseRenderGameModeSwitches(container, gameModes, getCurrentSettings, handleUpdate);
+}
+
+/**
+ * Legacy alias for {@link baseRenderFeatureFlagSwitches}.
+ *
+ * @pseudocode
+ * 1. Invoke {@link baseRenderFeatureFlagSwitches} with the provided arguments.
+ * 2. Return the promise from the underlying implementation.
+ *
+ * @param {HTMLElement} container - DOM element that will receive toggle controls.
+ * @param {Record<string, { enabled: boolean, tooltipId?: string }>} flags - Map of feature flag definitions.
+ * @param {() => Object} getCurrentSettings - Getter for the current settings snapshot.
+ * @param {(key: string, value: any, onError?: Function) => Promise} handleUpdate - Persist callback for setting updates.
+ * @param {Record<string, string>} [tooltipMap={}] - Optional localized tooltip copy map.
+ * @returns {ReturnType<typeof baseRenderFeatureFlagSwitches>} A promise that resolves when rendering side effects complete.
+ */
+export function renderFeatureFlagSwitches(
+  container,
+  flags,
+  getCurrentSettings,
+  handleUpdate,
+  tooltipMap = {}
+) {
+  return baseRenderFeatureFlagSwitches(
+    container,
+    flags,
+    getCurrentSettings,
+    handleUpdate,
+    tooltipMap
+  );
+}

--- a/tests/classicBattle/page-scaffold.test.js
+++ b/tests/classicBattle/page-scaffold.test.js
@@ -1041,8 +1041,8 @@ describe("Classic Battle page scaffold (behavioral)", () => {
     const roundEnded = engineMock.listeners.get("roundEnded");
     roundEnded?.({ playerScore: 4, opponentScore: 1 });
 
-  // Ensure any RAF-scheduled UI updates have run
-  currentEnv.testController.advanceFrame();
+    // Ensure any RAF-scheduled UI updates have run
+    currentEnv.testController.advanceFrame();
 
     expect(scoreboardMock.updateRoundCounter.mock.calls.length).toBeGreaterThan(initialRoundCalls);
     expect(scoreboardMock.updateScore.mock.calls.length).toBeGreaterThan(initialScoreCalls);


### PR DESCRIPTION
## Summary
- add src/helpers/settingsFormUtils.js to preserve the legacy settings form entry point while delegating to the modular implementations
- update progressBug.md to keep Prettier formatting consistent with repository rules
- fix indentation in tests/classicBattle/page-scaffold.test.js so the comment and frame advance are aligned with surrounding assertions

## Files Changed
- src/helpers/settingsFormUtils.js
- tests/classicBattle/page-scaffold.test.js
- progressBug.md

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- ⚠️ CI=1 npx vitest run (fails on existing suite issues unrelated to this change)
- ⚠️ npx vitest run --reporter=basic --testNamePattern "updates scoreboard text when a mock round starts" (fails because the full suite executes and surfaces pre-existing issues)
- ⚠️ npx playwright test (fails because the suite includes pre-existing broken tests)
- ⚠️ npm run rag:validate (fails due to missing MiniLM model artifacts in the shared environment)
- npm run validate:data
- npm run check:contrast

## Risk
- Low risk: the new module simply forwards calls to existing implementations and the small formatting tweaks do not affect runtime behavior.

------
https://chatgpt.com/codex/tasks/task_e_68d186aecee883269da379380f4a659c