### PR TITLE
Add missing updateTimer mock to classic battle tests

### DIFF
--- a/tests/helpers/classicBattle/roundResolved.statButton.test.js
+++ b/tests/helpers/classicBattle/roundResolved.statButton.test.js
@@ -28,7 +28,8 @@ vi.mock("../../../src/helpers/classicBattle/autoSelectHandlers.js", () => ({
 }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   clearRoundCounter: vi.fn(),
-  updateRoundCounter: vi.fn()
+  updateRoundCounter: vi.fn(),
+  updateTimer: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
   disableNextRoundButton: vi.fn(),

--- a/tests/helpers/classicBattle/roundResolverOnce.test.js
+++ b/tests/helpers/classicBattle/roundResolverOnce.test.js
@@ -27,7 +27,8 @@ vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
   _resetForTest: vi.fn()
 }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
-  updateScore: vi.fn()
+  updateScore: vi.fn(),
+  updateTimer: vi.fn()
 }));
 
 describe.sequential("classicBattle round resolver once", () => {


### PR DESCRIPTION
## Summary
- extend the setupScoreboard mock in the round resolved stat button test with an updateTimer spy
- add the updateTimer spy alongside updateScore in the roundResolverOnce test mock

## Files Changed
- tests/helpers/classicBattle/roundResolved.statButton.test.js
- tests/helpers/classicBattle/roundResolverOnce.test.js

## Testing
- npx vitest run tests/helpers/classicBattle/roundResolved.statButton.test.js
- npx vitest run tests/helpers/classicBattle/roundResolverOnce.test.js

## Risk
- Low: touches isolated test mocks only

------
https://chatgpt.com/codex/tasks/task_e_68d2c46853bc8326a9ffd7c51d7114a7