### PR TITLE
Align round store baseline with first round

### DIFF
--- a/src/helpers/classicBattle/roundStore.js
+++ b/src/helpers/classicBattle/roundStore.js
@@ -44,7 +44,7 @@ class RoundStore {
   constructor() {
     /** @type {RoundData} */
     this.currentRound = {
-      number: 0,
+      number: 1,
       state: "waitingForMatchStart"
     };
 
@@ -234,14 +234,14 @@ class RoundStore {
    * Reset store to initial state.
    *
    * @pseudocode
-   * 1. Restore the constructor baseline (round 0 waiting state).
+   * 1. Restore the constructor baseline (round 1 waiting state).
    * 2. Clear readiness flags, callbacks, and transition log entries.
    *
-   * Ensures the engine and scoreboard both reflect the pre-match round 0 state.
+   * Ensures the engine and scoreboard both reflect the pre-match round 1 state.
    */
   reset() {
     this.currentRound = {
-      number: 0,
+      number: 1,
       state: "waitingForMatchStart",
       selectedStat: undefined,
       outcome: undefined,

--- a/tests/unit/roundStore.test.js
+++ b/tests/unit/roundStore.test.js
@@ -19,9 +19,9 @@ describe("RoundStore", () => {
   });
 
   describe("initial state", () => {
-    it("should start with round 0 and waitingForMatchStart state", () => {
+    it("should start with the initial round and waitingForMatchStart state", () => {
       const round = roundStore.getCurrentRound();
-      expect(round.number).toBe(0);
+      expect(round.number).toBe(1);
       expect(round.state).toBe("waitingForMatchStart");
     });
 
@@ -165,7 +165,7 @@ describe("RoundStore", () => {
 
       roundStore.setRoundNumber(2);
 
-      expect(callback).toHaveBeenCalledWith(2, 0);
+      expect(callback).toHaveBeenCalledWith(2, 1);
     });
 
     it("should call stat selected callback", () => {


### PR DESCRIPTION
## Summary
- update the round store baseline so resets start from round 1
- adjust the round store unit tests to assert the new starting round and callback arguments

## Testing
- npx vitest tests/unit/roundStore.test.js --run

------
https://chatgpt.com/codex/tasks/task_e_68d7057995d0832695ee6f52a5ccf371