### PR TITLE
feat: forward battle events to scoreboard adapter

### DIFF
--- a/src/helpers/classicBattle/scoreboardAdapter.js
+++ b/src/helpers/classicBattle/scoreboardAdapter.js
@@ -1,7 +1,117 @@
+import {
+  clearMessage,
+  clearTimer,
+  showMessage,
+  updateRoundCounter,
+  updateScore,
+  updateTimer
+} from "../setupScoreboard.js";
+import { offBattleEvent, onBattleEvent } from "./battleEvents.js";
 import { roundStore } from "./roundStore.js";
 
 let bound = false;
 let scoreboardReadyPromise = Promise.resolve();
+const listenerRegistry = new Map();
+
+function registerListener(type, handler) {
+  onBattleEvent(type, handler);
+  listenerRegistry.set(type, handler);
+}
+
+function removeAllListeners() {
+  listenerRegistry.forEach((handler, type) => {
+    try {
+      offBattleEvent(type, handler);
+    } catch {}
+  });
+  listenerRegistry.clear();
+}
+
+function extractSeconds(detail) {
+  const seconds = detail?.secondsRemaining;
+  return typeof seconds === "number" && Number.isFinite(seconds) ? seconds : null;
+}
+
+function handleRoundStart(event) {
+  try {
+    clearMessage();
+  } catch {}
+  const roundNumber = event?.detail?.roundNumber;
+  if (typeof roundNumber === "number" && Number.isFinite(roundNumber)) {
+    try {
+      updateRoundCounter(roundNumber);
+    } catch {}
+  }
+}
+
+function handleRoundMessage(event) {
+  const { text, lock } = event?.detail || {};
+  if (typeof text === "undefined" || text === null) return;
+  const messageText = typeof text === "string" ? text : String(text);
+  try {
+    showMessage(messageText, { outcome: Boolean(lock) });
+  } catch {}
+}
+
+function handleRoundOutcome(event) {
+  const text = event?.detail?.text;
+  if (typeof text === "undefined" || text === null) return;
+  const outcomeText = typeof text === "string" ? text : String(text);
+  try {
+    showMessage(outcomeText, { outcome: true });
+  } catch {}
+}
+
+function handleMessageClear() {
+  try {
+    clearMessage();
+  } catch {}
+}
+
+function handleTimerShow(event) {
+  const seconds = extractSeconds(event?.detail || {});
+  if (seconds === null) return;
+  try {
+    updateTimer(seconds);
+  } catch {}
+}
+
+function handleTimerTick(event) {
+  const seconds = extractSeconds(event?.detail || {});
+  if (seconds === null) return;
+  try {
+    updateTimer(seconds);
+  } catch {}
+}
+
+function handleTimerHide() {
+  try {
+    clearTimer();
+  } catch {}
+}
+
+function handleScoreUpdate(event) {
+  const { player, opponent } = event?.detail || {};
+  const playerIsNumber = typeof player === "number" && Number.isFinite(player);
+  const opponentIsNumber = typeof opponent === "number" && Number.isFinite(opponent);
+  if (!playerIsNumber || !opponentIsNumber) {
+    return;
+  }
+  try {
+    updateScore(player, opponent);
+  } catch {}
+}
+
+function wireScoreboardListeners() {
+  registerListener("display.round.start", handleRoundStart);
+  registerListener("display.round.message", handleRoundMessage);
+  registerListener("display.round.outcome", handleRoundOutcome);
+  registerListener("display.message.clear", handleMessageClear);
+  registerListener("display.timer.show", handleTimerShow);
+  registerListener("display.timer.tick", handleTimerTick);
+  registerListener("display.timer.hide", handleTimerHide);
+  registerListener("display.score.update", handleScoreUpdate);
+}
 
 /**
  * Await the completion of scoreboard adapter wiring.
@@ -20,8 +130,9 @@ export function whenScoreboardReady() {
  *
  * @pseudocode
  * 1. Guard against double-binding.
- * 2. Wire RoundStore into scoreboard for centralized state management.
- * 3. Return a disposer that removes all listeners.
+ * 2. Subscribe to battle events and forward them to scoreboard helpers.
+ * 3. Wire RoundStore into scoreboard for centralized state management.
+ * 4. Return a disposer that removes all listeners.
  *
  * @returns {() => void} dispose function to remove listeners
  */
@@ -31,7 +142,10 @@ export function initScoreboardAdapter() {
   }
   bound = true;
 
-  scoreboardReadyPromise = Promise.resolve(roundStore.wireIntoScoreboardAdapter());
+  wireScoreboardListeners();
+
+  const roundStoreWiring = roundStore.wireIntoScoreboardAdapter();
+  scoreboardReadyPromise = Promise.resolve(roundStoreWiring).then(() => {});
 
   return disposeScoreboardAdapter;
 }
@@ -40,11 +154,12 @@ export function initScoreboardAdapter() {
  * Remove all adapter listeners.
  *
  * @pseudocode
- * 1. Reset RoundStore scoreboard-related callbacks.
+ * 1. Remove battle event listeners and RoundStore callbacks.
  * 2. Clear the bound flag and reset the ready promise.
  * @returns {void}
  */
 export function disposeScoreboardAdapter() {
+  removeAllListeners();
   // Clean up RoundStore integration
   try {
     roundStore.disconnectFromScoreboardAdapter();


### PR DESCRIPTION
## Summary
- subscribe the classic battle scoreboard adapter to display.* battle events and delegate to setupScoreboard helpers
- retain listener registrations so disposeScoreboardAdapter removes battle event handlers alongside round store cleanup
- wait for both battle event wiring and round store integration before resolving whenScoreboardReady

## Testing
- npm run check:jsdoc *(fails: pre-existing missing JSDoc for src/utils/scheduler.js:213 -> createTestController)*
- CI=1 npx prettier . --check
- npx eslint .
- npx vitest run --reporter=basic *(fails: pre-existing classic battle test regressions around cooldown skip handler, timer pause, opponent delay, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68d19b0d6a648326ac3408ddece1169e