### PR TITLE
Fix CLI stats grid layout CSS

### DIFF
--- a/src/pages/battleCLI.css
+++ b/src/pages/battleCLI.css
@@ -179,10 +179,6 @@ body[data-theme="retro"] .cli-stat.selected {
 }
 /* Add prompt indicator for stat selection */
 .cli-block[aria-label="Stat Selection"]:before {
-  content: ">> Choose your stat:";
-
-/* Add prompt indicator for stat selection */
-.cli-block[aria-label="Stat Selection"]:before {
   content: "-> Choose your stat:";
   display: block;
   color: #9cffcf;


### PR DESCRIPTION
## Summary
- remove the stray duplicate pseudo-element block so the `#cli-stats` grid declaration parses correctly again

## Testing
- npm run check:jsdoc
- npx prettier . --check --log-level=error
- npx eslint . *(fails: repository already contains prettier/prettier violations in unrelated files)*
- npx vitest run *(aborted after extensive progress output to avoid terminal flood; command was invoked)*
- npx playwright test playwright/cli-layout-assessment.spec.js
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d519c458508326a77c0fec51b28aa7