### PR TITLE
Include updateRoundCounter in classic battle scoreboard mocks

### DIFF
--- a/tests/helpers/classicBattle/onTransition.test.js
+++ b/tests/helpers/classicBattle/onTransition.test.js
@@ -10,7 +10,8 @@ vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
 }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   clearMessage: vi.fn(),
-  showMessage: vi.fn()
+  showMessage: vi.fn(),
+  updateRoundCounter: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/debugPanel.js", () => ({
   updateDebugPanel: vi.fn()

--- a/tests/helpers/classicBattle/orchestrator.events.test.js
+++ b/tests/helpers/classicBattle/orchestrator.events.test.js
@@ -15,7 +15,8 @@ describe("classic battle orchestrator UI events", () => {
       clearMessage,
       showMessage,
       clearTimer: vi.fn(),
-      updateTimer: vi.fn()
+      updateTimer: vi.fn(),
+      updateRoundCounter: vi.fn()
     }));
     vi.doMock("../../../src/helpers/classicBattle/debugPanel.js", () => ({
       updateDebugPanel


### PR DESCRIPTION
## Task Contract
- **Goal:** Ensure classic battle tests mock the full scoreboard helper API expected by the orchestrator, including `updateRoundCounter`.
- **Scope:** Update the scoreboard helper mocks within `tests/helpers/classicBattle/onTransition.test.js` and `tests/helpers/classicBattle/orchestrator.events.test.js`.
- **Out of Scope:** Any production code or additional test suites beyond the specified Vitest files.
- **Success Criteria:** Tests no longer warn about missing `updateRoundCounter` on the mocked scoreboard helper and the targeted Vitest suites pass.
- **Error Conditions:** Warnings persist about missing scoreboard helper methods or affected tests fail.

## Files Changed
- tests/helpers/classicBattle/onTransition.test.js
- tests/helpers/classicBattle/orchestrator.events.test.js

## Verification
- `npx vitest run tests/helpers/classicBattle/onTransition.test.js tests/helpers/classicBattle/orchestrator.events.test.js`

## Risk Note
- Low risk: changes only touch test mocks to mirror the helper API and do not affect runtime code.


------
https://chatgpt.com/codex/tasks/task_e_68d292b3fb748326b2ec9adedf599efe