### PR TITLE
Guard retro theme toggle when CLI root missing

### DIFF
--- a/src/pages/battleCLI.init.js
+++ b/src/pages/battleCLI.init.js
@@ -66,10 +66,16 @@ function focusNextHint() {
 }
 
 function applyRetroTheme(enabled) {
-  // #cli-root is guaranteed to exist in the CLI page
-  document.getElementById("cli-root").classList.toggle("cli-retro", Boolean(enabled));
+  const shouldEnable = Boolean(enabled);
+  const cliRoot = document.getElementById("cli-root");
+  if (cliRoot) {
+    cliRoot.classList.toggle("cli-retro", shouldEnable);
+  }
+  if (document.body) {
+    document.body.classList.toggle("cli-retro", shouldEnable);
+  }
   try {
-    localStorage.setItem("battleCLI.retro", enabled ? "1" : "0");
+    localStorage.setItem("battleCLI.retro", shouldEnable ? "1" : "0");
   } catch {}
 }
 


### PR DESCRIPTION
## Summary
- guard the retro theme helper when `#cli-root` is absent and mirror the class toggle onto `document.body`
- ensure the persisted retro theme flag uses the normalized boolean value

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: existing formatting issues in unrelated markdown/html files)*
- npx eslint .
- npx vitest run *(fails: existing classic battle tooltip initialization error; see console for details)*
- npx vitest run tests/pages/battleCLI.retroTheme.test.js
- npx playwright test *(aborted after two scenarios were interrupted when stopping the run)*

------
https://chatgpt.com/codex/tasks/task_e_68d5331c969c8326871c1b7ab794814a