### PR TITLE
refactor: use named roundUI import in auto advance spec

### DIFF
--- a/tests/unit/roundUI.autoAdvance.spec.js
+++ b/tests/unit/roundUI.autoAdvance.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 
 import * as scoreboard from "@/helpers/setupScoreboard.js";
-import * as roundUI from "@/helpers/classicBattle/roundUI.js";
+import { handleRoundResolvedEvent } from "@/helpers/classicBattle/roundUI.js";
 import * as roundManager from "@/helpers/classicBattle/roundManager.js";
 
 describe("roundUI auto-advance chain", () => {
@@ -26,7 +26,7 @@ describe("roundUI auto-advance chain", () => {
     const result = { message: "ok", playerScore: 1, opponentScore: 0, matchEnded: false };
     const event = new CustomEvent("roundResolved", { detail: { result, store: {} } });
 
-    await roundUI.handleRoundResolvedEvent(event, {
+    await handleRoundResolvedEvent(event, {
       scoreboard,
       computeNextRoundCooldown,
       createRoundTimer,


### PR DESCRIPTION
## Summary
- update the roundUI auto-advance spec to import `handleRoundResolvedEvent` via the repo alias
- use the named import in the test invocation to keep coverage the same while avoiding absolute paths

## Files Changed
- tests/unit/roundUI.autoAdvance.spec.js

## Testing
- npx vitest run tests/unit/roundUI.autoAdvance.spec.js

## Risk
- Low: test-only change to import style.


------
https://chatgpt.com/codex/tasks/task_e_68d719a0680483269e4e428ea7c5167d