### PR TITLE
Handle zero prompt delay in cooldown renderer

### DIFF
--- a/tests/helpers/CooldownRenderer.test.js
+++ b/tests/helpers/CooldownRenderer.test.js
@@ -284,4 +284,17 @@ describe("attachCooldownRenderer", () => {
     expect(snackbar.updateSnackbar).toHaveBeenCalledWith("Next round in: 0s");
     expect(scoreboard.updateTimer).toHaveBeenCalledWith(0);
   });
+
+  it("renders initial countdown immediately when prompt delay has elapsed", () => {
+    const detach = attachCooldownRenderer(timer, 4, {
+      waitForOpponentPrompt: true,
+      maxPromptWaitMs: 0
+    });
+
+    expect(snackbar.showSnackbar).toHaveBeenCalledWith("Next round in: 4s");
+    expect(scoreboard.updateTimer).toHaveBeenCalledWith(4);
+    expect(emitBattleEvent).not.toHaveBeenCalled();
+
+    detach();
+  });
 });


### PR DESCRIPTION
## Summary
- expose remaining prompt delay from the prompt delay controller
- ensure cooldown renderer queues or flushes ticks through a helper that short-circuits zero delays
- add regression coverage for immediate initial renders when no prompt wait remains

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: repository has existing formatting warnings outside the change scope)*
- npx eslint .
- CI=1 npx vitest run --reporter=basic
- npx playwright test *(fails in existing battle classic scenarios; see terminal log for details)*
- npm run check:contrast


------
https://chatgpt.com/codex/tasks/task_e_68d2d24872d083268bd700ef91d720aa