### PR TITLE
Refactor round store scoreboard wiring

### DIFF
--- a/src/helpers/classicBattle/scoreboardAdapter.js
+++ b/src/helpers/classicBattle/scoreboardAdapter.js
@@ -6,6 +6,7 @@ import {
   updateTimer,
   showAutoSelect,
   clearRoundCounter,
+  updateRoundCounter,
   updateScore
 } from "../setupScoreboard.js";
 import { onBattleEvent, offBattleEvent } from "./battleEvents.js";
@@ -185,7 +186,12 @@ export function initScoreboardAdapter() {
 
   wireScoreboardListeners();
 
-  scoreboardReadyPromise = Promise.resolve(roundStore.wireIntoScoreboardAdapter());
+  scoreboardReadyPromise = Promise.resolve(
+    roundStore.wireIntoScoreboardAdapter({
+      updateRoundCounter,
+      clearRoundCounter
+    })
+  );
 
   return disposeScoreboardAdapter;
 }

--- a/tests/unit/roundStore-integration.test.js
+++ b/tests/unit/roundStore-integration.test.js
@@ -14,6 +14,7 @@ import {
 
 // Mock setupScoreboard to track calls
 vi.mock("../../src/helpers/setupScoreboard.js", () => ({
+  clearRoundCounter: vi.fn(),
   updateRoundCounter: vi.fn(),
   showMessage: vi.fn(),
   clearMessage: vi.fn(),


### PR DESCRIPTION
## Summary
- replace the RoundStore scoreboard wiring with a synchronous hook that accepts scoreboard helpers
- update the scoreboard adapter to provide the statically imported counter helpers to the RoundStore
- extend the RoundStore integration test mock to include the clear counter helper and verify the new wiring

## Testing
- npx vitest tests/unit/roundStore-integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d71a18181c8326ad76325fb3833cd5