### PR TITLE
Fix race causing round counter diagnostics mismatch

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -293,6 +293,7 @@ export function disableNextRoundButton() {
   if (!btn) return;
   btn.disabled = true;
   delete btn.dataset.nextReady;
+  delete btn.dataset.nextFinalized;
   try {
     if (typeof process !== "undefined" && process.env && process.env.VITEST) {
       console.debug(`[test] disableNextRoundButton: disabled=${btn.disabled}`);

--- a/src/helpers/testApi.js
+++ b/src/helpers/testApi.js
@@ -270,7 +270,10 @@ const stateApi = {
         const ariaDisabled =
           typeof btn.getAttribute === "function" ? btn.getAttribute("aria-disabled") : null;
         return (
-          btn.dataset?.nextReady === "true" && btn.disabled !== true && ariaDisabled !== "true"
+          btn.dataset?.nextReady === "true" &&
+          btn.dataset?.nextFinalized === "true" &&
+          btn.disabled !== true &&
+          ariaDisabled !== "true"
         );
       };
 

--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -435,7 +435,10 @@ function setNextButtonReadyAttributes(btn) {
   } catch {}
   try {
     btn.setAttribute("data-next-ready", "true");
-    if (btn.dataset) btn.dataset.nextReady = "true";
+    if (btn.dataset) {
+      btn.dataset.nextReady = "true";
+      btn.dataset.nextFinalized = "pending";
+    }
   } catch {}
 }
 
@@ -481,6 +484,9 @@ function handleStatSelectionError(store, err) {
     resetCooldownFlag(store);
   } catch {}
   const btn = prepareNextButtonForUse("selection failure");
+  if (btn?.dataset) {
+    btn.dataset.nextFinalized = "true";
+  }
   logNextButtonRecovery("selection failure", btn, { cooldownStarted });
 }
 
@@ -622,10 +628,24 @@ function finalizeSelectionReady(store, options = {}) {
     try {
       const selectionMade = Boolean(store?.selectionMade);
       const expectAdvance = shouldStartCooldown || selectionMade;
+      const shouldForceVisibleAdvance = selectionMade || shouldStartCooldown;
       updateRoundCounterFromEngine({
         expectAdvance,
-        forceWhenEngineMatchesVisible: selectionMade
+        forceWhenEngineMatchesVisible: shouldForceVisibleAdvance
       });
+      try {
+        const finalizedBtn = getNextRoundButton();
+        if (finalizedBtn?.dataset) {
+          finalizedBtn.dataset.nextFinalized = "true";
+        }
+      } catch (contextErr) {
+        try {
+          console.debug(
+            "battleClassic: marking next button finalized failed",
+            contextErr
+          );
+        } catch {}
+      }
     } catch (err) {
       console.debug("battleClassic: updateRoundCounterFromEngine after selection failed", err);
     }


### PR DESCRIPTION
## Summary
- mark Next button readiness with a pending state and only finalize it after the round counter update completes
- clear the new finalization flag whenever the Next button is disabled so each round resets cleanly
- teach the Playwright Test API helper to wait for the finalized flag so diagnostics always see the advanced round

## Testing
- npx playwright test --grep "recovers round counter state" --repeat-each=10

------
https://chatgpt.com/codex/tasks/task_e_68d477217ee083269ac1bfa78efd051c