### PR TITLE
Call battle CLI stat dispatch synchronously

### DIFF
--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -1134,24 +1134,9 @@ export function selectStat(stat) {
   try {
     state.roundResolving = true;
     // Dispatch via the module export to ensure external spies (tests) observe the call.
-    // Schedule on a microtask to keep selection handler synchronous-looking.
-    try {
-      const schedule = initModule?.__scheduleMicrotask || __scheduleMicrotask;
-      const maybePromise = schedule(async () => {
-        const fn = initModule?.safeDispatch;
-        if (typeof fn === "function") {
-          await fn("statSelected");
-        } else {
-          console.error("[TEST LOG] safeDispatch not available on initModule");
-        }
-      });
-      if (maybePromise && typeof maybePromise.catch === "function") {
-        maybePromise.catch((err) => {
-          console.error("[TEST LOG] microtask dispatch error", err);
-        });
-      }
-    } catch (err) {
-      console.error("[TEST LOG] scheduling error", err);
+    const fn = initModule?.safeDispatch;
+    if (typeof fn === "function") {
+      fn("statSelected");
     }
   } catch (err) {
     console.error("Error dispatching statSelected", err);


### PR DESCRIPTION
## Task Contract
- **Inputs**: Existing `selectStat` implementation in `src/pages/battleCLI/init.js`, CLI keyboard handler tests.
- **Outputs**: Updated synchronous dispatch invocation and passing keyboard handler test run.
- **Success Criteria**: `selectStat` triggers `safeDispatch("statSelected")` in the same tick without dynamic import noise; keyboard handler tests observe synchronous dispatch and continue to pass.
- **Failure Modes**: `safeDispatch` not invoked synchronously, loss of spy visibility on the export, or regression in `battleCLI.onKeyDown` tests.

## Summary
- Invoke the exported `safeDispatch` directly from `selectStat` to keep stat selection dispatch synchronous while preserving spy access via the module namespace.
- Remove the microtask scheduling wrapper and its associated `[TEST LOG]` console noise introduced by the dynamic import path.

## Testing
- `npx vitest run tests/pages/battleCLI.onKeyDown.test.js`

## Files Changed
- `src/pages/battleCLI/init.js`

## Risk
- Low: change narrows dispatch timing but relies on existing synchronous-safe helper.


------
https://chatgpt.com/codex/tasks/task_e_68d668d65a5c8326a35dbc7ac0c66d23