### PR TITLE
Align CLI control hint expectations with en dash copy

### DIFF
--- a/playwright/cli-flows-improved.spec.mjs
+++ b/playwright/cli-flows-improved.spec.mjs
@@ -241,7 +241,7 @@ test.describe("CLI Battle Interface", () => {
       await ensureBattleReady(page);
 
       const controlsHint = page.locator("#cli-controls-hint");
-      await expect(controlsHint).toContainText("[1-5] Stats");
+      await expect(controlsHint).toContainText("[1–5] Stats");
       await expect(controlsHint).toContainText("[Enter] or [Space] Next");
       await expect(controlsHint).toContainText("[H] Help");
       await expect(controlsHint).toContainText("[Q] Quit");
@@ -436,7 +436,7 @@ test.describe("CLI Battle Interface", () => {
       await expect(shortcutsSection).toBeVisible();
 
       const helpList = page.locator("#cli-help");
-      await expect(helpList).toContainText("[1-5] Select Stat");
+      await expect(helpList).toContainText("[1–5] Select Stat");
       await expect(helpList).toContainText("[Enter] or [Space] Next");
       await expect(helpList).toContainText("[Q] Quit");
       await expect(helpList).toContainText("[H] Toggle Help");

--- a/playwright/cli-flows.spec.mjs
+++ b/playwright/cli-flows.spec.mjs
@@ -102,7 +102,7 @@ test.describe("CLI Keyboard Flows", () => {
 
       // Assert help text content
       const helpList = page.locator("#cli-help");
-      await expect(helpList).toContainText("[1-5] Select Stat");
+      await expect(helpList).toContainText("[1–5] Select Stat");
       await expect(helpList).toContainText("[Enter] or [Space] Next");
       await expect(helpList).toContainText("[Q] Quit");
       await expect(helpList).toContainText("[H] Toggle Help");

--- a/tests/pages/battleCLI.a11y.smoke.test.js
+++ b/tests/pages/battleCLI.a11y.smoke.test.js
@@ -20,7 +20,7 @@ describe("battleCLI accessibility smoke tests", () => {
     expect(hint).toBeTruthy();
     expect(hint?.getAttribute("aria-hidden")).toBe("true");
     expect(hint?.textContent?.trim()).toBe(
-      "[1-5] Stats | [Enter] or [Space] Next | [H] Help | [Q] Quit"
+      "[1–5] Stats | [Enter] or [Space] Next | [H] Help | [Q] Quit"
     );
   });
 


### PR DESCRIPTION
## Summary
- update CLI Playwright flow tests to expect the normalized “[1–5]” en dash tokens in footer and help text
- adjust the battleCLI accessibility smoke test to assert the en dash normalized copy

## Testing
- `npx playwright test playwright/cli-flows-improved.spec.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68d5354337c88326b5b43217f65741dd