### PR TITLE
Restore static scoreboard helpers and improve win target sync

### DIFF
--- a/src/helpers/classicBattle/winTargetSync.js
+++ b/src/helpers/classicBattle/winTargetSync.js
@@ -83,8 +83,31 @@ export function syncWinTargetDropdown() {
     const select = byId("points-select");
     if (!select) return;
 
-    const currentTarget = readPointsToWin();
+    let currentTarget = readPointsToWin();
+    if (typeof currentTarget !== "number" || !Number.isFinite(currentTarget)) {
+      try {
+        const fallback =
+          typeof document !== "undefined" && document?.body
+            ? Number(document.body.dataset?.target)
+            : NaN;
+        if (Number.isFinite(fallback)) {
+          currentTarget = fallback;
+        }
+      } catch {}
+    }
     if (typeof currentTarget !== "number" || !Number.isFinite(currentTarget)) return;
+
+    try {
+      const hasOption = Array.from(select.options || []).some(
+        (option) => Number(option.value) === currentTarget
+      );
+      if (!hasOption && typeof document !== "undefined") {
+        const option = document.createElement("option");
+        option.value = String(currentTarget);
+        option.textContent = String(currentTarget);
+        select.appendChild(option);
+      }
+    } catch {}
 
     select.value = String(currentTarget);
     const round = getCurrentRoundNumber();

--- a/src/helpers/setupScoreboard.js
+++ b/src/helpers/setupScoreboard.js
@@ -1,39 +1,87 @@
+import {
+  initScoreboard as initScoreboardImpl,
+  showMessage as showMessageImpl,
+  updateScore as updateScoreImpl,
+  clearMessage as clearMessageImpl,
+  showTemporaryMessage as showTemporaryMessageImpl,
+  clearTimer as clearTimerImpl,
+  updateTimer as updateTimerImpl,
+  showAutoSelect as showAutoSelectImpl,
+  updateRoundCounter as updateRoundCounterImpl,
+  clearRoundCounter as clearRoundCounterImpl
+} from "../components/Scoreboard.js";
 import { realScheduler } from "./scheduler.js";
 
-let sharedScoreboardModule = null;
+const noop = () => {};
+const domAvailable =
+  typeof window !== "undefined" && typeof document !== "undefined" && document !== null;
+const isTestEnv = typeof process !== "undefined" && process.env?.NODE_ENV === "test";
+const loggedWarnings = new Set();
+const loggedErrors = new Set();
 
-try {
-  sharedScoreboardModule = await import("../components/Scoreboard.js");
-} catch {
-  sharedScoreboardModule = null;
+/**
+ * Log a warning or error exactly once when outside of the test environment.
+ *
+ * @param {Set<string>} cache - Storage for previously emitted messages.
+ * @param {"warn"|"error"} level - Console method to use.
+ * @param {string} message - Message to emit.
+ * @param {unknown} [error] - Optional error to append.
+ * @returns {void}
+ */
+function logOnce(cache, level, message, error) {
+  if (isTestEnv || cache.has(message)) {
+    return;
+  }
+  cache.add(message);
+  try {
+    const logger = typeof console !== "undefined" ? console[level] : undefined;
+    if (typeof logger === "function") {
+      if (typeof error !== "undefined") {
+        logger(message, error);
+      } else {
+        logger(message);
+      }
+    }
+  } catch {}
 }
 
-const invokeSharedHelper = (name, args) => {
-  const helper =
-    sharedScoreboardModule && typeof sharedScoreboardModule[name] === "function"
-      ? sharedScoreboardModule[name]
-      : null;
-
-  if (!helper) {
-    return undefined;
+/**
+ * Determine the fallback return value for a scoreboard helper.
+ *
+ * @param {string} name - Helper name.
+ * @returns {unknown} fallback return value.
+ */
+function fallbackValue(name) {
+  if (name === "showTemporaryMessage") {
+    return noop;
   }
+  return undefined;
+}
 
+/**
+ * Safely execute a scoreboard helper, providing resilience and diagnostics.
+ *
+ * @param {string} name - Helper identifier.
+ * @param {Function|undefined} helper - Helper implementation.
+ * @param {unknown[]} args - Arguments for the helper.
+ * @returns {unknown} Helper result or fallback value.
+ */
+function runHelper(name, helper, args) {
+  if (!domAvailable) {
+    logOnce(loggedWarnings, "warn", "[scoreboard] DOM unavailable; scoreboard helpers disabled.");
+    return fallbackValue(name);
+  }
+  if (typeof helper !== "function") {
+    logOnce(loggedWarnings, "warn", `[scoreboard] Missing helper "${name}".`);
+    return fallbackValue(name);
+  }
   try {
     return helper(...args);
-  } catch {
-    return undefined;
+  } catch (error) {
+    logOnce(loggedErrors, "error", `[scoreboard] Helper "${name}" threw.`, error);
+    return fallbackValue(name);
   }
-};
-
-const showMessage = (...args) => invokeSharedHelper("showMessage", args);
-const updateScore = (...args) => invokeSharedHelper("updateScore", args);
-const clearMessage = (...args) => invokeSharedHelper("clearMessage", args);
-const showTemporaryMessage = (...args) => invokeSharedHelper("showTemporaryMessage", args);
-const clearTimer = (...args) => invokeSharedHelper("clearTimer", args);
-const updateTimer = (...args) => invokeSharedHelper("updateTimer", args);
-const showAutoSelect = (...args) => invokeSharedHelper("showAutoSelect", args);
-const updateRoundCounter = (...args) => invokeSharedHelper("updateRoundCounter", args);
-const clearRoundCounter = (...args) => invokeSharedHelper("clearRoundCounter", args);
+}
 
 /**
  * Locate the page header and initialize scoreboard element references.
@@ -48,26 +96,26 @@ const clearRoundCounter = (...args) => invokeSharedHelper("clearRoundCounter", a
  * @returns {void}
  */
 export function setupScoreboard(controls, scheduler = realScheduler) {
-  const header = document.querySelector("header");
-  controls.scheduler = scheduler;
-  const init = getScoreboardMethod("initScoreboard");
-  if (!header) {
-    init(null, controls);
-  } else {
-    init(header, controls);
+  const safeControls = controls ?? {};
+  safeControls.scheduler = scheduler;
+  const headerTarget = domAvailable ? document.querySelector("header") : null;
+  runHelper("initScoreboard", initScoreboardImpl, [headerTarget, safeControls]);
+
+  if (!domAvailable) {
+    return;
   }
 
   // Handle visibility changes for timer pause/resume
   try {
     const handleVisibilityChange = () => {
-      if (document.hidden && controls.pauseTimer) {
-        controls.pauseTimer();
+      if (document.hidden && safeControls.pauseTimer) {
+        safeControls.pauseTimer();
       }
     };
 
     const handleFocus = () => {
-      if (!document.hidden && controls.resumeTimer) {
-        controls.resumeTimer();
+      if (!document.hidden && safeControls.resumeTimer) {
+        safeControls.resumeTimer();
       }
     };
 
@@ -96,7 +144,127 @@ export function setupScoreboard(controls, scheduler = realScheduler) {
   } catch {}
 }
 
-const scoreboardApi = {
+/**
+ * Display a message on the shared scoreboard.
+ *
+ * @pseudocode
+ * 1. Execute the scoreboard helper with resilience safeguards.
+ * 2. Return the helper result (void).
+ *
+ * @param {...unknown} args - Arguments forwarded to the scoreboard helper.
+ * @returns {void}
+ */
+export function showMessage(...args) {
+  return runHelper("showMessage", showMessageImpl, args);
+}
+
+/**
+ * Update the scoreboard score counters.
+ *
+ * @pseudocode
+ * 1. Forward the score arguments to the scoreboard helper safely.
+ * 2. Return the helper result (void).
+ *
+ * @param {...unknown} args - Helper arguments.
+ * @returns {void}
+ */
+export function updateScore(...args) {
+  return runHelper("updateScore", updateScoreImpl, args);
+}
+
+/**
+ * Clear any visible scoreboard message.
+ *
+ * @pseudocode
+ * 1. Invoke the scoreboard helper with runtime safeguards.
+ * 2. Return the helper result (void).
+ *
+ * @param {...unknown} args - Helper arguments (unused).
+ * @returns {void}
+ */
+export function clearMessage(...args) {
+  return runHelper("clearMessage", clearMessageImpl, args);
+}
+
+/**
+ * Show a temporary scoreboard message and return a restore handler.
+ *
+ * @pseudocode
+ * 1. Execute the helper; on failure, return a noop restore function.
+ *
+ * @param {...unknown} args - Helper arguments.
+ * @returns {() => void} Restore callback from the helper or a noop fallback.
+ */
+export function showTemporaryMessage(...args) {
+  return runHelper("showTemporaryMessage", showTemporaryMessageImpl, args);
+}
+
+/**
+ * Clear the scoreboard timer display.
+ *
+ * @pseudocode
+ * 1. Forward the request to the scoreboard helper with safeguards.
+ *
+ * @param {...unknown} args - Helper arguments (unused).
+ * @returns {void}
+ */
+export function clearTimer(...args) {
+  return runHelper("clearTimer", clearTimerImpl, args);
+}
+
+/**
+ * Update the scoreboard timer with the provided values.
+ *
+ * @pseudocode
+ * 1. Call the scoreboard helper safely with the timer arguments.
+ *
+ * @param {...unknown} args - Helper arguments.
+ * @returns {void}
+ */
+export function updateTimer(...args) {
+  return runHelper("updateTimer", updateTimerImpl, args);
+}
+
+/**
+ * Highlight an auto-selected stat on the scoreboard.
+ *
+ * @pseudocode
+ * 1. Delegate to the scoreboard helper with resilience handling.
+ *
+ * @param {...unknown} args - Helper arguments.
+ * @returns {void}
+ */
+export function showAutoSelect(...args) {
+  return runHelper("showAutoSelect", showAutoSelectImpl, args);
+}
+
+/**
+ * Update the scoreboard round counter.
+ *
+ * @pseudocode
+ * 1. Execute the scoreboard helper with safeguards.
+ *
+ * @param {...unknown} args - Helper arguments.
+ * @returns {void}
+ */
+export function updateRoundCounter(...args) {
+  return runHelper("updateRoundCounter", updateRoundCounterImpl, args);
+}
+
+/**
+ * Clear the scoreboard round counter.
+ *
+ * @pseudocode
+ * 1. Safely invoke the scoreboard helper to clear the display.
+ *
+ * @param {...unknown} args - Helper arguments (unused).
+ * @returns {void}
+ */
+export function clearRoundCounter(...args) {
+  return runHelper("clearRoundCounter", clearRoundCounterImpl, args);
+}
+
+export const scoreboard = {
   setupScoreboard,
   showMessage,
   updateScore,
@@ -107,17 +275,4 @@ const scoreboardApi = {
   showAutoSelect,
   updateRoundCounter,
   clearRoundCounter
-};
-
-export {
-  showMessage,
-  updateScore,
-  clearMessage,
-  showTemporaryMessage,
-  clearTimer,
-  updateTimer,
-  showAutoSelect,
-  updateRoundCounter,
-  clearRoundCounter,
-  scoreboardApi as scoreboard
 };


### PR DESCRIPTION
## Summary
- restore static scoreboard helper exports in `setupScoreboard`, adding resilient wrappers with one-time logging, DOM gating, and the aggregated scoreboard API
- ensure win target synchronization falls back to stored targets and injects missing dropdown options so CLI settings reflect round selections

## Testing
- npm run check:jsdoc
- npx prettier src/helpers/setupScoreboard.js src/helpers/classicBattle/winTargetSync.js --check
- npx eslint src/helpers/setupScoreboard.js src/helpers/classicBattle/winTargetSync.js
- npx vitest run --reporter=basic
- npx playwright test --workers=1

------
https://chatgpt.com/codex/tasks/task_e_68d578033c24832692923efa8a06bda0