### PR TITLE
Handle en dash in CLI help expectations

### DIFF
--- a/playwright/cli-flows-improved.spec.mjs
+++ b/playwright/cli-flows-improved.spec.mjs
@@ -436,7 +436,7 @@ test.describe("CLI Battle Interface", () => {
       await expect(shortcutsSection).toBeVisible();
 
       const helpList = page.locator("#cli-help");
-      await expect(helpList).toContainText("[1-5] Select Stat");
+      await expect(helpList).toContainText(/\[1[-–]5\] Select Stat/);
       await expect(helpList).toContainText("[Enter] or [Space] Next");
       await expect(helpList).toContainText("[Q] Quit");
       await expect(helpList).toContainText("[H] Toggle Help");

--- a/playwright/cli-flows.spec.mjs
+++ b/playwright/cli-flows.spec.mjs
@@ -102,7 +102,7 @@ test.describe("CLI Keyboard Flows", () => {
 
       // Assert help text content
       const helpList = page.locator("#cli-help");
-      await expect(helpList).toContainText("[1-5] Select Stat");
+      await expect(helpList).toContainText(/\[1[-–]5\] Select Stat/);
       await expect(helpList).toContainText("[Enter] or [Space] Next");
       await expect(helpList).toContainText("[Q] Quit");
       await expect(helpList).toContainText("[H] Toggle Help");


### PR DESCRIPTION
## Summary
- allow the CLI help assertions to match either a hyphen or en dash in the stat range shortcut
- update both CLI flow Playwright specs to use a flexible matcher for the stat range help text

## Testing
- npx playwright test playwright/cli-flows.spec.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d535a6509083268993e220750d29a0