### PR TITLE
docs: add jsdoc for CLI verbose log helper

### DIFF
--- a/playwright/cli-flows.spec.mjs
+++ b/playwright/cli-flows.spec.mjs
@@ -79,6 +79,11 @@ const waitForCliApis = async (page, timeout = 8000) => {
   return testApiHandle;
 };
 
+/**
+ * Read and normalize the verbose log entries exposed by the CLI test API.
+ * @param {import('@playwright/test').JSHandle<unknown>} testApiHandle - Handle returned from the CLI test API helper.
+ * @returns {Promise<string[]>} Array of verbose log lines; non-array responses are coerced into trimmed strings.
+ */
 const readVerboseLog = async (testApiHandle) => {
   if (!testApiHandle) {
     return [];


### PR DESCRIPTION
## Summary
- document the CLI verbose log helper with a JSDoc block that describes the JSHandle parameter and normalized return value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d71c31b5d88326b348eac85b3e73df