### PR TITLE
Fix battle CLI timer test lint issues

### DIFF
--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -408,28 +408,6 @@ let resetPromise = Promise.resolve();
  * await initClassicBattleOrchestrator()
  * // Return a promise that resolves after both reset and orchestrator initialization are complete.
  * // Callers should await the returned promise to ensure the reset is finished.
- */
-let resetPromise = Promise.resolve();
-
-/**
- * Reset the match and reinitialize the battle orchestrator.
- *
- * @pseudocode
- * stopSelectionCountdown()
- * handleCountdownFinished()
- * roundResolving = false
- * clearVerboseLog()
- * remove play-again/start buttons
- * resetPromise = async () => {
- *   disposeClassicBattleOrchestrator()
- *   await resetGame(store)
- *   updateRoundHeader(0, engineFacade.getPointsToWin?.())
- *   updateScoreLine()
- *   setRoundMessage("")
- * }
- * await initClassicBattleOrchestrator()
- * // Return a promise that resolves after both reset and orchestrator initialization are complete.
- * // Callers should await the returned promise to ensure the reset is finished.
  * @returns {Promise<void>} A promise that resolves when the reset is complete.
  */
 export async function resetMatch() {

--- a/tests/pages/battleCLI.timerConsolidation.test.js
+++ b/tests/pages/battleCLI.timerConsolidation.test.js
@@ -1,200 +1,65 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";import { describe, it, expect, beforeEach, afterEach } from "vitest";import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { loadBattleCLI, cleanupBattleCLI } from "./utils/loadBattleCLI.js";
 
-import { initBattleScoreboardAdapter } from "../../src/helpers/battleScoreboard.js";import { loadBattleCLI, cleanupBattleCLI } from "./utils/loadBattleCLI.js";import { loadBattleCLI, cleanupBattleCLI } from "./utils/loadBattleCLI.js";
-
-import { emitBattleEvent } from "../../src/helpers/classicBattle/battleEvents.js";
-
-import { initBattleScoreboardAdapter } from "../../src/helpers/battleScoreboard.js";import { initBattleScoreboardAdapter } from "../../src/helpers/battleScoreboard.js";
-
 describe("battleCLI timer consolidation", () => {
-
-  beforeEach(async () => {import { emitBattleEvent } from "../../src/helpers/classicBattle/battleEvents.js";import { emitBattleEvent } from "../../src/helpers/classicBattle/battleEvents.js";
-
+  afterEach(async () => {
+    vi.restoreAllMocks();
     await cleanupBattleCLI();
-
+    vi.resetModules();
   });
 
-
-
-  afterEach(async () => {describe("battleCLI timer consolidation", () => {describe("battleCLI timer consolidation", () => {
-
-    await cleanupBattleCLI();
-
-  });  beforeEach(async () => {  beforeEach(async () => {
-
-
-
-  it("only updates cli-countdown timer in CLI mode, not shared scoreboard timer", async () => {    await cleanupBattleCLI();    await cleanupBattleCLI();
-
-    // Load battleCLI which creates the cli-countdown element
-
-    const mod = await loadBattleCLI();  });  });
-
+  it("only updates cli-countdown timer in CLI mode, not shared scoreboard timer", async () => {
+    const mod = await loadBattleCLI();
     await mod.init();
 
-
-
-    // Verify cli-countdown element exists
-
-    const cliCountdown = document.getElementById("cli-countdown");  afterEach(async () => {  afterEach(async () => {
-
-    expect(cliCountdown).toBeTruthy();
-
-    await cleanupBattleCLI();    await cleanupBattleCLI();
-
-    // Initialize the battle scoreboard adapter (this should skip timer updates in CLI mode)
-
-    const dispose = initBattleScoreboardAdapter();  });  });
-
-
-
-    // Check that next-round-timer remains empty (not updated by shared scoreboard)
-
+    const cliCountdown = document.getElementById("cli-countdown");
     const sharedTimer = document.getElementById("next-round-timer");
 
-    expect(sharedTimer).toBeTruthy();  it("only updates cli-countdown timer in CLI mode, not shared scoreboard timer", async () => {  it("only updates cli-countdown timer in CLI mode, not shared scoreboard timer", async () => {
+    expect(cliCountdown).toBeTruthy();
+    expect(sharedTimer?.textContent).toBe("");
 
-    expect(sharedTimer.textContent).toBe("");
+    const scoreboardModule = await import("../../src/components/Scoreboard.js");
+    const updateTimerSpy = vi.spyOn(scoreboardModule, "updateTimer");
 
-    // Load battleCLI which creates the cli-countdown element    // Load battleCLI which creates the cli-countdown element
-
-    // Emit a timer tick event
-
-    emitBattleEvent("round.timer.tick", { detail: { remainingMs: 5000 } });    const mod = await loadBattleCLI();    const mod = await loadBattleCLI();
-
-
-
-    // Wait for event processing    await mod.init();    await mod.init();
-
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-
-
-    // The shared timer should still be empty (not updated in CLI mode)
-
-    expect(sharedTimer.textContent).toBe("");    // Verify cli-countdown element exists    // Initialize the battle scoreboard adapter (this should skip timer updates in CLI mode)
-
-
-
-    // Clean up    const cliCountdown = document.getElementById("cli-countdown");    const dispose = initBattleScoreboardAdapter();
-
-    dispose();
-
-  });    expect(cliCountdown).toBeTruthy();
-
-});
-    // Verify cli-countdown element exists
-
-    // Initialize the battle scoreboard adapter (this should skip timer updates in CLI mode)    const cliCountdown = document.getElementById("cli-countdown");
-
-    const dispose = initBattleScoreboardAdapter();    expect(cliCountdown).toBeTruthy();
-
-
-
-    // Check that next-round-timer remains empty (not updated by shared scoreboard)    // Mock the updateTimer function to track calls
-
-    const sharedTimer = document.getElementById("next-round-timer");    const updateTimerSpy = vi.fn();
-
-    expect(sharedTimer).toBeTruthy();    vi.doMock("../../src/components/Scoreboard.js", () => ({
-
-    expect(sharedTimer.textContent).toBe("");      updateTimer: updateTimerSpy,
-
-      showMessage: vi.fn(),
-
-    // Emit a timer tick event      updateScore: vi.fn(),
-
-    emitBattleEvent("round.timer.tick", { detail: { remainingMs: 5000 } });      updateRoundCounter: vi.fn(),
-
-      clearRoundCounter: vi.fn(),
-
-    // Wait for event processing      showTemporaryMessage: vi.fn(),
-
-    await new Promise((resolve) => setTimeout(resolve, 10));      getState: vi.fn()
-
-    }));
-
-    // The shared timer should still be empty (not updated in CLI mode)
-
-    expect(sharedTimer.textContent).toBe("");    // Emit a timer tick event
-
-    emitBattleEvent("round.timer.tick", { detail: { remainingMs: 5000 } });
-
-    // Clean up
-
-    dispose();    // Wait for event processing
-
-  });    await new Promise((resolve) => setTimeout(resolve, 10));
-
-
-
-  it("shared scoreboard timer updates work in non-CLI mode", async () => {    // The shared scoreboard updateTimer should NOT have been called in CLI mode
-
-    // Remove cli-countdown element to simulate non-CLI mode    expect(updateTimerSpy).not.toHaveBeenCalled();
-
-    const cliCountdown = document.getElementById("cli-countdown");
-
-    if (cliCountdown) {    // Clean up
-
-      cliCountdown.remove();    dispose();
-
-    }    vi.restoreAllMocks();
-
-  });
-
-    // Initialize the battle scoreboard adapter
-
-    const dispose = initBattleScoreboardAdapter();  it("shared scoreboard timer updates work in non-CLI mode", async () => {
-
-    // Remove cli-countdown element to simulate non-CLI mode
-
-    // Check that next-round-timer exists    const cliCountdown = document.getElementById("cli-countdown");
-
-    const sharedTimer = document.getElementById("next-round-timer");    if (cliCountdown) {
-
-    expect(sharedTimer).toBeTruthy();      cliCountdown.remove();
-
-    }
-
-    // Emit a timer tick event
-
-    emitBattleEvent("round.timer.tick", { detail: { remainingMs: 3000 } });    // Mock the updateTimer function to track calls
-
-    const updateTimerSpy = vi.fn();
-
-    // Wait for event processing    vi.doMock("../../src/components/Scoreboard.js", () => ({
-
-    await new Promise((resolve) => setTimeout(resolve, 10));      updateTimer: updateTimerSpy,
-
-      showMessage: vi.fn(),
-
-    // The shared timer SHOULD have been updated in non-CLI mode      updateScore: vi.fn(),
-
-    expect(sharedTimer.textContent).toBe("Time Left: 3s");      updateRoundCounter: vi.fn(),
-
-      clearRoundCounter: vi.fn(),
-
-    // Clean up      showTemporaryMessage: vi.fn(),
-
-    dispose();      getState: vi.fn()
-
-  });    }));
-
-});
-    // Initialize the battle scoreboard adapter
+    const { initBattleScoreboardAdapter } = await import("../../src/helpers/battleScoreboard.js");
     const dispose = initBattleScoreboardAdapter();
 
-    // Emit a timer tick event
-    emitBattleEvent("round.timer.tick", { detail: { remainingMs: 3000 } });
+    const { emitBattleEvent } = await import("../../src/helpers/classicBattle/battleEvents.js");
+    emitBattleEvent("round.timer.tick", { remainingMs: 5000 });
 
-    // Wait for event processing
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    // The shared timer SHOULD have been updated in non-CLI mode
-    expect(sharedTimer.textContent).toBe("Time Left: 3s");
+    expect(updateTimerSpy).not.toHaveBeenCalled();
+    expect(sharedTimer?.textContent).toBe("");
 
-    // Clean up
+    dispose();
+  });
+
+  it("shared scoreboard timer updates work in non-CLI mode", async () => {
+    const mod = await loadBattleCLI();
+    await mod.init();
+
+    const cliCountdown = document.getElementById("cli-countdown");
+    expect(cliCountdown).toBeTruthy();
+    cliCountdown?.remove();
+
+    const sharedTimer = document.getElementById("next-round-timer");
+    expect(sharedTimer).toBeTruthy();
+
+    const scoreboardModule = await import("../../src/components/Scoreboard.js");
+    const updateTimerSpy = vi.spyOn(scoreboardModule, "updateTimer");
+
+    const { initBattleScoreboardAdapter } = await import("../../src/helpers/battleScoreboard.js");
+    const dispose = initBattleScoreboardAdapter();
+
+    const { emitBattleEvent } = await import("../../src/helpers/classicBattle/battleEvents.js");
+    emitBattleEvent("round.timer.tick", { remainingMs: 3000 });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(updateTimerSpy).toHaveBeenCalledWith(3);
+    expect(sharedTimer?.textContent?.trim()).toBe("Time Left: 3s");
+
     dispose();
   });
 });


### PR DESCRIPTION
## Summary
- deduplicate the battle CLI reset promise declaration
- rebuild the CLI timer consolidation test to remove corrupted duplicates and verify timer behavior

## Testing
- npm run check:jsdoc
- npx prettier . --check --log-level warn *(fails: existing formatting warnings in repository)*
- npx eslint .
- npx vitest run *(aborted: excessive progress output)*
- npx playwright test *(fails: known UI interaction flakes)*
- npm run check:contrast
- npm run validate:data
- npm run rag:validate *(fails: MiniLM model placeholders; offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5846e2a148326a3310423d7660833