### PR TITLE
Restore random card button visibility after generation

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -157,12 +157,18 @@ export function setupRandomCardButton(button, container) {
   if (!button || !container) return;
   button.addEventListener("click", async () => {
     button.classList.add("hidden");
+    button.disabled = true;
     container.innerHTML = "";
 
     const prefersReducedMotion = shouldReduceMotionSync();
-    await generateRandomCard(null, null, container, prefersReducedMotion, undefined, {
-      enableInspector: inspectorEnabled
-    });
+    try {
+      await generateRandomCard(null, null, container, prefersReducedMotion, undefined, {
+        enableInspector: inspectorEnabled
+      });
+    } finally {
+      button.classList.remove("hidden");
+      button.disabled = false;
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- ensure the random card button is only hidden while a card is being generated
- re-enable the button after generation and guard against concurrent clicks

## Testing
- npm run check:jsdoc
- npm run check:rag

------
https://chatgpt.com/codex/tasks/task_e_68dc226e6b1c83268d6df48d74ea5d69