### PR TITLE
Ensure opponent fallback activates when retries fail

### DIFF
--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -198,12 +198,17 @@ export async function selectOpponentJudoka({
   };
 
   let selection = pickRandom();
+  let forcedFallback = false;
   if (playerJudoka) {
     let attempts = 0;
     const maxAttempts = Math.max(pool.length || 0, 5);
     while (selection?.id === playerJudoka.id && attempts < maxAttempts) {
       selection = pickRandom();
       attempts += 1;
+    }
+    if (selection?.id === playerJudoka.id) {
+      forcedFallback = true;
+      selection = null;
     }
   }
 
@@ -212,9 +217,13 @@ export async function selectOpponentJudoka({
   if (typeof fallbackProvider === "function") {
     try {
       const fallback = await fallbackProvider();
-      if (fallback && typeof qaLogger === "function") {
+      if (typeof qaLogger === "function") {
         try {
-          qaLogger("Using fallback judoka for opponent");
+          qaLogger(
+            forcedFallback
+              ? "Using fallback judoka after retry exhaustion"
+              : "Using fallback judoka for opponent"
+          );
         } catch {}
       }
       return fallback || null;

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -75,6 +75,29 @@ describe.sequential("classicBattle card selection", () => {
     expect(getOpponentJudoka()).toEqual(expect.objectContaining({ id: 2 }));
   });
 
+  it("falls back when only the player judoka is available", async () => {
+    const qaLogger = vi.fn();
+    const fallbackProvider = vi.fn().mockResolvedValue({ id: 99 });
+    const { selectOpponentJudoka, _resetForTest } = await import(
+      "../../../src/helpers/classicBattle/cardSelection.js"
+    );
+    _resetForTest();
+
+    const result = await selectOpponentJudoka({
+      availableJudoka: [{ id: 1 }],
+      playerJudoka: { id: 1 },
+      randomJudoka: vi.fn(() => ({ id: 1 })),
+      fallbackProvider,
+      qaLogger
+    });
+
+    expect(result).toEqual({ id: 99 });
+    expect(fallbackProvider).toHaveBeenCalledTimes(1);
+    expect(qaLogger).toHaveBeenCalledWith(
+      "Using fallback judoka after retry exhaustion"
+    );
+  });
+
   it("excludes hidden judoka from selection", async () => {
     fetchJsonMock.mockImplementation(async (p) => {
       if (p.includes("judoka")) {


### PR DESCRIPTION
## Summary
- ensure `selectOpponentJudoka` forces the fallback path when retries still return the player judoka
- emit QA logging whenever the fallback provider supplies an opponent
- cover the single-judoka pool scenario with a regression test

## Testing
- npx vitest run tests/helpers/classicBattle/cardSelection.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc365f97a883269ac807059000091a