### PR TITLE
Address review feedback for scoreboard fallback

### DIFF
--- a/src/helpers/setupScoreboard.js
+++ b/src/helpers/setupScoreboard.js
@@ -8,31 +8,30 @@ try {
   sharedScoreboardModule = null;
 }
 
+const noop = () => {};
+
 /**
  * Retrieve a scoreboard helper method by name.
  *
  * @pseudocode
  * 1. Verify the shared module exists and exposes the requested method.
- * 2. Return the method when available; otherwise return null.
+ * 2. Return the method when available; otherwise return a noop fallback.
  *
  * @param {string} name - The helper method name to retrieve.
- * @returns {Function|null} The requested helper or null when unavailable.
+ * @returns {Function} The requested helper or a noop fallback when unavailable.
  */
 function getScoreboardMethod(name) {
-  if (
-    sharedScoreboardModule &&
-    typeof sharedScoreboardModule[name] === "function"
-  ) {
+  if (sharedScoreboardModule && typeof sharedScoreboardModule[name] === "function") {
     return sharedScoreboardModule[name];
   }
 
-  return null;
+  return noop;
 }
 
 const invokeSharedHelper = (name, args) => {
   const helper = getScoreboardMethod(name);
 
-  if (!helper) {
+  if (typeof helper !== "function") {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- restore the noop fallback when scoreboard helpers are unavailable to avoid null invocation errors
- update the helper documentation to describe the noop behavior and reinstate the defensive function guard

## Testing
- `npm run check:jsdoc`
- `CI=1 npx prettier . --check` *(fails: existing formatting errors under judokon/models and data assets)*
- `npx eslint .` *(fails: existing lint errors in unrelated CLI files)*
- `npx vitest run` *(terminated due to extremely verbose progress output)*

------
https://chatgpt.com/codex/tasks/task_e_68d581358a748326969967b7e3a29c01