### PR TITLE
Ensure countdown freeze persists for Test API updates

### DIFF
--- a/src/helpers/testApi.js
+++ b/src/helpers/testApi.js
@@ -375,10 +375,8 @@ const timerApi = {
 
         try {
           battleCLI.setCountdown(seconds);
-        } finally {
-          try {
-            battleCLI.__freezeUntil = 0;
-          } catch {}
+        } catch (err) {
+          logDevWarning("Failed to delegate countdown to battleCLI", err);
         }
 
         applyCountdown(seconds);


### PR DESCRIPTION
## Summary
- preserve the battle CLI freeze window when the Test API sets the countdown so that the value remains observable before engine updates
- add defensive logging when delegating to the classic battle helper fails, while still applying the countdown locally

## Testing
- npx playwright test playwright/countdown.spec.js
- CI=1 npx vitest run --reporter=basic
- npx playwright test *(fails: existing battle classic end-modal flows and CLI flows blocked by modal overlay / missing Test API)*
- CI=1 npx playwright test --reporter=line *(fails: battle classic end-modal scenarios blocked by modal overlay; interrupted run after abort)*
- npm run check:jsdoc
- npx prettier . --check --log-level warn
- npx eslint .
- npm run check:contrast
- npm run validate:data
- npm run rag:validate *(fails: MiniLM model assets not hydrated in repo)*
- grep -RIn "await import\(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle 2>/dev/null
- grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"

------
https://chatgpt.com/codex/tasks/task_e_68d44238776483268c4463c3baf14010