### PR TITLE
Defer battle CLI stat selection to microtask

### DIFF
--- a/src/pages/battleCLI/init.js
+++ b/src/pages/battleCLI/init.js
@@ -1755,10 +1755,9 @@ export function handleWaitingForPlayerActionKey(key) {
       showHint("Use 1-5, press H for help");
       return true;
     }
-    // Trigger stat selection immediately so DOM reflects the change synchronously.
-    // This trades the prior microtask defer for instant feedback—keep selectStat light
-    // enough to avoid introducing input lag in this hot path.
-    selectStat(stat);
+    // Schedule stat selection on a microtask so the DOM updates remain observable
+    // while matching the deferral behavior expected by latency-sensitive tests.
+    __scheduleMicrotask(() => selectStat(stat));
     return true;
   }
   if (key === "enter") {


### PR DESCRIPTION
## Summary
- schedule stat selection from digit key presses through the microtask helper to restore deferred execution

## Testing
- npx vitest run tests/pages/battleCLI/inputLatencyHardened.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d67698e11c8326996241e93b1d6902