### PR TITLE
Ensure score polling returns end-state snapshot

### DIFF
--- a/playwright/battle-classic/end-modal.spec.js
+++ b/playwright/battle-classic/end-modal.spec.js
@@ -329,6 +329,9 @@ async function waitForScoreDisplay(page, { timeout = 10000, previousObservation 
         player === previous.player &&
         opponent === previous.opponent
       ) {
+        if (matchEnded) {
+          return { player, opponent, roundNumber, matchEnded };
+        }
         return previous.matchEnded ? previous : false;
       }
 


### PR DESCRIPTION
## Summary
- ensure `waitForScoreDisplay` returns the latest snapshot when the engine reports `matchEnded`, even if the numeric scores match the previous poll

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: reports existing formatting warnings in progressBug.md/progressCLI.md)*
- npx eslint .
- npx vitest run --reporter basic
- npx playwright test
- npm run check:contrast
- npm run rag:validate *(fails: environment lacks hydrated MiniLM model assets)*
- npm run validate:data


------
https://chatgpt.com/codex/tasks/task_e_68d4566f7bf48326a635f66f868ceff2