### PR TITLE
Update unit tests to use helper aliases

### DIFF
--- a/tests/unit/cooldown.start.spec.js
+++ b/tests/unit/cooldown.start.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import * as roundManager from "/workspaces/judokon/src/helpers/classicBattle/roundManager.js";
+import * as roundManager from "@/helpers/classicBattle/roundManager.js";
 
 describe("cooldown auto-advance wiring", () => {
   beforeEach(() => {

--- a/tests/unit/roundStore.reset.spec.js
+++ b/tests/unit/roundStore.reset.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { roundStore } from "/workspaces/judokon/src/helpers/classicBattle/roundStore.js";
+import { roundStore } from "@/helpers/classicBattle/roundStore.js";
 
 describe("roundStore.reset", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- switch classic battle helper imports in unit specs to the `@/helpers` alias
- adjust round UI auto-advance spec to invoke the handler directly while stubbing scoreboard and renderer dependencies

## Testing
- `npx vitest tests/unit/cooldown.start.spec.js tests/unit/roundUI.autoAdvance.spec.js tests/unit/roundStore.reset.spec.js --run`


------
https://chatgpt.com/codex/tasks/task_e_68d70c139ed48326bfb7405ed6fedb0c