### PR TITLE
Align round reset number with initial state

### DIFF
--- a/src/helpers/classicBattle/roundStore.js
+++ b/src/helpers/classicBattle/roundStore.js
@@ -236,7 +236,7 @@ class RoundStore {
    */
   reset() {
     this.currentRound = {
-      number: 1,
+      number: 0,
       state: "waitingForMatchStart",
       selectedStat: undefined,
       outcome: undefined,

--- a/tests/unit/roundStore.reset.spec.js
+++ b/tests/unit/roundStore.reset.spec.js
@@ -10,7 +10,7 @@ describe("RoundStore.reset()", () => {
     roundStore.reset();
   });
 
-  it("resets roundNumber to 1 and clears per-round state", () => {
+  it("resets roundNumber to 0 and clears per-round state", () => {
     roundStore.setRoundNumber(5);
     roundStore.setRoundState("roundStart");
     roundStore.setSelectedStat("speed", { emitLegacyEvent: false });
@@ -20,7 +20,7 @@ describe("RoundStore.reset()", () => {
     roundStore.reset();
 
     const state = roundStore.getStateSnapshot();
-    expect(state.currentRound.number).toBe(1);
+    expect(state.currentRound.number).toBe(0);
     expect(state.currentRound.state).toBe("waitingForMatchStart");
     expect(state.currentRound.selectedStat).toBeUndefined();
     expect(state.currentRound.outcome).toBeUndefined();


### PR DESCRIPTION
## Summary
- align the RoundStore reset state with the constructor so the round number returns to 0
- update the reset unit test expectation to reflect the consistent pre-match round number

## Testing
- npx vitest run tests/unit/roundStore.test.js tests/unit/roundStore.reset.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d6fb9505e883268975b128344f8f14