### PR TITLE
Refactor cooldown readiness helpers for Playwright tests

### DIFF
--- a/playwright/helpers/cooldownFixtures.js
+++ b/playwright/helpers/cooldownFixtures.js
@@ -1,0 +1,36 @@
+/**
+ * Apply deterministic cooldown fixtures for the classic battle page.
+ * @pseudocode
+ * MERGE provided timer overrides with sensible defaults.
+ * INJECT them before page scripts using `addInitScript`.
+ * ENSURE the round select modal is available for user-driven start.
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {object} [options]
+ * @param {number} [options.cooldownMs=0] - Cooldown duration override in ms
+ * @param {number|null} [options.roundTimerMs=1] - Round timer override in ms (null to skip)
+ * @param {boolean} [options.showRoundSelectModal=true] - Whether to force the round select modal
+ * @returns {Promise<void>}
+ */
+export async function applyDeterministicCooldown(page, options = {}) {
+  const { cooldownMs = 0, roundTimerMs = 1, showRoundSelectModal = true } = options;
+
+  await page.addInitScript(
+    ({ cooldown, roundTimer, showModal }) => {
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      if (typeof roundTimer === "number") {
+        window.__OVERRIDE_TIMERS = { roundTimer };
+      }
+
+      window.__NEXT_ROUND_COOLDOWN_MS = cooldown;
+
+      if (showModal) {
+        const existingOverrides = window.__FF_OVERRIDES || {};
+        window.__FF_OVERRIDES = { ...existingOverrides, showRoundSelectModal: true };
+      }
+    },
+    { cooldown: cooldownMs, roundTimer: roundTimerMs, showModal: showRoundSelectModal }
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to wait for the Next button readiness via the Playwright Test API
- introduce deterministic cooldown fixtures for classic battle tests and refactor the cooldown spec to use them
- update the cooldown Playwright spec to rely on the new helpers for faster, API-driven readiness checks

## Testing
- npx playwright test playwright/battle-classic/cooldown.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d4628727048326b9bd38b44581afee