### PR TITLE
Ensure initializeSettingsPage navigation failure test mocks domReady

### DIFF
--- a/tests/helpers/settingsPage.test.js
+++ b/tests/helpers/settingsPage.test.js
@@ -272,6 +272,7 @@ describe("initializeSettingsPage", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const showSettingsError = vi.fn();
     const onDomReady = vi.fn();
+    vi.doMock("../../src/helpers/domReady.js", () => ({ onDomReady }));
     vi.doMock("../../src/helpers/showSettingsError.js", () => ({
       showSettingsError
     }));


### PR DESCRIPTION
## Summary
- register the local `onDomReady` spy as the mock implementation for `domReady` in the navigation failure test so `settingsPage` receives the spy

## Task Contract
- **Inputs:** tests/helpers/settingsPage.test.js, repository testing instructions
- **Outputs:** updated test ensuring the mocked `onDomReady` spy is injected
- **Success:** test captures the `onDomReady` callback without errors and downstream import uses the spy
- **Failure Modes:** mock not applied before harness setup, spy not called, vitest command fails

## Verification
- `npx vitest run tests/helpers/settingsPage.test.js`

## Risks
- Low; change is isolated to unit test mocking behavior

## Files Changed
- tests/helpers/settingsPage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d295415b108326807aba3fdc769ede