### PR TITLE
Fix hover zoom attribute when card already focused

### DIFF
--- a/src/helpers/setupHoverZoom.js
+++ b/src/helpers/setupHoverZoom.js
@@ -34,24 +34,41 @@ export function addHoverZoomMarkers() {
   cards.forEach((card) => {
     if (card.dataset.enlargeListenerAttached) return;
     card.dataset.enlargeListenerAttached = "true";
+
+    const setEnlarged = () => {
+      card.dataset.enlarged = "true";
+    };
+
     const reset = () => {
       delete card.dataset.enlarged;
     };
+
+    const hasKeyboardFocus = () => {
+      try {
+        if (card.matches(":focus-visible")) return true;
+      } catch {}
+      return card === document.activeElement;
+    };
+
     card.addEventListener("mouseenter", () => {
       reset();
       try {
         const reduceMotion =
           window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
         const disableAnimations = document.body?.hasAttribute("data-test-disable-animations");
-        if (reduceMotion || disableAnimations) {
-          card.dataset.enlarged = "true";
+        if (reduceMotion || disableAnimations || hasKeyboardFocus()) {
+          setEnlarged();
         }
-      } catch {}
+      } catch {
+        if (hasKeyboardFocus()) {
+          setEnlarged();
+        }
+      }
     });
     card.addEventListener("mouseleave", reset);
     card.addEventListener("transitionend", (event) => {
       if (event.propertyName === "transform") {
-        card.dataset.enlarged = "true";
+        setEnlarged();
       }
     });
   });


### PR DESCRIPTION
## Summary
- ensure hover zoom immediately marks cards as enlarged when they already have keyboard focus
- extract helpers for checking keyboard focus and re-use shared setter to keep transitions consistent

## Testing
- `npx playwright test playwright/hover-zoom.spec.js`
- `npm run check:jsdoc`
- `npx prettier src/helpers/setupHoverZoom.js --check`
- `npx eslint src/helpers/setupHoverZoom.js`
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68d556ff65248326884d208a43643159