### PR TITLE
Use alias import in cooldown spec

### DIFF
--- a/tests/unit/cooldown.start.spec.js
+++ b/tests/unit/cooldown.start.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import * as roundManager from "/workspaces/judokon/src/helpers/classicBattle/roundManager.js";
+import * as roundManager from "@/helpers/classicBattle/roundManager.js";
 
 describe("cooldown auto-advance wiring", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- replace the hard-coded absolute roundManager import in the cooldown unit test with the existing @ alias so Vitest resolves it regardless of workspace path

## Files Changed
- tests/unit/cooldown.start.spec.js

## Testing
- `npx vitest tests/unit/cooldown.start.spec.js`

## Risk
- Low risk: test-only import adjustment


------
https://chatgpt.com/codex/tasks/task_e_68d712ba39c083268254da5c8a8b43c4