### PR TITLE
Cache fallback judoka data in module scope

### DIFF
--- a/src/helpers/judokaUtils.js
+++ b/src/helpers/judokaUtils.js
@@ -1,6 +1,8 @@
 import { fetchJson } from "./dataUtils.js";
 import { DATA_DIR } from "./constants.js";
 
+let cachedFallback = null;
+
 /**
  * Retrieves the fallback judoka data (the entry with `id: 0`) from `judoka.json`.
  *
@@ -31,7 +33,7 @@ export async function getFallbackJudoka() {
       const entry = data.find((j) => j.id === 0);
       if (entry) {
         cachedFallback = entry;
-        return entry;
+        return cachedFallback;
       }
     }
     throw new Error("Fallback judoka with id 0 not found");


### PR DESCRIPTION
## Summary
- add a module-scoped cache for the fallback judoka data
- reuse the cached fallback judoka object across subsequent requests

## Testing
- `npm run check:jsdoc`
- `npm run check:rag`


------
https://chatgpt.com/codex/tasks/task_e_68dc22622cc88326bd0907182ca46f19