### PR TITLE
Use fake timers in cooldown start spec

### DIFF
--- a/tests/unit/cooldown.start.spec.js
+++ b/tests/unit/cooldown.start.spec.js
@@ -1,7 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as roundManager from "@/helpers/classicBattle/roundManager.js";
 
 describe("cooldown auto-advance wiring", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     // jsdom body for dataset checks used by cooldown
     if (typeof document !== "undefined") {
@@ -13,7 +21,9 @@ describe("cooldown auto-advance wiring", () => {
 
   it("emits countdown started and resolves ready at expiry", async () => {
     const bus = { emit: vi.fn() };
-    const scheduler = { setTimeout: (fn, ms) => setTimeout(fn, ms) };
+    const scheduler = {
+      setTimeout: vi.fn((fn, ms) => setTimeout(fn, ms))
+    };
     const showSnackbar = vi.fn();
     const dispatchBattleEvent = vi.fn();
 
@@ -29,7 +39,7 @@ describe("cooldown auto-advance wiring", () => {
     expect(bus.emit).toHaveBeenCalledWith("control.countdown.started", expect.any(Object));
 
     // Fast-forward timers to ensure expiry triggers
-    await new Promise((r) => setTimeout(r, 10));
+    await vi.runAllTimersAsync();
     // Ready promise should be present
     expect(controls).toBeTruthy();
     expect(typeof controls.ready?.then).toBe("function");


### PR DESCRIPTION
## Summary
- enable Vitest fake timers for the cooldown start unit test and restore them after each run
- stub the provided scheduler so it integrates with the fake clock and advance timers via Vitest helpers before asserting readiness

## Testing
- npx vitest run tests/unit/cooldown.start.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68d8239a3ccc832694ade40636485a9c