### PR TITLE
Add Playwright helper for waiting on round stats

### DIFF
--- a/playwright/battle-classic/end-modal.spec.js
+++ b/playwright/battle-classic/end-modal.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from "../fixtures/commonSetup.js";
 import { withMutedConsole } from "../../tests/utils/console.js";
 import { waitForModalOpen, waitForNextRoundReadyEvent } from "../fixtures/waits.js";
+import { waitForRoundStats } from "../helpers/battleStateHelper.js";
 
 async function waitForBattleInitialization(page) {
   const getBattleStoreReady = () =>
@@ -139,28 +140,7 @@ async function prepareClassicBattle(page, { seed = 42, cooldown = 500 } = {}) {
 }
 
 async function selectAdvantagedStat(page) {
-  const waitForStatsReady = () =>
-    page.evaluate(() => {
-      const store = window.__TEST_API?.inspect?.getBattleStore?.() ?? window.battleStore;
-      if (!store || typeof store !== "object") {
-        return false;
-      }
-      const playerStats = store.currentPlayerJudoka?.stats;
-      const opponentStats = store.currentOpponentJudoka?.stats;
-      const hasFiniteStat = (stats) => {
-        if (!stats || typeof stats !== "object") {
-          return false;
-        }
-        return Object.values(stats).some((value) => Number.isFinite(Number(value)));
-      };
-
-      if (!hasFiniteStat(playerStats) || !hasFiniteStat(opponentStats)) {
-        return false;
-      }
-      return true;
-    });
-
-  await expect.poll(waitForStatsReady, { timeout: 5000 }).toBeTruthy();
+  await waitForRoundStats(page);
 
   const statKey = await page.evaluate(() => {
     const store = window.__TEST_API?.inspect?.getBattleStore?.() ?? window.battleStore;


### PR DESCRIPTION
## Summary
- add a shared waitForRoundStats helper that reuses the Test API battle store and normalized stat reads
- document the helper with repo-standard JSDoc and expose a reusable STAT_WAIT_TIMEOUT_MS default
- switch the battle classic end modal test to call the helper instead of maintaining its own polling logic

## Testing
- npm run check:jsdoc *(fails: pre-existing missing JSDoc in src/pages/battleCLI)*
- npx prettier playwright/helpers/battleStateHelper.js playwright/battle-classic/end-modal.spec.js --check
- npx eslint .
- CI=1 npx vitest run --reporter=dot *(fails: command output exceeded environment limits)*
- npx playwright test *(fails: run interrupted after long runtime to avoid environment output overflow)*
- npm run check:contrast

------
https://chatgpt.com/codex/tasks/task_e_68d5c31cecd08326b446a586b2333d00