### PR TITLE
Use repo aliases in roundUI auto-advance test

### DIFF
--- a/tests/unit/roundUI.autoAdvance.spec.js
+++ b/tests/unit/roundUI.autoAdvance.spec.js
@@ -1,8 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 
-// Import the dynamic binding to hook roundResolved
-import { handleRoundResolvedEvent } from "/workspaces/judokon/src/helpers/classicBattle/roundUI.js";
-
 describe("roundUI auto-advance chain", () => {
   it("invokes cooldown flow with injected deps", async () => {
     // Arrange DOM basics used by handlers
@@ -14,14 +11,13 @@ describe("roundUI auto-advance chain", () => {
     `;
 
     // Spy required modules via dynamic handler call path
-    const scoreboardModule = await import("/workspaces/judokon/src/helpers/setupScoreboard.js");
+    const scoreboardModule = await import("@/helpers/setupScoreboard.js");
     vi.spyOn(scoreboardModule, "updateScore").mockImplementation(() => {});
 
-    const startRoundCooldown = vi.fn().mockResolvedValue({
-      controls: { ready: Promise.resolve() }
-    });
+    const roundUIModule = await import("@/helpers/classicBattle/roundUI.js");
+    const { handleRoundResolvedEvent } = roundUIModule;
     const computeNextRoundCooldown = vi.fn(() => 3);
-    const createRoundTimer = vi.fn(() => ({}));
+    const createRoundTimer = vi.fn(() => ({ start: vi.fn() }));
     const attachCooldownRenderer = vi.fn();
     const scoreboard = { updateScore: vi.fn(), showMessage: vi.fn(), clearRoundCounter: vi.fn() };
 
@@ -33,13 +29,11 @@ describe("roundUI auto-advance chain", () => {
         computeNextRoundCooldown,
         createRoundTimer,
         attachCooldownRenderer,
-        isOrchestrated: () => false,
-        // inject the internal helper by property shadowing
-        startRoundCooldown
+        isOrchestrated: () => false
       }
     );
 
     expect(computeNextRoundCooldown).toHaveBeenCalled();
-    expect(startRoundCooldown).toHaveBeenCalled();
+    expect(attachCooldownRenderer).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- replace the roundUI auto-advance unit test's absolute imports with the repository alias paths
- dynamically import the roundUI helpers during the test and assert the cooldown renderer hook to confirm the auto-advance flow

## Testing
- npx vitest run tests/unit/roundUI.autoAdvance.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d71342df908326b8f7d3fe4452ed92