### PR TITLE
Handle immediate opponent message delays

### DIFF
--- a/src/helpers/classicBattle/uiEventHandlers.js
+++ b/src/helpers/classicBattle/uiEventHandlers.js
@@ -17,6 +17,17 @@ function clearOpponentSnackbarTimeout() {
   opponentSnackbarId = 0;
 }
 
+function displayOpponentChoosingPrompt() {
+  try {
+    showSnackbar(t("ui.opponentChoosing"));
+    markOpponentPromptNow();
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.warn("Error showing opponent choosing message:", error);
+    }
+  }
+}
+
 /**
  * Bind dynamic UI helper event handlers on the shared battle EventTarget.
  *
@@ -63,25 +74,17 @@ export function bindUIHelperEventHandlersDynamic() {
         const resolvedDelay = Number.isFinite(delay) && delay > 0 ? delay : 0;
         clearOpponentSnackbarTimeout();
         if (resolvedDelay <= 0) {
-          try {
-            showSnackbar(t("ui.opponentChoosing"));
-            markOpponentPromptNow();
-          } catch {}
+          // Handle immediate display when delay is zero or negative by skipping the timeout setup.
+          displayOpponentChoosingPrompt();
           return;
         }
         opponentSnackbarId = setTimeout(() => {
-          try {
-            showSnackbar(t("ui.opponentChoosing"));
-            markOpponentPromptNow();
-          } catch {}
+          displayOpponentChoosingPrompt();
         }, resolvedDelay);
       } else {
         clearOpponentSnackbarTimeout();
         // Cancel any pending delay to ensure the immediate snackbar wins.
-        try {
-          showSnackbar(t("ui.opponentChoosing"));
-          markOpponentPromptNow();
-        } catch {}
+        displayOpponentChoosingPrompt();
       }
     } catch {}
   });


### PR DESCRIPTION
## Summary
- handle zero or negative opponent delay by clearing pending timers and displaying the opponent choosing prompt immediately
- extract a helper to display the opponent choosing prompt and guard it with development-only logging
- clarify the immediate opponent delay branch with an inline comment and reuse the helper across all paths

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- npx vitest run --reporter=basic
- npx playwright test *(fails: existing navigation/title assertions and opponent reveal flows)*
- npm run check:contrast
- npm run validate:data
- npm run rag:validate *(fails: missing local MiniLM model assets)*

------
https://chatgpt.com/codex/tasks/task_e_68d23c3db42483268652d601a885c59f