### PR TITLE
Allow prompt buffer overrides and update tests

### DIFF
--- a/src/helpers/CooldownRenderer.js
+++ b/src/helpers/CooldownRenderer.js
@@ -301,7 +301,8 @@ const createControllerInterface = (state) => ({
  * @param {{
  *   waitForOpponentPrompt?: boolean,
  *   maxPromptWaitMs?: number,
- *   promptPollIntervalMs?: number
+ *   promptPollIntervalMs?: number,
+ *   opponentPromptBufferMs?: number
  * }} [options] - Optional countdown delay configuration.
  * @returns {() => void} Detach function.
  */


### PR DESCRIPTION
## Summary
- add DEFAULT_OPPONENT_PROMPT_BUFFER_MS to classic battle round UI and allow computeOpponentPromptWaitBudget to accept overrides
- propagate prompt buffer overrides through handleRoundResolvedEvent and document new option in attachCooldownRenderer
- extend roundUI handler tests to cover default buffer and explicit overrides

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- npx vitest run
- npx playwright test *(fails: existing end-modal, opponent reveal, browse judoka, homepage, and CLI scenarios expect updated scores/navigation that differ in this environment)*
- npm run check:contrast
- npm run validate:data
- npm run rag:validate *(fails: MiniLM model assets are placeholders; hydration requires external download)*

------
https://chatgpt.com/codex/tasks/task_e_68d280bff2e48326834e76874308f048