### PR TITLE
Address review feedback for roundUI auto-advance unit test

### DIFF
--- a/tests/unit/roundUI.autoAdvance.spec.js
+++ b/tests/unit/roundUI.autoAdvance.spec.js
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 
-// Import the dynamic binding to hook roundResolved
+import * as scoreboard from "@/helpers/setupScoreboard.js";
 import * as roundUI from "@/helpers/classicBattle/roundUI.js";
 
 describe("roundUI auto-advance chain", () => {
-  it("calls startRoundCooldown on roundResolved", async () => {
+  it("starts the round cooldown pipeline when a round resolves", async () => {
     // Arrange DOM basics used by handlers
     global.document.body.innerHTML = `
       <div id="snackbar-container" role="status"></div>
@@ -14,27 +14,32 @@ describe("roundUI auto-advance chain", () => {
     `;
 
     // Spy required modules via dynamic handler call path
-    const scoreboard = await import("@/helpers/setupScoreboard.js");
     const updateScoreSpy = vi.spyOn(scoreboard, "updateScore").mockImplementation(() => {});
-
-    const rui = await import("@/helpers/classicBattle/roundUI.js");
-    expect(rui.startRoundCooldown).toBe(roundUI.startRoundCooldown);
 
     // Rebind handlers (as in runtime) and dispatch roundResolved
     const result = { message: "ok", playerScore: 1, opponentScore: 0, matchEnded: false };
     const event = new CustomEvent("roundResolved", { detail: { result } });
-    const createRoundTimer = () => ({ start: vi.fn() });
+    const createRoundTimer = vi.fn(() => ({ start: vi.fn() }));
     const attachCooldownRenderer = vi.fn();
-    await rui.handleRoundResolvedEvent(event, {
+    await roundUI.handleRoundResolvedEvent(event, {
       scoreboard,
       computeNextRoundCooldown: () => 5,
       createRoundTimer,
-      attachCooldownRenderer
+      attachCooldownRenderer,
+      isOrchestrated: () => false
     });
 
     // Assert cooldown was started
     await Promise.resolve();
-    expect(updateScoreSpy).toHaveBeenCalled();
-    expect(attachCooldownRenderer).toHaveBeenCalledWith(expect.any(Object), 5, expect.any(Object));
+    expect(updateScoreSpy).toHaveBeenCalledWith(1, 0);
+    expect(createRoundTimer).toHaveBeenCalledTimes(1);
+    expect(attachCooldownRenderer).toHaveBeenCalledWith(
+      createRoundTimer.mock.results[0]?.value,
+      5,
+      expect.objectContaining({
+        waitForOpponentPrompt: false,
+        maxPromptWaitMs: 0
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- remove redundant dynamic imports in the roundUI auto-advance spec
- inject dependencies directly through the static module import and update the assertions to reflect the cooldown pipeline
- rename the spec to describe the behavior exercised by the test

## Testing
- `npx vitest tests/unit/roundUI.autoAdvance.spec.js --run`


------
https://chatgpt.com/codex/tasks/task_e_68d7111596c88326852b4658cfc8539f