### PR TITLE
Fix home button quit binding to use battle store

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -274,11 +274,6 @@ function calculateRemainingOpponentMessageTime() {
   return 0;
 }
 
-// Attempt initial binding for home button early; store will be passed after init
-try {
-  bindHomeButton({});
-} catch {}
-
 function recordRoundCycleTrigger(source) {
   lastRoundCycleTriggerSource = source;
   lastRoundCycleTriggerTimestamp = getCurrentTimestamp();
@@ -1782,10 +1777,9 @@ async function init() {
     } catch (err) {
       console.debug("battleClassic: wiring quit button failed", err);
     }
-    // Wire Main Menu button to open confirmation modal
+    // Wire Main Menu button with battle store-aware handler
     try {
-      const homeBtn = document.getElementById("home-button");
-      if (homeBtn) homeBtn.addEventListener("click", () => quitMatch(store, homeBtn));
+      bindHomeButton(store);
     } catch (err) {
       console.debug("battleClassic: wiring home button failed", err);
     }


### PR DESCRIPTION
## Summary
- remove the placeholder binding of the home button and bind it once with the real battle store
- reuse the shared quit modal handler so the Home button no longer registers duplicate listeners

## Testing
- npx playwright test playwright/battle-classic/quit-flow.spec.js
- npx playwright test playwright/cli-flows.spec.mjs *(fails: Test API did not expose expected CLI helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c3814e188326ad8b15cff96ae0ec