### PR TITLE
Fix opponent snackbar timeout syntax

### DIFF
--- a/src/helpers/classicBattle/uiEventHandlers.js
+++ b/src/helpers/classicBattle/uiEventHandlers.js
@@ -79,7 +79,7 @@ export function bindUIHelperEventHandlersDynamic() {
             showSnackbar(t("ui.opponentChoosing"));
             markOpponentPromptNow();
           } catch {}
-        }
+        }, resolvedDelay);
       } else {
         clearOpponentSnackbarTimeout();
         // Cancel any pending delay to ensure the immediate snackbar wins.


### PR DESCRIPTION
## Summary
- close the scheduled opponent snackbar timeout call in `bindUIHelperEventHandlersDynamic`

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- CI=1 npx vitest run --reporter=basic *(fails: CooldownRenderer zero-delay async expectation, pre-existing)*
- npx playwright test *(fails: numerous classic battle and navigation specs, pre-existing timeouts)
- npm run check:contrast
- grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle 2>/dev/null && echo "❌ Dynamic import in hot path" || echo "No dynamic imports found"
- grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"

------
https://chatgpt.com/codex/tasks/task_e_68d24ca019b8832681eff5d3ce921808