### PR TITLE
Update opponent reveal test for round 2 snackbar state

### DIFF
--- a/playwright/battle-classic/opponent-reveal.spec.js
+++ b/playwright/battle-classic/opponent-reveal.spec.js
@@ -272,6 +272,11 @@ test.describe("Classic Battle Opponent Reveal", () => {
 
         const nextRoundStat = page.locator(selectors.statButton(0)).first();
         await expect(nextRoundStat).toBeEnabled();
+
+        await nextRoundStat.click();
+
+        const snackbar = page.locator(selectors.snackbarContainer());
+        await expect(snackbar).toContainText(/Opponent is choosing/i);
       }, ["log", "info", "warn", "error", "debug"]));
   });
 


### PR DESCRIPTION
## Summary
- extend the round-advancement Playwright test to click the round-two stat button and confirm the snackbar returns to the "Opponent is choosing" state using the shared selectors

## Testing
- `npm run check:jsdoc` *(fails: existing missing JSDoc in src/pages/battleCLI/init.js)*
- `npx prettier . --check` *(fails: existing formatting issues in src/pages/battleCLI/init.js)*
- `npx eslint .` *(fails: existing lint/prettier issues in src/pages/battleCLI/init.js)*
- `npx vitest run` *(aborted due to extremely large animated console output; unable to obtain pass/fail signal)*
- `npx playwright test playwright/battle-classic/opponent-reveal.spec.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68d3221c28748326aaf2b95f7e3c4872