### PR TITLE
Fix agent workflow tag detection in embedding generator

### DIFF
--- a/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
+++ b/design/productRequirementsDocuments/prdVectorDatabaseRAG.md
@@ -68,7 +68,9 @@ Ultimately, these issues increase the risk of bugs reaching players, slow down t
 ### Embedding Refresh Pipeline
 
 After editing PRDs, tooltips, game rules, or any markdown under
-`design/codeStandards` or the agent workflow documentation in `design/productRequirementsDocuments/prdAIAgentWorkflows.md`, run
+`design/codeStandards`—including the agent workflow documentation in
+`design/productRequirementsDocuments/prdAIAgentWorkflows.md` and the RAG
+operations sections in `design/productRequirementsDocuments/prdVectorDatabaseRAG.md`—run
 `npm run generate:embeddings` from the repository root. The script at
 `scripts/generateEmbeddings.js` downloads the **quantized** `Xenova/all-MiniLM-L6-v2` model the first time it runs, so the command will fail without internet access. Cache the model locally or run it in an environment with a connection. Commit the updated `client_embeddings.json`—now pretty-printed for readability—so other agents work with the latest vectors. If you hit out-of-memory errors during generation, rerun the command with a higher heap limit (e.g. `node --max-old-space-size=8192 scripts/generateEmbeddings.js`). A GitHub Actions workflow could automate this
 regeneration whenever those folders change.

--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -705,13 +705,14 @@ function determineTags(relativePath, ext, isTest) {
   const tags = ["prd"];
   if (relativePath.startsWith("design/productRequirementsDocuments")) {
     tags.push("design-doc");
+    if (
+      relativePath.includes("prdAIAgentWorkflows") ||
+      relativePath.includes("prdVectorDatabaseRAG")
+    ) {
+      tags.push("agent-workflow");
+    }
   } else if (relativePath.startsWith("design/codeStandards")) {
     tags.push("design-guideline");
-  } else if (
-    relativePath.startsWith("design/productRequirementsDocuments/prdAIAgentWorkflows") ||
-    relativePath.startsWith("design/productRequirementsDocuments/prdVectorDatabaseRAG")
-  ) {
-    tags.push("agent-workflow");
   } else if (relativePath.startsWith("design/architecture")) {
     tags.push("architecture-doc");
   } else if (/^(README|CONTRIBUTING|MIGRATION)\.md$/.test(path.basename(relativePath))) {


### PR DESCRIPTION
## Summary
- ensure agent workflow PRDs receive the `agent-workflow` tag alongside `design-doc`
- clarify the embedding refresh guidance to call out both agent workflow PRDs

## Testing
- npm run check:jsdoc
- npm run check:rag

------
https://chatgpt.com/codex/tasks/task_e_68d977016f2083269bd70cde0bd69a87