### PR TITLE
Address review feedback on stat dispatch microtask scheduling

### DIFF
--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -1122,23 +1122,23 @@ export function selectStat(stat) {
     // Dispatch via the module export to ensure external spies (tests) observe the call.
     // Schedule on a microtask to keep selection handler synchronous-looking.
     try {
-      const schedule = initModule?.__scheduleMicrotask ?? __scheduleMicrotask;
+      const schedule = initModule.__scheduleMicrotask || __scheduleMicrotask;
       const maybePromise = schedule(async () => {
-        try {
-          const fn = initModule?.safeDispatch;
-          if (typeof fn === "function") {
-            await fn("statSelected");
-          }
-        } catch (err) {
-          try {
-            console.error("[TEST LOG] dispatch error", err);
-          } catch {}
+        const fn = initModule.safeDispatch;
+        if (typeof fn === "function") {
+          await fn("statSelected");
+        } else {
+          console.error("[TEST LOG] safeDispatch not available on initModule");
         }
       });
-      if (typeof maybePromise?.catch === "function") {
-        maybePromise.catch(() => {});
+      if (maybePromise && typeof maybePromise.catch === "function") {
+        maybePromise.catch((err) => {
+          console.error("[TEST LOG] microtask dispatch error", err);
+        });
       }
-    } catch {}
+    } catch (err) {
+      console.error("[TEST LOG] scheduling error", err);
+    }
   } catch (err) {
     console.error("Error dispatching statSelected", err);
   }

--- a/tests/helpers/selectionHandler.test.js
+++ b/tests/helpers/selectionHandler.test.js
@@ -81,11 +81,12 @@ describe("handleStatSelection helpers", () => {
     timers.cleanup();
   });
 
-  it("ignores repeated selections", async () => {
+  it("ignores repeated selections and emits events in correct order", async () => {
     await handleStatSelection(store, "power", { playerVal: 1, opponentVal: 2 });
     await handleStatSelection(store, "speed", { playerVal: 3, opponentVal: 4 });
 
     expect(stopTimer).toHaveBeenCalledTimes(1);
+    // Expect statSelected, roundReset, then input.ignored events
     expect(emitBattleEvent).toHaveBeenCalledTimes(3);
     expect(emitBattleEvent).toHaveBeenNthCalledWith(1, "statSelected", expect.any(Object));
     expect(emitBattleEvent).toHaveBeenNthCalledWith(2, "roundReset", { reason: "playerSelection" });

--- a/tests/pages/battleCLI.onKeyDown.test.js
+++ b/tests/pages/battleCLI.onKeyDown.test.js
@@ -203,8 +203,8 @@ describe("battleCLI onKeyDown", () => {
   it("dispatches statSelected in waitingForPlayerAction state", async () => {
     document.body.dataset.battleState = "waitingForPlayerAction";
     onKeyDown(new KeyboardEvent("keydown", { key: "1" }));
-    await Promise.resolve();
-    await Promise.resolve();
+    // Wait for microtask scheduling to complete
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(dispatchSpy).toHaveBeenCalledWith("statSelected");
   });
 


### PR DESCRIPTION
## Summary
- simplify the statSelected microtask scheduling fallback and surface explicit logging for failure modes
- clarify duplicate selection test naming while documenting the expected event order
- replace chained Promise.resolve microtask waits with an explicit zero-timeout delay in the CLI key handler test

## Testing
- npx vitest run tests/pages/battleCLI.onKeyDown.test.js tests/helpers/selectionHandler.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6307efe5083269e7b948f1362e224