### PR TITLE
Remove unused vi import from stat buttons test

### DIFF
--- a/tests/helpers/classicBattle/statButtons.disableAfterSelection.test.js
+++ b/tests/helpers/classicBattle/statButtons.disableAfterSelection.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 // Bind battle event helpers
 import {


### PR DESCRIPTION
## Task Contract
- **Inputs**: `tests/helpers/classicBattle/statButtons.disableAfterSelection.test.js`, eslint warning output.
- **Outputs**: Updated Vitest import removing the unused `vi`, fresh eslint run to confirm the warning is cleared.
- **Success**: Test file no longer imports `vi`, `npx eslint tests/helpers/classicBattle/statButtons.disableAfterSelection.test.js` exits cleanly.
- **Error Handling**: Surface and resolve any lint failures before completion.

## Files Changed
- `tests/helpers/classicBattle/statButtons.disableAfterSelection.test.js`: Drop the unused `vi` symbol from the Vitest import to silence the lint warning.

## Verification Summary
- eslint: PASS (`npx eslint tests/helpers/classicBattle/statButtons.disableAfterSelection.test.js`)
- vitest: not run (not requested)
- playwright: not run (not requested)
- jsdoc: not run (not requested)

## Risk & Follow-Up
- **Risk**: Low; change is limited to removing an unused import from a test file.
- **Follow-Up**: None required.


------
https://chatgpt.com/codex/tasks/task_e_68d5a8084cec832687e3599b3ca78a47