### PR TITLE
Expose draw pipeline resolver for random judoka tests

### DIFF
--- a/src/helpers/randomJudokaPage.js
+++ b/src/helpers/randomJudokaPage.js
@@ -356,6 +356,22 @@ export async function setupRandomJudokaPage() {
       if (typeof labelText !== "string" || !labelText.trim()) return;
       updateDrawButtonLabel(drawButton, labelText);
     };
+    randomJudokaApi.resolveDrawPipeline = async () => {
+      if (!drawButton.drawPromise) return false;
+
+      await Promise.resolve();
+
+      try {
+        const cardContainer = document.getElementById("card-container");
+        const cardEl = cardContainer?.querySelector(".card-container");
+        if (cardEl) {
+          cardEl.dispatchEvent(new Event("animationend"));
+        }
+      } catch {}
+
+      await drawButton.drawPromise.catch(() => {});
+      return true;
+    };
   }
 
   const onSelect = (j) => addToHistory(historyManager, historyList, j);

--- a/tests/helpers/randomJudokaPage.featureFlags.test.js
+++ b/tests/helpers/randomJudokaPage.featureFlags.test.js
@@ -104,9 +104,7 @@ describe("randomJudokaPage feature flags", () => {
     drawBtn.fallbackDelayMs = 0;
     drawBtn.timers = { setTimeout: () => 0, clearTimeout: () => {} };
     drawBtn.click();
-    await Promise.resolve();
-    container.querySelector(".card-container")?.dispatchEvent(new Event("animationend"));
-    await drawBtn.drawPromise;
+    await window.__TEST_API.randomJudoka.resolveDrawPipeline();
 
     expect(container.querySelector(".debug-panel")).toBeNull();
 


### PR DESCRIPTION
## Summary
- expose a resolveDrawPipeline helper on the random judoka test API to deterministically settle draws
- update the feature flag test to rely on the helper instead of manual promise flushing

## Files Changed
- src/helpers/randomJudokaPage.js
- tests/helpers/randomJudokaPage.featureFlags.test.js

## Testing
- npx vitest run tests/helpers/randomJudokaPage.featureFlags.test.js

## Risk
- Low: changes are limited to test-only helpers and a single integration test


------
https://chatgpt.com/codex/tasks/task_e_68d44ef3caa483269ed133af8ec15c54