### PR TITLE
Reset fallback cache between tests

### DIFF
--- a/src/helpers/judokaUtils.js
+++ b/src/helpers/judokaUtils.js
@@ -62,3 +62,16 @@ export async function getFallbackJudoka() {
     return cachedFallback;
   }
 }
+
+/**
+ * Resets the cached fallback judoka so subsequent calls refetch data.
+ *
+ * @pseudocode
+ * 1. Set the module-scoped `cachedFallback` reference back to `null`.
+ * 2. Allow future calls to `getFallbackJudoka` to perform a fresh fetch.
+ *
+ * @returns {void} Nothing.
+ */
+export function resetFallbackCache() {
+  cachedFallback = null;
+}

--- a/tests/helpers/judokaUtils.test.js
+++ b/tests/helpers/judokaUtils.test.js
@@ -7,10 +7,17 @@ vi.mock("../../src/helpers/dataUtils.js", () => ({
   fetchJson: mockFetchJson
 }));
 
-afterEach(() => {
+afterEach(async () => {
   vi.resetModules();
   vi.clearAllMocks();
   mockFetchJson.mockReset();
+
+  const { resetFallbackCache } = await import(
+    "../../src/helpers/judokaUtils.js"
+  );
+  if (resetFallbackCache) {
+    resetFallbackCache();
+  }
 });
 
 /**
@@ -41,7 +48,7 @@ async function importGetFallbackJudoka() {
 async function invokeWithConsoleErrorCapture(callback) {
   return withMutedConsole(async () => {
     const errorCalls = [];
-    const original = console.error;
+    const mutedConsoleError = console.error;
     console.error = (...args) => {
       errorCalls.push(args);
     };
@@ -49,7 +56,7 @@ async function invokeWithConsoleErrorCapture(callback) {
       const result = await callback();
       return { result, errorCalls };
     } finally {
-      console.error = original;
+      console.error = mutedConsoleError;
     }
   }, ["error"]);
 }


### PR DESCRIPTION
## Summary
- export a resetFallbackCache helper so tests can clear the module-scoped cached fallback judoka data
- reset the fallback cache in the judoka utils test teardown to ensure isolation between scenarios
- clarify the muted console restoration variable name during console error capture

## Testing
- `npx vitest run tests/helpers/judokaUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68dc3ea75cf88326baa10913d1e21cd1