### PR TITLE
Prevent duplicate engine bridge listeners

### DIFF
--- a/src/helpers/classicBattle/engineBridge.js
+++ b/src/helpers/classicBattle/engineBridge.js
@@ -2,6 +2,68 @@ import { emitBattleEvent } from "./battleEvents.js";
 import * as engineFacade from "../battleEngineFacade.js";
 import { STATS } from "../battleEngineFacade.js";
 
+const trackedEngines = typeof WeakSet === "function" ? new WeakSet() : new Set();
+
+function getTrackableEngine() {
+  if (typeof engineFacade.requireEngine !== "function") {
+    return null;
+  }
+
+  try {
+    const engine = engineFacade.requireEngine();
+    return engine && typeof engine === "object" ? engine : null;
+  } catch {
+    return null;
+  }
+}
+
+function handleRoundEnded(detail) {
+  emitBattleEvent("roundResolved", detail);
+  try {
+    const player = Number(detail?.playerScore) || 0;
+    const opponent = Number(detail?.opponentScore) || 0;
+    emitBattleEvent("display.score.update", { player, opponent });
+  } catch {}
+}
+
+function handleMatchEndedLegacy(detail) {
+  emitBattleEvent("matchOver", detail);
+}
+
+function handleRoundStarted(detail) {
+  emitBattleEvent("round.started", {
+    roundIndex: Number(detail?.round) || 0,
+    availableStats: Array.isArray(STATS) ? STATS.slice() : []
+  });
+}
+
+function handleTimerTick(detail) {
+  const remaining = Number(detail?.remaining) || 0;
+  if (detail?.phase === "round") {
+    emitBattleEvent("round.timer.tick", { remainingMs: Math.max(0, remaining) * 1000 });
+  } else if (detail?.phase === "cooldown") {
+    emitBattleEvent("cooldown.timer.tick", { remainingMs: Math.max(0, remaining) * 1000 });
+  }
+}
+
+function handleMatchEndedPrd(detail) {
+  const outcome = detail?.outcome;
+  const winner =
+    outcome === "matchWinPlayer"
+      ? "player"
+      : outcome === "matchWinOpponent"
+        ? "opponent"
+        : "none";
+  emitBattleEvent("match.concluded", {
+    winner,
+    scores: {
+      player: Number(detail?.playerScore) || 0,
+      opponent: Number(detail?.opponentScore) || 0
+    },
+    reason: outcome || "unknown"
+  });
+}
+
 /**
  * Bridge events emitted by the battle engine to classic-battle `emitBattleEvent` names.
  *
@@ -16,55 +78,20 @@ import { STATS } from "../battleEngineFacade.js";
  */
 export function bridgeEngineEvents() {
   try {
+    const engine = getTrackableEngine();
+    if (engine && trackedEngines.has(engine)) {
+      return;
+    }
     const onEngine = engineFacade.on;
     if (typeof onEngine !== "function") return;
-    // Legacy bridge → classic events
-    onEngine("roundEnded", (detail) => {
-      emitBattleEvent("roundResolved", detail);
-      // Also emit display.score.update for scoreboard
-      try {
-        const player = Number(detail?.playerScore) || 0;
-        const opponent = Number(detail?.opponentScore) || 0;
-        emitBattleEvent("display.score.update", { player, opponent });
-      } catch {}
-    });
-    onEngine("matchEnded", (detail) => {
-      emitBattleEvent("matchOver", detail);
-    });
-    // PRD taxonomy bridge → dot-namespaced events
-    onEngine("roundStarted", (detail) => {
-      // Emit `round.started({ roundIndex, availableStats })`
-      emitBattleEvent("round.started", {
-        roundIndex: Number(detail?.round) || 0,
-        availableStats: Array.isArray(STATS) ? STATS.slice() : []
-      });
-    });
-    onEngine("timerTick", (detail) => {
-      const remaining = Number(detail?.remaining) || 0;
-      if (detail?.phase === "round") {
-        emitBattleEvent("round.timer.tick", { remainingMs: Math.max(0, remaining) * 1000 });
-      } else if (detail?.phase === "cooldown") {
-        // Prefer orchestrator emission for cooldown ticks, but mirror here when available
-        emitBattleEvent("cooldown.timer.tick", { remainingMs: Math.max(0, remaining) * 1000 });
-      }
-    });
-    onEngine("matchEnded", (detail) => {
-      // Also emit PRD match.concluded with winner + scores
-      const outcome = detail?.outcome;
-      const winner =
-        outcome === "matchWinPlayer"
-          ? "player"
-          : outcome === "matchWinOpponent"
-            ? "opponent"
-            : "none";
-      emitBattleEvent("match.concluded", {
-        winner,
-        scores: {
-          player: Number(detail?.playerScore) || 0,
-          opponent: Number(detail?.opponentScore) || 0
-        },
-        reason: outcome || "unknown"
-      });
-    });
+    onEngine("roundEnded", handleRoundEnded);
+    onEngine("matchEnded", handleMatchEndedLegacy);
+    onEngine("roundStarted", handleRoundStarted);
+    onEngine("timerTick", handleTimerTick);
+    onEngine("matchEnded", handleMatchEndedPrd);
+
+    if (engine) {
+      trackedEngines.add(engine);
+    }
   } catch {}
 }

--- a/tests/classicBattle/engineBridge.test.js
+++ b/tests/classicBattle/engineBridge.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, test, vi } from "vitest";
+
+const createListenersMap = () => {
+  const listeners = new Map();
+  const on = vi.fn((event, handler) => {
+    const existing = listeners.get(event) || [];
+    existing.push(handler);
+    listeners.set(event, existing);
+  });
+  const emit = (event, detail) => {
+    const handlers = listeners.get(event) || [];
+    handlers.forEach((handler) => handler(detail));
+  };
+  return { listeners, on, emit };
+};
+
+describe("bridgeEngineEvents", () => {
+  test("attaches one listener set per engine instance", async () => {
+    vi.resetModules();
+    const { listeners, on, emit } = createListenersMap();
+    const engine = { id: "engine" };
+    const requireEngine = vi.fn(() => engine);
+
+    vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+      __esModule: true,
+      emitBattleEvent: vi.fn()
+    }));
+
+    vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+      __esModule: true,
+      on,
+      requireEngine,
+      STATS: ["speed", "power"]
+    }));
+
+    const { bridgeEngineEvents } = await import(
+      "../../src/helpers/classicBattle/engineBridge.js"
+    );
+    const { emitBattleEvent } = await import(
+      "../../src/helpers/classicBattle/battleEvents.js"
+    );
+
+    bridgeEngineEvents();
+    bridgeEngineEvents();
+
+    expect(on).toHaveBeenCalledTimes(5);
+    expect(listeners.get("roundEnded")).toHaveLength(1);
+    expect(listeners.get("roundStarted")).toHaveLength(1);
+    expect(listeners.get("timerTick")).toHaveLength(1);
+    expect(listeners.get("matchEnded")).toHaveLength(2);
+
+    const roundDetail = { playerScore: 3, opponentScore: 1 };
+    emitBattleEvent.mockClear();
+    emit("roundEnded", roundDetail);
+    expect(emitBattleEvent.mock.calls).toEqual([
+      ["roundResolved", roundDetail],
+      ["display.score.update", { player: 3, opponent: 1 }]
+    ]);
+
+    const roundStartDetail = { round: 2 };
+    emitBattleEvent.mockClear();
+    emit("roundStarted", roundStartDetail);
+    expect(emitBattleEvent.mock.calls).toEqual([
+      ["round.started", { roundIndex: 2, availableStats: ["speed", "power"] }]
+    ]);
+
+    const roundTickDetail = { phase: "round", remaining: 5 };
+    emitBattleEvent.mockClear();
+    emit("timerTick", roundTickDetail);
+    expect(emitBattleEvent.mock.calls).toEqual([
+      ["round.timer.tick", { remainingMs: 5000 }]
+    ]);
+
+    const cooldownTickDetail = { phase: "cooldown", remaining: 4 };
+    emitBattleEvent.mockClear();
+    emit("timerTick", cooldownTickDetail);
+    expect(emitBattleEvent.mock.calls).toEqual([
+      ["cooldown.timer.tick", { remainingMs: 4000 }]
+    ]);
+
+    const matchDetail = { outcome: "matchWinPlayer", playerScore: 4, opponentScore: 2 };
+    emitBattleEvent.mockClear();
+    emit("matchEnded", matchDetail);
+    expect(emitBattleEvent.mock.calls).toEqual([
+      ["matchOver", matchDetail],
+      [
+        "match.concluded",
+        { winner: "player", scores: { player: 4, opponent: 2 }, reason: "matchWinPlayer" }
+      ]
+    ]);
+  });
+});


### PR DESCRIPTION
## Task Contract
- **Inputs:** `src/helpers/classicBattle/engineBridge.js`, classic battle replay flows, unit test harness.
- **Outputs:** Guarded listener registration that avoids duplicate event handlers and a regression test ensuring the guard works.
- **Success:** Calling `bridgeEngineEvents()` repeatedly only registers one handler per engine event while still emitting the expected classic battle events.
- **Error:** Listener duplication persists or existing replay flows regress.

## Files Changed
- `src/helpers/classicBattle/engineBridge.js`: Track bridged engine instances and reuse shared handlers so duplicate listener registration exits early while preserving existing emissions.
- `tests/classicBattle/engineBridge.test.js`: Add vitest coverage that mocks the engine facade, calls `bridgeEngineEvents()` twice, and asserts handlers/emissions occur only once per event.

## Verification Summary
- eslint: NOT RUN (not requested)
- vitest: PASS (`npx vitest run tests/classicBattle/engineBridge.test.js`)
- playwright: NOT RUN (not requested)
- jsdoc: PASS (`npm run check:jsdoc` via commit hook)

## Risk & Follow-Up
- Risk: Low – change is limited to event listener guards and supporting unit test.
- Follow-Up: None.


------
https://chatgpt.com/codex/tasks/task_e_68dc364879248326916563a98ad3d95c