### PR TITLE
Refine battle CLI timer utilities

### DIFF
--- a/tests/utils/timerTestUtils.js
+++ b/tests/utils/timerTestUtils.js
@@ -1,0 +1,38 @@
+export function createTimerIdFactory() {
+  let current = 0;
+  return () => {
+    current += 1;
+    return current;
+  };
+}
+
+export function createTimerIdManager() {
+  let nextTimeoutIdFactory = createTimerIdFactory();
+  let nextIntervalIdFactory = createTimerIdFactory();
+
+  return {
+    reset() {
+      nextTimeoutIdFactory = createTimerIdFactory();
+      nextIntervalIdFactory = createTimerIdFactory();
+    },
+    getNextTimeoutId() {
+      return nextTimeoutIdFactory();
+    },
+    getNextIntervalId() {
+      return nextIntervalIdFactory();
+    }
+  };
+}
+
+export function cleanupTimers(timer, interval) {
+  if (timer) {
+    if (typeof timer.stop === "function") {
+      timer.stop();
+    } else {
+      clearTimeout(timer);
+    }
+  }
+  if (interval) {
+    clearInterval(interval);
+  }
+}


### PR DESCRIPTION
## Summary
- extract the deterministic timer id helpers into a shared test utility for reuse
- add a reusable timer cleanup helper and adopt it across the battle CLI handler tests
- keep timer variables scoped while maintaining the consistent naming requested in review feedback

## Testing
- `npx vitest tests/pages/battleCLI.handlers.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d70aaa791483268eb524693233963e