### PR TITLE
Improve battle timer countdown polling

### DIFF
--- a/playwright/battle-classic/timer.spec.js
+++ b/playwright/battle-classic/timer.spec.js
@@ -1,6 +1,48 @@
 import { test, expect } from "@playwright/test";
 import { withMutedConsole } from "../../tests/utils/console.js";
 
+async function readCountdown(page) {
+  return page.evaluate(() => {
+    const getter = window.__TEST_API?.timers?.getCountdown;
+    if (typeof getter !== "function") return null;
+    return getter();
+  });
+}
+
+async function waitForCountdownDecrease(page, initialValue, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastSeen = initialValue;
+
+  while (Date.now() < deadline) {
+    const current = await readCountdown(page);
+    if (typeof current === "number") {
+      lastSeen = current;
+      if (current < initialValue) {
+        return current;
+      }
+    }
+
+    await page.evaluate(
+      () =>
+        new Promise((resolve) => {
+          if (typeof requestAnimationFrame === "function") {
+            requestAnimationFrame(() => resolve());
+            return;
+          }
+          if (typeof queueMicrotask === "function") {
+            queueMicrotask(resolve);
+            return;
+          }
+          setTimeout(resolve, 0);
+        })
+    );
+  }
+
+  throw new Error(
+    `Countdown did not decrease within ${timeoutMs}ms (last value ${lastSeen})`
+  );
+}
+
 test.describe("Classic Battle timer", () => {
   test("displays and counts down selection timer after round selection", async ({ page }) => {
     await withMutedConsole(async () => {
@@ -22,35 +64,31 @@ test.describe("Classic Battle timer", () => {
       // Verify modal is dismissed
       await expect(page.getByRole("dialog")).not.toBeVisible();
 
-      // Verify timer appears and shows countdown
-      const timerLocator = page.getByTestId("next-round-timer");
-      await expect(timerLocator).toContainText(/Time Left: \d+s/);
-
       await page.evaluate(() =>
         window.__TEST_API?.state?.waitForBattleState?.("waitingForPlayerAction")
       );
 
-      // Wait for timer to update using semantic expectation on the countdown element
-      await expect(timerLocator).toContainText(/Time Left: [1-9]\d*s/, { timeout: 5000 });
+      // Verify timer appears and shows countdown
+      const timerLocator = page.getByTestId("next-round-timer");
+      await expect(timerLocator).toContainText(/Time Left: \d+s/);
 
-      // Verify timer shows a decreasing value by checking it updates
-      const initialText = await timerLocator.textContent();
-      const initialMatch = initialText?.match(/Time Left: (\d+)s/);
-      expect(initialMatch).toBeTruthy();
+      const initialCountdown = await readCountdown(page);
+      expect(initialCountdown).not.toBeNull();
+      const initialCountdownValue = /** @type {number} */ (initialCountdown);
+      expect(initialCountdownValue).toBeGreaterThan(0);
+      await expect(timerLocator).toContainText(
+        new RegExp(`Time Left: ${initialCountdownValue}s`)
+      );
 
-      // Wait for the timer to tick down at least once
-      await page.waitForFunction(
-        (initialTime) => {
-          const timerEl = document.querySelector('[data-testid="next-round-timer"]');
-          if (!timerEl) return false;
-          const currentText = timerEl.textContent || "";
-          const match = currentText.match(/Time Left: (\d+)s/);
-          if (!match) return false;
-          const currentTime = parseInt(match[1], 10);
-          return currentTime < initialTime;
-        },
-        parseInt(initialMatch[1], 10),
-        { timeout: 5000 }
+      const decreasedCountdown = await waitForCountdownDecrease(
+        page,
+        initialCountdownValue
+      );
+
+      expect(decreasedCountdown).toBeLessThan(initialCountdownValue);
+
+      await expect(timerLocator).toContainText(
+        new RegExp(`Time Left: ${decreasedCountdown}s`)
       );
 
       // Verify battle state is properly initialized

--- a/src/helpers/testApi.js
+++ b/src/helpers/testApi.js
@@ -703,6 +703,47 @@ const timerApi = {
   },
 
   /**
+   * Retrieve the active countdown value displayed in the UI.
+   *
+   * @pseudocode
+   * 1. Locate the timer element using the shared data-testid/id selectors.
+   * 2. Attempt to parse a numeric value from dataset attributes (`data-remaining-time`).
+   * 3. Fallback to parsing the text content that follows the `Time Left: {n}s` pattern.
+   * 4. Return the parsed integer when available; otherwise return `null` to indicate no countdown.
+   *
+   * @returns {number|null} Countdown seconds or `null` when unavailable.
+   */
+  getCountdown() {
+    try {
+      if (typeof document === "undefined") return null;
+
+      const timerEl =
+        document.querySelector('[data-testid="next-round-timer"]') ||
+        document.getElementById("next-round-timer");
+      if (!timerEl) return null;
+
+      const parseIntSafe = (value) => {
+        const numeric = Number.parseInt(String(value ?? ""), 10);
+        return Number.isNaN(numeric) ? null : numeric;
+      };
+
+      const datasetValue =
+        timerEl.getAttribute("data-remaining-time") ?? timerEl.dataset?.remainingTime;
+      const fromDataset = parseIntSafe(datasetValue);
+      if (fromDataset !== null) {
+        return fromDataset;
+      }
+
+      const textMatch = (timerEl.textContent || "").match(/Time Left:\s*(\d+)s/i);
+      if (!textMatch) return null;
+
+      return parseIntSafe(textMatch[1]);
+    } catch {
+      return null;
+    }
+  },
+
+  /**
    * Skip cooldown immediately without waiting
    */
   skipCooldown() {


### PR DESCRIPTION
## Summary
- expose a `timers.getCountdown` helper in the Playwright test API for parsing the scoreboard timer
- refactor the classic battle timer Playwright spec to await internal countdown updates instead of `page.waitForFunction`

## Testing
- npx playwright test playwright/battle-classic/timer.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d789c54d748326853514896bb55005