### PR TITLE
Fix start button focus wiring in CLI

### DIFF
--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -69,7 +69,6 @@ import {
 } from "./dom.js";
 import { createCliDomFragment } from "./cliDomTemplate.js";
 import { resolveRoundForTest as resolveRoundForTestHelper } from "./testSupport.js";
-import { bindStartHandlers } from "./startHandlers.js";
 
 // Initialize engine and subscribe to engine events when available.
 try {
@@ -530,6 +529,7 @@ async function renderStartButton() {
         { once: true }
       );
     } catch {}
+    ensureStartButtonFocus();
     return;
   }
   if (byId("start-match-button")) return;
@@ -585,6 +585,7 @@ async function renderStartButton() {
   });
   section.append(btn);
   main.insertBefore(section, main.firstChild);
+  ensureStartButtonFocus();
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove the unused `bindStartHandlers` import from the battle CLI init module
- invoke `ensureStartButtonFocus()` after wiring the static start button and after inserting the dynamic button so both code paths restore focus

## Testing
- npx eslint src/pages/battleCLI/init.js

------
https://chatgpt.com/codex/tasks/task_e_68d5a80365388326bb8baa142078095b