### PR TITLE
Address review feedback for startMatch and scoreboard fallback

### DIFF
--- a/playwright/battle-classic/opponent-reveal.spec.js
+++ b/playwright/battle-classic/opponent-reveal.spec.js
@@ -132,29 +132,19 @@ async function startMatch(page, selector) {
     await ensureStatSelectionVisible();
   };
 
-  let ensuredDuringFallback = false;
-
   try {
     await expect(button).toBeVisible({ timeout: 7_000 });
     await button.click();
+    await ensureBattleReady();
+    return;
   } catch (error) {
-    const readyWithoutClick = await ensureBattleReady()
-      .then(() => true)
-      .catch(() => false);
-
-    if (readyWithoutClick) {
-      ensuredDuringFallback = true;
-    } else {
-      throw error;
-    }
-  }
-
-  if (!ensuredDuringFallback) {
     try {
       await ensureBattleReady();
-    } catch (error) {
+      return;
+    } catch {
       try {
         await ensureStatSelectionVisible();
+        return;
       } catch {
         throw error;
       }


### PR DESCRIPTION
## Summary
- simplify the `startMatch` helper to use a straightforward three-step fallback
- harden the scoreboard fallback by capturing any existing global getter and skipping initialization when unavailable

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: repository contains pre-existing formatting and parse issues outside touched files)*
- npx eslint . *(fails: repository contains existing parsing and prettier violations outside touched files)*
- npx vitest run *(fails: existing test suites use ESM imports incompatible with current runner configuration)*
- npx playwright test *(fails: local server resources unavailable and tests interrupted)*
- npm run check:contrast
- npm run rag:validate *(fails: MiniLM model assets unavailable in container)*
- npm run validate:data

------
https://chatgpt.com/codex/tasks/task_e_68d5810c7f6c83269536bdc9230b6759