### PR TITLE
Align battleCLI stat dispatch microtask scheduling

### DIFF
--- a/tests/helpers/selectionHandler.test.js
+++ b/tests/helpers/selectionHandler.test.js
@@ -86,8 +86,10 @@ describe("handleStatSelection helpers", () => {
     await handleStatSelection(store, "speed", { playerVal: 3, opponentVal: 4 });
 
     expect(stopTimer).toHaveBeenCalledTimes(1);
-    expect(emitBattleEvent).toHaveBeenCalledTimes(2);
-    expect(emitBattleEvent).toHaveBeenNthCalledWith(2, "input.ignored", {
+    expect(emitBattleEvent).toHaveBeenCalledTimes(3);
+    expect(emitBattleEvent).toHaveBeenNthCalledWith(1, "statSelected", expect.any(Object));
+    expect(emitBattleEvent).toHaveBeenNthCalledWith(2, "roundReset", { reason: "playerSelection" });
+    expect(emitBattleEvent).toHaveBeenNthCalledWith(3, "input.ignored", {
       kind: "duplicateSelection"
     });
     expect(dispatchBattleEvent).toHaveBeenCalledWith("roundResolved");

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -200,9 +200,11 @@ describe("battleCLI onKeyDown", () => {
     expect(() => emitBattleEvent("matchOver")).not.toThrow();
   });
 
-  it("dispatches statSelected in waitingForPlayerAction state", () => {
+  it("dispatches statSelected in waitingForPlayerAction state", async () => {
     document.body.dataset.battleState = "waitingForPlayerAction";
     onKeyDown(new KeyboardEvent("keydown", { key: "1" }));
+    await Promise.resolve();
+    await Promise.resolve();
     expect(dispatchSpy).toHaveBeenCalledWith("statSelected");
   });
 


### PR DESCRIPTION
## Summary
- use a static self-import of init.js so selectStat schedules safeDispatch via the module export rather than a dynamic import
- route the deferred statSelected dispatch through the shared __scheduleMicrotask seam to keep tests controllable and update affected unit specs to await the microtask and account for roundReset events

## Testing
- npx vitest run tests/pages/battleCLI/handlerLatency.spec.js
- npx vitest run tests/pages/battleCLI.onKeyDown.test.js
- npx vitest run tests/helpers/selectionHandler.test.js
- npm run check:jsdoc *(fails: existing missing JSDoc blocks)*
- npx prettier . --check *(fails: repository ships unformatted embeddings)*
- npx eslint . *(warns: unused eslint-disable directive)*
- npx vitest run *(passes with existing unhandled document warning)*
- npx playwright test *(aborted after several specs due to time)*
- npm run check:contrast
- npm run rag:validate *(fails: missing MiniLM model assets)
- npm run validate:data *(fails: missing MiniLM model assets)

------
https://chatgpt.com/codex/tasks/task_e_68d5c2ef39c083268448709f4717a37d