### PR TITLE
Extract reusable microtask flush helper for battleCLI tests

### DIFF
--- a/tests/pages/battleCLI.selectedStat.test.js
+++ b/tests/pages/battleCLI.selectedStat.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { loadBattleCLI, cleanupBattleCLI } from "./utils/loadBattleCLI.js";
+import { flushMicrotasks } from "../utils/flushMicrotasks.js";
 
 const baseOpts = {
   battleStats: ["speed", "strength"],
@@ -19,7 +20,7 @@ describe("battleCLI stat interactions", () => {
     const mod = await loadBattleCLI(baseOpts);
     await mod.renderStatList();
     mod.handleWaitingForPlayerActionKey("1");
-    await Promise.resolve();
+    await flushMicrotasks();
     expect(document.querySelector('[data-stat-index="1"]').classList.contains("selected")).toBe(
       true
     );
@@ -29,7 +30,7 @@ describe("battleCLI stat interactions", () => {
     const mod = await loadBattleCLI(baseOpts);
     await mod.renderStatList();
     mod.handleWaitingForPlayerActionKey("2");
-    await Promise.resolve();
+    await flushMicrotasks();
     expect(document.getElementById("cli-stats").dataset.selectedIndex).toBe("2");
   });
 
@@ -48,7 +49,7 @@ describe("battleCLI stat interactions", () => {
     const hiddenVal = document.querySelector("#player-card li.stat span")?.textContent;
     expect(hiddenVal).toBe("5");
     mod.handleWaitingForPlayerActionKey("1");
-    await Promise.resolve();
+    await flushMicrotasks();
     expect(statEl.classList.contains("selected")).toBe(true);
   });
 });

--- a/tests/utils/flushMicrotasks.js
+++ b/tests/utils/flushMicrotasks.js
@@ -1,0 +1,18 @@
+/**
+ * Flushes pending microtasks to ensure async DOM updates settle before assertions.
+ *
+ * @pseudocode
+ * 1. Normalize the iteration count to a safe integer >= 1
+ * 2. Await Promise.resolve() for the requested number of iterations
+ * 3. Each await processes the current microtask queue
+ *
+ * @param {number} [iterations=1] Number of event loop microtask turns to await
+ * @returns {Promise<void>} Resolves once the requested microtask turns are processed
+ */
+export async function flushMicrotasks(iterations = 1) {
+  const total = Number.isFinite(iterations) && iterations > 0 ? Math.ceil(iterations) : 1;
+  for (let remaining = total; remaining > 0; remaining -= 1) {
+    // eslint-disable-next-line no-await-in-loop -- deliberate sequencing to process microtasks serially
+    await Promise.resolve();
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared `flushMicrotasks` test utility for deterministic async DOM assertions
- update the battleCLI stat selection tests to use the shared helper instead of inline `Promise.resolve()` awaits

## Testing
- npx vitest run tests/pages/battleCLI.selectedStat.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d5c137a6cc8326b8013d7f54e18b41