### PR TITLE
Fix CLI invalid key message persistence

### DIFF
--- a/src/pages/battleCLI.init.js
+++ b/src/pages/battleCLI.init.js
@@ -41,6 +41,7 @@ function setCountdown(value) {
   } catch {}
   // atomically set attribute then text
   el.dataset.remainingTime = String(value ?? 0);
+  if (el.dataset.status === "error") return;
   el.textContent = value !== null ? `Timer: ${String(value).padStart(2, "0")}` : "";
   // Briefly freeze countdown UI so test writes are observable before engine overrides
   try {

--- a/src/pages/battleCLI/events.js
+++ b/src/pages/battleCLI/events.js
@@ -137,9 +137,19 @@ export function onKeyDown(e) {
   if (!shouldProcessKey(lower)) return;
   const handled = routeKeyByState(lower);
   const countdown = byId("cli-countdown");
+  if (!countdown) return;
+
   if (handled === false && lower !== "tab") {
-    if (countdown) countdown.textContent = "Invalid key, press H for help";
-  } else if (countdown && countdown.textContent) {
+    countdown.textContent = "Invalid key, press H for help";
+    countdown.dataset.status = "error";
+    return;
+  }
+
+  if (countdown.dataset.status === "error") {
+    delete countdown.dataset.status;
+  }
+
+  if (countdown.textContent) {
     countdown.textContent = "";
   }
 }


### PR DESCRIPTION
## Summary
- ensure the CLI countdown marks an error state while displaying the invalid key message so timer updates do not overwrite it
- guard countdown updates in the selection timer, engine subscription, and test helper so they respect the error state and reset it when needed
- clear the countdown error state when timers stop so regular updates resume cleanly

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- CI=1 npx vitest run --reporter=basic
- CI=1 npx playwright test *(fails: existing battle-classic end modal scenarios timing out)*
- npm run rag:validate *(fails: missing local MiniLM model assets)*
- npm run validate:data
- grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle --exclude=client_embeddings.json
- grep -RInE "console.(warn|error)(" tests | grep -v "tests/utils/console.js"
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d408cabce48326811f55f78290e4d7