### PR TITLE
Adjust stat selection Playwright test to match scoreboard structure

### DIFF
--- a/playwright/battle-classic/stat-selection.spec.js
+++ b/playwright/battle-classic/stat-selection.spec.js
@@ -26,7 +26,8 @@ test.describe("Classic Battle stat selection", () => {
 
       // Click the first stat button
       const score = page.getByTestId("score-display");
-      await expect(score.locator('[data-side="player"]')).toHaveCount(0);
+      await expect(score.locator('[data-side="player"]')).toHaveText(/You:\s*0/);
+      await expect(score.locator('[data-side="opponent"]')).toHaveText(/Opponent:\s*0/);
       await buttons.first().click();
 
       // Timer should be cleared or show 0s after stat selection


### PR DESCRIPTION
## Task Contract
- **Inputs**: Playwright failure logs for `playwright/battle-classic/stat-selection.spec.js`, Classic Battle scoreboard behaviour.
- **Outputs**: Updated end-to-end test expectations that reflect the current scoreboard DOM structure.
- **Success Criteria**: The Playwright test passes locally with the revised assertions, ensuring coverage of both player and opponent scoreboard spans before and after stat selection.
- **Failure Modes**: Scoreboard assertions remain outdated, causing Playwright failures.

## Summary
- Update the Classic Battle stat selection Playwright test to expect structured scoreboard spans for both player and opponent before the first stat selection.

## Files Changed
- `playwright/battle-classic/stat-selection.spec.js`

## Testing
- `npx playwright test playwright/battle-classic/stat-selection.spec.js`

## Risk
- Low: Only adjusts test assertions to match existing DOM output without altering application logic.


------
https://chatgpt.com/codex/tasks/task_e_68d3cc945fb083269883ac8dca7a03f2