### PR TITLE
Handle immediate opponent snackbar without timeout

### DIFF
--- a/src/helpers/classicBattle/uiEventHandlers.js
+++ b/src/helpers/classicBattle/uiEventHandlers.js
@@ -20,6 +20,8 @@ function clearOpponentSnackbarTimeout() {
 function displayOpponentChoosingPrompt() {
   try {
     showSnackbar(t("ui.opponentChoosing"));
+  } catch {}
+  try {
     markOpponentPromptNow();
   } catch {}
 }
@@ -76,7 +78,12 @@ export function bindUIHelperEventHandlersDynamic() {
         clearOpponentSnackbarTimeout();
         if (resolvedDelay <= 0) {
           // Handle immediate display when delay is zero or negative by skipping the timeout setup.
-          displayOpponentChoosingPrompt();
+          try {
+            showSnackbar(t("ui.opponentChoosing"));
+          } catch {}
+          try {
+            markOpponentPromptNow();
+          } catch {}
           return;
         }
         opponentSnackbarId = setTimeout(() => {


### PR DESCRIPTION
## Task Contract
- **Inputs**: `src/helpers/classicBattle/uiEventHandlers.js`
- **Outputs**: Updated opponent snackbar timing logic for the `statSelected` listener.
- **Success Criteria**: Immediate opponent prompts skip scheduling, timers still handle positive delays, and classic battle opponent message tests continue to pass.
- **Failure Criteria**: Leaving a pending timeout when the resolved delay is non-positive or regressing existing delayed behavior.

## Summary
- Ensure the opponent snackbar prompt directly fires when the resolved delay is zero or negative.
- Keep the delayed path unchanged while guaranteeing the timeout handle stays cleared when unused.
- Always mark the opponent prompt immediately, even if showing the snackbar throws.

## Files Changed
- `src/helpers/classicBattle/uiEventHandlers.js`

## Testing
- `npx vitest run tests/classicBattle/opponent-message-handler.improved.test.js`

## Risk
- Low: Changes are confined to snackbar scheduling for the opponent prompt with coverage from targeted unit tests.


------
https://chatgpt.com/codex/tasks/task_e_68d2bec69f348326be416f88e2091fd3