### PR TITLE
Fix classic battle round result display

### DIFF
--- a/src/helpers/classicBattle/uiEventHandlers.js
+++ b/src/helpers/classicBattle/uiEventHandlers.js
@@ -3,7 +3,7 @@ import { getOpponentCardData } from "./opponentController.js";
 import * as scoreboard from "../setupScoreboard.js";
 import { showSnackbar } from "../showSnackbar.js";
 import { t } from "../i18n.js";
-import { renderOpponentCard, showRoundOutcome } from "./uiHelpers.js";
+import { renderOpponentCard, showRoundOutcome, showStatComparison } from "./uiHelpers.js";
 import { updateDebugPanel } from "./debugPanel.js";
 import { getOpponentDelay } from "./snackbar.js";
 import { markOpponentPromptNow } from "./opponentPromptTracker.js";
@@ -99,8 +99,21 @@ export function bindUIHelperEventHandlersDynamic() {
 
   onBattleEvent("roundResolved", async (e) => {
     clearOpponentSnackbarTimeout();
-    const { stat, playerVal, opponentVal, result } = e.detail || {};
+    const { store, stat, playerVal, opponentVal, result } = e.detail || {};
     if (!result) return;
+    try {
+      const numericPlayer = Number(playerVal);
+      const numericOpponent = Number(opponentVal);
+      if (
+        store &&
+        typeof store === "object" &&
+        typeof stat === "string" &&
+        Number.isFinite(numericPlayer) &&
+        Number.isFinite(numericOpponent)
+      ) {
+        showStatComparison(store, stat, numericPlayer, numericOpponent);
+      }
+    } catch {}
     try {
       showRoundOutcome(result.message || "", stat, playerVal, opponentVal);
       updateDebugPanel();


### PR DESCRIPTION
## Summary
- update the classic battle round-resolved UI handler to import `showStatComparison`
- ensure round resolution events synchronise the stat comparison display before updating debug panels

## Testing
- `npm run test -- --run tests/helpers/classicBattle/statSelection.test.js`

## Task Contract
- **Inputs:** classic battle stat selection flow emitting `roundResolved` events without updating `#round-result`
- **Outputs:** event handler that forwards stat data to `showStatComparison` so the stat comparison text appears
- **Success Criteria:** `tests/helpers/classicBattle/statSelection.test.js` passes with the expected "Power – You: ..." text rendered
- **Failure Modes:** handler skips update when stat data is missing or invalid, leaving `#round-result` empty

## Files Changed
- src/helpers/classicBattle/uiEventHandlers.js

## Risk
- Low: change only adds guarded DOM updates during round resolution events

------
https://chatgpt.com/codex/tasks/task_e_68d56b35ebdc83269a8b4b1f7ad75637