### PR TITLE
Align default win target fallback with documentation

### DIFF
--- a/design/productRequirementsDocuments/prdGameModes.md
+++ b/design/productRequirementsDocuments/prdGameModes.md
@@ -100,7 +100,7 @@ The engine contains no UI code. Game modes translate events into messages and de
 
 | Priority | Feature           | Description                                                                                        |
 | -------- | ----------------- | -------------------------------------------------------------------------------------------------- |
-| P1       | Classic Battle    | 1v1 battle vs opponent, stat-based combat to a user-selected 3/5/10 point win target (short/medium/long, default 5) |
+| P1       | Classic Battle    | 1v1 battle vs opponent, stat-based combat to a user-selected 3/5/10 point win target (short/medium/long; default: medium (5 points)) |
 | P1       | Team Battle Modes | Gender-specific team-based battles                                                                 |
 | P1       | Judoka Creation   | Interface for new character creation                                                               |
 | P2       | Judoka Update     | Edit existing characters and save changes                                                          |
@@ -116,7 +116,7 @@ The engine contains no UI code. Game modes translate events into messages and de
 
 **Japanese**: 試合 (バトルモード)
 **URL**: `battleJudoka.html`
-A 1v1 stat-based match against an AI opponent using a deck of 25 random judoka cards. On first visit, a modal prompts the player to choose a win target of 3, 5, or 10 points (short/medium/long; default 5); first to that target wins. [Read full PRD](prdBattleClassic.md)
+A 1v1 stat-based match against an AI opponent using a deck of 25 random judoka cards. On first visit, a modal prompts the player to choose a win target of 3, 5, or 10 points (short/medium/long; default: medium (5 points)); first to that target wins. [Read full PRD](prdBattleClassic.md)
 
 #### Goals
 
@@ -128,7 +128,7 @@ A 1v1 stat-based match against an AI opponent using a deck of 25 random judoka c
 - Draw one random card from each deck per round.
 - Player selects a stat to compare.
 - Higher stat wins; score increases by one.
-- End match when either player reaches a user-selected win target of 3, 5, or 10 points (default 5) or after 25 rounds.
+- End match when either player reaches a user-selected win target of 3, 5, or 10 points (default: medium (5 points)) or after 25 rounds.
 
 #### Acceptance Criteria
 

--- a/src/config/battleDefaults.js
+++ b/src/config/battleDefaults.js
@@ -19,7 +19,7 @@ export const POINTS_TO_WIN_OPTIONS = [3, 5, 10];
  * 2. Consumers should read and persist user selections separately.
  * @returns {number}
  */
-export const DEFAULT_POINTS_TO_WIN = 10;
+export const DEFAULT_POINTS_TO_WIN = 5;
 export const FEATURE_FLAGS = {
   autoSelect: { enabled: true },
   enableTestMode: { enabled: false },

--- a/tests/fixtures/uiTooltipManifest.js
+++ b/tests/fixtures/uiTooltipManifest.js
@@ -33,17 +33,17 @@ export const uiTooltipManifest = [
   },
   {
     tooltipId: "ui.roundQuick",
-    component: "Round length selector (3-point short match)",
+    component: "Round length selector (short, 3-point match)",
     source: "design/productRequirementsDocuments/prdGameModes.md"
   },
   {
     tooltipId: "ui.roundMedium",
-    component: "Round length selector (5-point medium match)",
+    component: "Round length selector (medium, 5-point match)",
     source: "design/productRequirementsDocuments/prdGameModes.md"
   },
   {
     tooltipId: "ui.roundLong",
-    component: "Round length selector (10-point long match)",
+    component: "Round length selector (long, 10-point match)",
     source: "design/productRequirementsDocuments/prdGameModes.md"
   },
   {


### PR DESCRIPTION
## Summary
- update the Classic Battle default points-to-win fallback to match the documented medium setting
- clarify documentation references so all references describe the medium (5-point) default consistently
- synchronize tooltip manifest terminology with the short/medium/long labels used elsewhere

## Testing
- npm run check:jsdoc
- npm run check:rag

------
https://chatgpt.com/codex/tasks/task_e_68d8dffca80083268aface943fa19d24