### PR TITLE
Restore dynamic scoreboard loading and add win target tests

### DIFF
--- a/src/helpers/classicBattle/winTargetSync.js
+++ b/src/helpers/classicBattle/winTargetSync.js
@@ -73,7 +73,7 @@ function readPointsToWin() {
  * @pseudocode
  * 1. Lookup `#points-select`; exit when missing.
  * 2. Read the current points-to-win from the battle engine.
- * 3. When valid, set the dropdown value to match.
+ * 3. When valid, ensure the dropdown exposes the sanitized target option.
  * 4. Refresh the CLI header metadata using the stored round number.
  *
  * @returns {void}
@@ -97,20 +97,26 @@ export function syncWinTargetDropdown() {
     }
     if (typeof currentTarget !== "number" || !Number.isFinite(currentTarget)) return;
 
+    const normalizedTarget = Math.trunc(currentTarget);
+    if (!Number.isFinite(normalizedTarget) || normalizedTarget <= 0) {
+      return;
+    }
+
     try {
       const hasOption = Array.from(select.options || []).some(
-        (option) => Number(option.value) === currentTarget
+        (option) => Number(option.value) === normalizedTarget
       );
       if (!hasOption && typeof document !== "undefined") {
         const option = document.createElement("option");
-        option.value = String(currentTarget);
-        option.textContent = String(currentTarget);
+        option.value = String(normalizedTarget);
+        option.textContent = String(normalizedTarget);
         select.appendChild(option);
       }
     } catch {}
 
-    select.value = String(currentTarget);
+    const normalizedValue = String(normalizedTarget);
+    select.value = normalizedValue;
     const round = getCurrentRoundNumber();
-    updateRoundHeader(round, currentTarget);
+    updateRoundHeader(round, normalizedTarget);
   } catch {}
 }

--- a/tests/helpers/classicBattle/winTargetSync.test.js
+++ b/tests/helpers/classicBattle/winTargetSync.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
+  getPointsToWin: vi.fn()
+}));
+
+describe("syncWinTargetDropdown", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    document.body.innerHTML = `
+      <div id="cli-root" data-round="3" data-target="5"></div>
+      <div id="cli-round"></div>
+      <select id="points-select">
+        <option value="3">3</option>
+        <option value="5">5</option>
+      </select>
+    `;
+    document.body.dataset.target = "5";
+    const select = document.getElementById("points-select");
+    if (select) {
+      select.value = "5";
+    }
+  });
+
+  it("injects missing target option and updates header metadata", async () => {
+    const battleFacade = await import("../../../src/helpers/battleEngineFacade.js");
+    battleFacade.getPointsToWin.mockReturnValue(7);
+    const { syncWinTargetDropdown } = await import(
+      "../../../src/helpers/classicBattle/winTargetSync.js"
+    );
+
+    syncWinTargetDropdown();
+
+    const select = document.getElementById("points-select");
+    expect(select?.value).toBe("7");
+    const options = Array.from(select?.options ?? []).map((option) => option.value);
+    expect(options).toContain("7");
+    expect(document.getElementById("cli-round")?.textContent).toBe("Round 3 Target: 7");
+    expect(document.getElementById("cli-root")?.dataset.target).toBe("7");
+  });
+
+  it("falls back to stored dataset target when facade target is invalid", async () => {
+    const battleFacade = await import("../../../src/helpers/battleEngineFacade.js");
+    battleFacade.getPointsToWin.mockReturnValue(Number.NaN);
+    document.body.dataset.target = "11";
+    const { syncWinTargetDropdown } = await import(
+      "../../../src/helpers/classicBattle/winTargetSync.js"
+    );
+
+    syncWinTargetDropdown();
+
+    const select = document.getElementById("points-select");
+    expect(select?.value).toBe("11");
+    const options = Array.from(select?.options ?? []).map((option) => option.value);
+    expect(options).toContain("11");
+    expect(document.getElementById("cli-round")?.textContent).toBe("Round 3 Target: 11");
+    expect(document.getElementById("cli-root")?.dataset.target).toBe("11");
+  });
+
+  it("ignores invalid targets that would not render in the dropdown", async () => {
+    const battleFacade = await import("../../../src/helpers/battleEngineFacade.js");
+    battleFacade.getPointsToWin.mockReturnValue(-3);
+    const header = document.getElementById("cli-round");
+    if (header) {
+      header.textContent = "Round 3 Target: 5";
+    }
+    const { syncWinTargetDropdown } = await import(
+      "../../../src/helpers/classicBattle/winTargetSync.js"
+    );
+
+    syncWinTargetDropdown();
+
+    const select = document.getElementById("points-select");
+    expect(select?.value).toBe("5");
+    const options = Array.from(select?.options ?? []).map((option) => option.value);
+    expect(options).not.toContain("-3");
+    expect(document.getElementById("cli-round")?.textContent).toBe("Round 3 Target: 5");
+  });
+});


### PR DESCRIPTION
## Summary
- reinstate dynamic scoreboard helper loading with logger-based one-time diagnostics and DOM gating
- sanitize injected win target values so the CLI dropdown and header stay in sync with the engine
- add coverage for scoreboard error/DOM fallbacks and new classic battle win target sync scenarios

## Testing
- npm run check:jsdoc
- npx prettier . --check *(fails: SyntaxError in tests/pages/battleCLI.timerConsolidation.test.js prior to this change)*
- npx eslint . *(fails: parsing errors in existing battleCLI sources)*
- npx vitest run --reporter=basic *(fails: duplicate `resetPromise` symbol in battleCLI init baseline code)*
- npx vitest run tests/helpers/setupScoreboard.test.js tests/helpers/classicBattle/winTargetSync.test.js
- npx playwright test --workers=1 *(fails: existing battle-classic Playwright scenarios timing out/interrupting)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d58549c8a0832696a2d9c056543dd9