### PR TITLE
Fix verbose log focus when enabling verbose mode

### DIFF
--- a/src/pages/battleCLI.html
+++ b/src/pages/battleCLI.html
@@ -217,7 +217,12 @@
           data-flag="cliVerbose"
           hidden
         >
-          <pre id="cli-verbose-log" aria-atomic="false" class="pre-wrap"></pre>
+          <pre
+            id="cli-verbose-log"
+            aria-atomic="false"
+            class="pre-wrap"
+            tabindex="-1"
+          ></pre>
         </section>
         <div id="cli-prompt" role="status" aria-label="Command prompt">
           &gt; <span id="cli-cursor" aria-label="Cursor">_</span>

--- a/src/pages/battleCLI/cliDomTemplate.js
+++ b/src/pages/battleCLI/cliDomTemplate.js
@@ -128,7 +128,12 @@ export const CLI_DOM_TEMPLATE = `
       </section>
       <div class="ascii-sep">------------------------</div>
       <section aria-label="Verbose Log" id="cli-verbose-section" class="cli-block" data-flag="cliVerbose" hidden>
-        <pre id="cli-verbose-log" aria-atomic="false" class="pre-wrap"></pre>
+        <pre
+          id="cli-verbose-log"
+          aria-atomic="false"
+          class="pre-wrap"
+          tabindex="-1"
+        ></pre>
       </section>
       <div id="cli-prompt" role="status" aria-label="Command prompt">
         &gt; <span id="cli-cursor" aria-hidden="true">_</span>

--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -2249,13 +2249,24 @@ export async function setupFlags() {
     if (indicator) indicator.style.display = verboseEnabled ? "inline" : "none";
     if (verboseEnabled) {
       try {
-        // Scroll the verbose section into view
-        if (section) section.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        // Scroll the verbose section into view when supported
+        if (section && typeof section.scrollIntoView === "function") {
+          section.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        }
         // Focus the verbose log for keyboard navigation
         const pre = byId("cli-verbose-log");
         if (pre) {
+          if (pre.tabIndex !== -1) {
+            pre.tabIndex = -1;
+          }
           pre.scrollTop = pre.scrollHeight;
-          pre.focus({ preventScroll: true });
+          try {
+            pre.focus({ preventScroll: true });
+          } catch {
+            try {
+              pre.focus();
+            } catch {}
+          }
         }
       } catch {}
     }


### PR DESCRIPTION
## Summary
- make the verbose log output focusable in the CLI template and static HTML
- guard verbose toggle logic against missing scrollIntoView support and add a focus fallback
- normalize the verbose log focus path to work in test environments lacking preventScroll support

## Testing
- npx vitest run tests/pages/battleCLI.verboseVisibility.test.js
- npx vitest run tests/pages/battleCLI.a11y.focus.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d58fad65e883269da94ebb6a968a20