### PR TITLE
Guard settings readiness promise assignment

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -72,8 +72,10 @@ export const settingsReadyPromise = new Promise((resolve) => {
   document.addEventListener("settings:ready", resolve, { once: true });
 });
 
-// Expose readiness for tests to await.
-window.settingsReadyPromise = settingsReadyPromise;
+// Expose readiness for tests to await in browser environments.
+if (typeof window !== "undefined") {
+  window.settingsReadyPromise = settingsReadyPromise;
+}
 
 let errorPopupTimeoutId;
 


### PR DESCRIPTION
## Summary
- guard the browser-only `settingsReadyPromise` attachment to avoid referencing `window` when it is undefined

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc2275b3488326bf93b2d88a8f409e