### PR TITLE
Expose scoreboard API bundle for tests

### DIFF
--- a/src/helpers/setupScoreboard.js
+++ b/src/helpers/setupScoreboard.js
@@ -70,7 +70,7 @@ function setupScoreboard(controls, scheduler = realScheduler) {
     }
   } catch {}
 }
-export {
+const scoreboardApi = {
   setupScoreboard,
   showMessage,
   updateScore,
@@ -81,4 +81,18 @@ export {
   showAutoSelect,
   updateRoundCounter,
   clearRoundCounter
+};
+
+export {
+  setupScoreboard,
+  showMessage,
+  updateScore,
+  clearMessage,
+  showTemporaryMessage,
+  clearTimer,
+  updateTimer,
+  showAutoSelect,
+  updateRoundCounter,
+  clearRoundCounter,
+  scoreboardApi as scoreboard
 };


### PR DESCRIPTION
## Task Contract
- **Inputs:** `src/helpers/setupScoreboard.js`
- **Outputs:** Updated scoreboard helper exports exposing a bundled API object.
- **Success Criteria:** `showRoundOutcome` unit tests can mock scoreboard helpers without runtime errors.
- **Potential Failure Modes:** Misaligned exports breaking existing scoreboard consumers.

## Summary
- add a `scoreboard` aggregate export alongside existing named exports so mocks can access `showMessage` safely.

## Testing
- `npx vitest run tests/helpers/uiHelpers.showRoundOutcome.test.js`

## Files Changed
- `src/helpers/setupScoreboard.js`

## Risk
- Low: change only augments module exports without altering runtime logic.


------
https://chatgpt.com/codex/tasks/task_e_68d56b491efc83268677d612567ea20d