### PR TITLE
Update stat button aria-describedby expectations

### DIFF
--- a/tests/classicBattle/statButtons.test.js
+++ b/tests/classicBattle/statButtons.test.js
@@ -74,7 +74,14 @@ describe("Stat Buttons", () => {
     const statButtons = container.querySelectorAll("button");
     expect(statButtons.length).toBeGreaterThan(0);
     statButtons.forEach((button) => {
-      expect(button.getAttribute("aria-describedby")).toBe("round-message");
+      const stat = button.dataset.stat;
+      expect(stat).toBeTruthy();
+      const expectedId = `stat-${stat}-desc`;
+      expect(button.getAttribute("aria-describedby")).toBe(expectedId);
+      const descEl = document.getElementById(expectedId);
+      if (descEl) {
+        expect(descEl.classList.contains("sr-only")).toBe(true);
+      }
       expect(button.getAttribute("aria-label")).toMatch(/^Select \w+ stat for battle$/);
     });
   });


### PR DESCRIPTION
## Summary
- adjust stat button tests to derive the aria-describedby ID from each button's data-stat attribute
- retain the existing aria-label regex assertion and optionally verify hidden descriptions use the sr-only class when present

## Testing
- npx vitest run tests/classicBattle/statButtons.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d714832fbc83268ac1242f0c889da8