### PR TITLE
Enhance test API detection for automation environments

### DIFF
--- a/src/helpers/testApi.js
+++ b/src/helpers/testApi.js
@@ -38,6 +38,21 @@ function logDevWarning(message, error) {
   } catch {}
 }
 
+function isAutomationNavigator(nav) {
+  if (!nav) return false;
+
+  try {
+    if (nav.webdriver === true) return true;
+
+    const userAgent = typeof nav.userAgent === "string" ? nav.userAgent : "";
+    if (userAgent.includes("Playwright/Headless")) {
+      return true;
+    }
+  } catch {}
+
+  return false;
+}
+
 // Test mode detection
 function isTestMode() {
   // Check for common test environment indicators
@@ -54,6 +69,12 @@ function isTestMode() {
       window.location?.href?.includes("localhost")
     )
       return true;
+
+    if (isAutomationNavigator(window.navigator)) return true;
+  }
+
+  if (typeof navigator !== "undefined" && isAutomationNavigator(navigator)) {
+    return true;
   }
 
   // Check feature flag
@@ -799,5 +820,7 @@ export function getTestAPI() {
 if (isTestMode()) {
   exposeTestAPI();
 }
+
+export const __test = { isTestMode };
 
 export default testApi;

--- a/tests/helpers/testApi.test.js
+++ b/tests/helpers/testApi.test.js
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/helpers/featureFlags.js", () => ({
+  isEnabled: vi.fn(() => false)
+}));
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalVitestFlag = process.env.VITEST;
+const originalTestFlag = window.__TEST__;
+const originalHref = window.location.href;
+const originalTestApi = window.__TEST_API;
+const originalBattleStateApi = window.__BATTLE_STATE_API;
+const originalTimerApi = window.__TIMER_API;
+const originalInitApi = window.__INIT_API;
+const originalInspectApi = window.__INSPECT_API;
+const originalViewportApi = window.__VIEWPORT_API;
+const originalOpponentDelay = window.__OPPONENT_RESOLVE_DELAY_MS;
+const originalWebdriverDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "webdriver");
+const originalUserAgentDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "userAgent");
+
+function setNavigatorWebdriver(value) {
+  Object.defineProperty(window.navigator, "webdriver", {
+    configurable: true,
+    get: () => value
+  });
+}
+
+function restoreWindowProperty(key, value) {
+  if (value === undefined) {
+    delete window[key];
+  } else {
+    window[key] = value;
+  }
+}
+
+describe("testApi.isTestMode", () => {
+  beforeEach(() => {
+    vi.resetModules();
+
+    process.env.NODE_ENV = "production";
+    delete process.env.VITEST;
+
+    restoreWindowProperty("__TEST__", undefined);
+    restoreWindowProperty("__TEST_API", undefined);
+    restoreWindowProperty("__BATTLE_STATE_API", undefined);
+    restoreWindowProperty("__TIMER_API", undefined);
+    restoreWindowProperty("__INIT_API", undefined);
+    restoreWindowProperty("__INSPECT_API", undefined);
+    restoreWindowProperty("__VIEWPORT_API", undefined);
+    delete window.__OPPONENT_RESOLVE_DELAY_MS;
+    delete window.__initCalled;
+
+    window.history.replaceState({}, "", "https://example.com/");
+
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (jsdom)",
+      writable: false
+    });
+
+    setNavigatorWebdriver(false);
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+
+    if (originalVitestFlag === undefined) {
+      delete process.env.VITEST;
+    } else {
+      process.env.VITEST = originalVitestFlag;
+    }
+
+    restoreWindowProperty("__TEST__", originalTestFlag);
+    restoreWindowProperty("__TEST_API", originalTestApi);
+    restoreWindowProperty("__BATTLE_STATE_API", originalBattleStateApi);
+    restoreWindowProperty("__TIMER_API", originalTimerApi);
+    restoreWindowProperty("__INIT_API", originalInitApi);
+    restoreWindowProperty("__INSPECT_API", originalInspectApi);
+    restoreWindowProperty("__VIEWPORT_API", originalViewportApi);
+
+    if (originalOpponentDelay === undefined) {
+      delete window.__OPPONENT_RESOLVE_DELAY_MS;
+    } else {
+      window.__OPPONENT_RESOLVE_DELAY_MS = originalOpponentDelay;
+    }
+
+    window.history.replaceState({}, "", originalHref);
+
+    if (originalWebdriverDescriptor) {
+      Object.defineProperty(window.navigator, "webdriver", originalWebdriverDescriptor);
+    } else {
+      delete window.navigator.webdriver;
+    }
+
+    if (originalUserAgentDescriptor) {
+      Object.defineProperty(window.navigator, "userAgent", originalUserAgentDescriptor);
+    }
+
+    delete window.__initCalled;
+
+    vi.clearAllMocks();
+  });
+
+  it("treats webdriver automation as test mode and exposes the API", async () => {
+    const mod = await import("../../src/helpers/testApi.js");
+    const { __test, exposeTestAPI, getTestAPI } = mod;
+
+    expect(__test.isTestMode()).toBe(false);
+    expect(window.__TEST_API).toBeUndefined();
+
+    setNavigatorWebdriver(true);
+
+    expect(__test.isTestMode()).toBe(true);
+
+    exposeTestAPI();
+
+    expect(window.__TEST_API).toBe(getTestAPI());
+    expect(window.__INIT_API).toBeDefined();
+
+    window.__initCalled = true;
+    await expect(window.__INIT_API.waitForBattleReady(5)).resolves.toBe(true);
+    delete window.__initCalled;
+
+    expect(window.__TEST_API.timers.setOpponentResolveDelay(25)).toBe(true);
+    expect(window.__OPPONENT_RESOLVE_DELAY_MS).toBe(25);
+    expect(window.__TEST_API.timers.setOpponentResolveDelay(null)).toBe(true);
+    expect(window.__OPPONENT_RESOLVE_DELAY_MS).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- treat Playwright automation contexts as test mode by checking `navigator.webdriver` and headless user agents
- expose an internal `__test` handle for `isTestMode` to support focused regression tests
- add a Vitest regression that stubs `navigator.webdriver`, verifies the test API mounts, and exercises `waitForBattleReady`/`setOpponentResolveDelay`

## Testing
- `npm run check:jsdoc`
- `CI=1 npx prettier . --check` *(fails: repo has 13 pre-existing formatting differences outside the touched files)*
- `npx eslint .` *(emits existing warning in tests/helpers/randomJudokaPage.historyPanel.test.js)*
- `npx vitest run`
- `npx playwright test` *(fails: numerous Classic Battle Playwright specs currently red; see test log for details)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: MiniLM model assets absent in repository; RAG evaluation cannot load embeddings)*
- `npm run validate:data`

------
https://chatgpt.com/codex/tasks/task_e_68d2dad527cc8326b52ece618927235f