### PR TITLE
Follow-up: align stat hotkeys smoke test with keyboard interaction

### DIFF
--- a/playwright/battle-classic/stat-hotkeys.smoke.spec.js
+++ b/playwright/battle-classic/stat-hotkeys.smoke.spec.js
@@ -1,13 +1,9 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Stat hotkeys", () => {
-  test("clicking the first stat selects it", async ({ page }) => {
+  test("pressing the 1 hotkey selects the first stat", async ({ page }) => {
     await page.addInitScript(() => {
       window.__FF_OVERRIDES = { ...(window.__FF_OVERRIDES || {}), statHotkeys: true };
-      window.__FEATURE_FLAGS__ = {
-        ...(window.__FEATURE_FLAGS__ || {}),
-        statHotkeys: true
-      };
     });
     await page.goto("/src/pages/battleClassic.html");
 
@@ -18,7 +14,7 @@ test.describe("Stat hotkeys", () => {
       "true"
     );
 
-    await first.click();
+    await page.locator("body").press("1");
 
     await expect(page.locator("body")).toHaveAttribute(
       "data-stat-selected",


### PR DESCRIPTION
## Summary
- rename the stat hotkeys smoke test to describe its keyboard-driven focus
- trigger stat selection via the 1 hotkey instead of a mouse click
- rely on `__FF_OVERRIDES` for the `statHotkeys` flag to avoid duplicate configuration

## Testing
- not run (already covered by existing automation)


------
https://chatgpt.com/codex/tasks/task_e_68d7e080cbec8326b16f24f29ba572d3