### PR TITLE
Improve agent workflow tag detection

### DIFF
--- a/tests/scripts/generateEmbeddings.test.js
+++ b/tests/scripts/generateEmbeddings.test.js
@@ -70,14 +70,23 @@ describe("normalizeAndFilter", () => {
 
 describe("determineTags", () => {
   it("tags agent workflow PRDs with agent-workflow", () => {
-    const tags = determineTags(
+    const aiWorkflowTags = determineTags(
       "design/productRequirementsDocuments/prdAIAgentWorkflows.md",
       ".md",
       false
     );
-    expect(tags).toContain("prd");
-    expect(tags).toContain("design-doc");
-    expect(tags).toContain("agent-workflow");
+    expect(aiWorkflowTags).toContain("prd");
+    expect(aiWorkflowTags).toContain("design-doc");
+    expect(aiWorkflowTags).toContain("agent-workflow");
+
+    const vectorDbTags = determineTags(
+      "design/productRequirementsDocuments/prdVectorDatabaseRAG.md",
+      ".md",
+      false
+    );
+    expect(vectorDbTags).toContain("prd");
+    expect(vectorDbTags).toContain("design-doc");
+    expect(vectorDbTags).toContain("agent-workflow");
   });
 
   it("excludes agent-workflow for other PRDs", () => {


### PR DESCRIPTION
## Summary
- ensure agent workflow PRDs receive the `agent-workflow` tag alongside `design-doc` with precise filename matching
- clarify the embedding refresh guidance to call out both agent workflow PRDs
- add determineTags unit coverage for agent workflow tagging, covering both agent workflow PRDs

## Testing
- npm run check:jsdoc
- npm run check:rag
- npx vitest run tests/scripts/generateEmbeddings.test.js


------
https://chatgpt.com/codex/tasks/task_e_68d9811a754c8326ac5837e477923154