### PR TITLE
Refactor battleCLI dual-write test timing

### DIFF
--- a/tests/pages/battleCLI.dualWrite.test.js
+++ b/tests/pages/battleCLI.dualWrite.test.js
@@ -15,11 +15,6 @@ function createDeferred() {
   return { promise, resolve, reject };
 }
 
-async function tick() {
-  await Promise.resolve();
-  await vi.advanceTimersByTimeAsync(0);
-}
-
 describe("battleCLI dual-write scoreboard (Phase 2)", () => {
   let mockSharedScoreboard;
   let timers;
@@ -30,9 +25,8 @@ describe("battleCLI dual-write scoreboard (Phase 2)", () => {
     const modulePromise = import(DOM_MODULE_PATH);
     const exports = scoreboardModule ?? mockSharedScoreboard;
     deferred.resolve({ __esModule: true, ...exports });
-    await tick();
     const module = await modulePromise;
-    await tick();
+    await module.waitForSharedScoreboard();
     return module;
   }
 


### PR DESCRIPTION
## Summary
- expose a `waitForSharedScoreboard` helper in the battleCLI DOM module so tests can deterministically await the shared Scoreboard import
- update the dual-write scoreboard test to await the new readiness hook instead of advancing fake timers with a zero-duration tick

## Testing
- npm run check:jsdoc
- npx prettier . --check
- npx eslint .
- npx vitest run tests/pages/battleCLI.dualWrite.test.js
- (attempted) CI=1 npx vitest run --reporter=dot *(terminated early due to environment constraints)*
- (attempted) npx playwright test *(terminated early after 61 tests due to environment constraints)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d44e9ebcc483269bdd838b12f9f29f