### PR TITLE
Handle timing-specific startMatch fallback

### DIFF
--- a/playwright/battle-classic/opponent-reveal.spec.js
+++ b/playwright/battle-classic/opponent-reveal.spec.js
@@ -99,6 +99,17 @@ async function startMatchAndAwaitStats(page, selector) {
   try {
     await startMatch(page, selector);
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const isTimingIssue =
+      typeof message === "string" &&
+      (/timeout/i.test(message) ||
+        message.includes("waitForBattleState") ||
+        message.includes("waitForBattleReady"));
+
+    if (!isTimingIssue) {
+      throw error;
+    }
+
     const statsReady = await page
       .locator(selectors.statButton(0))
       .first()


### PR DESCRIPTION
## Summary
- tighten the startMatchAndAwaitStats helper so that the stat-button fallback only runs on known timing or battle-state wait failures
- keep the existing stat-button visibility check so that transient hiccups are still tolerated while surfacing unrelated errors immediately

## Testing
- `npm run check:jsdoc`
- `CI=1 npx prettier . --check` *(fails: SyntaxError in playwright/settings-collapse.spec.js)*
- `CI=1 npx eslint .` *(fails: existing parsing error and unused variable warnings in Playwright specs)*
- `NO_COLOR=1 npx vitest run --reporter=basic` *(fails: pre-existing battleCLI tests)*
- `CI=1 npx playwright test` *(fails: SyntaxError in playwright/settings-collapse.spec.js)*
- `npm run check:contrast`

------
https://chatgpt.com/codex/tasks/task_e_68d3154fa3e88326be6c73074d894c43