### PR TITLE
Ensure round resolved prompt buffer uses overrides

### DIFF
--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -530,18 +530,20 @@ export async function handleRoundResolvedEvent(event, deps = {}) {
             typeof deps.attachCooldownRendererOptions === "object"
               ? { ...deps.attachCooldownRendererOptions }
               : {};
-          const promptBufferOverride = resolveOpponentPromptBuffer(
+          const resolvedBuffer = resolveOpponentPromptBuffer(
             cooldownResult,
-            attachRendererOptions
+            deps.attachCooldownRendererOptions
           );
           let promptBudget = null;
           if (delayOpponentMessageFlag) {
             try {
-              promptBudget = computeOpponentPromptWaitBudget(promptBufferOverride);
+              promptBudget = computeOpponentPromptWaitBudget(resolvedBuffer);
             } catch {
               promptBudget = computeOpponentPromptWaitBudget();
             }
-            attachRendererOptions.opponentPromptBufferMs = promptBudget.bufferMs;
+            const rendererBuffer =
+              resolvedBuffer !== undefined ? resolvedBuffer : promptBudget.bufferMs;
+            attachRendererOptions.opponentPromptBufferMs = rendererBuffer;
             attachRendererOptions.maxPromptWaitMs = promptBudget.totalMs;
             const pollNumeric = Number(attachRendererOptions.promptPollIntervalMs);
             const resolvedPollInterval =


### PR DESCRIPTION
## Summary
- derive the resolved opponent prompt buffer before computing the wait budget
- honour overrides from injected renderer options or cooldown results when delaying opponent prompts
- persist the effective buffer on renderer options alongside the existing wait configuration

## Testing
- npx vitest run tests/helpers/classicBattle/roundUI.handlers.test.js
- npx vitest run --reporter tap
- npm run check:jsdoc
- ./node_modules/.bin/prettier . --check *(fails: repository already contains unformatted artifacts in `minilm_temp/` and `progressBug.md`)*
- npx eslint .
- npx playwright test *(fails under container conditions: numerous UI expectations time out or abort because the mock backend/resources are unavailable)*
- npm run check:contrast
- npm run rag:validate *(fails: MiniLM model placeholders + offline environment prevent hydration)*
- npm run validate:data
- grep -RIn "await import\(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle 2>/dev/null
- grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"

------
https://chatgpt.com/codex/tasks/task_e_68d2be6899688326b5f2921cff5ce907