### PR TITLE
Fix scoreboard sync to use round result

### DIFF
--- a/src/helpers/classicBattle/selectionHandler.js
+++ b/src/helpers/classicBattle/selectionHandler.js
@@ -605,17 +605,30 @@ export async function syncResultDisplay(store, stat, playerVal, opponentVal, opt
     }
   } catch {}
 
+  let playerScore = Number(result?.playerScore);
+  let opponentScore = Number(result?.opponentScore);
+  const scoresAreNumbers = Number.isFinite(playerScore) && Number.isFinite(opponentScore);
+
+  if (!scoresAreNumbers) {
+    try {
+      const engineScores = getScores();
+      playerScore = Number(engineScores?.playerScore);
+      opponentScore = Number(engineScores?.opponentScore);
+    } catch {}
+  }
+
+  playerScore = Number.isFinite(playerScore) ? playerScore : 0;
+  opponentScore = Number.isFinite(opponentScore) ? opponentScore : 0;
+
   try {
-    const { playerScore, opponentScore } = getScores();
-    try {
-      scoreboard.updateScore(Number(playerScore) || 0, Number(opponentScore) || 0);
-    } catch {}
-    try {
-      const el = document.getElementById("score-display");
-      if (el) {
-        el.innerHTML = `<span data-side=\"player\">You: ${Number(playerScore) || 0}</span>\n<span data-side=\"opponent\">Opponent: ${Number(opponentScore) || 0}</span>`;
-      }
-    } catch {}
+    scoreboard.updateScore(playerScore, opponentScore);
+  } catch {}
+
+  try {
+    const el = document.getElementById("score-display");
+    if (el) {
+      el.innerHTML = `<span data-side=\"player\">You: ${playerScore}</span>\n<span data-side=\"opponent\">Opponent: ${opponentScore}</span>`;
+    }
   } catch {}
 
   try {


### PR DESCRIPTION
## Summary
- ensure syncResultDisplay updates the scoreboard with the resolved round totals before falling back to engine snapshots
- normalize the player and opponent scores before updating the shared scoreboard markup

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: repository already contains unformatted design/product requirements docs)*
- npx eslint .
- npx vitest run *(aborted after extended execution; repository suite produces extremely long progress output in this environment)*
- npx playwright test *(aborted after extended execution in this environment)*
- npm run check:contrast
- npm run rag:validate *(fails: MiniLM model artifacts unavailable offline)*
- npm run validate:data

------
https://chatgpt.com/codex/tasks/task_e_68d55e08d000832691af2f0f0c26b49f