### PR TITLE
Align Playwright win target expectations with battle rounds

### DIFF
--- a/playwright/battle-classic/round-select.server.spec.js
+++ b/playwright/battle-classic/round-select.server.spec.js
@@ -21,14 +21,14 @@ test.describe("Classic Battle round select (server integration)", () => {
       await expect(page.getByRole("button", { name: "Medium" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Long" })).toBeVisible();
 
-      // Select Long battle (15 points)
+      // Select Long battle (10 points)
       await page.getByRole("button", { name: "Long" }).click();
 
       // Verify modal is dismissed
       await expect(page.getByRole("dialog")).not.toBeVisible();
 
       // Verify server correctly sets the target attribute
-      await expect(page.locator("body")).toHaveAttribute("data-target", "15");
+      await expect(page.locator("body")).toHaveAttribute("data-target", "10");
 
       // Verify battle state is properly initialized
       await expect(page.getByTestId("round-counter")).toContainText("Round 1");
@@ -49,12 +49,12 @@ test.describe("Classic Battle round select (server integration)", () => {
 
       await page.goto("/src/pages/battleClassic.html");
 
-      // Wait for modal and select Quick battle (5 points)
+      // Wait for modal and select Quick battle (3 points)
       await page.getByRole("dialog").waitFor();
       await page.getByRole("button", { name: "Quick" }).click();
 
       // Verify server correctly sets target for Quick battle
-      await expect(page.locator("body")).toHaveAttribute("data-target", "5");
+      await expect(page.locator("body")).toHaveAttribute("data-target", "3");
 
       // Verify battle initializes with correct state
       await expect(page.getByTestId("round-counter")).toContainText("Round 1");
@@ -72,7 +72,7 @@ test.describe("Classic Battle round select (server integration)", () => {
       await page.getByRole("button", { name: "Medium" }).click();
 
       // Verify server correctly updates target for Medium battle
-      await expect(page.locator("body")).toHaveAttribute("data-target", "10");
+      await expect(page.locator("body")).toHaveAttribute("data-target", "5");
     }, ["log", "info", "warn", "error", "debug"]);
   });
 });

--- a/playwright/battle-classic/round-select.spec.js
+++ b/playwright/battle-classic/round-select.spec.js
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 import { withMutedConsole } from "../../tests/utils/console.js";
 
 test.describe("Classic Battle round select", () => {
-  test("user can select Long battle (15 points) and modal updates correctly", async ({ page }) => {
+  test("user can select Long battle (10 points) and modal updates correctly", async ({ page }) => {
     await withMutedConsole(async () => {
       // Force the round select modal to show in Playwright tests
       await page.addInitScript(() => {
@@ -24,14 +24,14 @@ test.describe("Classic Battle round select", () => {
       await expect(page.getByRole("button", { name: "Medium" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Long" })).toBeVisible();
 
-      // Click the Long option (15 points)
+      // Click the Long option (10 points)
       await page.getByRole("button", { name: "Long" }).click();
 
       // Verify modal is dismissed
       await expect(page.getByRole("dialog")).not.toBeVisible();
 
       // Verify battle state is updated (body should have target data attribute)
-      await expect(page.locator("body")).toHaveAttribute("data-target", "15");
+      await expect(page.locator("body")).toHaveAttribute("data-target", "10");
 
       // Verify round counter shows initial state
       await expect(page.getByTestId("round-counter")).toContainText("Round 1");

--- a/playwright/battle-classic/timer.spec.js
+++ b/playwright/battle-classic/timer.spec.js
@@ -66,7 +66,7 @@ test.describe("Classic Battle timer", () => {
       await expect(page.getByRole("dialog")).toBeVisible();
       await expect(page.getByText("Select Match Length")).toBeVisible();
 
-      // Select Medium battle (10 points) which should start a timer
+      // Select Medium battle (5 points) which should start a timer
       await page.getByRole("button", { name: "Medium" }).click();
 
       // Verify modal is dismissed
@@ -94,7 +94,7 @@ test.describe("Classic Battle timer", () => {
       await expect(timerLocator).toContainText(new RegExp(`Time Left: ${decreasedCountdown}s`));
 
       // Verify battle state is properly initialized
-      await expect(page.locator("body")).toHaveAttribute("data-target", "10");
+      await expect(page.locator("body")).toHaveAttribute("data-target", "5");
       await expect(page.getByTestId("round-counter")).toContainText("Round 1");
     }, ["log", "info", "warn", "error", "debug"]);
   });
@@ -108,7 +108,7 @@ test.describe("Classic Battle timer", () => {
 
       await page.goto("/src/pages/battleClassic.html");
 
-      // Wait for modal and select Long battle (15 points)
+      // Wait for modal and select Long battle (10 points)
       await page.getByRole("dialog").waitFor();
       await page.getByRole("button", { name: "Long" }).click();
 
@@ -117,7 +117,7 @@ test.describe("Classic Battle timer", () => {
       await expect(timerLocator).toContainText(/Time Left: \d+s/);
 
       // Verify battle state is set correctly
-      await expect(page.locator("body")).toHaveAttribute("data-target", "15");
+      await expect(page.locator("body")).toHaveAttribute("data-target", "10");
 
       // Verify round counter and score display are initialized
       await expect(page.getByTestId("round-counter")).toContainText("Round 1");

--- a/playwright/cli-flows-improved.spec.mjs
+++ b/playwright/cli-flows-improved.spec.mjs
@@ -206,7 +206,7 @@ test.describe("CLI Battle Interface", () => {
 
       const roundDisplay = page.locator("#cli-round");
       await expect(roundDisplay).toContainText("Round");
-      await expect(roundDisplay).toContainText("Target: 10");
+      await expect(roundDisplay).toContainText("Target: 5");
 
       const scoreDisplay = page.locator("#cli-score");
       await expect(scoreDisplay).toContainText("You: 0 Opponent: 0");
@@ -273,10 +273,11 @@ test.describe("CLI Battle Interface", () => {
 
       const pointsSelect = page.locator("#points-select");
       await expect(pointsSelect).toHaveAttribute("aria-label", "Points to win");
-      await expect(pointsSelect).toHaveValue("10");
+      await expect(pointsSelect).toHaveValue("5");
 
       try {
-        await pointsSelect.selectOption("5");
+        await pointsSelect.selectOption("3");
+        await expect(pointsSelect).toHaveValue("3");
       } catch {}
       const optionCount = await pointsSelect.evaluate((element) => element.options.length);
       expect(optionCount).toBeGreaterThan(0);

--- a/playwright/win-target-sync.spec.js
+++ b/playwright/win-target-sync.spec.js
@@ -13,10 +13,10 @@ async function openSettingsPanel(page) {
 
 test.describe("Round Selection - Win Target Synchronization", () => {
   const testCases = [
-    { key: "1", points: "5", name: "Quick" },
-    { key: "2", points: "10", name: "Medium" },
-    { key: "3", points: "15", name: "Long" },
-    { key: "1", points: "5", name: "Quick (sync check)" } // Additional case for sync
+    { key: "1", points: "3", name: "Quick" },
+    { key: "2", points: "5", name: "Medium" },
+    { key: "3", points: "10", name: "Long" },
+    { key: "1", points: "3", name: "Quick (sync check)" } // Additional case for sync
   ];
 
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary
- update classic battle round select and timer specs to assert the 3/5/10 win targets
- adjust CLI flow and synchronization tests to expect the Medium default (5) and cover alternate win targets
- audit the Playwright suite to remove remaining win-target references to the old 5/10/15 values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d91aed892c8326ab1f8c0dbd0b4388