### PR TITLE
Fix strict equality check in cooldown test

### DIFF
--- a/tests/unit/cooldown.start.spec.js
+++ b/tests/unit/cooldown.start.spec.js
@@ -46,7 +46,7 @@ describe("cooldown auto-advance wiring", () => {
         return id;
       }),
       clearTimeout: vi.fn((id) => {
-        if (id == null) {
+        if (id === null || id === undefined) {
           return false;
         }
         return pendingTimeouts.delete(id);


### PR DESCRIPTION
## Task Contract
- **Inputs:** Lint error from `tests/unit/cooldown.start.spec.js` complaining about `==` usage.
- **Outputs:** Updated test file using strict equality to satisfy ESLint.
- **Success Criteria:** ESLint passes for the touched file without introducing regressions.
- **Failure Modes:** ESLint still fails or tests no longer simulate scheduler correctly.

## Summary
- Replace the loose null comparison in the cooldown scheduler test helper with an explicit strict null/undefined check to satisfy lint rules.

## Files Changed
- tests/unit/cooldown.start.spec.js

## Testing
- `npx eslint tests/unit/cooldown.start.spec.js --cache`

## Risk
- Low risk: change is limited to a unit test helper and preserves original logic.


------
https://chatgpt.com/codex/tasks/task_e_68d92dd60eb88326893758e817e7a5b0