### PR TITLE
Add navigation landmarks across mode pages

### DIFF
--- a/src/helpers/settings/gameModeSwitches.js
+++ b/src/helpers/settings/gameModeSwitches.js
@@ -1,7 +1,14 @@
 import { ToggleSwitch } from "../../components/ToggleSwitch.js";
+import navigationItems from "../../data/navigationItems.js";
 import { updateNavigationItemHidden } from "../gameModeUtils.js";
 import { showSettingsError } from "../showSettingsError.js";
 import { showSnackbar } from "../showSnackbar.js";
+
+const NAVIGABLE_MODE_IDS = new Set(
+  navigationItems
+    .map((item) => item.gameModeId)
+    .filter((id) => typeof id === "number")
+);
 
 /**
  * Handle a game mode toggle change.
@@ -79,6 +86,9 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
   }
   const sortedModes = [...gameModes].sort((a, b) => a.order - b.order);
   sortedModes.forEach((mode) => {
+    if (!NAVIGABLE_MODE_IDS.has(mode.id)) {
+      return;
+    }
     const current = getCurrentSettings();
     const currentModes = current.gameModes ?? {};
     const isChecked = Object.hasOwn(currentModes, mode.id) ? currentModes[mode.id] : !mode.isHidden;

--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -43,6 +43,15 @@
         <div class="header-spacer right"></div>
       </header>
 
+      <nav class="top-navbar" role="navigation" aria-label="Main navigation">
+        <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html" aria-current="page">Browse Judoka</a>
+        <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
+        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
+        <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+        <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
+      </nav>
+
       <main class="kodokan-grid" role="main">
         <div class="filter-bar">
           <button

--- a/src/pages/changeLog.html
+++ b/src/pages/changeLog.html
@@ -43,6 +43,15 @@
         <div class="header-spacer right"></div>
       </header>
 
+      <nav class="top-navbar" role="navigation" aria-label="Main navigation">
+        <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+        <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
+        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
+        <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+        <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
+      </nav>
+
       <main class="container" role="main">
         <h1>Recent Judoka Updates</h1>
         <div id="loading-container"></div>

--- a/src/pages/createJudoka.html
+++ b/src/pages/createJudoka.html
@@ -41,6 +41,15 @@
       <div class="header-spacer right"></div>
     </header>
 
+    <nav class="top-navbar" role="navigation" aria-label="Main navigation">
+      <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
+      <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+      <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
+      <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
+      <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+      <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
+    </nav>
+
     <main class="container" role="main">
       <!-- Section for the carousel -->
       <section id="carousel-section">

--- a/src/pages/meditation.html
+++ b/src/pages/meditation.html
@@ -43,6 +43,15 @@
         <div class="header-spacer right"></div>
       </header>
 
+      <nav class="top-navbar" role="navigation" aria-label="Main navigation">
+        <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+        <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
+        <a class="primary-button" data-testid="nav-11" href="./meditation.html" aria-current="page">Meditation</a>
+        <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+        <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
+      </nav>
+
       <main class="container meditation-screen" role="main">
         <h1 class="meditation-title">Pause. Breathe. Reflect.</h1>
 

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -30,6 +30,15 @@
         </div>
       </header>
 
+      <nav class="top-navbar" role="navigation" aria-label="Main navigation">
+        <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+        <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
+        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
+        <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+        <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
+      </nav>
+
       <main class="prd-viewer" role="main">
         <aside class="sidebar" aria-label="PRD list" role="navigation">
           <ul id="prd-list" class="sidebar-list"></ul>

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -42,6 +42,15 @@
         </div>
       </header>
 
+      <nav class="top-navbar" role="navigation" aria-label="Main navigation">
+        <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+        <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
+        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
+        <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html" aria-current="page">Random Judoka</a>
+        <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
+      </nav>
+
       <div class="card-section">
         <div id="card-container" data-testid="card-container" class="card-container"></div>
         <template id="card-placeholder-template">

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -42,6 +42,15 @@
         <div class="header-spacer right"></div>
       </header>
 
+      <nav class="top-navbar" role="navigation" aria-label="Main navigation">
+        <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+        <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
+        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
+        <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+        <a class="primary-button" data-testid="nav-13" href="./settings.html" aria-current="page">Settings</a>
+      </nav>
+
       <main class="container" role="main">
         <h1 class="settings-header">Settings</h1>
         <form id="settings-form" class="settings-form">

--- a/src/pages/updateJudoka.html
+++ b/src/pages/updateJudoka.html
@@ -41,6 +41,15 @@
       <div class="header-spacer right"></div>
     </header>
 
+    <nav class="top-navbar" role="navigation" aria-label="Main navigation">
+      <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
+      <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+      <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html" aria-current="page">Update Judoka</a>
+      <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
+      <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+      <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
+    </nav>
+
     <main class="container" role="main">
       <!-- Section for the carousel -->
       <section id="carousel-section">


### PR DESCRIPTION
## Summary
- add a top navigation bar with nav-* test ids to the random judoka, browse judoka, settings, create/update judoka, change log, meditation, and PRD viewer pages so the navigation landmark is immediately visible
- filter the settings page game mode toggles to only show modes that have corresponding navigation entries

## Testing
- npx playwright test playwright/random-judoka.spec.js playwright/browse-judoka.spec.js playwright/static-pages.spec.js playwright/settings.spec.js playwright/prd-reader.spec.js playwright/pseudo-japanese-toggle.spec.js playwright/meditation-screen.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d2b0372e8c8326826f32c15ba8b8dd