### PR TITLE
docs: clarify CLI API handle disposal

### DIFF
--- a/playwright/cli-flows.spec.mjs
+++ b/playwright/cli-flows.spec.mjs
@@ -10,10 +10,12 @@ const buildCliUrl = (testInfo) => {
 };
 
 /**
- * Wait for CLI test APIs to be available and return a handle for direct API access.
- * @param {import('@playwright/test').Page} page - Playwright page object
- * @param {number} timeout - Timeout in ms (default: 8000)
- * @returns {Promise<import('@playwright/test').JSHandle<unknown>>} Test API handle - caller must dispose
+ * Waits for CLI test APIs to be available and returns a handle for direct API access.
+ * Callers must dispose the returned handle once their assertions complete.
+ *
+ * @param {import("@playwright/test").Page} page Playwright page object under test.
+ * @param {number} [timeout=8000] Timeout in milliseconds to wait for CLI helpers.
+ * @returns {Promise<import("@playwright/test").JSHandle<unknown>>} Handle for CLI test APIs.
  * @pseudocode wait for test API, verify helpers, return JSHandle
  */
 const waitForCliApis = async (page, timeout = 8000) => {


### PR DESCRIPTION
## Summary
- document the waitForCliApis helper parameters and return value following the repository JSDoc format
- note that the returned CLI API handle must be disposed after use

## Testing
- npx prettier playwright/cli-flows.spec.mjs --check

------
https://chatgpt.com/codex/tasks/task_e_68d71c2b236c8326bdca39ba560f2266