### PR TITLE
Fix canonical timer usage in pause timer test

### DIFF
--- a/tests/helpers/classicBattle/pauseTimer.test.js
+++ b/tests/helpers/classicBattle/pauseTimer.test.js
@@ -96,10 +96,10 @@ describe("classicBattle timer pause", () => {
       playerVal,
       opponentVal
     });
-    await timer.runAllTimersAsync();
+    await timers.runAllTimersAsync();
     await promise;
-    timer.advanceTimersByTime(1000);
-    await timer.runAllTimersAsync();
+    timers.advanceTimersByTime(1000);
+    await timers.runAllTimersAsync();
     const messages = showMessage.mock.calls.map((c) => c[0]);
     expect(messages.some((m) => /Time's up! Auto-selecting/.test(m))).toBe(false);
   });


### PR DESCRIPTION
## Summary
- update the pause timer classic battle test to use the timers instance returned by useCanonicalTimers

## Testing
- npx vitest run tests/helpers/classicBattle/pauseTimer.test.js tests/helpers/classicBattle/stallRecovery.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d19ef1e16883269c85fdcedb56d4ad