### PR TITLE
Refactor CLI play test to use Test API waiters

### DIFF
--- a/playwright/battle-cli-play.spec.js
+++ b/playwright/battle-cli-play.spec.js
@@ -1,13 +1,23 @@
 import { test, expect } from "@playwright/test";
 import { withMutedConsole } from "../tests/utils/console.js";
+import { waitForBattleState, waitForTestApi } from "./helpers/battleStateHelper.js";
 
 test.describe("Battle CLI - Play", () => {
   test("should be able to select a stat and see the result", async ({ page }) => {
     await withMutedConsole(async () => {
       await page.goto("/src/pages/battleCLI.html?autostart=1");
 
-      await page.waitForFunction(() => window.__TEST_API?.state?.dispatchBattleEvent);
-      await page.waitForFunction(() => window.__TEST_API?.cli?.resolveRound);
+      await waitForTestApi(page);
+
+      const isReady = await page.evaluate(() =>
+        window.__TEST_API?.init?.waitForBattleReady?.(10_000)
+      );
+      expect(isReady).toBe(true);
+
+      await waitForBattleState(page, "waitingForPlayerAction", {
+        timeout: 10_000,
+        allowFallback: false
+      });
 
       // Wait for the stats to be ready
       const statsContainer = page.locator("#cli-stats");
@@ -24,39 +34,55 @@ test.describe("Battle CLI - Play", () => {
       // Click the first stat button
       await statButton.click();
 
+      await waitForBattleState(page, "roundDecision", {
+        timeout: 10_000,
+        allowFallback: false
+      });
+
       const statKey = await statButton.getAttribute("data-stat");
       expect(statKey, "stat button should expose a data-stat attribute").toBeTruthy();
 
-      await page.evaluate(async (stat) => {
-        window.__TEST_API.timers.expireSelectionTimer();
+      await page.evaluate(() => window.__TEST_API.timers.expireSelectionTimer());
 
-        await new Promise((resolve) => {
-          if (typeof requestAnimationFrame === "function") {
-            requestAnimationFrame(() => resolve());
-          } else if (typeof queueMicrotask === "function") {
-            queueMicrotask(resolve);
-          } else {
-            resolve();
-          }
-        });
-
-        await window.__TEST_API.cli.resolveRound({
-          detail: {
-            stat,
-            playerVal: 88,
-            opponentVal: 42,
-            result: {
-              message: "Player wins the round!",
-              playerScore: 1,
-              opponentScore: 0
+      const resolution = await page.evaluate(
+        async (stat) =>
+          window.__TEST_API.cli.resolveRound({
+            detail: {
+              stat,
+              playerVal: 88,
+              opponentVal: 42,
+              result: {
+                message: "Player wins the round!",
+                outcome: "winPlayer",
+                playerScore: 1,
+                opponentScore: 0
+              }
             }
-          }
-        });
-      }, statKey);
+          }),
+        statKey
+      );
+
+      expect(resolution).toBeTruthy();
+      expect(resolution?.detail?.stat).toBe(statKey);
+
+      const stateAfterResolution = await page.evaluate(() =>
+        window.__TEST_API.state.getBattleState()
+      );
+      if (stateAfterResolution === "roundDecision") {
+        const advanced = await page.evaluate(() =>
+          window.__TEST_API.state.dispatchBattleEvent("outcome=winPlayer")
+        );
+        expect(advanced).toBe(true);
+      }
+
+      await waitForBattleState(page, "roundOver", {
+        timeout: 10_000,
+        allowFallback: false
+      });
 
       // Wait for the round message to show the result
       const roundMessage = page.locator("#round-message");
-      await expect(roundMessage).not.toBeEmpty({ timeout: 10000 });
+      await expect(roundMessage).toContainText("Player wins the round!", { timeout: 10_000 });
     }, ["log", "info", "warn", "error", "debug"]);
   });
 });


### PR DESCRIPTION
## Summary
- replace ad-hoc polling in `battle-cli-play.spec.js` with Test API readiness helpers
- deterministically resolve rounds via state-aware waits and API-dispatched outcome events
- add assertions for resolution results and rely on battle state transitions instead of requestAnimationFrame hacks

## Testing
- `npx prettier playwright/battle-cli-play.spec.js --check`
- `npx eslint playwright/battle-cli-play.spec.js`
- `npx vitest run --reporter=basic`
- `npx playwright test playwright/battle-cli-play.spec.js`
- `npx playwright test` *(fails: known match end modal tests blocked by modal overlay; see test output)*
- `npm run check:jsdoc`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68d43a824b5c8326ace0c57b4d21db4f