### PR TITLE
Address review feedback for countdown helpers

### DIFF
--- a/playwright/battle-classic/timer.spec.js
+++ b/playwright/battle-classic/timer.spec.js
@@ -3,9 +3,14 @@ import { withMutedConsole } from "../../tests/utils/console.js";
 
 async function readCountdown(page) {
   return page.evaluate(() => {
-    const getter = window.__TEST_API?.timers?.getCountdown;
-    if (typeof getter !== "function") return null;
-    return getter();
+    try {
+      const getter = window.__TEST_API?.timers?.getCountdown;
+      if (typeof getter !== "function") return null;
+      return getter();
+    } catch (error) {
+      console.warn("Failed to read countdown:", error);
+      return null;
+    }
   });
 }
 
@@ -74,8 +79,9 @@ test.describe("Classic Battle timer", () => {
 
       const initialCountdown = await readCountdown(page);
       expect(initialCountdown).not.toBeNull();
+      expect(typeof initialCountdown).toBe("number");
+      expect(initialCountdown).toBeGreaterThan(0);
       const initialCountdownValue = /** @type {number} */ (initialCountdown);
-      expect(initialCountdownValue).toBeGreaterThan(0);
       await expect(timerLocator).toContainText(
         new RegExp(`Time Left: ${initialCountdownValue}s`)
       );

--- a/src/helpers/testApi.js
+++ b/src/helpers/testApi.js
@@ -717,19 +717,17 @@ const timerApi = {
     try {
       if (typeof document === "undefined") return null;
 
-      const timerEl =
-        document.querySelector('[data-testid="next-round-timer"]') ||
-        document.getElementById("next-round-timer");
+      const timerEl = document.querySelector('[data-testid="next-round-timer"]');
       if (!timerEl) return null;
 
-      const parseIntSafe = (value) => {
+      const parseTimerValue = (value) => {
         const numeric = Number.parseInt(String(value ?? ""), 10);
         return Number.isNaN(numeric) ? null : numeric;
       };
 
       const datasetValue =
         timerEl.getAttribute("data-remaining-time") ?? timerEl.dataset?.remainingTime;
-      const fromDataset = parseIntSafe(datasetValue);
+      const fromDataset = parseTimerValue(datasetValue);
       if (fromDataset !== null) {
         return fromDataset;
       }
@@ -737,7 +735,7 @@ const timerApi = {
       const textMatch = (timerEl.textContent || "").match(/Time Left:\s*(\d+)s/i);
       if (!textMatch) return null;
 
-      return parseIntSafe(textMatch[1]);
+      return parseTimerValue(textMatch[1]);
     } catch {
       return null;
     }


### PR DESCRIPTION
## Summary
- ensure the timer test API uses the same data-testid selector and clarify the parsing helper name
- harden the Playwright countdown reader with defensive error handling and explicit type validation before assertions

## Testing
- npx playwright test playwright/battle-classic/timer.spec.js

## Risk
- Low; changes are limited to test infrastructure and validated by Playwright coverage

------
https://chatgpt.com/codex/tasks/task_e_68d791bc1ad8832681db1bb45b3f7974