### PR TITLE
Avoid duplicate statSelected emission in roundStore

### DIFF
--- a/src/helpers/classicBattle/roundStore.js
+++ b/src/helpers/classicBattle/roundStore.js
@@ -136,9 +136,9 @@ class RoundStore {
     if (this.callbacks.onStatSelected) {
       this.callbacks.onStatSelected(stat);
     }
-
-    // Emit legacy event for backward compatibility
-    emitBattleEvent("statSelected", { stat });
+    // Emission of the legacy `statSelected` event now happens upstream in the
+    // selection handler. We intentionally avoid a duplicate emit here to
+    // prevent double notifications while still supporting legacy callbacks.
   }
 
   /**

--- a/tests/unit/roundStore.test.js
+++ b/tests/unit/roundStore.test.js
@@ -95,7 +95,7 @@ describe("RoundStore", () => {
   });
 
   describe("stat selection", () => {
-    it("should set selected stat and emit events", async () => {
+    it("should set selected stat without emitting legacy event", async () => {
       const { emitBattleEvent } = await import("../../src/helpers/classicBattle/battleEvents.js");
 
       roundStore.setSelectedStat("strength");
@@ -103,9 +103,7 @@ describe("RoundStore", () => {
       const round = roundStore.getCurrentRound();
       expect(round.selectedStat).toBe("strength");
 
-      expect(emitBattleEvent).toHaveBeenCalledWith("statSelected", {
-        stat: "strength"
-      });
+      expect(emitBattleEvent).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- stop `roundStore.setSelectedStat` from firing the legacy `statSelected` event now that the selection handler emits it
- document the intent to rely on the selection handler while keeping callback support
- update the round store unit test to assert no legacy emission occurs

## Testing
- npx vitest run tests/unit/roundStore.test.js
- npx vitest run tests/helpers/selectionHandler.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d19eb7e4e08326ac5edfb46fef796d