### PR TITLE
Address normalized stat normalization lookup guard

### DIFF
--- a/playwright/helpers/battleStateHelper.js
+++ b/playwright/helpers/battleStateHelper.js
@@ -179,7 +179,11 @@ export async function waitForRoundStats(page, { timeout = STAT_WAIT_TIMEOUT_MS }
             return Number(direct);
           }
 
-          if (normalizedKey !== key && Number.isFinite(Number(stats[normalizedKey]))) {
+          if (
+            normalizedKey !== key &&
+            normalizedKey in stats &&
+            Number.isFinite(Number(stats[normalizedKey]))
+          ) {
             return Number(stats[normalizedKey]);
           }
 


### PR DESCRIPTION
## Summary
- ensure waitForRoundStats only reads normalized stat keys that exist on the stats object

## Testing
- npx eslint playwright/helpers/battleStateHelper.js

------
https://chatgpt.com/codex/tasks/task_e_68d6300a57248326b8b894b81842046e