### PR TITLE
Add data-stat attribute to CLI stat rows

### DIFF
--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -1252,8 +1252,11 @@ function buildStatRows(stats, judoka) {
       const idx = Number(s.statIndex) || 0;
       if (!idx) return;
       const key = STATS[idx - 1];
-      if (key) statDisplayNames[key] = s.name;
       const div = document.createElement("div");
+      if (key) {
+        statDisplayNames[key] = s.name;
+        div.dataset.stat = key;
+      }
       div.className = "cli-stat";
       div.id = `cli-stat-${idx}`;
       div.setAttribute("role", "option");


### PR DESCRIPTION
## Summary
- set the CLI stat rows to expose their stat key through a data-stat attribute during creation
- retain existing stat display mapping while adding the new dataset property alongside the stat index dataset

## Testing
- npx playwright test playwright/battle-cli-play.spec.js
- npx playwright test playwright/battle-cli-start.spec.js playwright/battle-cli-restart.spec.js playwright/cli-flows.spec.mjs playwright/cli-flows-improved.spec.mjs playwright/cli-layout-assessment.spec.js playwright/cli-scroll.spec.js playwright/cli.spec.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d3b080adf083269134892b6bc61423