### PR TITLE
Reorder top navbar links across pages

### DIFF
--- a/src/pages/browseJudoka.html
+++ b/src/pages/browseJudoka.html
@@ -45,10 +45,12 @@
 
       <nav class="top-navbar" role="navigation" aria-label="Main navigation">
         <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
-        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html" aria-current="page">Browse Judoka</a>
         <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
-        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
         <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html" aria-current="page"
+          >Browse Judoka</a
+        >
+        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
         <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
       </nav>
 

--- a/src/pages/changeLog.html
+++ b/src/pages/changeLog.html
@@ -45,10 +45,10 @@
 
       <nav class="top-navbar" role="navigation" aria-label="Main navigation">
         <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
-        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
         <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
-        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
         <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
         <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
       </nav>
 

--- a/src/pages/createJudoka.html
+++ b/src/pages/createJudoka.html
@@ -43,10 +43,10 @@
 
     <nav class="top-navbar" role="navigation" aria-label="Main navigation">
       <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
-      <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
       <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
-      <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
       <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+      <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+      <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
       <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
     </nav>
 

--- a/src/pages/meditation.html
+++ b/src/pages/meditation.html
@@ -45,10 +45,12 @@
 
       <nav class="top-navbar" role="navigation" aria-label="Main navigation">
         <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
-        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
         <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
-        <a class="primary-button" data-testid="nav-11" href="./meditation.html" aria-current="page">Meditation</a>
         <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+        <a class="primary-button" data-testid="nav-11" href="./meditation.html" aria-current="page"
+          >Meditation</a
+        >
         <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
       </nav>
 

--- a/src/pages/prdViewer.html
+++ b/src/pages/prdViewer.html
@@ -32,10 +32,10 @@
 
       <nav class="top-navbar" role="navigation" aria-label="Main navigation">
         <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
-        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
         <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
-        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
         <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
         <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
       </nav>
 

--- a/src/pages/randomJudoka.html
+++ b/src/pages/randomJudoka.html
@@ -44,10 +44,16 @@
 
       <nav class="top-navbar" role="navigation" aria-label="Main navigation">
         <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
-        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
         <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
+        <a
+          class="primary-button"
+          data-testid="nav-12"
+          href="./randomJudoka.html"
+          aria-current="page"
+          >Random Judoka</a
+        >
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
         <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
-        <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html" aria-current="page">Random Judoka</a>
         <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
       </nav>
 

--- a/src/pages/settings.html
+++ b/src/pages/settings.html
@@ -44,11 +44,13 @@
 
       <nav class="top-navbar" role="navigation" aria-label="Main navigation">
         <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
-        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
         <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html">Update Judoka</a>
-        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
         <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
-        <a class="primary-button" data-testid="nav-13" href="./settings.html" aria-current="page">Settings</a>
+        <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+        <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
+        <a class="primary-button" data-testid="nav-13" href="./settings.html" aria-current="page"
+          >Settings</a
+        >
       </nav>
 
       <main class="container" role="main">

--- a/src/pages/updateJudoka.html
+++ b/src/pages/updateJudoka.html
@@ -43,10 +43,12 @@
 
     <nav class="top-navbar" role="navigation" aria-label="Main navigation">
       <a class="primary-button" data-testid="nav-1" href="./battleClassic.html">Classic Battle</a>
-      <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
-      <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html" aria-current="page">Update Judoka</a>
-      <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
+      <a class="primary-button" data-testid="nav-9" href="./updateJudoka.html" aria-current="page"
+        >Update Judoka</a
+      >
       <a class="primary-button" data-testid="nav-12" href="./randomJudoka.html">Random Judoka</a>
+      <a class="primary-button" data-testid="nav-7" href="./browseJudoka.html">Browse Judoka</a>
+      <a class="primary-button" data-testid="nav-11" href="./meditation.html">Meditation</a>
       <a class="primary-button" data-testid="nav-13" href="./settings.html">Settings</a>
     </nav>
 


### PR DESCRIPTION
## Summary
- reorder the `.top-navbar` links on the settings, browse, random, meditation, update, create Judoka, changelog, and PRD viewer pages so they follow the Classic Battle → Update Judoka → Random Judoka → Browse Judoka → Meditation → Settings sequence
- preserve existing data-testid and aria attributes while matching the new navigation order

## Testing
- `npm run check:jsdoc`
- `npx prettier . --check` *(fails: repository contains pre-existing formatting issues in unrelated files such as minilm_temp assets and progress*.md notes)*
- `npx eslint .`
- `npx vitest run`
- `npx playwright test` *(fails: multiple existing opponent reveal, CLI scroll, homepage, and settings specs timing out or asserting outdated content)*
- `npm run check:contrast`
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle`
- `grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68d2eff7aa648326a9c78b09f0d9dadc