### PR TITLE
Refine dispatcher telemetry logging

### DIFF
--- a/src/helpers/classicBattle/nextRound/expirationHandlers.js
+++ b/src/helpers/classicBattle/nextRound/expirationHandlers.js
@@ -417,14 +417,14 @@ export async function dispatchReadyWithOptions(params) {
       (bag.handleNextRound_dispatchViaOptions_count || 0) + 1;
   }
   try {
-    try {
-      if (typeof process !== "undefined" && process.env?.VITEST) {
-        console.error("[TEST] dispatchReadyWithOptions calling provided dispatcher", {
-          name: dispatchBattleEvent?.name,
-          isMock: !!dispatchBattleEvent?.mock
-        });
-      }
-    } catch {}
+    const invocationDetails = {
+      name: info.name,
+      isMock: Boolean(dispatchBattleEvent?.mock)
+    };
+    emitTelemetry?.("handleNextRound_dispatchViaOptions_invocation", invocationDetails);
+    if (bag) {
+      bag.handleNextRound_dispatchViaOptions_invocation = invocationDetails;
+    }
     const result = dispatchBattleEvent("ready");
     const resolved = await Promise.resolve(result);
     const dispatched = resolved !== false;


### PR DESCRIPTION
## Summary
- route the dispatchReadyWithOptions diagnostics through emitTelemetry and the debug bag instead of a Vitest-only console.error

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- npx eslint src/helpers/classicBattle/nextRound/expirationHandlers.js
- npx vitest run
- npx playwright test
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d1a23a98708326860a1f2984d4082b