### PR TITLE
Address review feedback on round number normalization

### DIFF
--- a/src/helpers/classicBattle/scoreboardAdapter.js
+++ b/src/helpers/classicBattle/scoreboardAdapter.js
@@ -5,6 +5,7 @@ import {
   clearTimer,
   updateTimer,
   showAutoSelect,
+  updateRoundCounter,
   clearRoundCounter,
   updateScore
 } from "../setupScoreboard.js";
@@ -47,12 +48,24 @@ function extractSeconds(detail) {
   return typeof seconds === "number" && Number.isFinite(seconds) ? seconds : null;
 }
 
+/**
+ * Parse and normalize a round number from various input types.
+ *
+ * @pseudocode
+ * 1. Return finite numbers as-is when already numeric.
+ * 2. Accept non-empty strings and attempt numeric conversion.
+ * 3. Return null whenever parsing fails (NaN, infinite, empty input, etc.).
+ *
+ * @param {number | string | *} value value to parse as a round number
+ * @returns {number | null} finite number if valid, null otherwise
+ */
 function parseRoundNumber(value) {
   if (typeof value === "number") {
     return Number.isFinite(value) ? value : null;
   }
 
   if (typeof value === "string" && value.trim().length > 0) {
+    // Number(...) tolerates leading/trailing whitespace (e.g., " 3 "), which we accept intentionally.
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : null;
   }
@@ -68,7 +81,7 @@ function handleRoundStart(event) {
   const roundNumber = parseRoundNumber(detail.roundNumber);
   const roundIndex = parseRoundNumber(detail.roundIndex);
   const normalizedRoundNumber = roundNumber ?? roundIndex;
-  if (typeof normalizedRoundNumber === "number") {
+  if (normalizedRoundNumber !== null) {
     roundStore.setRoundNumber(normalizedRoundNumber, { emitLegacyEvent: false });
   } else {
     try {

--- a/tests/helpers/scoreboard.adapter.test.js
+++ b/tests/helpers/scoreboard.adapter.test.js
@@ -35,9 +35,7 @@ describe("scoreboardAdapter maps display.* events to Scoreboard", () => {
     const { initScoreboard, resetScoreboard } = await import("../../src/components/Scoreboard.js");
     resetScoreboard();
     initScoreboard(header);
-    ({ roundStore } = await import(
-      "../../src/helpers/classicBattle/roundStore.js"
-    ));
+    ({ roundStore } = await import("../../src/helpers/classicBattle/roundStore.js"));
     const scoreboardAdapterModule = await import(
       "../../src/helpers/classicBattle/scoreboardAdapter.js"
     );
@@ -98,5 +96,29 @@ describe("scoreboardAdapter maps display.* events to Scoreboard", () => {
     emitBattleEvent("display.round.start", { roundNumber: "3" });
     await vi.advanceTimersByTimeAsync(220);
     expect(document.getElementById("round-counter").textContent).toBe("Round 3");
+  });
+
+  it("handles edge cases in round number parsing", async () => {
+    const counter = () => document.getElementById("round-counter").textContent;
+
+    emitBattleEvent("display.round.start", { roundNumber: " 7 " });
+    await vi.advanceTimersByTimeAsync(220);
+    expect(counter()).toBe("Round 7");
+
+    emitBattleEvent("display.round.start", { roundIndex: "5" });
+    await vi.advanceTimersByTimeAsync(220);
+    expect(counter()).toBe("Round 5");
+
+    emitBattleEvent("display.round.start", { roundNumber: "invalid" });
+    await vi.advanceTimersByTimeAsync(220);
+    expect(counter()).toBe("");
+
+    emitBattleEvent("display.round.start", { roundNumber: "" });
+    await vi.advanceTimersByTimeAsync(220);
+    expect(counter()).toBe("");
+
+    emitBattleEvent("display.round.start", { roundNumber: "   " });
+    await vi.advanceTimersByTimeAsync(220);
+    expect(counter()).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- add pseudocode documentation for `parseRoundNumber` and clarify accepted whitespace handling
- guard round updates with a null check and ensure `updateRoundCounter` is wired into the adapter
- expand scoreboard adapter tests to cover numeric string fallbacks and invalid input clearing

## Testing
- npx eslint src/helpers/classicBattle/scoreboardAdapter.js tests/helpers/scoreboard.adapter.test.js
- npx vitest tests/helpers/scoreboard.adapter.test.js --run

------
https://chatgpt.com/codex/tasks/task_e_68d71bde55308326a5b5ba7a34a57364