### PR TITLE
Refactor battleCLI countdown test to use finish hook

### DIFF
--- a/tests/pages/battleCLI.countdown.test.js
+++ b/tests/pages/battleCLI.countdown.test.js
@@ -22,9 +22,10 @@ describe("battleCLI countdown", () => {
     emitBattleEvent("battleStateChange", { to: "waitingForPlayerAction" });
     const cd = document.getElementById("cli-countdown");
     expect(cd.dataset.remainingTime).toBe("30");
-    vi.advanceTimersByTime(30000);
-    // Some environments may not flush the exact expiry tick; force it via test hook.
-    await mod.forceSelectionExpiry();
+    mod.startSelectionCountdown?.(30);
+    const finishSelection = mod.getSelectionFinishFn?.();
+    expect(typeof finishSelection).toBe("function");
+    await finishSelection?.();
     // Either the auto-select helper is invoked, or the UI shows a selection result
     const bar = document.querySelector("#snackbar-container .snackbar");
     expect(
@@ -39,8 +40,10 @@ describe("battleCLI countdown", () => {
     const emitSpy = vi.spyOn(battleEventsMod, "emitBattleEvent");
     const { autoSelectStat } = await import("../../src/helpers/classicBattle/autoSelectStat.js");
     battleEvents.emitBattleEvent("battleStateChange", { to: "waitingForPlayerAction" });
-    vi.advanceTimersByTime(30000);
-    await mod.forceSelectionExpiry();
+    mod.startSelectionCountdown?.(30);
+    const finishSelection = mod.getSelectionFinishFn?.();
+    expect(typeof finishSelection).toBe("function");
+    await finishSelection?.();
     expect(autoSelectStat).not.toHaveBeenCalled();
     expect(emitSpy).toHaveBeenCalledWith("statSelectionStalled");
     emitSpy.mockRestore();


### PR DESCRIPTION
## Summary
- replace long fake timer advances in the countdown test with direct access to the countdown controller
- assert the exposed finish handler exists before awaiting it to resolve selection behaviour
- ensure both auto-select and stalled branches execute without needing manual expiry helpers

## Testing
- npx vitest run tests/pages/battleCLI.countdown.test.js

## Files Changed
- tests/pages/battleCLI.countdown.test.js

## Risk
- Low risk: exercises existing countdown hooks without altering production code paths.

------
https://chatgpt.com/codex/tasks/task_e_68d42f0dcba483269456dae2bf0c5b86