### PR TITLE
Remove unused helper from opponent reveal Playwright spec

### DIFF
--- a/playwright/battle-classic/opponent-reveal.spec.js
+++ b/playwright/battle-classic/opponent-reveal.spec.js
@@ -202,15 +202,6 @@ async function startMatch(page, selector) {
   }
 }
 
-async function expireSelectionTimer(page) {
-  const expired = await page.evaluate(() => {
-    return window.__TEST_API?.timers?.expireSelectionTimer?.() ?? null;
-  });
-
-  expect(expired).not.toBeNull();
-  expect(expired).toBe(true);
-}
-
 /**
  * Convenience helper to start a match and wait for stat availability.
  * @pseudocode


### PR DESCRIPTION
## Summary
- remove the unused expireSelectionTimer helper from the opponent reveal Playwright spec

## Testing
- npx eslint playwright/battle-classic/opponent-reveal.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d6fa74e0c48326ae2eb485f13945ef