### PR TITLE
Refine RoundStore scoreboard wiring

### DIFF
--- a/src/helpers/classicBattle/scoreboardAdapter.js
+++ b/src/helpers/classicBattle/scoreboardAdapter.js
@@ -5,6 +5,7 @@ import {
   clearTimer,
   updateTimer,
   showAutoSelect,
+  updateRoundCounter,
   clearRoundCounter,
   updateScore
 } from "../setupScoreboard.js";
@@ -199,10 +200,10 @@ export function initScoreboardAdapter() {
 
   wireScoreboardListeners();
 
-  scoreboardReadyPromise = roundStore.wireIntoScoreboardAdapter(
+  scoreboardReadyPromise = roundStore.wireIntoScoreboardAdapter({
     updateRoundCounter,
     clearRoundCounter
-  );
+  });
 
   return disposeScoreboardAdapter;
 }

--- a/tests/unit/roundStore-integration.test.js
+++ b/tests/unit/roundStore-integration.test.js
@@ -15,10 +15,13 @@ import {
 // Mock setupScoreboard to track calls
 vi.mock("../../src/helpers/setupScoreboard.js", () => ({
   updateRoundCounter: vi.fn(),
+  clearRoundCounter: vi.fn(),
   showMessage: vi.fn(),
   clearMessage: vi.fn(),
+  showTemporaryMessage: vi.fn(),
   updateTimer: vi.fn(),
   clearTimer: vi.fn(),
+  showAutoSelect: vi.fn(),
   updateScore: vi.fn()
 }));
 


### PR DESCRIPTION
## Summary
- ensure the RoundStore scoreboard wiring registers callbacks immediately with safe helper fallbacks
- update the scoreboard adapter to use the statically imported counter helpers and refresh the integration tests

## Testing
- npx vitest run tests/unit/roundStore-integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d71e141e888326ae9698ed0690e755