### PR TITLE
docs: align CLI helper JSDoc import quotes

### DIFF
--- a/playwright/cli-flows.spec.mjs
+++ b/playwright/cli-flows.spec.mjs
@@ -13,9 +13,9 @@ const buildCliUrl = (testInfo) => {
  * Waits for CLI test APIs to be available and returns a handle for direct API access.
  * Callers must dispose the returned handle once their assertions complete.
  *
- * @param {import("@playwright/test").Page} page Playwright page object under test.
+ * @param {import('@playwright/test').Page} page Playwright page object under test.
  * @param {number} [timeout=8000] Timeout in milliseconds to wait for CLI helpers.
- * @returns {Promise<import("@playwright/test").JSHandle<unknown>>} Handle for CLI test APIs.
+ * @returns {Promise<import('@playwright/test').JSHandle<unknown>>} Handle for CLI test APIs.
  * @pseudocode wait for test API, verify helpers, return JSHandle
  */
 const waitForCliApis = async (page, timeout = 8000) => {


### PR DESCRIPTION
## Summary
- switch waitForCliApis JSDoc import type quotes to single quotes to match repository style

## Testing
- npx prettier playwright/cli-flows.spec.mjs --check

------
https://chatgpt.com/codex/tasks/task_e_68d71d44ee848326a1ea19d13a20330d