### PR TITLE
Add match completion helper and streamline Playwright end modal spec

### DIFF
--- a/playwright/battle-classic/end-modal.spec.js
+++ b/playwright/battle-classic/end-modal.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from "../fixtures/commonSetup.js";
 import { withMutedConsole } from "../../tests/utils/console.js";
-import { waitForModalOpen, waitForNextRoundReadyEvent } from "../fixtures/waits.js";
+import { waitForModalOpen } from "../fixtures/waits.js";
 import { waitForRoundStats } from "../helpers/battleStateHelper.js";
 
 async function waitForBattleInitialization(page) {
@@ -222,524 +222,43 @@ async function selectAdvantagedStat(page) {
   await fallbackButton.click();
 }
 
-async function waitForScoreDisplay(page, { timeout = 10000, previousObservation = null } = {}) {
-  const readScores = () =>
-    page.evaluate(async (previous) => {
-      const helper = window.__classicQuickWin;
-      let facade = helper?.facade ?? null;
-
-      if (!facade && helper?.ensureFacade) {
-        try {
-          facade = await helper.ensureFacade();
-        } catch {}
-      }
-
-      if (!facade) {
-        try {
-          facade = await import("/src/helpers/battleEngineFacade.js");
-          if (helper) {
-            helper.facade = facade;
-          }
-        } catch {
-          facade = null;
-        }
-      }
-
-      const getScores = typeof facade?.getScores === "function" ? facade.getScores : null;
-      if (!getScores) {
-        return false;
-      }
-
-      let engineScores = null;
-      let matchEnded = false;
-      try {
-        engineScores = getScores();
-        matchEnded =
-          typeof facade?.isMatchEnded === "function"
-            ? facade.isMatchEnded()
-            : (() => {
-                try {
-                  return facade.requireEngine?.().matchEnded === true;
-                } catch {
-                  return false;
-                }
-              })();
-      } catch {
-        return false;
-      }
-
-      let player = Number(engineScores?.playerScore ?? engineScores?.player ?? NaN);
-      let opponent = Number(engineScores?.opponentScore ?? engineScores?.opponent ?? NaN);
-
-      if (!Number.isFinite(player) || !Number.isFinite(opponent)) {
-        try {
-          const scoreNode = document.getElementById("score-display");
-          if (!scoreNode) {
-            return false;
-          }
-          const text = scoreNode.textContent || "";
-          const match = text.match(/You:\s*(\d+)[\s\S]*Opponent:\s*(\d+)/i);
-          if (!match) {
-            return false;
-          }
-          player = Number(match[1]);
-          opponent = Number(match[2]);
-        } catch {
-          return false;
-        }
-      }
-
-      let roundNumber = null;
-      try {
-        const counter = document.getElementById("round-counter");
-        if (counter) {
-          const roundMatch = counter.textContent?.match(/(\d+)/);
-          if (roundMatch) {
-            const parsed = Number(roundMatch[1]);
-            if (Number.isFinite(parsed)) {
-              roundNumber = parsed;
-            }
-          }
-          if (roundNumber === null) {
-            const highest = Number(counter.dataset?.highestRound);
-            if (Number.isFinite(highest)) {
-              roundNumber = highest;
-            }
-          }
-        }
-      } catch {}
-
-      if (
-        previous &&
-        typeof previous === "object" &&
-        previous !== null &&
-        roundNumber === previous.roundNumber &&
-        player === previous.player &&
-        opponent === previous.opponent
-      ) {
-        if (matchEnded) {
-          return { player, opponent, roundNumber, matchEnded };
-        }
-        return previous.matchEnded ? previous : false;
-      }
-
-      return { player, opponent, roundNumber, matchEnded };
-    }, previousObservation);
-
-  let snapshot = null;
-  const pollScores = async () => {
-    const result = await readScores();
-    if (result && typeof result === "object") {
-      snapshot = result;
-      return true;
+async function resolveMatchFromCurrentRound(page, { timeout = 15000 } = {}) {
+  const matchPromise = page.evaluate((limit) => {
+    const api = window.__TEST_API?.state;
+    if (!api?.waitForMatchCompletion) {
+      throw new Error("waitForMatchCompletion helper unavailable");
     }
-    return false;
+    return api.waitForMatchCompletion(limit);
+  }, timeout);
+
+  await selectAdvantagedStat(page);
+
+  const match = await matchPromise;
+  if (!match) {
+    throw new Error("Failed to observe match completion payload.");
+  }
+  if (match.timedOut) {
+    throw new Error("Match did not conclude before timeout.");
+  }
+
+  const detailScores = match.scores ?? match.detail?.scores ?? null;
+  if (!detailScores) {
+    throw new Error("Match completion payload did not include scores.");
+  }
+
+  const normalizedScores = {
+    player: Number(detailScores.player),
+    opponent: Number(detailScores.opponent)
   };
 
-  await expect.poll(pollScores, { timeout }).toBeTruthy();
-
-  if (!snapshot) {
-    const fallback = await readScores();
-    if (fallback && typeof fallback === "object") {
-      snapshot = fallback;
-    }
+  if (!Number.isFinite(normalizedScores.player) || !Number.isFinite(normalizedScores.opponent)) {
+    throw new Error("Match completion payload contained non-numeric scores.");
   }
 
-  if (!snapshot) {
-    throw new Error("Failed to observe score update from battle engine.");
-  }
-
-  return snapshot;
-}
-
-async function readDomScoreSnapshot(page) {
-  return page.evaluate(() => {
-    const parseScore = (value) => {
-      if (typeof value === "number" && Number.isFinite(value)) return value;
-      if (typeof value === "string") {
-        const parsed = Number(value.trim());
-        return Number.isFinite(parsed) ? parsed : null;
-      }
-      return null;
-    };
-
-    const pickNumber = (source, keys) => {
-      if (!source || typeof source !== "object") return null;
-      for (const key of keys) {
-        const parsed = parseScore(source[key]);
-        if (parsed !== null) return parsed;
-      }
-      return null;
-    };
-
-    const node = document.getElementById("score-display");
-    if (!node) return null;
-
-    const dataset = node.dataset ?? {};
-    const player = pickNumber(dataset, ["player", "playerScore", "you", "user"]);
-    const opponent = pickNumber(dataset, ["opponent", "opponentScore", "cpu", "enemy"]);
-
-    if (player !== null && opponent !== null) {
-      const endedAttr = dataset.matchEnded ?? node.getAttribute?.("data-match-ended");
-      const ended =
-        typeof endedAttr === "boolean"
-          ? endedAttr
-          : typeof endedAttr === "string"
-            ? endedAttr.trim().toLowerCase() === "true"
-            : null;
-      return { player, opponent, matchEnded: ended, domInferred: ended };
-    }
-
-    const textContent = node.textContent || "";
-    const match = textContent.match(/You:[^0-9]*([0-9]+)[\s\S]*?Opponent:[^0-9]*([0-9]+)/i);
-    if (match) {
-      return {
-        player: Number(match[1]),
-        opponent: Number(match[2]),
-        matchEnded: null,
-        domInferred: null
-      };
-    }
-
-    return null;
-  });
-}
-
-function normalizeStoreSnapshot(rawSnapshot) {
-  if (!rawSnapshot || typeof rawSnapshot !== "object") {
-    return null;
-  }
-  const player = Number(rawSnapshot.player);
-  const opponent = Number(rawSnapshot.opponent);
-  if (!Number.isFinite(player) || !Number.isFinite(opponent)) {
-    return null;
-  }
-  const matchEnded =
-    typeof rawSnapshot.ended === "boolean"
-      ? rawSnapshot.ended
-      : typeof rawSnapshot.ended === "string"
-        ? /^(true|1|yes|on)$/i.test(rawSnapshot.ended.trim())
-        : null;
-  return { player, opponent, matchEnded, domInferred: null };
-}
-
-async function readStoreScoreSnapshot(page) {
-  const rawSnapshot = await page.evaluate(() => {
-    try {
-      const store = window.__TEST_API?.inspect?.getBattleStore?.() ?? window.battleStore;
-      if (!store || typeof store !== "object") return null;
-
-      const pickFirst = (source, keys) => {
-        if (!source || typeof source !== "object") return null;
-        for (const key of keys) {
-          const value = source[key];
-          if (value !== undefined && value !== null) {
-            return value;
-          }
-        }
-        return null;
-      };
-
-      const scoreCandidates = [
-        store.scoreboard,
-        store.scores,
-        store.score,
-        store.currentScore,
-        store.engine?.scoreboard,
-        store.engine?.scores
-      ];
-
-      for (const candidate of scoreCandidates) {
-        if (!candidate || typeof candidate !== "object") continue;
-
-        const player = pickFirst(candidate, [
-          "player",
-          "playerScore",
-          "you",
-          "user",
-          "playerPoints"
-        ]);
-        const opponent = pickFirst(candidate, [
-          "opponent",
-          "opponentScore",
-          "cpu",
-          "enemy",
-          "opponentPoints"
-        ]);
-
-        if (player !== null && opponent !== null) {
-          const ended =
-            candidate.matchEnded ??
-            candidate.completed ??
-            candidate.matchComplete ??
-            candidate.finished ??
-            null;
-          return { player, opponent, ended };
-        }
-      }
-    } catch (error) {
-      if (typeof console !== "undefined" && typeof console.debug === "function") {
-        console.debug("[test] readStoreScoreSnapshot failed:", error?.message ?? error);
-      }
-    }
-    return null;
-  });
-
-  return normalizeStoreSnapshot(rawSnapshot);
-}
-
-async function readScoreSnapshot(page, previousScores = null) {
-  const domSnapshot = await readDomScoreSnapshot(page);
-  if (domSnapshot) {
-    return domSnapshot;
-  }
-
-  if (previousScores && typeof previousScores === "object") {
-    const player = Number(previousScores.player);
-    const opponent = Number(previousScores.opponent);
-    if (Number.isFinite(player) && Number.isFinite(opponent)) {
-      const ended =
-        typeof previousScores.matchEnded === "boolean" ? previousScores.matchEnded : null;
-      return { player, opponent, matchEnded: ended, domInferred: null };
-    }
-  }
-
-  const storeSnapshot = await readStoreScoreSnapshot(page);
-  if (storeSnapshot) {
-    return storeSnapshot;
-  }
-
-  return { player: null, opponent: null, matchEnded: null, domInferred: null };
-}
-
-async function readModalVisibility(page) {
-  return page.evaluate(() => {
-    const modal = document.getElementById("match-end-modal");
-    if (!modal) {
-      return false;
-    }
-    const style =
-      typeof window.getComputedStyle === "function" ? window.getComputedStyle(modal) : null;
-    if (!style) {
-      return false;
-    }
-    const opacity = Number(style.opacity);
-    const fullyTransparent = Number.isFinite(opacity) && opacity <= 0.01;
-    return (
-      modal.hidden !== true &&
-      style.display !== "none" &&
-      style.visibility !== "hidden" &&
-      style.pointerEvents !== "none" &&
-      !fullyTransparent
-    );
-  });
-}
-
-async function readRoundResolvingFlag(page) {
-  return page.evaluate(() => {
-    try {
-      const store = window.__TEST_API?.inspect?.getBattleStore?.() ?? window.battleStore;
-      const round = store?.round ?? store?.currentRound ?? null;
-      return round?.resolving === true;
-    } catch {
-      return false;
-    }
-  });
-}
-
-async function readEngineMatchEndState(page) {
-  return page.evaluate(() => {
-    try {
-      const store = window.__TEST_API?.inspect?.getBattleStore?.() ?? window.battleStore;
-      const engine = store?.engine;
-      if (!engine) {
-        return null;
-      }
-      if (typeof engine.isMatchEnded === "function") {
-        return engine.isMatchEnded() === true;
-      }
-      if (typeof engine.matchEnded === "boolean") {
-        return engine.matchEnded;
-      }
-      if (typeof store?.matchEnded === "boolean") {
-        return store.matchEnded;
-      }
-    } catch {}
-    return null;
-  });
-}
-
-async function readRoundOutcomeState(page, { previousScores = null } = {}) {
-  const scoreState = await readScoreSnapshot(page, previousScores);
-  const [modalVisible, roundResolving] = await Promise.all([
-    readModalVisibility(page),
-    readRoundResolvingFlag(page)
-  ]);
-
-  let matchEnded = false;
-
-  if (typeof scoreState.domInferred === "boolean") {
-    matchEnded = scoreState.domInferred;
-  } else if (typeof scoreState.matchEnded === "boolean") {
-    matchEnded = scoreState.matchEnded;
-  } else if (modalVisible) {
-    matchEnded = true;
-  } else {
-    const engineEnded = await readEngineMatchEndState(page);
-    matchEnded = engineEnded === true;
-  }
-
-  const hasScores = Number.isFinite(scoreState.player) && Number.isFinite(scoreState.opponent);
-  const scores = hasScores
-    ? {
-        player: Number(scoreState.player),
-        opponent: Number(scoreState.opponent),
-        matchEnded
-      }
-    : null;
-
-  return { matchEnded, modalVisible, roundResolving, scores };
-}
-
-async function waitForMatchCompletion(page, timeout = 15000) {
-  await expect
-    .poll(
-      async () => {
-        const state = await readRoundOutcomeState(page);
-        if (!state.matchEnded) {
-          return false;
-        }
-        if (state.modalVisible) {
-          return true;
-        }
-        return !state.roundResolving;
-      },
-      { timeout }
-    )
-    .toBeTruthy();
-}
-
-/**
- * @pseudocode
- * WAIT for the scoreboard to report the current totals.
- * IF either side has scored, RETURN the scores.
- * OTHERWISE reset the "next round" readiness flag and wait for the next round event.
- * CLICK the next button and choose a favourable stat for the player.
- * REPEAT until a decisive score is observed or the maximum number of rounds is exceeded.
- * THROW with diagnostics when no decisive score is produced.
- */
-async function resolveMatchFromCurrentRound(page, { maxRounds = 5, nextTimeout = 5000 } = {}) {
-  let lastScores = await waitForScoreDisplay(page);
-
-  const resolveIfDecisive = (snapshot = lastScores) => {
-    if (!snapshot) {
-      return null;
-    }
-    if (snapshot.matchEnded || snapshot.player + snapshot.opponent >= 1) {
-      return { player: snapshot.player, opponent: snapshot.opponent };
-    }
-    return null;
+  return {
+    ...match,
+    scores: normalizedScores
   };
-
-  const initialResolution = resolveIfDecisive(lastScores);
-  if (initialResolution) {
-    return initialResolution;
-  }
-
-  for (let attempt = 0; attempt < maxRounds; attempt += 1) {
-    const scores = await waitForScoreDisplay(page, { previousObservation: lastScores });
-    if (scores) {
-      lastScores = scores;
-      const roundResult = resolveIfDecisive(scores);
-      if (roundResult) {
-        return roundResult;
-      }
-    } else {
-      const fallbackResolution = resolveIfDecisive();
-      if (fallbackResolution) {
-        return fallbackResolution;
-      }
-    }
-
-    await expect
-      .poll(
-        async () => {
-          const state = await readRoundOutcomeState(page, { previousScores: lastScores });
-          if (
-            state.scores &&
-            Number.isFinite(state.scores.player) &&
-            Number.isFinite(state.scores.opponent)
-          ) {
-            lastScores = state.scores;
-          }
-          return !state.modalVisible && !state.roundResolving;
-        },
-        { timeout: nextTimeout }
-      )
-      .toBeTruthy();
-
-    const postModalResolution = resolveIfDecisive(lastScores);
-    if (postModalResolution) {
-      return postModalResolution;
-    }
-
-    await page.evaluate(() => {
-      if (typeof window !== "undefined") {
-        window.__nextReadySeen = false;
-        window.__nextReadyInit = false;
-      }
-    });
-
-    const outcomeState = await readRoundOutcomeState(page, { previousScores: lastScores });
-    if (outcomeState.scores) {
-      lastScores = outcomeState.scores;
-    }
-
-    if (outcomeState.matchEnded) {
-      return (
-        resolveIfDecisive(lastScores) ?? {
-          player: lastScores?.player ?? 0,
-          opponent: lastScores?.opponent ?? 0
-        }
-      );
-    }
-
-    await waitForNextRoundReadyEvent(page, nextTimeout);
-    const nextButton = page
-      .locator("#next-button, [data-role='next-round'], [data-testid='next-button']")
-      .first();
-    await expect(nextButton).toBeVisible();
-    await expect(nextButton).toBeEnabled();
-    await nextButton.click();
-
-    const nextReadySettled = await page.evaluate(async (limit) => {
-      const waitForReady = window.__TEST_API?.state?.waitForNextButtonReady;
-      if (typeof waitForReady === "function") {
-        return waitForReady(limit);
-      }
-      return null;
-    }, nextTimeout);
-
-    const postClickResolution = resolveIfDecisive();
-    if (postClickResolution) {
-      return postClickResolution;
-    }
-
-    if (nextReadySettled === false) {
-      throw new Error("Next round button did not become ready before timeout.");
-    }
-
-    await page.waitForSelector("#stat-buttons button[data-stat]");
-    await selectAdvantagedStat(page);
-  }
-
-  const diagnostic =
-    lastScores && typeof lastScores === "object"
-      ? `You: ${lastScores.player}, Opponent: ${lastScores.opponent}`
-      : "unknown";
-  throw new Error(
-    `Match did not resolve within expected rounds (attempted ${maxRounds}). Last observed scores: ${diagnostic}`
-  );
 }
 
 function expectDecisiveFinalScore(scores) {
@@ -762,11 +281,10 @@ test.describe("Classic Battle End Game Flow", () => {
         // Wait for cards and stat buttons
         await page.waitForSelector("#stat-buttons button[data-stat]");
 
-        // Choose a stat with a deterministic advantage for the player
-        await selectAdvantagedStat(page);
-
-        const scores = await resolveMatchFromCurrentRound(page);
-        await waitForMatchCompletion(page);
+        // Resolve the round using the deterministic stat selection helper
+        const match = await resolveMatchFromCurrentRound(page);
+        const { scores } = match;
+        expect(match.timedOut).toBe(false);
 
         // Verify match completion
         const scoreDisplay = page.locator("#score-display");
@@ -775,6 +293,7 @@ test.describe("Classic Battle End Game Flow", () => {
         expectDecisiveFinalScore(scores);
 
         // Confirm the match end modal is presented to the user
+        expect(match.dom?.modal?.visible).toBe(true);
         await waitForModalOpen(page);
         const matchEndModal = page.locator("#match-end-modal").first();
         await expect(matchEndModal).toBeVisible();
@@ -801,10 +320,10 @@ test.describe("Classic Battle End Game Flow", () => {
         await page.click("#round-select-2");
         await applyQuickWinTarget(page);
         await page.waitForSelector("#stat-buttons button[data-stat]");
-        await selectAdvantagedStat(page);
 
-        const scores = await resolveMatchFromCurrentRound(page);
-        await waitForMatchCompletion(page);
+        const match = await resolveMatchFromCurrentRound(page);
+        const { scores } = match;
+        expect(match.timedOut).toBe(false);
 
         // Verify score display shows completion
         const scoreDisplay = page.locator("#score-display");
@@ -830,10 +349,10 @@ test.describe("Classic Battle End Game Flow", () => {
         await page.click("#round-select-2");
         await applyQuickWinTarget(page);
         await page.waitForSelector("#stat-buttons button[data-stat]");
-        await selectAdvantagedStat(page);
 
-        const scores = await resolveMatchFromCurrentRound(page);
-        await waitForMatchCompletion(page);
+        const match = await resolveMatchFromCurrentRound(page);
+        const { scores } = match;
+        expect(match.timedOut).toBe(false);
 
         // Verify match ended
         const scoreDisplay = page.locator("#score-display");
@@ -870,10 +389,10 @@ test.describe("Classic Battle End Game Flow", () => {
         await page.click("#round-select-2");
         await applyQuickWinTarget(page);
         await page.waitForSelector("#stat-buttons button[data-stat]");
-        await selectAdvantagedStat(page);
 
-        const scores = await resolveMatchFromCurrentRound(page);
-        await waitForMatchCompletion(page);
+        const match = await resolveMatchFromCurrentRound(page);
+        const { scores } = match;
+        expect(match.timedOut).toBe(false);
         expect(errors.length).toBe(0);
 
         // Verify match completed successfully
@@ -896,10 +415,10 @@ test.describe("Classic Battle End Game Flow", () => {
         await page.click("#round-select-2");
         await applyQuickWinTarget(page);
         await page.waitForSelector("#stat-buttons button[data-stat]");
-        await selectAdvantagedStat(page);
 
-        const scores = await resolveMatchFromCurrentRound(page);
-        await waitForMatchCompletion(page);
+        const match = await resolveMatchFromCurrentRound(page);
+        const { scores } = match;
+        expect(match.timedOut).toBe(false);
 
         // Verify score display is clear and readable
         const scoreDisplay = page.locator("#score-display");
@@ -922,10 +441,10 @@ test.describe("Classic Battle End Game Flow", () => {
         await page.click("#round-select-2");
         await applyQuickWinTarget(page);
         await page.waitForSelector("#stat-buttons button[data-stat]");
-        await selectAdvantagedStat(page);
 
-        const scores = await resolveMatchFromCurrentRound(page);
-        await waitForMatchCompletion(page);
+        const match = await resolveMatchFromCurrentRound(page);
+        const { scores } = match;
+        expect(match.timedOut).toBe(false);
 
         // Verify match completed
         const scoreDisplay = page.locator("#score-display");
@@ -956,10 +475,10 @@ test.describe("Classic Battle End Game Flow", () => {
         await page.click("#round-select-2");
         await applyQuickWinTarget(page);
         await page.waitForSelector("#stat-buttons button[data-stat]");
-        await selectAdvantagedStat(page);
 
-        const scores = await resolveMatchFromCurrentRound(page);
-        await waitForMatchCompletion(page);
+        const match = await resolveMatchFromCurrentRound(page);
+        const { scores } = match;
+        expect(match.timedOut).toBe(false);
         expect(errors.length).toBe(0);
 
         // Verify match completed without throwing errors
@@ -977,9 +496,9 @@ test.describe("Classic Battle End Game Flow", () => {
         await page.click("#round-select-2");
         await applyQuickWinTarget(page);
         await page.waitForSelector("#stat-buttons button[data-stat]");
-        await selectAdvantagedStat(page);
-        const scores = await resolveMatchFromCurrentRound(page);
-        await waitForMatchCompletion(page);
+        const match = await resolveMatchFromCurrentRound(page);
+        const { scores } = match;
+        expect(match.timedOut).toBe(false);
 
         const scoreDisplay = page.locator("#score-display");
         await expect(scoreDisplay).toContainText(`You: ${scores.player}`);


### PR DESCRIPTION
## Summary
- add a waitForMatchCompletion helper to the battle test API that normalizes match.concluded payloads and captures UI state
- refactor the classic battle end modal Playwright spec to resolve matches via the new helper instead of polling loops
- assert modal visibility and score expectations using the emitted match payload for faster, event-driven checks

## Testing
- npx playwright test playwright/battle-classic/end-modal.spec.js --reporter=list

------
https://chatgpt.com/codex/tasks/task_e_68d6d9aff588832696061816cdd9890a