### PR TITLE
Guard battle CLI init for documentless environments

### DIFF
--- a/tests/pages/battleCLI/handlerLatency.spec.js
+++ b/tests/pages/battleCLI/handlerLatency.spec.js
@@ -3,6 +3,20 @@ import * as init from "../../../src/pages/battleCLI/init.js";
 // Import DOM helpers used within module under test to stub safely
 import * as domMod from "../../../src/pages/battleCLI/dom.js";
 
+describe("battleCLI init import guards", () => {
+  it("does not throw when document is undefined", async () => {
+    const originalDocument = globalThis.document;
+    vi.resetModules();
+    try {
+      globalThis.document = undefined;
+      await expect(import("../../../src/pages/battleCLI/init.js")).resolves.toBeTruthy();
+    } finally {
+      globalThis.document = originalDocument;
+      vi.resetModules();
+    }
+  });
+});
+
 describe("battleCLI waitingForPlayerAction handler latency", () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="cli-countdown"></div>';


### PR DESCRIPTION
## Summary
- add a single hasDocument flag and early-return guards around battle CLI DOM mutations and auto bootstrapping
- ensure init() only runs scoreboard wiring when the DOM exists so the module can load without browser globals
- extend the handler latency spec to re-import the module with global.document cleared and assert it no longer throws

## Testing
- npx vitest run tests/pages/battleCLI/handlerLatency.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d7c581bb688326978622de9e1423f6