### PR TITLE
Add tests for scoreboard adapter roundIndex string handling

### DIFF
--- a/src/helpers/classicBattle/roundStore.js
+++ b/src/helpers/classicBattle/roundStore.js
@@ -120,7 +120,7 @@ class RoundStore {
    * 3. Notify subscribers of the new round number.
    * 4. Emit legacy event unless explicitly disabled.
    *
-   * @param {number} number - New round number (1-based)
+   * @param {number} number - New round number (1-based, zero allowed for pre-match state)
    * @param {{ emitLegacyEvent?: boolean }} [options] - Optional behavior overrides
    * @param {boolean} [options.emitLegacyEvent=true] - Whether to emit the legacy display.round.start event
    */
@@ -298,7 +298,7 @@ class RoundStore {
           };
 
     const applyRoundNumber = (roundNumber) => {
-      if (roundNumber > 0) {
+      if (typeof roundNumber === "number" && Number.isFinite(roundNumber) && roundNumber >= 0) {
         guard(() => safeUpdate(roundNumber));
         return;
       }

--- a/tests/helpers/scoreboard.adapter.test.js
+++ b/tests/helpers/scoreboard.adapter.test.js
@@ -92,12 +92,16 @@ describe("scoreboardAdapter maps display.* events to Scoreboard", () => {
     expect(document.getElementById("round-counter").textContent).toBe("Round 3");
   });
 
-  it("handles string roundIndex values and clears invalid strings", async () => {
+  it("handles string roundIndex values, zero, and clears invalid strings", async () => {
     const roundCounter = () => document.getElementById("round-counter").textContent;
 
     emitBattleEvent("display.round.start", { roundIndex: "5" });
     await vi.advanceTimersByTimeAsync(220);
     expect(roundCounter()).toBe("Round 5");
+
+    emitBattleEvent("display.round.start", { roundIndex: 0 });
+    await vi.advanceTimersByTimeAsync(220);
+    expect(roundCounter()).toBe("Round 0");
 
     emitBattleEvent("display.round.start", { roundIndex: "not-a-number" });
     await vi.advanceTimersByTimeAsync(220);


### PR DESCRIPTION
## Summary
- add coverage for string-based roundIndex payloads to the scoreboard adapter tests
- verify that invalid and empty string payloads clear the round counter
- allow roundIndex zero updates to propagate so the scoreboard displays "Round 0"

## Testing
- npx vitest run tests/helpers/scoreboard.adapter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d790646854832698ca8fd5a4d37f7f