### PR TITLE
Sync deterministic mode with enableTestMode flag

### DIFF
--- a/src/helpers/classicBattle/controller.js
+++ b/src/helpers/classicBattle/controller.js
@@ -1,6 +1,7 @@
 import { createBattleStore, startRound } from "./roundManager.js";
 import { initClassicBattleOrchestrator } from "./orchestrator.js";
 import { initFeatureFlags, isEnabled, featureFlagsEmitter } from "../featureFlags.js";
+import { setTestMode } from "../testModeUtils.js";
 import {
   startCoolDown,
   pauseTimer,
@@ -41,8 +42,13 @@ export class ClassicBattleController extends EventTarget {
    */
   async init() {
     await initFeatureFlags();
+    this.#syncTestMode();
     this.#emitFeatureFlags();
-    featureFlagsEmitter.addEventListener("change", () => this.#emitFeatureFlags());
+    const handleFeatureFlagsChange = () => {
+      this.#syncTestMode();
+      this.#emitFeatureFlags();
+    };
+    featureFlagsEmitter.addEventListener("change", handleFeatureFlagsChange);
 
     // Create the battle engine and assign it to the store
     createBattleEngine();
@@ -66,6 +72,10 @@ export class ClassicBattleController extends EventTarget {
    */
   #emitFeatureFlags() {
     this.dispatchEvent(new CustomEvent("featureFlagsChange", { detail: { isEnabled } }));
+  }
+
+  #syncTestMode() {
+    setTestMode({ enabled: isEnabled("enableTestMode") });
   }
 
   /**

--- a/tests/helpers/classicBattle/controller.init.test.js
+++ b/tests/helpers/classicBattle/controller.init.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const helpersPath = "../../../src/helpers";
+const controllerModule = `${helpersPath}/classicBattle/controller.js`;
+
+describe("ClassicBattleController.init", () => {
+  let setTestMode;
+  let initFeatureFlags;
+  let isEnabled;
+  let featureFlagsEmitter;
+
+  beforeEach(() => {
+    vi.resetModules();
+
+    setTestMode = vi.fn();
+    initFeatureFlags = vi.fn().mockResolvedValue();
+    isEnabled = vi.fn().mockReturnValue(false);
+    featureFlagsEmitter = new EventTarget();
+
+    vi.doMock(`${helpersPath}/testModeUtils.js`, () => ({
+      setTestMode
+    }));
+    vi.doMock(`${helpersPath}/featureFlags.js`, () => ({
+      initFeatureFlags,
+      isEnabled,
+      featureFlagsEmitter
+    }));
+    vi.doMock(`${helpersPath}/classicBattle/roundManager.js`, () => ({
+      createBattleStore: () => ({}),
+      startRound: vi.fn()
+    }));
+    vi.doMock(`${helpersPath}/classicBattle/orchestrator.js`, () => ({
+      initClassicBattleOrchestrator: vi.fn().mockResolvedValue({})
+    }));
+    vi.doMock(`${helpersPath}/battleEngineFacade.js`, () => ({
+      startCoolDown: vi.fn(),
+      pauseTimer: vi.fn(),
+      resumeTimer: vi.fn(),
+      createBattleEngine: vi.fn(),
+      getEngine: vi.fn(() => ({}))
+    }));
+  });
+
+  it("enables deterministic RNG after feature flags resolve", async () => {
+    let resolveFlags;
+    initFeatureFlags.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFlags = resolve;
+        })
+    );
+    isEnabled.mockImplementation((flag) => flag === "enableTestMode");
+
+    const { ClassicBattleController } = await import(controllerModule);
+    const controller = new ClassicBattleController();
+
+    const initPromise = controller.init();
+    expect(setTestMode).not.toHaveBeenCalled();
+
+    resolveFlags?.();
+    await initPromise;
+
+    expect(setTestMode).toHaveBeenCalledTimes(1);
+    expect(setTestMode).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  it("re-syncs deterministic mode when feature flags change", async () => {
+    let enableTestMode = true;
+    isEnabled.mockImplementation((flag) => (flag === "enableTestMode" ? enableTestMode : false));
+
+    const { ClassicBattleController } = await import(controllerModule);
+    const controller = new ClassicBattleController();
+
+    await controller.init();
+    expect(setTestMode).toHaveBeenLastCalledWith({ enabled: true });
+
+    enableTestMode = false;
+    featureFlagsEmitter.dispatchEvent(new Event("change"));
+
+    expect(setTestMode).toHaveBeenCalledTimes(2);
+    expect(setTestMode).toHaveBeenLastCalledWith({ enabled: false });
+  });
+});


### PR DESCRIPTION
## Summary
- update the classic battle controller to import test mode utilities and sync deterministic mode with the enableTestMode flag
- call setTestMode after feature flags initialize and whenever the feature flag emitter fires to enable or disable the seeded RNG
- add unit tests that mock feature flags and test mode utilities to verify deterministic mode toggles on init and on flag changes

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check --log-level warn`
- `npx eslint .`
- `npx vitest run`
- `npx playwright test --reporter=line` *(fails in existing specs: classic battle end-modal/opponent reveal, browse judoka, homepage, meditation)*
- `npm run check:contrast` *(fails with the same classic battle end-modal/opponent reveal issues)*
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json`
- `grep -RInE "console\.(warn|error)\(" tests --exclude=client_embeddings.json | grep -v "tests/utils/console.js"`

------
https://chatgpt.com/codex/tasks/task_e_68d2847d1e188326828416b65681f6b1