### PR TITLE
test: mock waitForBattleReady in test API spec

### DIFF
--- a/tests/helpers/testApi.test.js
+++ b/tests/helpers/testApi.test.js
@@ -120,6 +120,10 @@ describe("testApi.isTestMode", () => {
 
     exposeTestAPI();
 
+    const waitForBattleReadySpy = vi
+      .spyOn(window.__INIT_API, "waitForBattleReady")
+      .mockResolvedValue(true);
+
     expect(window.__TEST_API).toBe(getTestAPI());
     expect(window.__INIT_API).toBeDefined();
 
@@ -128,6 +132,7 @@ describe("testApi.isTestMode", () => {
     try {
       await expect(window.__INIT_API.waitForBattleReady(5)).resolves.toBe(true);
     } finally {
+      waitForBattleReadySpy.mockRestore();
       if (originalInitCalled === undefined) {
         delete window.__initCalled;
       } else {


### PR DESCRIPTION
## Task Contract
- **Inputs:** Existing Vitest spec `tests/helpers/testApi.test.js`.
- **Outputs:** Updated test ensures deterministic resolution of `waitForBattleReady` without relying on real timers.
- **Success Criteria:** Test stubs `window.__INIT_API.waitForBattleReady` (or controls timers) so the promise resolves immediately, and cleanup restores original behavior.
- **Failure Modes:** Forgetting to restore the spy/timers or leaving the polling loop asynchronous would cause flaky behavior in other specs.

## Summary
- Mocked `window.__INIT_API.waitForBattleReady` during the webdriver test to resolve immediately.
- Restored the spy in the existing cleanup block to maintain isolation between specs.

## Files Changed
- tests/helpers/testApi.test.js

## Testing
- `npx vitest run tests/helpers/testApi.test.js`

## Risk
- **Low:** Change is isolated to a single deterministic unit test.

------
https://chatgpt.com/codex/tasks/task_e_68d823c285a083268ac5df2206e93ea1