### PR TITLE
Address review feedback on scoreboard helpers

### DIFF
--- a/src/helpers/classicBattle/winTargetSync.js
+++ b/src/helpers/classicBattle/winTargetSync.js
@@ -86,7 +86,16 @@ export function syncWinTargetDropdown() {
     const currentTarget = readPointsToWin();
     if (typeof currentTarget !== "number" || !Number.isFinite(currentTarget)) return;
 
-    select.value = String(currentTarget);
+    const value = String(currentTarget);
+    const hasOption = Array.from(select.options || []).some((option) => option.value === value);
+    if (!hasOption) {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = value;
+      select.appendChild(option);
+    }
+
+    select.value = value;
     const round = getCurrentRoundNumber();
     updateRoundHeader(round, currentTarget);
   } catch {}

--- a/src/helpers/setupScoreboard.js
+++ b/src/helpers/setupScoreboard.js
@@ -18,7 +18,8 @@ const scoreboardFunctionNames = [
 
 const missingScoreboardExports = [];
 
-const scoreboardFunctions = scoreboardFunctionNames.reduce((functions, name) => {
+const scoreboardFunctions = {};
+for (const name of scoreboardFunctionNames) {
   let candidate;
   try {
     candidate = scoreboardModule?.[name];
@@ -26,15 +27,18 @@ const scoreboardFunctions = scoreboardFunctionNames.reduce((functions, name) => 
     candidate = undefined;
   }
   if (typeof candidate === "function") {
-    functions[name] = candidate;
+    scoreboardFunctions[name] = candidate;
   } else {
-    functions[name] = noop;
+    scoreboardFunctions[name] = noop;
     missingScoreboardExports.push(name);
   }
-  return functions;
-}, {});
+}
 
-if (missingScoreboardExports.length > 0) {
+if (
+  missingScoreboardExports.length > 0 &&
+  typeof process !== "undefined" &&
+  process.env.NODE_ENV === "development"
+) {
   console.warn(
     "[setupScoreboard] Using fallback implementations for Scoreboard exports:",
     missingScoreboardExports.join(", ")
@@ -107,7 +111,7 @@ export function setupScoreboard(controls, scheduler = realScheduler) {
  * @pseudocode
  * 1. Invoke the namespace export `showMessage` with the provided arguments.
  *
- * @type {typeof scoreboardFunctions.showMessage}
+ * @function
  */
 export const showMessage = scoreboardFunctions.showMessage;
 
@@ -117,7 +121,7 @@ export const showMessage = scoreboardFunctions.showMessage;
  * @pseudocode
  * 1. Invoke the namespace export `updateScore` with the provided arguments.
  *
- * @type {typeof scoreboardFunctions.updateScore}
+ * @function
  */
 export const updateScore = scoreboardFunctions.updateScore;
 
@@ -127,7 +131,7 @@ export const updateScore = scoreboardFunctions.updateScore;
  * @pseudocode
  * 1. Invoke the namespace export `clearMessage` with the provided arguments.
  *
- * @type {typeof scoreboardFunctions.clearMessage}
+ * @function
  */
 export const clearMessage = scoreboardFunctions.clearMessage;
 
@@ -137,7 +141,7 @@ export const clearMessage = scoreboardFunctions.clearMessage;
  * @pseudocode
  * 1. Invoke the namespace export `showTemporaryMessage` with the provided arguments.
  *
- * @type {typeof scoreboardFunctions.showTemporaryMessage}
+ * @function
  */
 export const showTemporaryMessage = scoreboardFunctions.showTemporaryMessage;
 
@@ -147,7 +151,7 @@ export const showTemporaryMessage = scoreboardFunctions.showTemporaryMessage;
  * @pseudocode
  * 1. Invoke the namespace export `clearTimer` with the provided arguments.
  *
- * @type {typeof scoreboardFunctions.clearTimer}
+ * @function
  */
 export const clearTimer = scoreboardFunctions.clearTimer;
 
@@ -157,7 +161,7 @@ export const clearTimer = scoreboardFunctions.clearTimer;
  * @pseudocode
  * 1. Invoke the namespace export `updateTimer` with the provided arguments.
  *
- * @type {typeof scoreboardFunctions.updateTimer}
+ * @function
  */
 export const updateTimer = scoreboardFunctions.updateTimer;
 
@@ -167,7 +171,7 @@ export const updateTimer = scoreboardFunctions.updateTimer;
  * @pseudocode
  * 1. Invoke the namespace export `showAutoSelect` with the provided arguments.
  *
- * @type {typeof scoreboardFunctions.showAutoSelect}
+ * @function
  */
 export const showAutoSelect = scoreboardFunctions.showAutoSelect;
 
@@ -177,7 +181,7 @@ export const showAutoSelect = scoreboardFunctions.showAutoSelect;
  * @pseudocode
  * 1. Invoke the namespace export `updateRoundCounter` with the provided arguments.
  *
- * @type {typeof scoreboardFunctions.updateRoundCounter}
+ * @function
  */
 export const updateRoundCounter = scoreboardFunctions.updateRoundCounter;
 
@@ -187,7 +191,7 @@ export const updateRoundCounter = scoreboardFunctions.updateRoundCounter;
  * @pseudocode
  * 1. Invoke the namespace export `clearRoundCounter` with the provided arguments.
  *
- * @type {typeof scoreboardFunctions.clearRoundCounter}
+ * @function
  */
 export const clearRoundCounter = scoreboardFunctions.clearRoundCounter;
 
@@ -196,19 +200,6 @@ export const clearRoundCounter = scoreboardFunctions.clearRoundCounter;
  *
  * @pseudocode
  * 1. Collect `setupScoreboard` and the forwarded helper functions in a single object.
- *
- * @type {{
- *   setupScoreboard: typeof setupScoreboard,
- *   showMessage: typeof showMessage,
- *   updateScore: typeof updateScore,
- *   clearMessage: typeof clearMessage,
- *   showTemporaryMessage: typeof showTemporaryMessage,
- *   clearTimer: typeof clearTimer,
- *   updateTimer: typeof updateTimer,
- *   showAutoSelect: typeof showAutoSelect,
- *   updateRoundCounter: typeof updateRoundCounter,
- *   clearRoundCounter: typeof clearRoundCounter
- * }}
  */
 const scoreboardApi = {
   setupScoreboard,

--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -1507,10 +1507,10 @@ export function restorePointsToWin() {
   try {
     const select = byId("points-select");
     if (!select) return;
-    const optionValues = Array.from(select.options || [])
+    const selectOptionValues = Array.from(select.options || [])
       .map((option) => Number(option.value))
       .filter((value) => Number.isFinite(value));
-    const validTargets = new Set([...POINTS_TO_WIN_OPTIONS, ...optionValues]);
+    const validTargets = new Set([...POINTS_TO_WIN_OPTIONS, ...selectOptionValues]);
     const storage = wrap(BATTLE_POINTS_TO_WIN, { fallback: "none" });
     const saved = Number(storage.get());
     if (validTargets.has(saved)) {


### PR DESCRIPTION
## Summary
- rework scoreboard helper loading to use a simple loop, gate fallback warnings to development, and normalize JSDoc annotations
- rename CLI win target option helpers for clarity and keep validation consistent with DOM options
- update win target synchronization to inject missing dropdown options before applying engine values

## Testing
- `npm run check:jsdoc`
- `npx prettier src/helpers/setupScoreboard.js src/helpers/classicBattle/winTargetSync.js src/pages/battleCLI/init.js --check`
- `npx eslint .`
- `npx vitest run --reporter basic`
- `npx playwright test` *(fails: opponent reveal spec leaves card visible; repro tracked)*
- `npx playwright test playwright/win-target-sync.spec.js`
- `npx playwright test playwright/battle-classic/opponent-reveal.spec.js` *(fails as above)*
- `npm run check:contrast`
- `npm run rag:validate` *(fails: MiniLM artifacts unavailable in container)*
- `npm run validate:data`
- `node scripts/checkHotPaths.js` *(reports existing dynamic import in hot path)*
- `grep -RIn "await import(" src/helpers/classicBattle src/helpers/battleEngineFacade.js src/helpers/battle`
- `grep -RInE "console\.(warn|error)\(" tests | grep -v "tests/utils/console.js"`


------
https://chatgpt.com/codex/tasks/task_e_68d57b7b7748832683ea60c483b11703