### PR TITLE
Flush battleCLI stat selection microtasks in tests

### DIFF
--- a/tests/pages/battleCLI.selectedStat.test.js
+++ b/tests/pages/battleCLI.selectedStat.test.js
@@ -19,6 +19,7 @@ describe("battleCLI stat interactions", () => {
     const mod = await loadBattleCLI(baseOpts);
     await mod.renderStatList();
     mod.handleWaitingForPlayerActionKey("1");
+    await Promise.resolve();
     expect(document.querySelector('[data-stat-index="1"]').classList.contains("selected")).toBe(
       true
     );
@@ -28,6 +29,7 @@ describe("battleCLI stat interactions", () => {
     const mod = await loadBattleCLI(baseOpts);
     await mod.renderStatList();
     mod.handleWaitingForPlayerActionKey("2");
+    await Promise.resolve();
     expect(document.getElementById("cli-stats").dataset.selectedIndex).toBe("2");
   });
 
@@ -46,6 +48,7 @@ describe("battleCLI stat interactions", () => {
     const hiddenVal = document.querySelector("#player-card li.stat span")?.textContent;
     expect(hiddenVal).toBe("5");
     mod.handleWaitingForPlayerActionKey("1");
+    await Promise.resolve();
     expect(statEl.classList.contains("selected")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- flush the battleCLI stat selection microtask queue in the CLI tests before asserting on DOM updates

## Testing
- npx vitest run tests/pages/battleCLI.selectedStat.test.js

## Files Changed
- tests/pages/battleCLI.selectedStat.test.js

## Risk
- Low: test-only timing adjustment to await queued microtasks

------
https://chatgpt.com/codex/tasks/task_e_68d5bef8ebb4832682c0a94f109a4c7b