### PR TITLE
Adjust round store legacy event emission

### DIFF
--- a/src/helpers/classicBattle/roundStore.js
+++ b/src/helpers/classicBattle/roundStore.js
@@ -107,8 +107,11 @@ class RoundStore {
   /**
    * Set the current round number.
    * @param {number} number - New round number (1-based)
+   * @param {{ emitLegacyEvent?: boolean }} [options] - Optional behavior overrides
    */
-  setRoundNumber(number) {
+  setRoundNumber(number, options = {}) {
+    const { emitLegacyEvent = true } =
+      typeof options === "object" && options !== null ? options : {};
     const oldNumber = this.currentRound.number;
     if (oldNumber === number) return;
 
@@ -119,10 +122,12 @@ class RoundStore {
       this.callbacks.onRoundNumberChange(number, oldNumber);
     }
 
-    // Emit legacy event for backward compatibility
-    emitBattleEvent("display.round.start", {
-      roundNumber: number
-    });
+    if (emitLegacyEvent) {
+      // Emit legacy event for backward compatibility
+      emitBattleEvent("display.round.start", {
+        roundNumber: number
+      });
+    }
   }
 
   /**

--- a/src/helpers/classicBattle/scoreboardAdapter.js
+++ b/src/helpers/classicBattle/scoreboardAdapter.js
@@ -56,6 +56,7 @@ function handleRoundStart(event) {
   const roundNumber =
     typeof detail.roundNumber === "number" ? detail.roundNumber : detail.roundIndex;
   if (typeof roundNumber === "number" && Number.isFinite(roundNumber)) {
+    roundStore.setRoundNumber(roundNumber, { emitLegacyEvent: false });
     try {
       updateRoundCounter(roundNumber);
     } catch {}


### PR DESCRIPTION
## Summary
- allow roundStore.setRoundNumber to optionally skip emitting the legacy display event
- ensure the scoreboard adapter updates the round store without re-triggering legacy events

## Testing
- npx vitest tests/helpers/scoreboard.adapter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d7148e129483269d2e7185d7fa6a1a