### PR TITLE
Guard resolveStatButtonsReady for non-browser contexts

### DIFF
--- a/src/helpers/classicBattle/statButtons.js
+++ b/src/helpers/classicBattle/statButtons.js
@@ -60,19 +60,22 @@ export function disableStatButtons(buttons, container) {
  * Resolve any promises waiting for stat buttons to be ready.
  *
  * @pseudocode
- * 1. Check if window.__resolveStatButtonsReady function exists.
- * 2. If it exists, call it to resolve the waiting promise.
- * 3. Otherwise, set window.statButtonsReadyPromise to a resolved promise.
- * 4. This ensures any code waiting for stat buttons is unblocked.
+ * 1. Resolve the target window from the provided argument or global scope.
+ * 2. If `target.__resolveStatButtonsReady` exists, invoke it to resolve the waiting promise.
+ * 3. Otherwise, assign a resolved promise to `target.statButtonsReadyPromise`.
+ * 4. If no target window is available (e.g., Node environments), exit early.
  *
- * @param {Window} [win=window] - Window object to use for global state
+ * @param {Window} [win] - Window object to use for global state when provided.
  * @returns {void}
  */
-export function resolveStatButtonsReady(win = window) {
-  if (typeof win.__resolveStatButtonsReady === "function") {
-    win.__resolveStatButtonsReady();
+export function resolveStatButtonsReady(win) {
+  const target = win ?? (typeof window !== "undefined" ? window : undefined);
+  if (!target) return;
+
+  if (typeof target.__resolveStatButtonsReady === "function") {
+    target.__resolveStatButtonsReady();
   } else {
-    win.statButtonsReadyPromise = Promise.resolve();
+    target.statButtonsReadyPromise = Promise.resolve();
   }
 }
 

--- a/tests/helpers/classicBattle/statButtons.resolve.node.test.js
+++ b/tests/helpers/classicBattle/statButtons.resolve.node.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { resolveStatButtonsReady } from "../../../src/helpers/classicBattle/statButtons.js";
+
+describe("resolveStatButtonsReady in non-browser environments", () => {
+  it("does not throw when window is unavailable", () => {
+    const hadWindow = Object.prototype.hasOwnProperty.call(globalThis, "window");
+    const originalWindow = globalThis.window;
+
+    if (hadWindow) {
+      delete globalThis.window;
+    }
+
+    expect(() => resolveStatButtonsReady()).not.toThrow();
+
+    if (hadWindow) {
+      globalThis.window = originalWindow;
+    } else {
+      delete globalThis.window;
+    }
+  });
+});


### PR DESCRIPTION
## Task Contract
- **Inputs:** `src/helpers/classicBattle/statButtons.js`
- **Outputs:** Guarded `resolveStatButtonsReady` implementation and supporting unit test.
- **Success Criteria:** Function no longer throws without a `window` global, and automated test confirms Node compatibility.
- **Non-Goals / Risks:** Does not modify other classic battle helpers or change public APIs beyond internal window handling.

## Summary
- Guard `resolveStatButtonsReady` against missing `window` globals while preserving existing resolver behavior.
- Add a unit test that runs the helper in a Node environment to ensure no global `window` usage leaks.

## Files Changed
- `src/helpers/classicBattle/statButtons.js`
- `tests/helpers/classicBattle/statButtons.resolve.node.test.js`

## Testing
- `npx vitest run tests/helpers/classicBattle/statButtons.resolve.node.test.js`

## Risk
- Low: The change only touches window resolution logic and adds isolated test coverage.

------
https://chatgpt.com/codex/tasks/task_e_68dc3654a53c83269058e9b297e85d2f