### PR TITLE
Add minimal auto-advance timeout test

### DIFF
--- a/tests/helpers/classicBattle/timeoutInterrupt.minimal.test.js
+++ b/tests/helpers/classicBattle/timeoutInterrupt.minimal.test.js
@@ -91,4 +91,74 @@ describe("timeout → interruptRound → minimal auto-advance", () => {
       timersControl?.cleanup?.();
     } catch {}
   });
+
+  it("auto-advances after timeout", async () => {
+    const { initClassicBattleOrchestrator, getBattleStateMachine } = await import(
+      "../../../src/helpers/classicBattle/orchestrator.js"
+    );
+    const { onBattleEvent, offBattleEvent } = await import(
+      "../../../src/helpers/classicBattle/battleEvents.js"
+    );
+    const store = { selectionMade: false, playerChoice: null };
+    await initClassicBattleOrchestrator(store, undefined, {});
+    const machine = getBattleStateMachine();
+
+    const transitions = [];
+    const recordTransition = (event) => {
+      if (event?.detail) transitions.push(event.detail);
+    };
+    onBattleEvent("battleStateChange", recordTransition);
+
+    try {
+      await machine.dispatch("matchStart");
+      await machine.dispatch("ready");
+      await machine.dispatch("ready");
+      await machine.dispatch("cardsRevealed");
+
+      await machine.dispatch("interruptRound");
+
+      const { dispatchBattleEvent } = await import(
+        "../../../src/helpers/classicBattle/eventDispatcher.js"
+      );
+      const readyCallsBeforeAdvance = dispatchBattleEvent.mock.calls.filter(
+        ([eventName]) => eventName === "ready"
+      );
+      expect(readyCallsBeforeAdvance).toHaveLength(0);
+
+      const transitionCheckpoint = transitions.length;
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      const readyCallsAfterAdvance = dispatchBattleEvent.mock.calls.filter(
+        ([eventName]) => eventName === "ready"
+      );
+      expect(readyCallsAfterAdvance).toHaveLength(1);
+      expect(readyDispatchTracker.events).toHaveLength(1);
+      expect(readyDispatchTracker.events[0]?.[0]).toBe("ready");
+      expect(readyDispatchTracker.events[0]).toEqual(["ready"]);
+
+      const readyDispatchesDuringAdvance =
+        readyCallsAfterAdvance.length - readyCallsBeforeAdvance.length;
+      expect(readyDispatchesDuringAdvance).toBe(1);
+      expect(readyCallsAfterAdvance).toEqual(readyDispatchTracker.events);
+
+      await vi.runOnlyPendingTimersAsync();
+      const readyCallsAfterFlushing = dispatchBattleEvent.mock.calls.filter(
+        ([eventName]) => eventName === "ready"
+      );
+      expect(readyCallsAfterFlushing).toEqual(readyDispatchTracker.events);
+
+      const recentTransitions = transitions.slice(transitionCheckpoint);
+      expect(recentTransitions).toEqual([
+        expect.objectContaining({ from: "cooldown", to: "roundStart", event: "ready" }),
+        expect.objectContaining({
+          from: "roundStart",
+          to: "waitingForPlayerAction",
+          event: "cardsRevealed"
+        })
+      ]);
+    } finally {
+      offBattleEvent("battleStateChange", recordTransition);
+    }
+  }, 10000);
 });


### PR DESCRIPTION
## Summary
- add a minimal timeout auto-advance regression test for interrupt-driven rounds
- assert single ready dispatch using the shared tracker and mocked dispatcher

## Task Contract
- **Inputs:** existing classic battle timeout interrupt minimal test harness and mocks
- **Outputs:** additional vitest case validating auto-advance dispatch behaviour
- **Success:** new test covers the timeout auto-advance path and passes under fake timers
- **Error:** regressions still undetected or test fails due to unmet expectations

## Files Changed
- `tests/helpers/classicBattle/timeoutInterrupt.minimal.test.js` — add timeout auto-advance coverage mirroring the cooldown suite with ready dispatch assertions

## Verification Summary
- eslint: Not Run (not requested)
- vitest: ✅ `npx vitest run tests/helpers/classicBattle/timeoutInterrupt.minimal.test.js`
- playwright: Not Run (not requested)
- jsdoc: Not Run (not requested)

## Risk + Follow-up
- Risk: Low — new test coverage only
- Follow-up: None


------
https://chatgpt.com/codex/tasks/task_e_68d19aff1c788326bebec2e0d5532423