### PR TITLE
Improve agent workflow tag detection

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -689,6 +689,17 @@ async function loadModel() {
   });
 }
 
+/**
+ * Derive the tag set for a given file path.
+ *
+ * @pseudocode
+ * 1. If the file is JSON or data JS, assign `data` tags with specific
+ *    subcategories for judoka or tooltip files.
+ * 2. If the file is JS/TS, categorize as either `code` or `test-code`.
+ * 3. Otherwise mark as PRD documentation and add specific tags based on the
+ *    document collection, including a precise match for agent workflow PRDs.
+ * 4. Return the accumulated tag list.
+ */
 function determineTags(relativePath, ext, isTest) {
   const isDataJs = relativePath.startsWith("src/data/") && ext === ".js";
   if (ext === ".json" || isDataJs) {
@@ -705,9 +716,10 @@ function determineTags(relativePath, ext, isTest) {
   const tags = ["prd"];
   if (relativePath.startsWith("design/productRequirementsDocuments")) {
     tags.push("design-doc");
+    const fileName = path.basename(relativePath);
     if (
-      relativePath.includes("prdAIAgentWorkflows") ||
-      relativePath.includes("prdVectorDatabaseRAG")
+      fileName === "prdAIAgentWorkflows.md" ||
+      fileName === "prdVectorDatabaseRAG.md"
     ) {
       tags.push("agent-workflow");
     }
@@ -1015,7 +1027,8 @@ export {
   normalizeText,
   normalizeAndFilter,
   extractAllowedValues,
-  createSparseVector
+  createSparseVector,
+  determineTags
 };
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/tests/scripts/generateEmbeddings.test.js
+++ b/tests/scripts/generateEmbeddings.test.js
@@ -5,7 +5,8 @@ import {
   JSON_FIELD_ALLOWLIST,
   BOILERPLATE_STRINGS,
   extractAllowedValues,
-  normalizeAndFilter
+  normalizeAndFilter,
+  determineTags
 } from "../../scripts/generateEmbeddings.js";
 
 describe("JSON_FIELD_ALLOWLIST", () => {
@@ -64,5 +65,28 @@ describe("normalizeAndFilter", () => {
     for (const boiler of BOILERPLATE_STRINGS) {
       expect(normalizeAndFilter(boiler, seen)).toBeUndefined();
     }
+  });
+});
+
+describe("determineTags", () => {
+  it("tags agent workflow PRDs with agent-workflow", () => {
+    const tags = determineTags(
+      "design/productRequirementsDocuments/prdAIAgentWorkflows.md",
+      ".md",
+      false
+    );
+    expect(tags).toContain("prd");
+    expect(tags).toContain("design-doc");
+    expect(tags).toContain("agent-workflow");
+  });
+
+  it("excludes agent-workflow for other PRDs", () => {
+    const tags = determineTags(
+      "design/productRequirementsDocuments/prdDevelopmentStandards.md",
+      ".md",
+      false
+    );
+    expect(tags).toContain("design-doc");
+    expect(tags).not.toContain("agent-workflow");
   });
 });


### PR DESCRIPTION
## Summary
- ensure agent workflow PRDs receive the `agent-workflow` tag alongside `design-doc` with precise filename matching
- clarify the embedding refresh guidance to call out both agent workflow PRDs
- add determineTags unit coverage for agent workflow tagging

## Testing
- npm run check:jsdoc
- npm run check:rag
- npx vitest run tests/scripts/generateEmbeddings.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9782c8b8c83268e3d5882d0490515