### PR TITLE
Align PRD viewer references with implementation anchor

### DIFF
--- a/design/productRequirementsDocuments/prdPRDViewer.md
+++ b/design/productRequirementsDocuments/prdPRDViewer.md
@@ -110,6 +110,14 @@ Non-technical stakeholders struggle even more with raw markdown formatting, lead
 - Requires an up-to-date file list from the `design/productRequirementsDocuments` directory.
 - Deep-linking uses the `?doc=` query parameter so URLs can bookmark a specific PRD.
 
+### Implementation notes
+
+- History helpers in `src/helpers/prdReader/history.js` coordinate URL updates. Initial loads call `replaceHistory` to
+  canonicalize the `?doc=` parameter without polluting the stack, while in-app navigation uses `pushHistory` so browser
+  back/forward buttons step through the same document order as the sidebar.
+- The viewer binds `popstate` events through `bindHistory`, ensuring sidebar selection and the main content stay in sync
+  when users navigate via the browser chrome or external history controls.
+
 ---
 
 ## Mockups / Visual Reference

--- a/docs/product-docs.md
+++ b/docs/product-docs.md
@@ -1,9 +1,0 @@
-# Product Requirements Document Reader
-
-The PRD reader lists available specifications in a sidebar and renders
-documents into the main content area. Keyboard arrows, swipe gestures and
-explicit navigation buttons move between documents while preserving the URL and
-browser history.
-
-History updates are managed by `src/helpers/prdReader/history.js` which provides
-helpers to push or replace state and to react to `popstate` events.

--- a/progressRefactor.md
+++ b/progressRefactor.md
@@ -20,7 +20,7 @@ Produce a small, actionable plan to make `design/productRequirementsDocuments/` 
 - `docs/testing-guide.md` / `docs/validation-commands.md` / `docs/TestValuePolicy.md` → `prdTestingStandards.md` plus `prdCodeStandards.md` (exists; ensure evaluation rubrics and command matrix live in PRDs).
 - `docs/components.md` → `prdUIDesignSystem.md` (exists).
 - `docs/roundUI.md` → `prdBattleMarkup.md` or `prdUIDesignSystem.md` (decide based on whether the content is markup contract vs component style guidance).
-- `docs/product-docs.md` → `prdPRDViewer.md` (exists).
+- Former `docs/product-docs.md` content now lives in `design/productRequirementsDocuments/prdPRDViewer.md#implementation-notes` (exists).
 - `docs/technical/architecture.md` / `design/architecture.md` → `prdArchitecture.md` (exists; collapse duplicate Markdown after integrating callouts).
 - `docs/technical/battleMarkup.md` / `design/battleMarkup.md` → `prdBattleMarkup.md` (exists; treat Markdown as temporary appendix until canonical schema lives in PRD).
 - `docs/technical/dataSchemas.md` → `prdDataSchemas.md` (exists).
@@ -61,8 +61,8 @@ Below are the unmapped documents discovered in the inventory scan with a recomme
   - Action: Assimilate (migrate component descriptions and examples into PRD appendix)
   - Rationale: Component-level guidance supports the UI design system and should be consolidated under `prdUIDesignSystem.md`.
 
-- `docs/product-docs.md` -> `prdPRDViewer.md`
-  - Action: Stub (create redirect stub pointing to `prdPRDViewer.md` and note owner)
+- Former `docs/product-docs.md` content lives in `design/productRequirementsDocuments/prdPRDViewer.md#implementation-notes`
+  - Action: Stub (create redirect stub pointing to the implementation-notes anchor and note owner)
   - Rationale: This is documentation about product docs themselves; the PRD viewer PRD is the natural owner.
 
 - `docs/rag-system.md` -> `prdVectorDatabaseRAG.md`

--- a/reports/prd-mapping-report.csv
+++ b/reports/prd-mapping-report.csv
@@ -2,7 +2,7 @@
 "docs/battle-cli.md","prdBattleCLI.md"
 "docs/battleCLI.md","prdBattleCLI.md"
 "docs/components.md",""
-"docs/product-docs.md",""
+"docs/product-docs.md","design/productRequirementsDocuments/prdPRDViewer.md#implementation-notes"
 "docs/rag-system.md",""
 "docs/round-selection.md","prdRoundSelection.md"
 "docs/roundUI.md",""

--- a/reports/prd-mapping-report.json
+++ b/reports/prd-mapping-report.json
@@ -17,7 +17,7 @@
   },
   {
     "source": "docs/product-docs.md",
-    "mappedTo": null
+    "mappedTo": "design/productRequirementsDocuments/prdPRDViewer.md#implementation-notes"
   },
   {
     "source": "docs/rag-system.md",


### PR DESCRIPTION
## Summary
- add an implementation notes subsection to the PRD Viewer PRD detailing the history helper behavior
- retarget progress reports and mapping data from docs/product-docs.md to the PRD implementation-notes anchor
- remove the obsolete docs/product-docs.md stub now that the PRD owns the guidance

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d671e085a883269e2c73e0d3b6ffee