### PR TITLE
Add clearRoundCounter stubs to scoreboard mocks

### DIFF
--- a/tests/helpers/CooldownRenderer.test.js
+++ b/tests/helpers/CooldownRenderer.test.js
@@ -65,7 +65,9 @@ vi.mock("../../src/helpers/showSnackbar.js", () => ({
 
 vi.mock("../../src/helpers/setupScoreboard.js", () => ({
   clearTimer: vi.fn(),
-  updateTimer: vi.fn()
+  updateTimer: vi.fn(),
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
 }));
 
 vi.mock("../../src/helpers/classicBattle/battleEvents.js", () => ({

--- a/tests/helpers/autoSelectStat.min.test.js
+++ b/tests/helpers/autoSelectStat.min.test.js
@@ -3,7 +3,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.doMock("../../src/helpers/setupScoreboard.js", () => ({
   showAutoSelect: vi.fn(),
   updateTimer: vi.fn(),
-  clearTimer: vi.fn()
+  clearTimer: vi.fn(),
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
 }));
 
 describe("autoSelectStat basic path", () => {

--- a/tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js
+++ b/tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js
@@ -25,7 +25,9 @@ describe("skip handler clears fallback timer", () => {
       showMessage: () => {},
       showAutoSelect: () => {},
       showTemporaryMessage: () => () => {},
-      updateTimer: vi.fn()
+      updateTimer: vi.fn(),
+      updateRoundCounter: vi.fn(),
+      clearRoundCounter: vi.fn()
     }));
     vi.doMock("../../../src/helpers/showSnackbar.js", () => ({
       showSnackbar: vi.fn(),

--- a/tests/helpers/classicBattle/debugPanel.test.js
+++ b/tests/helpers/classicBattle/debugPanel.test.js
@@ -28,7 +28,9 @@ vi.mock("../../../src/helpers/showSnackbar.js", () => ({
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   showMessage: vi.fn(),
   clearTimer: vi.fn(),
-  updateTimer: vi.fn()
+  updateTimer: vi.fn(),
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
 }));
 vi.mock("../../../src/helpers/battle/index.js", () => ({ showResult: vi.fn() }));
 vi.mock("../../../src/helpers/classicBattle/selectionHandler.js", () => ({

--- a/tests/helpers/classicBattle/interruptHandlers.test.js
+++ b/tests/helpers/classicBattle/interruptHandlers.test.js
@@ -13,7 +13,9 @@ vi.mock("../../../src/helpers/classicBattle/eventDispatcher.js", () => ({
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   showMessage: vi.fn(),
   clearTimer: vi.fn(),
-  updateTimer: vi.fn()
+  updateTimer: vi.fn(),
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/skipHandler.js", () => ({
   resetSkipState: vi.fn()

--- a/tests/helpers/classicBattle/onTransition.helpers.test.js
+++ b/tests/helpers/classicBattle/onTransition.helpers.test.js
@@ -11,7 +11,9 @@ vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
 }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   clearMessage: vi.fn(),
-  showMessage: vi.fn()
+  showMessage: vi.fn(),
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/debugPanel.js", () => ({
   updateDebugPanel: vi.fn()

--- a/tests/helpers/classicBattle/onTransition.test.js
+++ b/tests/helpers/classicBattle/onTransition.test.js
@@ -11,7 +11,8 @@ vi.mock("../../../src/helpers/classicBattle/roundManager.js", () => ({
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   clearMessage: vi.fn(),
   showMessage: vi.fn(),
-  updateRoundCounter: vi.fn()
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/debugPanel.js", () => ({
   updateDebugPanel: vi.fn()

--- a/tests/helpers/classicBattle/opponentDelay.test.js
+++ b/tests/helpers/classicBattle/opponentDelay.test.js
@@ -28,7 +28,9 @@ beforeEach(() => {
     clearTimer,
     updateTimer: vi.fn(),
     updateScore: vi.fn(),
-    showAutoSelect: vi.fn()
+    showAutoSelect: vi.fn(),
+    updateRoundCounter: vi.fn(),
+    clearRoundCounter: vi.fn()
   }));
 
   vi.mock("../../../src/helpers/showSnackbar.js", () => ({

--- a/tests/helpers/classicBattle/orchestrator.events.test.js
+++ b/tests/helpers/classicBattle/orchestrator.events.test.js
@@ -16,7 +16,8 @@ describe("classic battle orchestrator UI events", () => {
       showMessage,
       clearTimer: vi.fn(),
       updateTimer: vi.fn(),
-      updateRoundCounter: vi.fn()
+      updateRoundCounter: vi.fn(),
+      clearRoundCounter: vi.fn()
     }));
     vi.doMock("../../../src/helpers/classicBattle/debugPanel.js", () => ({
       updateDebugPanel

--- a/tests/helpers/classicBattle/roundResolverOnce.test.js
+++ b/tests/helpers/classicBattle/roundResolverOnce.test.js
@@ -28,7 +28,9 @@ vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
 }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   updateScore: vi.fn(),
-  updateTimer: vi.fn()
+  updateTimer: vi.fn(),
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
 }));
 
 describe.sequential("classicBattle round resolver once", () => {

--- a/tests/helpers/classicBattle/timerService.drift.test.js
+++ b/tests/helpers/classicBattle/timerService.drift.test.js
@@ -19,7 +19,9 @@ describe("timerService drift handling", () => {
       showTemporaryMessage: () => () => {},
       showAutoSelect: vi.fn(),
       clearTimer: vi.fn(),
-      updateTimer: vi.fn()
+      updateTimer: vi.fn(),
+      updateRoundCounter: vi.fn(),
+      clearRoundCounter: vi.fn()
     }));
     vi.doMock("../../../src/helpers/timerUtils.js", () => ({
       getDefaultTimer: () => 30
@@ -46,7 +48,9 @@ describe("timerService drift handling", () => {
       showTemporaryMessage: () => () => {},
       showAutoSelect: vi.fn(),
       clearTimer: vi.fn(),
-      updateTimer: vi.fn()
+      updateTimer: vi.fn(),
+      updateRoundCounter: vi.fn(),
+      clearRoundCounter: vi.fn()
     }));
     vi.doMock("../../../src/helpers/classicBattle/uiHelpers.js", () => ({
       enableNextRoundButton: vi.fn(),

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -16,7 +16,9 @@ describe("timerService next round handling", () => {
       showTemporaryMessage: () => () => {},
       showAutoSelect: vi.fn(),
       clearTimer: vi.fn(),
-      updateTimer: vi.fn()
+      updateTimer: vi.fn(),
+      updateRoundCounter: vi.fn(),
+      clearRoundCounter: vi.fn()
     }));
     vi.doMock("../../../src/helpers/showSnackbar.js", () => ({
       showSnackbar: vi.fn(),

--- a/tests/helpers/classicBattle/timerStateExposure.test.js
+++ b/tests/helpers/classicBattle/timerStateExposure.test.js
@@ -15,7 +15,8 @@ vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   showMessage: vi.fn(),
   clearTimer: vi.fn(),
   updateTimer: vi.fn(),
-  updateRoundCounter: vi.fn()
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
 }));
 vi.mock("../../../src/helpers/classicBattle/debugPanel.js", () => ({
   updateDebugPanel: vi.fn()

--- a/tests/helpers/classicBattlePage.syncScoreDisplay.test.js
+++ b/tests/helpers/classicBattlePage.syncScoreDisplay.test.js
@@ -55,7 +55,9 @@ describe("syncScoreDisplay", () => {
         el.textContent = `You: ${p}\nOpponent: ${o}`;
       },
       clearTimer: vi.fn(),
-      updateTimer: vi.fn()
+      updateTimer: vi.fn(),
+      updateRoundCounter: vi.fn(),
+      clearRoundCounter: vi.fn()
     }));
 
     vi.doMock("../../src/config/loadSettings.js", () => ({

--- a/tests/helpers/integrationHarness.js
+++ b/tests/helpers/integrationHarness.js
@@ -450,7 +450,9 @@ export function createTimerServiceHarness(customConfig = {}) {
         showTemporaryMessage: vi.fn(() => () => {}),
         showAutoSelect: vi.fn(),
         clearTimer: vi.fn(),
-        updateTimer: vi.fn()
+        updateTimer: vi.fn(),
+        updateRoundCounter: vi.fn(),
+        clearRoundCounter: vi.fn()
       }),
       "../../src/helpers/timerUtils.js": () => ({
         getDefaultTimer: () => 30

--- a/tests/helpers/timerService.autoSelect.test.js
+++ b/tests/helpers/timerService.autoSelect.test.js
@@ -14,7 +14,9 @@ describe("timerService with auto-select", () => {
       showMessage: () => {},
       showAutoSelect: () => {},
       showTemporaryMessage: () => () => {},
-      updateTimer: () => {}
+      updateTimer: () => {},
+      updateRoundCounter: () => {},
+      clearRoundCounter: () => {}
     }));
     vi.doMock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
       updateDebugPanel: () => {}

--- a/tests/helpers/timerService.autoSelectDisabled.test.js
+++ b/tests/helpers/timerService.autoSelectDisabled.test.js
@@ -15,7 +15,9 @@ describe("timerService without auto-select", () => {
       showMessage,
       showAutoSelect: () => {},
       showTemporaryMessage: () => () => {},
-      updateTimer: () => {}
+      updateTimer: () => {},
+      updateRoundCounter: () => {},
+      clearRoundCounter: () => {}
     }));
     vi.doMock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
       updateDebugPanel: () => {}

--- a/tests/helpers/timerService.ordering.test.js
+++ b/tests/helpers/timerService.ordering.test.js
@@ -16,7 +16,9 @@ describe("timerService timeout ordering", () => {
       showMessage: () => {},
       showAutoSelect: () => {},
       showTemporaryMessage: () => () => {},
-      updateTimer: () => {}
+      updateTimer: () => {},
+      updateRoundCounter: () => {},
+      clearRoundCounter: () => {}
     }));
     vi.doMock("../../src/helpers/classicBattle/uiHelpers.js", () => ({
       updateDebugPanel: () => {},

--- a/tests/helpers/timerService.test.js
+++ b/tests/helpers/timerService.test.js
@@ -13,7 +13,9 @@ vi.mock("../../src/helpers/setupScoreboard.js", () => ({
   showMessage: () => {},
   showAutoSelect: () => {},
   showTemporaryMessage: () => () => {},
-  updateTimer: vi.fn()
+  updateTimer: vi.fn(),
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
 }));
 
 vi.mock("../../src/helpers/classicBattle/uiHelpers.js", () => ({

--- a/tests/helpers/uiHelpers.resetBattleUI.test.js
+++ b/tests/helpers/uiHelpers.resetBattleUI.test.js
@@ -6,7 +6,9 @@ vi.mock("../../src/helpers/classicBattle/timerService.js", () => ({
 
 vi.mock("../../src/helpers/setupScoreboard.js", () => ({
   clearMessage: vi.fn(),
-  clearTimer: vi.fn()
+  clearTimer: vi.fn(),
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
 }));
 
 vi.mock("../../src/helpers/classicBattle/uiService.js", () => ({

--- a/tests/helpers/uiHelpers.showRoundOutcome.test.js
+++ b/tests/helpers/uiHelpers.showRoundOutcome.test.js
@@ -6,7 +6,9 @@ vi.mock("../../src/helpers/battle/battleUI.js", () => ({
 }));
 
 vi.mock("../../src/helpers/setupScoreboard.js", () => ({
-  showMessage: vi.fn()
+  showMessage: vi.fn(),
+  updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn()
 }));
 
 import { showResult } from "../../src/helpers/battle/battleUI.js";


### PR DESCRIPTION
## Summary
- add `clearRoundCounter` stubs alongside `updateRoundCounter` in scoreboard mocks across helper tests and harnesses to reflect the production API

## Testing
- npx vitest tests/helpers/classicBattle/onTransition.test.js tests/helpers/classicBattle/orchestrator.events.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d708e4452c8326b9f4f62b314ae844