### PR TITLE
Use expect.poll when waiting for CLI verbose transcript

### DIFF
--- a/playwright/cli-flows.spec.mjs
+++ b/playwright/cli-flows.spec.mjs
@@ -206,7 +206,18 @@ test.describe("CLI Keyboard Flows", () => {
 
       await startBattle(page);
 
-      const verboseTranscript = await readVerboseLog(testApiHandle);
+      /** @type {string[]} */
+      let verboseTranscript = [];
+      await expect
+        .poll(
+          async () => {
+            verboseTranscript = await readVerboseLog(testApiHandle);
+            return verboseTranscript.length > 0;
+          },
+          { timeout: 8000 }
+        )
+        .toBe(true);
+
       expect(verboseTranscript.length).toBeGreaterThan(0);
       expect(verboseTranscript.join(" ")).toContain("waitingForPlayerAction");
     }, ["log", "warn", "error"]);


### PR DESCRIPTION
## Summary
- wait for the CLI verbose transcript using Playwright's expect.poll before asserting its contents
- retain the final transcript checks while storing the polled result for subsequent assertions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d71f9d2bcc8326bd4a1a9f1cb800a3