### PR TITLE
Handle country mapping load retries

### DIFF
--- a/src/helpers/api/countryService.js
+++ b/src/helpers/api/countryService.js
@@ -40,8 +40,14 @@ export async function loadCountryMapping() {
       }
     })();
   }
-  mapping = await mappingPromise;
-  return mapping;
+  try {
+    mapping = await mappingPromise;
+    return mapping;
+  } catch (error) {
+    mappingPromise = undefined;
+    mapping = undefined;
+    throw error;
+  }
 }
 
 /**

--- a/tests/unit/countryService.loadCountryMapping.test.js
+++ b/tests/unit/countryService.loadCountryMapping.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const fetchJson = vi.fn();
+const importJsonModule = vi.fn();
+const getItem = vi.fn();
+const setItem = vi.fn();
+const debugLog = vi.fn();
+
+vi.mock("../../src/helpers/dataUtils.js", () => ({
+  fetchJson,
+  importJsonModule,
+}));
+
+vi.mock("../../src/helpers/storage.js", () => ({
+  getItem,
+  setItem,
+}));
+
+vi.mock("../../src/helpers/debug.js", () => ({
+  debugLog,
+}));
+
+describe("loadCountryMapping", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    fetchJson.mockReset();
+    importJsonModule.mockReset();
+    getItem.mockReset();
+    setItem.mockReset();
+    debugLog.mockReset();
+  });
+
+  it("retries after a failed fetch/import attempt", async () => {
+    getItem.mockReturnValue(undefined);
+
+    fetchJson.mockRejectedValueOnce(new Error("network down"));
+    importJsonModule.mockRejectedValueOnce(new Error("import fail"));
+
+    const { loadCountryMapping } = await import("../../src/helpers/api/countryService.js");
+
+    await expect(loadCountryMapping()).rejects.toThrow("import fail");
+
+    const mapping = {
+      vu: { code: "vu", country: "Vanuatu", active: true },
+    };
+
+    fetchJson.mockResolvedValueOnce(mapping);
+
+    const result = await loadCountryMapping();
+
+    expect(result).toEqual(mapping);
+    expect(fetchJson).toHaveBeenCalledTimes(2);
+    expect(importJsonModule).toHaveBeenCalledTimes(1);
+    expect(setItem).toHaveBeenCalledWith("countryCodeMapping", mapping);
+    expect(setItem).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Task Contract
- **Inputs:** Existing `loadCountryMapping` implementation and surrounding tests.
- **Outputs:** Resilient `loadCountryMapping` that clears cached promises on failure plus regression coverage demonstrating recovery.
- **Success Criteria:** Errors propagate while subsequent calls can retry; automated tests cover the failure-then-success scenario.
- **Failure Modes:** Ignored errors or stuck promise cache prevents retries; regression test fails.

## Summary
- Reset the cached mapping promise when awaiting it fails so subsequent calls can retry loading.
- Added a unit test that forces an initial fetch/import failure followed by a successful retry to validate recovery.

## Testing
- `npx vitest run tests/unit/countryService.loadCountryMapping.test.js`

## Files Changed
- `src/helpers/api/countryService.js`
- `tests/unit/countryService.loadCountryMapping.test.js`

## Risk
- Low. Changes are isolated to the country mapping loader and covered by a focused regression test.


------
https://chatgpt.com/codex/tasks/task_e_68dc36661f0c8326814088f5d34398f8