### PR TITLE
Handle immediate opponent message delays

### DIFF
--- a/src/helpers/classicBattle/uiEventHandlers.js
+++ b/src/helpers/classicBattle/uiEventHandlers.js
@@ -62,6 +62,13 @@ export function bindUIHelperEventHandlersDynamic() {
         const delay = Number(getOpponentDelay());
         const resolvedDelay = Number.isFinite(delay) && delay > 0 ? delay : 0;
         clearOpponentSnackbarTimeout();
+        if (resolvedDelay <= 0) {
+          try {
+            showSnackbar(t("ui.opponentChoosing"));
+            markOpponentPromptNow();
+          } catch {}
+          return;
+        }
         opponentSnackbarId = setTimeout(() => {
           try {
             showSnackbar(t("ui.opponentChoosing"));


### PR DESCRIPTION
## Summary
- handle zero or negative opponent delay by clearing pending timers and displaying the opponent choosing prompt immediately

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- npx vitest run *(fails: existing CooldownRenderer/round resolver expectations on updateTimer mocks)*
- npx playwright test *(fails: numerous existing navigation/title assertions)*
- npm run check:contrast
- npx vitest run tests/classicBattle/opponent-message-handler.improved.test.js --reporter=basic


------
https://chatgpt.com/codex/tasks/task_e_68d1adef993083268e5bdb8fbcd33a54