### PR TITLE
Refactor round store scoreboard wiring

### DIFF
--- a/src/helpers/classicBattle/roundStore.js
+++ b/src/helpers/classicBattle/roundStore.js
@@ -261,48 +261,47 @@ class RoundStore {
   /**
    * Wire RoundStore into scoreboard adapter.
    * This replaces event-driven round number updates with direct store subscriptions.
+   *
+   * @param {(roundNumber: number) => void} [updateRoundCounter]
+   * @param {() => void} [clearRoundCounter]
+   * @returns {Promise<void>} Resolved promise for scoreboard ready chaining
    */
-  wireIntoScoreboardAdapter() {
-    // Import scoreboard adapter dynamically to avoid circular dependencies
-    return import("../setupScoreboard.js")
-      .then(({ updateRoundCounter, clearRoundCounter }) => {
-        const applyRoundNumber = (roundNumber) => {
-          const hasUpdate = typeof updateRoundCounter === "function";
-          const hasClear = typeof clearRoundCounter === "function";
-          if (roundNumber > 0) {
-            if (hasUpdate) {
-              updateRoundCounter(roundNumber);
-            }
-            return;
-          }
-          if (hasClear) {
-            clearRoundCounter();
-            return;
-          }
-          if (hasUpdate) {
-            updateRoundCounter(roundNumber);
-          }
-        };
-
-        // Subscribe to round number changes
-        this.onRoundNumberChange((newNumber) => {
-          try {
-            applyRoundNumber(newNumber);
-          } catch (error) {
-            console.warn("RoundStore: Failed to update round counter:", error);
-          }
-        });
-
-        // Set initial round number if already set
-        try {
-          applyRoundNumber(this.currentRound.number);
-        } catch (error) {
-          console.warn("RoundStore: Failed to initialize round counter:", error);
+  wireIntoScoreboardAdapter(updateRoundCounter, clearRoundCounter) {
+    const applyRoundNumber = (roundNumber) => {
+      const hasUpdate = typeof updateRoundCounter === "function";
+      const hasClear = typeof clearRoundCounter === "function";
+      if (roundNumber > 0) {
+        if (hasUpdate) {
+          updateRoundCounter(roundNumber);
         }
-      })
-      .catch((error) => {
-        console.warn("RoundStore: Failed to wire into scoreboard adapter:", error);
-      });
+        return;
+      }
+      if (hasClear) {
+        clearRoundCounter();
+        return;
+      }
+      if (hasUpdate) {
+        updateRoundCounter(roundNumber);
+      }
+    };
+
+    // Subscribe to round number changes
+    this.onRoundNumberChange((newNumber) => {
+      try {
+        applyRoundNumber(newNumber);
+      } catch (error) {
+        console.warn("RoundStore: Failed to update round counter:", error);
+      }
+    });
+
+    // Set initial round number if already set
+    try {
+      applyRoundNumber(this.currentRound.number);
+    } catch (error) {
+      console.warn("RoundStore: Failed to initialize round counter:", error);
+    }
+
+    return Promise.resolve();
   }
 
   /**

--- a/src/helpers/classicBattle/scoreboardAdapter.js
+++ b/src/helpers/classicBattle/scoreboardAdapter.js
@@ -189,7 +189,10 @@ export function initScoreboardAdapter() {
 
   wireScoreboardListeners();
 
-  scoreboardReadyPromise = Promise.resolve(roundStore.wireIntoScoreboardAdapter());
+  scoreboardReadyPromise = roundStore.wireIntoScoreboardAdapter(
+    updateRoundCounter,
+    clearRoundCounter
+  );
 
   return disposeScoreboardAdapter;
 }


### PR DESCRIPTION
## Summary
- update the round store to accept scoreboard helper callbacks directly and resolve immediately when wiring
- invoke the revised round store wiring with statically imported scoreboard helpers in the scoreboard adapter

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d71970a46083269ba07a4227cbba51