### PR TITLE
Address review feedback on JSON helpers

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -353,10 +353,16 @@ function createJsonProcessItem({
   extractor,
   writeEntry,
   seenTexts,
-  extractAllowedValuesFn = extractAllowedValues
+  extractAllowedValuesFn
 }) {
+  const extractFn = extractAllowedValuesFn || extractAllowedValues;
   return async (item, id, overrideText) => {
-    const textToEmbed = overrideText ?? extractAllowedValuesFn(base, item);
+    const overrideCandidate =
+      typeof overrideText === "string" ? overrideText.trim() : overrideText;
+    const textToEmbed =
+      overrideCandidate === undefined || overrideCandidate === null || overrideCandidate === ""
+        ? extractFn(base, item)
+        : overrideText;
     const chunkText = textToEmbed
       ? normalizeAndFilter(String(textToEmbed), seenTexts)
       : undefined;
@@ -1105,6 +1111,10 @@ async function generate() {
   );
 }
 
+/**
+ * Internal test helpers for JSON processing functions.
+ * @internal These functions are exposed only for testing purposes and should not be used in production code.
+ */
 const __jsonTestHelpers = {
   createJsonProcessItem,
   processJsonArrayEntries,


### PR DESCRIPTION
## Summary
- ensure JSON processor respects dependency-injected allowlist extractor while treating blank overrides as absent
- document the internal __jsonTestHelpers export for test-only usage
- extend Vitest coverage for blank override text and skipped array entries without allowlisted values

## Testing
- npx vitest run tests/scripts/generateEmbeddings.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc25d04494832696209ec09f17f264