### PR TITLE
Preserve CLI countdown freeze after Test API delegation

### DIFF
--- a/src/helpers/testApi.js
+++ b/src/helpers/testApi.js
@@ -452,8 +452,8 @@ const timerApi = {
           logDevDebug("Failed to delegate countdown to battleCLI", err);
         } finally {
           try {
-            if (battleCLI.__freezeUntil !== undefined) {
-              battleCLI.__freezeUntil = delegationSucceeded ? 0 : Date.now() + 500;
+            if (battleCLI.__freezeUntil !== undefined && !delegationSucceeded) {
+              battleCLI.__freezeUntil = Date.now() + 500;
             }
           } catch {}
         }


### PR DESCRIPTION
## Summary
- ensure the Test API leaves the battle CLI countdown freeze window intact when delegating countdown updates so manual values remain observable

## Testing
- npx playwright test playwright/countdown.spec.js --grep "setCountdown" --timeout=0

------
https://chatgpt.com/codex/tasks/task_e_68d519943f048326ad95b3187768e884