### PR TITLE
Refactor verbose CLI test to use setupFlags helper

### DIFF
--- a/tests/pages/battleCLI.verboseVisibility.test.js
+++ b/tests/pages/battleCLI.verboseVisibility.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { loadBattleCLI, cleanupBattleCLI } from "./utils/loadBattleCLI.js";
+import { setupFlags } from "../../src/pages/index.js";
 
 describe("battleCLI verbose mode visibility", () => {
   beforeEach(async () => {
@@ -13,6 +14,7 @@ describe("battleCLI verbose mode visibility", () => {
   it("shows verbose section and sets focus when verbose is enabled", async () => {
     const mod = await loadBattleCLI();
     await mod.init();
+    const { toggleVerbose } = await setupFlags();
 
     // Get the verbose elements
     const checkbox = document.getElementById("verbose-toggle");
@@ -24,17 +26,15 @@ describe("battleCLI verbose mode visibility", () => {
     expect(log).toBeTruthy();
 
     // Initially, verbose should be disabled
+    expect(checkbox.checked).toBe(false);
     expect(section.hidden).toBe(true);
     expect(section.getAttribute("aria-expanded")).toBe("false");
 
-    // Enable verbose by checking the checkbox
-    checkbox.checked = true;
-    checkbox.dispatchEvent(new Event("change"));
-
-    // Wait for the async toggle to complete
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // Enable verbose using the internal toggle helper
+    await toggleVerbose(true);
 
     // Now verbose section should be visible and expanded
+    expect(checkbox.checked).toBe(true);
     expect(section.hidden).toBe(false);
     expect(section.getAttribute("aria-expanded")).toBe("true");
 
@@ -45,24 +45,23 @@ describe("battleCLI verbose mode visibility", () => {
   it("hides verbose section when verbose is disabled", async () => {
     const mod = await loadBattleCLI();
     await mod.init();
+    const { toggleVerbose } = await setupFlags();
 
     // Get the verbose elements
     const checkbox = document.getElementById("verbose-toggle");
     const section = document.getElementById("cli-verbose-section");
 
     // Enable verbose first
-    checkbox.checked = true;
-    checkbox.dispatchEvent(new Event("change"));
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await toggleVerbose(true);
 
+    expect(checkbox.checked).toBe(true);
     expect(section.hidden).toBe(false);
 
     // Disable verbose
-    checkbox.checked = false;
-    checkbox.dispatchEvent(new Event("change"));
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await toggleVerbose(false);
 
     // Now verbose section should be hidden
+    expect(checkbox.checked).toBe(false);
     expect(section.hidden).toBe(true);
     expect(section.getAttribute("aria-expanded")).toBe("false");
   });


### PR DESCRIPTION
## Summary
- import the setupFlags helper into the verbose visibility test
- use the toggleVerbose routine instead of dispatching change events and timeouts while keeping checkbox assertions

## Testing
- npx vitest run tests/pages/battleCLI.verboseVisibility.test.js *(fails: esbuild reports "The symbol \"initModule\" has already been declared" in src/pages/battleCLI/init.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d99b06488326bcc176869c05b532