### PR TITLE
Use alias import in roundStore reset spec

### DIFF
--- a/tests/unit/roundStore.reset.spec.js
+++ b/tests/unit/roundStore.reset.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { roundStore } from "/workspaces/judokon/src/helpers/classicBattle/roundStore.js";
+import { roundStore } from "@/helpers/classicBattle/roundStore.js";
 
 describe("roundStore.reset", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- replace the absolute roundStore import in the reset spec with the configured alias

## Testing
- npx vitest tests/unit/roundStore.reset.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d714e906b083268faca2926a99f4eb