### PR TITLE
Wire stat hotkeys when rendering classic battle buttons

### DIFF
--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -10,7 +10,8 @@ import { computeRoundResult } from "../helpers/classicBattle/roundResolver.js";
 import {
   disableStatButtons,
   setStatButtonsEnabled,
-  resolveStatButtonsReady
+  resolveStatButtonsReady,
+  wireStatHotkeys
 } from "../helpers/classicBattle/statButtons.js";
 import { quitMatch } from "../helpers/classicBattle/quitModal.js";
 import { bindUIHelperEventHandlersDynamic } from "../helpers/classicBattle/uiEventHandlers.js";
@@ -64,6 +65,7 @@ let isStartingRoundCycle = false;
 // Suppress duplicate round cycle starts when manual Next clicks trigger both
 // `round.start` and `ready` back-to-back.
 let lastManualRoundStartTimestamp = 0;
+let detachStatHotkeys;
 const READY_SUPPRESSION_WINDOW_MS = (() => {
   if (typeof window === "undefined") {
     return 200;
@@ -1250,6 +1252,12 @@ function renderStatButtons(store) {
   } catch (err) {
     console.debug("battleClassic: disableNextRoundButton before selection failed", err);
   }
+  try {
+    if (typeof detachStatHotkeys === "function") {
+      detachStatHotkeys();
+    }
+  } catch {}
+  detachStatHotkeys = undefined;
   container.innerHTML = "";
   for (const stat of STATS) {
     const btn = document.createElement("button");
@@ -1295,6 +1303,9 @@ function renderStatButtons(store) {
       () => resolveStatButtonsReady(),
       () => {}
     );
+    try {
+      detachStatHotkeys = wireStatHotkeys(buttons);
+    } catch {}
   } catch {} // Ignore errors if setting stat buttons enabled fails
 }
 


### PR DESCRIPTION
## Task Contract
- **Inputs:** Existing classic battle stat button rendering logic in `battleClassic.init.js`.
- **Outputs:** Updated rendering flow that attaches numeric hotkeys with proper disposal between renders.
- **Success Criteria:** Stat buttons mount with hotkeys bound after each render, pressing "1" toggles the body attribute in Playwright smoke test, and previous listeners are cleaned up before re-render.
- **Failure Modes:** Repeated renders could leak listeners or hotkeys might not trigger selection.

## Summary
- Import the stat hotkey wiring helper and keep a module-level disposer so listeners can be replaced safely between renders.
- Dispose any existing hotkey listener before rebuilding the stat buttons and reattach hotkeys after enabling the new buttons.

## Files Changed
- `src/pages/battleClassic.init.js`

## Testing
- `npx playwright test playwright/battle-classic/stat-hotkeys.smoke.spec.js`

## Risk
- Low: Changes are limited to classic battle stat button rendering and event listener lifecycle management.

------
https://chatgpt.com/codex/tasks/task_e_68d8022c9a7c8326b25ef09ffcc12bed