### PR TITLE
Align win target documentation with enforced trio

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This suite includes a DOM regression test (`tests/pages/battleJudoka.dom.test.js
 - Controls: number keys [1–5] select stats, Enter/Space advances, Q quits, H toggles a help panel, and Esc closes help or quit dialogs. Stats can also be selected by clicking or tapping, and rounds can be advanced with a click. Closing the help panel with its button ignores the next background click to avoid accidental advancement.
 - State badge: `#battle-state-badge` reflects the current machine state.
 - Bottom line: snackbars render as a single status line using `#snackbar-container`.
-- Win target: choose 5/10/15 from the header; persisted in localStorage under `battleCLI.pointsToWin`.
+- Win target: choose 3/5/10 (short/medium/long) from the header; persisted in localStorage under `battleCLI.pointsToWin`.
 - Optional verbose log: enable header toggle to record recent state transitions.
 - Bootstrap helpers: `autostartBattle()`, `renderStatList()`, and `restorePointsToWin()` orchestrate CLI startup.
 

--- a/design/productRequirementsDocuments/prdBattleCLI.md
+++ b/design/productRequirementsDocuments/prdBattleCLI.md
@@ -211,7 +211,7 @@ This appendix consolidates the previously separate CLI usage, module structure, 
 - Stats: selectable via keyboard and clickable/tappable rows (≥44px).
 - State badge: `#battle-state-badge` reflects the current machine state for visibility and tests.
 - Bottom line / Snackbar: Status line renders in `#snackbar-container` for short messages and countdown hints.
-- Win target: Header selector (5/10/15) persisted to `localStorage` at `battleCLI.pointsToWin`.
+- Win target: Header selector (3/5/10 — short/medium/long) persisted to `localStorage` at `battleCLI.pointsToWin`.
 - Verbose log: Optional header toggle to enable an event/state transition log for debugging.
 
 ### Module Structure

--- a/design/productRequirementsDocuments/prdBattleQuick.md
+++ b/design/productRequirementsDocuments/prdBattleQuick.md
@@ -18,7 +18,7 @@ Quick Battle is Ju-Do-Kon!’s **fastest battle mode**. It is a **single-round, 
 
 ## Problem Statement
 
-Classic Battle introduces players to stats and outcomes, but even its shortest format (5-point win target) takes multiple rounds. Players sometimes want a **super-fast match** — to test a single card, to demo the game, or to play in very short breaks.
+Classic Battle introduces players to stats and outcomes, but even its shortest format (3-point win target) takes multiple rounds. Players sometimes want a **super-fast match** — to test a single card, to demo the game, or to play in very short breaks.
 
 Quick Battle addresses this by offering a **single-round resolution**, cutting friction while reusing the familiar battle loop.
 

--- a/design/productRequirementsDocuments/prdGameModes.md
+++ b/design/productRequirementsDocuments/prdGameModes.md
@@ -100,7 +100,7 @@ The engine contains no UI code. Game modes translate events into messages and de
 
 | Priority | Feature           | Description                                                                                        |
 | -------- | ----------------- | -------------------------------------------------------------------------------------------------- |
-| P1       | Classic Battle    | 1v1 battle vs opponent, stat-based combat to a user-selected 5/10/15 point win target (default 10) |
+| P1       | Classic Battle    | 1v1 battle vs opponent, stat-based combat to a user-selected 3/5/10 point win target (short/medium/long, default 5) |
 | P1       | Team Battle Modes | Gender-specific team-based battles                                                                 |
 | P1       | Judoka Creation   | Interface for new character creation                                                               |
 | P2       | Judoka Update     | Edit existing characters and save changes                                                          |
@@ -116,7 +116,7 @@ The engine contains no UI code. Game modes translate events into messages and de
 
 **Japanese**: 試合 (バトルモード)
 **URL**: `battleJudoka.html`
-A 1v1 stat-based match against an AI opponent using a deck of 25 random judoka cards. On first visit, a modal prompts the player to choose a win target of 5, 10, or 15 points (default 10); first to that target wins. [Read full PRD](prdBattleClassic.md)
+A 1v1 stat-based match against an AI opponent using a deck of 25 random judoka cards. On first visit, a modal prompts the player to choose a win target of 3, 5, or 10 points (short/medium/long; default 5); first to that target wins. [Read full PRD](prdBattleClassic.md)
 
 #### Goals
 
@@ -128,7 +128,7 @@ A 1v1 stat-based match against an AI opponent using a deck of 25 random judoka c
 - Draw one random card from each deck per round.
 - Player selects a stat to compare.
 - Higher stat wins; score increases by one.
-- End match when either player reaches a user-selected win target of 5, 10, or 15 points (default 10) or after 25 rounds.
+- End match when either player reaches a user-selected win target of 3, 5, or 10 points (default 5) or after 25 rounds.
 
 #### Acceptance Criteria
 

--- a/design/productRequirementsDocuments/prdRoundSelection.md
+++ b/design/productRequirementsDocuments/prdRoundSelection.md
@@ -10,7 +10,7 @@ Round selection is the first user interaction in a match flow and affects match 
 
 ## Goals / Success Metrics
 
-- Provide an accessible modal that lets users choose points-to-win (e.g., 5/10/15).
+- Provide an accessible modal that lets users choose points-to-win (short/medium/long: 3/5/10).
 - Persist the last choice for returning players.
 - Support `?autostart=1` for automated flows and testing.
 
@@ -21,7 +21,7 @@ Round selection is the first user interaction in a match flow and affects match 
 
 ## Prioritized Functional Requirements
 
-P1 - Round Selection Modal: Modal appears at match start unless autostart or saved preference exists. Options: 5, 10, 15 points.
+P1 - Round Selection Modal: Modal appears at match start unless autostart or saved preference exists. Options: 3, 5, 10 points (short/medium/long).
 
 Acceptance Criteria:
 

--- a/design/productRequirementsDocuments/prdTooltipSystem.md
+++ b/design/productRequirementsDocuments/prdTooltipSystem.md
@@ -114,9 +114,9 @@ The tooltip system maintains a canonical manifest so that designers and engineer
 | `ui.quitMatch`      | Classic Battle quit confirmation flow         | [`design/productRequirementsDocuments/prdBattleClassic.md`](../../design/productRequirementsDocuments/prdBattleClassic.md) |
 | `ui.drawCard`       | Random Judoka draw button                     | [`src/helpers/randomJudokaPage.js`](../../src/helpers/randomJudokaPage.js)                                                 |
 | `card.flag`         | Judoka card flag badge                        | [`src/helpers/cardTopBar.js`](../../src/helpers/cardTopBar.js)                                                             |
-| `ui.roundQuick`     | Round length selector (5-point quick match)   | [`design/productRequirementsDocuments/prdGameModes.md`](../../design/productRequirementsDocuments/prdGameModes.md)         |
-| `ui.roundMedium`    | Round length selector (10-point medium match) | [`design/productRequirementsDocuments/prdGameModes.md`](../../design/productRequirementsDocuments/prdGameModes.md)         |
-| `ui.roundLong`      | Round length selector (15-point long match)   | [`design/productRequirementsDocuments/prdGameModes.md`](../../design/productRequirementsDocuments/prdGameModes.md)         |
+| `ui.roundQuick`     | Round length selector (3-point short match)   | [`design/productRequirementsDocuments/prdGameModes.md`](../../design/productRequirementsDocuments/prdGameModes.md)         |
+| `ui.roundMedium`    | Round length selector (5-point medium match)  | [`design/productRequirementsDocuments/prdGameModes.md`](../../design/productRequirementsDocuments/prdGameModes.md)         |
+| `ui.roundLong`      | Round length selector (10-point long match)   | [`design/productRequirementsDocuments/prdGameModes.md`](../../design/productRequirementsDocuments/prdGameModes.md)         |
 | `ui.toggleLayout`   | Browse Judoka layout toggle                   | [`src/pages/browseJudoka.html`](../../src/pages/browseJudoka.html)                                                         |
 
 **Update process**

--- a/design/stateHandlerAudit.md
+++ b/design/stateHandlerAudit.md
@@ -12,7 +12,7 @@ Generated: 2025-09-10T13:13:37.758Z
 ### waitingForMatchStart
 
 **ID**: 1 | **Type**: initial
-**Description**: Idle state before the match begins. UI shows Start/Ready and win target selection (5, 10, or 15).
+**Description**: Idle state before the match begins. UI shows Start/Ready and win target selection (3, 5, or 10 for short/medium/long).
 
 **Required onEnter actions**: 2
 

--- a/progressClassic.md
+++ b/progressClassic.md
@@ -14,7 +14,7 @@ Key:
 ## Issue 1 — Mismatch in win-target options
 
 - Status: ✔ Verified
-- Summary: UI offers [5, 10, 15] points but `prdBattleClassic.md` lists [3, 5, 10].
+- Summary: UI offers [3, 5, 10] points in alignment with `prdBattleClassic.md`.
 - Accuracy: Confirmed by checking `prdBattleClassic.md` vs. `src/data/battleRounds.js` and `src/helpers/classicBattle/roundSelectModal.js` (fallback).
 - Fix plan feasibility: Feasible and low-risk.
 - Suggested fix steps:
@@ -38,6 +38,7 @@ Key:
 - Playwright tests pass (6/6).
 - Data validation passes.
 - No regressions detected.
+- Documentation + spec now reflect the enforced 3/5/10 win target trio.
 
 ---
 

--- a/src/helpers/classicBattle/stateTable.js
+++ b/src/helpers/classicBattle/stateTable.js
@@ -106,7 +106,7 @@ export const CLASSIC_BATTLE_STATES = [
         on: "matchPointReached",
         target: "matchDecision",
         guard: "playerScore >= winTarget || opponentScore >= winTarget",
-        note: "Checks the user-selected win target (5/10/15)."
+        note: "Checks the user-selected win target (3/5/10)."
       },
       { on: "continue", target: "cooldown" },
       { on: "interrupt", target: "interruptRound" }

--- a/tests/fixtures/uiTooltipManifest.js
+++ b/tests/fixtures/uiTooltipManifest.js
@@ -33,17 +33,17 @@ export const uiTooltipManifest = [
   },
   {
     tooltipId: "ui.roundQuick",
-    component: "Round length selector (5-point quick match)",
+    component: "Round length selector (3-point short match)",
     source: "design/productRequirementsDocuments/prdGameModes.md"
   },
   {
     tooltipId: "ui.roundMedium",
-    component: "Round length selector (10-point medium match)",
+    component: "Round length selector (5-point medium match)",
     source: "design/productRequirementsDocuments/prdGameModes.md"
   },
   {
     tooltipId: "ui.roundLong",
-    component: "Round length selector (15-point long match)",
+    component: "Round length selector (10-point long match)",
     source: "design/productRequirementsDocuments/prdGameModes.md"
   },
   {


### PR DESCRIPTION
## Summary
- update Classic Battle documentation (round selection, game modes, CLI, quick battle, README) to reference the short/medium/long 3/5/10 win targets
- refresh tooltip manifest entries and state handler note to match the supported options
- note in the progress summary that specs now align with the enforced configuration and adjust related comments

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d84f9daacc8326a1df41ec2a1d268c