### PR TITLE
Add CLI verbose log reader helper for tests

### DIFF
--- a/src/helpers/testApi.js
+++ b/src/helpers/testApi.js
@@ -1229,6 +1229,42 @@ const cliApi = {
       dispatched: resolution?.dispatched ?? false,
       emitted: resolution?.emitted ?? false
     };
+  },
+
+  /**
+   * Read the verbose log contents for CLI assertions.
+   *
+   * @returns {string[]} Trimmed verbose log lines; empty when unavailable.
+   * @pseudocode
+   * if document undefined -> return []
+   * pre = document.getElementById("cli-verbose-log")
+   * if !pre or textContent not string -> return []
+   * return pre.textContent.split("\n").map(trim).filter(Boolean)
+   */
+  readVerboseLog() {
+    if (typeof document === "undefined") {
+      return [];
+    }
+
+    let pre;
+    try {
+      pre = document.getElementById("cli-verbose-log");
+    } catch {
+      return [];
+    }
+
+    if (!pre || typeof pre.textContent !== "string") {
+      return [];
+    }
+
+    try {
+      return pre.textContent
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+    } catch {
+      return [];
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- add a `cliApi.readVerboseLog` helper that reads the CLI verbose log into trimmed lines for assertions

## Testing
- npx playwright test playwright/cli-flows.spec.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d7c561d82c832697c126726b87a09f