### PR TITLE
Skip unsupported game mode toggles

### DIFF
--- a/src/helpers/settings/gameModeSwitches.js
+++ b/src/helpers/settings/gameModeSwitches.js
@@ -93,12 +93,14 @@ export function handleGameModeChange({ input, mode, label, getCurrentSettings, h
  * Render game mode toggle switches within the settings page.
  *
  * @description
- * Create a ToggleSwitch for each provided game mode and wire change handlers
- * to persist updates and update navigation visibility.
+ * Create a ToggleSwitch for each provided game mode that has a corresponding
+ * navigation entry and wire change handlers to persist updates and update
+ * navigation visibility.
  *
  * @pseudocode
  * 1. Validate `container` and `gameModes` input; return early when invalid.
- * 2. Sort `gameModes` by `order` and iterate each entry.
+ * 2. Sort `gameModes` by `order` and iterate each entry that resolves to a
+ *    navigation mode.
  * 3. For each mode:
  *    a. Build a `ToggleSwitch` with proper label, tooltip, and accessibility attributes.
  *    b. Append description text when available and set `aria-describedby`.
@@ -121,6 +123,9 @@ export function renderGameModeSwitches(container, gameModes, getCurrentSettings,
   }
   const sortedModes = [...gameModes].sort((a, b) => a.order - b.order);
   sortedModes.forEach((mode) => {
+    if (resolveNavigationModeId(mode.id) === null) {
+      return;
+    }
     const current = getCurrentSettings();
     const currentModes = current.gameModes ?? {};
     const isChecked = Object.hasOwn(currentModes, mode.id) ? currentModes[mode.id] : !mode.isHidden;

--- a/tests/helpers/settingsFormUtils.test.js
+++ b/tests/helpers/settingsFormUtils.test.js
@@ -39,15 +39,31 @@ describe("formUtils ARIA", () => {
 
   it("adds data-tooltip-id for game mode switches", () => {
     const container = document.createElement("div");
-    const modes = [{ id: "classicBattle", name: "Classic Battle", order: 1 }];
+    const modes = [{ id: 1, name: "Classic Battle", order: 1 }];
     renderGameModeSwitches(
       container,
       modes,
       () => ({ gameModes: {} }),
       () => {}
     );
-    const input = container.querySelector("#mode-classicBattle");
-    expect(input).toBeTruthy();
+    const input = container.querySelector("#mode-1");
+    expect(input).toHaveAttribute("data-tooltip-id", "mode.1");
+  });
+
+  it("skips modes without navigation entries", () => {
+    const container = document.createElement("div");
+    const modes = [
+      { id: 1, name: "Classic", order: 1 },
+      { id: 999, name: "Unsupported", order: 2 }
+    ];
+    renderGameModeSwitches(
+      container,
+      modes,
+      () => ({ gameModes: {} }),
+      () => {}
+    );
+    expect(container.querySelector("#mode-1")).toBeTruthy();
+    expect(container.querySelector("#mode-999")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- skip rendering game mode toggles when the mode has no matching navigation entry
- document the navigation requirement in `renderGameModeSwitches`
- expand settings form tests to cover tooltip fallback and unsupported modes

## Verification Summary
- `npx vitest tests/helpers/settingsFormUtils.test.js`

## Files Changed
- src/helpers/settings/gameModeSwitches.js
- tests/helpers/settingsFormUtils.test.js

## Risk
- Low: only filters out settings toggles for modes lacking navigation support and adjusts related tests.

------
https://chatgpt.com/codex/tasks/task_e_68d30d99f5a883269a807ccdd59e7e5a