### PR TITLE
Address review feedback on stat hotkey smoke test

### DIFF
--- a/playwright/battle-classic/stat-hotkeys.smoke.spec.js
+++ b/playwright/battle-classic/stat-hotkeys.smoke.spec.js
@@ -1,10 +1,13 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Stat hotkeys", () => {
-  test("pressing 1 selects the first stat", async ({ page }) => {
+  test("clicking the first stat selects it", async ({ page }) => {
     await page.addInitScript(() => {
       window.__FF_OVERRIDES = { ...(window.__FF_OVERRIDES || {}), statHotkeys: true };
-      window.__TEST__ = window.__TEST__ || {};
+      window.__FEATURE_FLAGS__ = {
+        ...(window.__FEATURE_FLAGS__ || {}),
+        statHotkeys: true
+      };
     });
     await page.goto("/src/pages/battleClassic.html");
 
@@ -14,22 +17,8 @@ test.describe("Stat hotkeys", () => {
       "data-buttons-ready",
       "true"
     );
-    await first.focus(); // ensure document receives keydown consistently
 
-    await page.evaluate(() => {
-      window.__TEST__ = window.__TEST__ || {};
-      if (typeof window.__TEST__.selectStatByIndex !== "function") {
-        window.__TEST__.selectStatByIndex = (index) => {
-          const buttons = document.querySelectorAll("#stat-buttons button");
-          const target = buttons[index];
-          if (target && !target.disabled) target.click();
-        };
-      }
-    });
-
-    await page.evaluate(() => {
-      window.__TEST__?.selectStatByIndex?.(0);
-    });
+    await first.click();
 
     await expect(page.locator("body")).toHaveAttribute(
       "data-stat-selected",


### PR DESCRIPTION
## Summary
- rename the stat hotkey smoke test to reflect the actual interaction it performs
- replace the DOM-based helper with a natural Playwright click while keeping the flag setup and readiness checks

## Testing
- npx playwright test playwright/battle-classic/stat-hotkeys.smoke.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d7d398cf8883268fc40533a639af1f