### PR TITLE
Update CLI shortcut expectations for en dash copy

### DIFF
--- a/playwright/cli-flows-improved.spec.mjs
+++ b/playwright/cli-flows-improved.spec.mjs
@@ -241,7 +241,7 @@ test.describe("CLI Battle Interface", () => {
       await ensureBattleReady(page);
 
       const controlsHint = page.locator("#cli-controls-hint");
-      await expect(controlsHint).toContainText("[1-5] Stats");
+      await expect(controlsHint).toContainText("[1–5] Stats");
       await expect(controlsHint).toContainText("[Enter] or [Space] Next");
       await expect(controlsHint).toContainText("[H] Help");
       await expect(controlsHint).toContainText("[Q] Quit");
@@ -436,7 +436,7 @@ test.describe("CLI Battle Interface", () => {
       await expect(shortcutsSection).toBeVisible();
 
       const helpList = page.locator("#cli-help");
-      await expect(helpList).toContainText("[1-5] Select Stat");
+      await expect(helpList).toContainText("[1–5] Select Stat");
       await expect(helpList).toContainText("[Enter] or [Space] Next");
       await expect(helpList).toContainText("[Q] Quit");
       await expect(helpList).toContainText("[H] Toggle Help");

--- a/playwright/cli-flows.spec.mjs
+++ b/playwright/cli-flows.spec.mjs
@@ -102,7 +102,7 @@ test.describe("CLI Keyboard Flows", () => {
 
       // Assert help text content
       const helpList = page.locator("#cli-help");
-      await expect(helpList).toContainText("[1-5] Select Stat");
+      await expect(helpList).toContainText("[1–5] Select Stat");
       await expect(helpList).toContainText("[Enter] or [Space] Next");
       await expect(helpList).toContainText("[Q] Quit");
       await expect(helpList).toContainText("[H] Toggle Help");


### PR DESCRIPTION
## Summary
- align CLI Playwright shortcut assertions with the en dash copy rendered by normalizeShortcutCopy
- ensure both the footer hint and help list checks expect the updated glyph

## Testing
- npx playwright test playwright/cli-flows-improved.spec.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d5359361d0832695487769f4001591