### PR TITLE
docs: add pseudocode annotation for CLI verbose log helper

### DIFF
--- a/playwright/cli-flows.spec.mjs
+++ b/playwright/cli-flows.spec.mjs
@@ -85,6 +85,7 @@ const waitForCliApis = async (page, timeout = 8000) => {
  * Read and normalize the verbose log entries exposed by the CLI test API.
  * @param {import('@playwright/test').JSHandle<unknown>} testApiHandle - Handle returned from the CLI test API helper.
  * @returns {Promise<string[]>} Array of verbose log lines; non-array responses are coerced into trimmed strings.
+ * @pseudocode evaluate API handle, extract log entries, normalize to string array, handle errors gracefully
  */
 const readVerboseLog = async (testApiHandle) => {
   if (!testApiHandle) {


### PR DESCRIPTION
## Summary
- document the CLI verbose log helper with a JSDoc block that describes the JSHandle parameter and normalized return value
- add the required @pseudocode annotation to the verbose log helper documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d71d75f6908326b78123ef4eb53d80