### PR TITLE
docs: document feature flag helpers

### DIFF
--- a/src/helpers/featureFlags.js
+++ b/src/helpers/featureFlags.js
@@ -110,7 +110,12 @@ export async function setFlag(flag, value) {
  * Useful for default-on behavior during bootstrap where eventual persistence
  * is acceptable.
  *
- * @param {string} flag
+ * @pseudocode
+ * 1. Merge `{ enabled: true }` into the cached flag entry.
+ * 2. Attempt to persist the change by delegating to `setFlag(flag, true)`.
+ * 3. Ignore any errors because this helper is invoked in hot paths.
+ *
+ * @param {string} flag - Feature flag identifier to enable.
  * @returns {void}
  */
 export function enableFlag(flag) {

--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -559,6 +559,14 @@ function handleStatSelectionError(store, err) {
 /**
  * Prepares the UI before stat selection occurs and captures the timestamp of
  * the opponent choosing prompt for minimum duration enforcement.
+ *
+ * @pseudocode
+ * 1. Stop any active stat selection timer utilities.
+ * 2. Cancel the global `__battleClassicStopSelectionTimer` hook when available.
+ * 3. Show the "opponent choosing" snackbar and record the prompt timestamp.
+ * 4. Return any window-provided delay override value.
+ *
+ * @returns {number} Delay override in milliseconds, or `0` when none provided.
  */
 export function prepareUiBeforeSelection() {
   try {


### PR DESCRIPTION
## Task Contract
- **Inputs:** Undocumented helper functions for feature flag enablement and classic battle UI preparation.
- **Outputs:** Complete JSDoc blocks including required `@pseudocode` annotations and parameter/return details.
- **Success:** `npm run check:jsdoc` and `npm run check:rag` executed via commit hook and both passed.
- **Errors:** None observed.

## Files Changed
- src/helpers/featureFlags.js
- src/pages/battleClassic.init.js

## Summary
- Document `enableFlag` with explicit pseudocode and parameter description.
- Clarify `prepareUiBeforeSelection` behavior, including snackbar/timer coordination and return value semantics.

## Testing
- `npm run check:jsdoc`
- `npm run check:rag`

## Risk
- Low: documentation-only updates.


------
https://chatgpt.com/codex/tasks/task_e_68d8164d0ba88326bc393dfd54ade776