### PR TITLE
Adjust embedding data processing

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -854,8 +854,8 @@ async function generate() {
 
     if (isJson || isDataJs) {
       const json = isJson ? JSON.parse(text) : (await import(pathToFileURL(fullPath))).default;
-      const processItem = async (item, id) => {
-        const textToEmbed = extractAllowedValues(base, item);
+      const processItem = async (item, id, overrideText) => {
+        const textToEmbed = overrideText ?? extractAllowedValues(base, item);
         const chunkText = textToEmbed
           ? normalizeAndFilter(String(textToEmbed), seenTexts)
           : undefined;
@@ -893,14 +893,14 @@ async function generate() {
         for (const [index, item] of json.entries()) {
           const allowed = extractAllowedValues(baseName, item);
           if (!allowed) continue;
-          await processItem({ text: allowed }, `item-${index + 1}`);
+          await processItem(item, `item-${index + 1}`, allowed);
         }
       } else if (json && typeof json === "object") {
         const flat = collectKeyPaths(json);
         for (const [keyPath, value] of flat) {
           const allowed = extractAllowedValues(baseName, { [keyPath]: value });
           if (!allowed) continue;
-          await processItem({ text: `${keyPath}: ${allowed}` }, keyPath);
+          await processItem({ [keyPath]: value }, keyPath, `${keyPath}: ${allowed}`);
         }
       }
     } else if (isMarkdown) {


### PR DESCRIPTION
## Summary
- allow `processItem` in the embedding generator to reuse allowlisted text or compute it from the original record
- ensure array and key-path entries forward the real data objects with override text so the embedder keeps keyed context

## Testing
- npm run check:jsdoc
- npm run check:rag

------
https://chatgpt.com/codex/tasks/task_e_68dc15e00f508326bef268604d57ad51