### PR TITLE
Refactor stat buttons accessibility test harness

### DIFF
--- a/src/helpers/classicBattle/uiHelpers.js
+++ b/src/helpers/classicBattle/uiHelpers.js
@@ -794,8 +794,9 @@ export function initStatButtons(store) {
  */
 export async function applyStatLabels() {
   const names = await loadStatNames().catch(() => ({}));
-  const entries = Object.keys(STATS || {});
-  for (const key of entries) {
+  const statKeys = Array.isArray(STATS) ? STATS : Object.keys(STATS || {});
+  for (const rawKey of statKeys) {
+    const key = String(rawKey);
     const selector = `#stat-buttons [data-stat='${key}']`;
     /** @type {HTMLButtonElement|null} */
     const btn = document.querySelector(selector);


### PR DESCRIPTION
## Summary
- add a stat buttons harness in the component test utilities to render the production markup
- refactor the stat buttons accessibility test to use the harness and assert real aria descriptions
- fix applyStatLabels to iterate the actual stat keys when wiring descriptions

## Testing
- npx vitest run tests/accessibility/statButtons.aria.test.js


------
https://chatgpt.com/codex/tasks/task_e_68d7127c44a083268e1819e9929d4287