### PR TITLE
Normalize round number parsing in scoreboard adapter

### DIFF
--- a/src/helpers/classicBattle/scoreboardAdapter.js
+++ b/src/helpers/classicBattle/scoreboardAdapter.js
@@ -47,15 +47,29 @@ function extractSeconds(detail) {
   return typeof seconds === "number" && Number.isFinite(seconds) ? seconds : null;
 }
 
+function parseRoundNumber(value) {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
 function handleRoundStart(event) {
   try {
     clearMessage();
   } catch {}
   const detail = event?.detail || {};
-  const roundNumber =
-    typeof detail.roundNumber === "number" ? detail.roundNumber : detail.roundIndex;
-  if (typeof roundNumber === "number" && Number.isFinite(roundNumber)) {
-    roundStore.setRoundNumber(roundNumber, { emitLegacyEvent: false });
+  const roundNumber = parseRoundNumber(detail.roundNumber);
+  const roundIndex = parseRoundNumber(detail.roundIndex);
+  const normalizedRoundNumber = roundNumber ?? roundIndex;
+  if (typeof normalizedRoundNumber === "number") {
+    roundStore.setRoundNumber(normalizedRoundNumber, { emitLegacyEvent: false });
   } else {
     try {
       clearRoundCounter();

--- a/tests/helpers/scoreboard.adapter.test.js
+++ b/tests/helpers/scoreboard.adapter.test.js
@@ -73,4 +73,10 @@ describe("scoreboardAdapter maps display.* events to Scoreboard", () => {
     expect(scoreText).toContain("You: 2");
     expect(scoreText).toContain("Opponent: 1");
   });
+
+  it("accepts string round numbers when starting a round", async () => {
+    emitBattleEvent("display.round.start", { roundNumber: "3" });
+    await vi.advanceTimersByTimeAsync(220);
+    expect(document.getElementById("round-counter").textContent).toBe("Round 3");
+  });
 });


### PR DESCRIPTION
## Task Contract
- **Inputs:** `display.round.start` payloads providing `roundNumber`/`roundIndex` as numbers or numeric strings.
- **Outputs:** Updated round counter via `roundStore` when the payload is valid; scoreboard counter cleared on invalid payloads.
- **Success:** Numeric and numeric-string payloads normalize to numbers and update the round counter without clearing it.
- **Error:** Truly invalid payloads (non-numeric/NaN) trigger the existing `clearRoundCounter` fallback.

## Files Changed
- `src/helpers/classicBattle/scoreboardAdapter.js`: Normalize round identifiers through a helper that accepts numbers or numeric strings and maintains the clear fallback for invalid inputs.
- `tests/helpers/scoreboard.adapter.test.js`: Verify that string round numbers update the round counter instead of clearing it.

## Verification Summary
- eslint: PASS (`npx eslint src/helpers/classicBattle/scoreboardAdapter.js tests/helpers/scoreboard.adapter.test.js`)
- vitest: 2 passed, 0 failed (`npx vitest tests/helpers/scoreboard.adapter.test.js`)
- playwright: Not Run (not requested)
- jsdoc: FAIL (pre-existing missing docs: `enableFlag`, `prepareUiBeforeSelection`)

## Risk & Follow-Up
- Risk: Low. Changes are scoped to round-number parsing with existing fallbacks preserved.
- Follow-Up: None.


------
https://chatgpt.com/codex/tasks/task_e_68d71a26e1a48326a7b3a9d9d5b53cab