### PR TITLE
Normalize CLI layout color assertions

### DIFF
--- a/playwright/cli-layout-assessment.spec.js
+++ b/playwright/cli-layout-assessment.spec.js
@@ -71,12 +71,27 @@ test.describe("CLI Layout Assessment - Desktop Focused", () => {
       };
     });
 
-    // Allow for both standard and CLI immersive themes
-    expect(bodyStyles.background).toMatch(
-      /rgb\((?:11, 12, 12|5, 5, 5)\)|#0b0c0c|#050505|rgb\(0, 0, 0\)|#000/
-    );
-    expect(bodyStyles.color).toMatch(
-      /rgb\((?:242, 242, 242|214, 245, 214)\)|#f2f2f2|#d6f5d6|rgb\(140, 255, 107\)|#8cff6b/
-    );
+    // Allow for both standard and CLI immersive themes (normalize to avoid spacing/format drift)
+    const normalizedBackground = bodyStyles.background.replace(/\s+/g, "").toLowerCase();
+    const normalizedColor = bodyStyles.color.replace(/\s+/g, "").toLowerCase();
+
+    expect(
+      ["rgb(11,12,12)", "rgb(5,5,5)", "rgb(0,0,0)", "#0b0c0c", "#050505", "#000"].includes(
+        normalizedBackground
+      ),
+      `Unexpected CLI background color: ${bodyStyles.background}`
+    ).toBe(true);
+
+    expect(
+      [
+        "rgb(242,242,242)",
+        "rgb(214,245,214)",
+        "rgb(140,255,107)",
+        "#f2f2f2",
+        "#d6f5d6",
+        "#8cff6b"
+      ].includes(normalizedColor),
+      `Unexpected CLI text color: ${bodyStyles.color}`
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- normalize the CLI layout color contrast assertion so spacing/format differences in computed CSS values do not cause false negatives

## Testing
- npm run check:jsdoc
- CI=1 npx prettier . --check *(fails: existing parse error in `src/pages/battleCLI.css` due to duplicate unclosed block)*
- npx eslint . *(fails: existing prettier/prettier findings in legacy files)*
- CI=1 npx vitest run --reporter=basic
- CI=1 npx playwright test *(fails: existing CLI layout/mobile touch target regressions in other specs)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d519adadd08326bc5e0da4c54badca