### PR TITLE
Fix cooldown renderer prompt delay handling

### DIFF
--- a/src/helpers/CooldownRenderer.js
+++ b/src/helpers/CooldownRenderer.js
@@ -134,10 +134,9 @@ export function attachCooldownRenderer(timer, initialRemaining) {
   const queueTickAfterPromptDelay = (normalized, suppressEvents, forceAsync = false) => {
     queuedTickPayload = { value: normalized, suppressEvents };
     const waitMs = getRemainingPromptDelayMs();
-    if (!forceAsync && waitMs <= 0) {
+    if (waitMs <= 0) {
       const payload = queuedTickPayload;
-      queuedTickPayload = null;
-      pendingDelayId = null;
+      clearCountdownDelay();
       if (payload) {
         processTick(payload.value, { suppressEvents: payload.suppressEvents });
       }
@@ -180,11 +179,7 @@ export function attachCooldownRenderer(timer, initialRemaining) {
     try {
       const normalizedInitial = normalizeRemaining(initialValue);
       const promptPending = Number(getOpponentPromptTimestamp()) <= 0;
-      if (promptPending || getRemainingPromptDelayMs() > 0) {
-        queueTickAfterPromptDelay(normalizedInitial, true, promptPending);
-      } else {
-        processTick(normalizedInitial, { suppressEvents: true });
-      }
+      queueTickAfterPromptDelay(normalizedInitial, true, promptPending);
     } catch {}
   }
   return () => {


### PR DESCRIPTION
## Summary
- short-circuit queued ticks when no prompt delay remains so countdown renders immediately
- route initial renders through the queue helper to update the scoreboard before any engine ticks

## Testing
- `npx vitest run tests/helpers/CooldownRenderer.test.js tests/helpers/classicBattle/timerService.nextRound.test.js`

## Risk
- Low

## Files Changed
- `src/helpers/CooldownRenderer.js`


------
https://chatgpt.com/codex/tasks/task_e_68d1ae0d1cd08326b207a2c25b6b826d