### PR TITLE
Fix ESLint unused variable warnings

### DIFF
--- a/scripts/prepareLocalModel.mjs
+++ b/scripts/prepareLocalModel.mjs
@@ -14,7 +14,7 @@
  *    - If successful, copy/cache files into models/minilm.
  * 5. On failure, print actionable guidance for strict-offline environments.
  */
-import { mkdir, stat, cp, writeFile } from "node:fs/promises";
+import { mkdir, stat, cp } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 

--- a/tests/pages/battleCLI.verboseWinTarget.test.js
+++ b/tests/pages/battleCLI.verboseWinTarget.test.js
@@ -41,6 +41,8 @@ describe("battleCLI verbose win target", () => {
 
     await mod.init();
 
+    expect(() => getListener(changeSpy, "change")).not.toThrow();
+
     const initModule = await import("../../src/pages/battleCLI/init.js");
     const { toggleVerbose } = await initModule.setupFlags();
     expect(toggleVerbose).toEqual(expect.any(Function));


### PR DESCRIPTION
## Summary
- remove the unused writeFile import from the local model preparation script
- assert the battleCLI test registers a change listener so the spy is exercised

## Testing
- npx eslint scripts/prepareLocalModel.mjs tests/pages/battleCLI.verboseWinTarget.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d84c1b06d48326977b6582b7371f40