### PR TITLE
Ensure scoreboard round counter updates immediately on round start

### DIFF
--- a/src/helpers/classicBattle/scoreboardAdapter.js
+++ b/src/helpers/classicBattle/scoreboardAdapter.js
@@ -83,6 +83,9 @@ function handleRoundStart(event) {
   const normalizedRoundNumber = roundNumber ?? roundIndex;
   if (typeof normalizedRoundNumber === "number") {
     roundStore.setRoundNumber(normalizedRoundNumber, { emitLegacyEvent: false });
+    try {
+      updateRoundCounter(normalizedRoundNumber);
+    } catch {}
   } else {
     try {
       clearRoundCounter();

--- a/tests/classicBattle/page-scaffold.test.js
+++ b/tests/classicBattle/page-scaffold.test.js
@@ -1043,6 +1043,9 @@ describe("Classic Battle page scaffold (behavioral)", () => {
     const { emitBattleEvent } = await import("../../src/helpers/classicBattle/battleEvents.js");
     emitBattleEvent("display.round.start", { roundNumber: 3 });
 
+    expect(scoreboardMock.updateRoundCounter.mock.calls.length).toBeGreaterThan(initialRoundCalls);
+    expect(scoreboardMock.updateRoundCounter.mock.calls.at(-1)).toEqual([3]);
+
     const roundEnded = engineMock.listeners.get("roundEnded");
     roundEnded?.({ playerScore: 4, opponentScore: 1 });
 


### PR DESCRIPTION
## Task Contract
- **Inputs:** User request to call the scoreboard round counter update during `display.round.start` handling and cover the behavior with tests.
- **Outputs:** Adjusted classic battle scoreboard adapter and accompanying Vitest coverage.
- **Success Criteria:** Scoreboard round counter updates synchronously with `display.round.start` events and Vitest asserts the updated counter is surfaced.

## Summary
- Call `updateRoundCounter` as soon as the round store accepts a new round number in the classic battle scoreboard adapter.
- Extend the classic battle page scaffold test to verify `display.round.start` immediately bumps the mocked counter to the new round.

## Files Changed
- `src/helpers/classicBattle/scoreboardAdapter.js`
- `tests/classicBattle/page-scaffold.test.js`

## Verification
- `npm test -- --run tests/classicBattle/page-scaffold.test.js`

## Risk Note
- Low risk: change is localized to round start handling and corresponding behavioral test coverage.

------
https://chatgpt.com/codex/tasks/task_e_68d7c5776a248326813cec3a11ef758e