### PR TITLE
Fix unused headless mode timing test lint warning

### DIFF
--- a/tests/helpers/headlessMode.timing.test.js
+++ b/tests/helpers/headlessMode.timing.test.js
@@ -56,7 +56,7 @@ describe("headless mode timing", () => {
       return { ...actual, resolveDelay: () => 250 };
     });
 
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((cb, ms) => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((cb) => {
       cb?.();
       return 1;
     });


### PR DESCRIPTION
## Task Contract
- **Given** a lint warning from `no-unused-vars` in `tests/helpers/headlessMode.timing.test.js`
- **When** the unused `ms` parameter is removed from the mocked `setTimeout` implementation
- **Then** the lint warning is resolved while preserving the test behaviour

## Summary
- Update the headless mode timing test mock to drop the unused `ms` parameter so ESLint no longer reports `no-unused-vars`.

## Files Changed
- tests/helpers/headlessMode.timing.test.js

## Verification
- `npm run check:jsdoc`
- `npx prettier . --check`
- `npx eslint .`
- `npx vitest run` *(fails: existing mock in `roundStore` expects `updateRoundCounter` export; not introduced by this change)*
- `npx playwright test` *(fails: existing UI timing issues around `#match-end-modal`; not introduced by this change)*
- `npm run check:contrast`

## Risk
- Low risk: only adjusts a test double signature without affecting runtime code.


------
https://chatgpt.com/codex/tasks/task_e_68d439c1b4c48326881eab232f75ce47