### PR TITLE
Use canonical timer control in stall recovery test

### DIFF
--- a/tests/helpers/classicBattle/stallRecovery.test.js
+++ b/tests/helpers/classicBattle/stallRecovery.test.js
@@ -78,8 +78,8 @@ describe("classicBattle stalled stat selection recovery", () => {
     await battleMod.startRound(store, battleMod.applyRoundUI);
     await battleMod.__triggerStallPromptNow(store);
     expect(document.querySelector("header #round-message").textContent).toMatch(/stalled/i);
-    timerSpy.advanceTimersByTime(5000);
-    await vi.runAllTimersAsync();
+    timers.advanceTimersByTime(5000);
+    await timers.runAllTimersAsync();
     const score = document.querySelector("header #score-display").textContent;
     expect(score).toBe("You: 1\nOpponent: 0");
   });


### PR DESCRIPTION
## Task Contract
- **Inputs:** `tests/helpers/classicBattle/stallRecovery.test.js`
- **Outputs:** Updated test to rely on canonical timer control utilities.
- **Success Criteria:** The stalled stat selection recovery test advances and flushes timers via the `useCanonicalTimers()` handle while continuing to restore real timers after each test run.
- **Error Handling:** If canonical timers cannot be used, the test should still clean up timers via `timers.cleanup()` to avoid leaks.

## Files Changed
- `tests/helpers/classicBattle/stallRecovery.test.js`: replace the stale `timerSpy` and direct `vi.runAllTimersAsync()` calls with the `timers` helpers returned by `useCanonicalTimers()` while keeping the existing cleanup contract.

## Verification Summary
- eslint: **FAIL** – Pre-existing prettier/prettier violation in `tests/helpers/classicBattle/scheduleNextRound.fallback.test.js`.
- vitest: **1289 passed, 8 failed** – Multiple classic battle suites already failing (e.g., scoreboard adapter, pause timer, cooldown skip handler).
- playwright: **FAIL** – 39 known failing specs (e.g., opponent reveal flows, static page navigation).
- jsdoc: **FAIL** – Existing missing JSDoc for `createTestController` in `src/utils/scheduler.js`.
- prettier: **FAIL** – Formatting issue in `tests/helpers/classicBattle/scheduleNextRound.fallback.test.js` predates this change.
- check:contrast: **PASS** – `npm run check:contrast` reports no issues.
- rag:validate: **FAIL** – Missing local MiniLM model artifacts prevents hydration (`npm run rag:prepare:models` required).
- validate:data: **PASS** – Data validation script completes without errors.

## Risk & Follow-Up
- **Risk Level:** Low; adjustment is isolated to timer utilities within a single test.
- **Follow-Up:** Investigate and resolve the standing formatter, lint, unit, Playwright, and RAG model issues in separate efforts.

------
https://chatgpt.com/codex/tasks/task_e_68d18fdd484c8326b813d51f89f7298d