### PR TITLE
Add tests for scoreboard adapter roundIndex string handling

### DIFF
--- a/tests/helpers/scoreboard.adapter.test.js
+++ b/tests/helpers/scoreboard.adapter.test.js
@@ -91,4 +91,20 @@ describe("scoreboardAdapter maps display.* events to Scoreboard", () => {
     await vi.advanceTimersByTimeAsync(220);
     expect(document.getElementById("round-counter").textContent).toBe("Round 3");
   });
+
+  it("handles string roundIndex values and clears invalid strings", async () => {
+    const roundCounter = () => document.getElementById("round-counter").textContent;
+
+    emitBattleEvent("display.round.start", { roundIndex: "5" });
+    await vi.advanceTimersByTimeAsync(220);
+    expect(roundCounter()).toBe("Round 5");
+
+    emitBattleEvent("display.round.start", { roundIndex: "not-a-number" });
+    await vi.advanceTimersByTimeAsync(220);
+    expect(roundCounter()).toBe("");
+
+    emitBattleEvent("display.round.start", { roundIndex: "" });
+    await vi.advanceTimersByTimeAsync(220);
+    expect(roundCounter()).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage for string-based roundIndex payloads to the scoreboard adapter tests
- verify that invalid and empty string payloads clear the round counter

## Testing
- npx vitest run tests/helpers/scoreboard.adapter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d789792da4832689b7d3548646aef9