### PR TITLE
docs: document scheduler test controller

### DIFF
--- a/src/utils/scheduler.js
+++ b/src/utils/scheduler.js
@@ -203,6 +203,13 @@ export function resume() {
  * This function is only functional in test environments and allows tests to
  * control the scheduler's timing deterministically without global monkey-patching.
  *
+ * @summary Provide deterministic control over scheduler timing in tests by overriding RAF APIs.
+ * @pseudocode
+ * 1. Verify the test environment flag is enabled.
+ * 2. Capture original `requestAnimationFrame`/`cancelAnimationFrame` references.
+ * 3. Override RAF handlers to prevent automatic execution and manage IDs manually.
+ * 4. Expose helpers to advance frames/time and inspect execution state.
+ * 5. Restore original handlers when disposing the controller.
  * @throws {Error} If called outside of test environment
  * @returns {object} Test controller with methods to control timing
  * @property {() => void} advanceFrame - Advance the scheduler by one frame


### PR DESCRIPTION
## Summary
- add a summary and pseudocode steps to the `createTestController` JSDoc so its responsibilities are easier to follow for test authors

## Testing
- npm run check:jsdoc
- npx prettier . --check --log-level warn
- npx eslint .
- npx vitest run *(fails: existing roundStore mock expectations)*
- npx playwright test *(fails: existing classic battle and browse judoka assertions)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d195e89a3c83269788165ae560646f