### PR TITLE
Fix orchestrator fallback gating and update tests

### DIFF
--- a/src/helpers/testApi.js
+++ b/src/helpers/testApi.js
@@ -153,10 +153,29 @@ const stateApi = {
   getBattleState() {
     try {
       const machine = getBattleStateMachine();
-      return machine?.getState?.() || null;
-    } catch {
-      return null;
-    }
+      const state = machine?.getState?.();
+      if (typeof state === "string" && state) {
+        return state;
+      }
+    } catch {}
+
+    try {
+      const bodyState = document.body?.dataset?.battleState;
+      if (typeof bodyState === "string" && bodyState) {
+        return bodyState;
+      }
+    } catch {}
+
+    try {
+      const attrState = document
+        .querySelector("[data-battle-state]")
+        ?.getAttribute("data-battle-state");
+      if (typeof attrState === "string" && attrState) {
+        return attrState;
+      }
+    } catch {}
+
+    return null;
   },
 
   /**

--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -586,6 +586,10 @@ async function applySelectionResult(store, result) {
   } catch {}
   ensureScoreboardReflectsResult(result);
   const matchEnded = await confirmMatchOutcome(store, result);
+  if (!matchEnded && store && typeof store === "object" && !store.orchestrator) {
+    const played = Number(store.roundsPlayed) || 0;
+    store.roundsPlayed = played + 1;
+  }
   if (!matchEnded) {
     scheduleNextReadyAfterSelection(store);
   } else {

--- a/tests/helpers/classicBattle/handleStatSelection.machine.test.js
+++ b/tests/helpers/classicBattle/handleStatSelection.machine.test.js
@@ -36,19 +36,26 @@ describe("handleStatSelection machine interaction", () => {
       selectionMade: false,
       playerChoice: null,
       statTimeoutId: null,
-      autoSelectId: null
+      autoSelectId: null,
+      orchestrator: {}
     };
     dispatchMock = (await import("../../../src/helpers/classicBattle/eventDispatcher.js"))
       .dispatchBattleEvent;
     dispatchCalls = [];
-    dispatchMock.mockImplementation((...args) => {
+    dispatchMock.mockImplementation(async (...args) => {
       dispatchCalls.push(args);
+      if (args[0] === "statSelected") {
+        return true;
+      }
+      return false;
     });
     resolveSpy = vi.spyOn(selection, "resolveRoundDirect");
+    document.body.dataset.battleState = "roundDecision";
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    delete document.body.dataset.battleState;
   });
 
   it("dispatches statSelected once without resolving", async () => {

--- a/tests/helpers/selectionHandler.test.js
+++ b/tests/helpers/selectionHandler.test.js
@@ -147,6 +147,8 @@ describe("handleStatSelection helpers", () => {
 
   it("passes zero delay to resolveRoundDirect during orchestrator fallback", async () => {
     document.body.dataset.battleState = "active";
+    store.orchestrator = {};
+    getBattleState.mockReturnValue("roundDecision");
     dispatchBattleEvent.mockResolvedValue(false);
 
     const timerUtils = await import("../../src/helpers/classicBattle/timerUtils.js");
@@ -165,5 +167,6 @@ describe("handleStatSelection helpers", () => {
     expect(timerUtils.resolveDelay).toHaveBeenCalledTimes(1);
 
     delete document.body.dataset.battleState;
+    getBattleState.mockReturnValue(null);
   });
 });


### PR DESCRIPTION
## Summary
- extend the classic battle test API state accessor to fall back to DOM data attributes when the orchestrator machine is missing
- guard orchestrator fallback resolution paths in the selection handler and increment roundsPlayed only for non-orchestrated matches
- update selection handler vitest suites to provide orchestrator context so the new gating logic is exercised

## Testing
- npx vitest run --reporter=basic
- npx playwright test playwright/battle-classic/opponent-reveal.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d46386b7f8832697370b0fef0c78fe