### PR TITLE
Ensure CLI stats maintain minimum row height

### DIFF
--- a/src/pages/battleCLI.css
+++ b/src/pages/battleCLI.css
@@ -12,9 +12,11 @@
 }
 
 :focus {
-	outline: none;
-	box-shadow: 0 0 0 3px rgba(255, 209, 102, 0.12), 0 0 0 1px var(--cli-focus);
-	border-radius: 3px;
+  outline: none;
+  box-shadow:
+    0 0 0 3px rgba(255, 209, 102, 0.12),
+    0 0 0 1px var(--cli-focus);
+  border-radius: 3px;
 }
 html,
 body {
@@ -221,6 +223,7 @@ body {
 #cli-stats {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-auto-rows: minmax(44px, auto);
   gap: 8px;
   min-height: 8rem; /* Reserve space for layout stability and touch targets */
 }
@@ -467,6 +470,7 @@ select:focus,
   }
   #cli-stats {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    grid-auto-rows: minmax(44px, auto);
     min-height: 8rem; /* Maintain reservation on mobile */
   }
   .ascii-sep {
@@ -498,5 +502,9 @@ select:focus,
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.cli-caret, .cli-anim { animation: none !important; transition: none !important; }
+  .cli-caret,
+  .cli-anim {
+    animation: none !important;
+    transition: none !important;
+  }
 }


### PR DESCRIPTION
## Summary
- ensure the CLI stat grid enforces a 44px minimum row size by adding grid-auto-rows at default and mobile breakpoints
- reformat shared focus and reduced-motion rules to keep Prettier aligned after the structural change

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: existing formatting issues in docs/progress & CLI HTML prior to this change)*
- npx eslint .
- npx vitest run *(fails: existing applyRetroTheme test cannot find #cli-root in jsdom)*
- npx playwright test *(fails: existing classic battle end-modal replay test)*
- npm run check:contrast
- npm run rag:validate *(fails threshold on "default sound setting" query)*
- npm run validate:data
- grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle *(reports existing dynamic imports in test hooks)*
- grep -RInE "console\.(warn|error)" tests | grep -v "tests/utils/console.js" *(reports existing intentional console usage in helpers/tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d51d84185883268261272e93bf424b