### PR TITLE
Fix scoreboard init helper lookup

### DIFF
--- a/src/helpers/setupScoreboard.js
+++ b/src/helpers/setupScoreboard.js
@@ -8,13 +8,23 @@ try {
   sharedScoreboardModule = null;
 }
 
-const invokeSharedHelper = (name, args) => {
+function getScoreboardMethod(name) {
   const helper =
     sharedScoreboardModule && typeof sharedScoreboardModule[name] === "function"
       ? sharedScoreboardModule[name]
       : null;
 
-  if (!helper) {
+  if (helper) {
+    return helper;
+  }
+
+  return () => {};
+}
+
+const invokeSharedHelper = (name, args) => {
+  const helper = getScoreboardMethod(name);
+
+  if (typeof helper !== "function") {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- add a safe `getScoreboardMethod` helper for scoreboard setup
- reuse the helper for all scoreboard invocations to avoid missing function errors

## Testing
- `npx playwright test playwright/battle-classic/opponent-reveal.spec.js --grep "timer functionality"`
- `npm run check:jsdoc`
- `CI=1 npx prettier . --check --log-level warn` *(fails: existing parse error in tests/pages/battleCLI.timerConsolidation.test.js)*
- `npx eslint .` *(fails: existing lint violations in battleClassic.init.js and tests/pages/battleCLI.timerConsolidation.test.js)*
- `npx vitest run` *(aborted: excessive progress output, command interrupted)*
- `CI=1 npx playwright test --reporter=line` *(aborted: lengthy run, command interrupted)*
- `npm run check:contrast`


------
https://chatgpt.com/codex/tasks/task_e_68d578c798788326a07158b63e3029f6