### PR TITLE
Ensure scoreboard spans exist before animating updates

### DIFF
--- a/src/components/ScoreboardView.js
+++ b/src/components/ScoreboardView.js
@@ -126,10 +126,23 @@ export class ScoreboardView {
       return;
     }
     // Immediate set for determinism, optional animate when prior spans exist
-    const playerSpan = this.scoreEl.querySelector('span[data-side="player"]');
-    const opponentSpan = this.scoreEl.querySelector('span[data-side="opponent"]');
     const endVals = { p: Number(player) || 0, o: Number(opponent) || 0 };
-    if (!playerSpan || !opponentSpan) return;
+    let playerSpan = this.scoreEl.querySelector('span[data-side="player"]');
+    let opponentSpan = this.scoreEl.querySelector('span[data-side="opponent"]');
+    if (!playerSpan || !opponentSpan) {
+      // Ensure deterministic text content even if initial markup lacks spans.
+      this._scoreAnimId += 1;
+      if (this._scoreRaf) {
+        cancel(this._scoreRaf);
+        this._scoreRaf = null;
+      }
+      this.scoreEl.innerHTML = `<span data-side="player">You: ${endVals.p}</span>\n<span data-side="opponent">Opponent: ${endVals.o}</span>`;
+      playerSpan = this.scoreEl.querySelector('span[data-side="player"]');
+      opponentSpan = this.scoreEl.querySelector('span[data-side="opponent"]');
+      if (!playerSpan || !opponentSpan) {
+        return;
+      }
+    }
     const parse = (el) => {
       if (!el) return 0;
       const m = el.textContent && el.textContent.match(/(\d+)/);


### PR DESCRIPTION
## Summary
- ensure the scoreboard view rebuilds its span markup when it is missing so score updates no longer short circuit
- cancel any pending score animations when rebuilding the markup to keep the animation id in sync

## Testing
- npx playwright test playwright/battle-classic/end-modal.spec.js -g "handles match completion and score display"
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- npx vitest run --reporter=basic
- npx playwright test *(fails: pre-existing classic battle flakes)*
- npm run check:contrast
- npm run rag:validate *(fails: MiniLM model assets unavailable in environment)*
- npm run validate:data

------
https://chatgpt.com/codex/tasks/task_e_68d3bcb266ac8326a1acdfcc32c39de7