### PR TITLE
Address review comments for stat button resolver JSDoc and tests

### DIFF
--- a/src/helpers/classicBattle/statButtons.js
+++ b/src/helpers/classicBattle/statButtons.js
@@ -47,16 +47,6 @@ export function disableStatButtons(buttons, container) {
 }
 
 /**
- * Resolve any promises or global resolvers waiting for stat buttons to be ready.
- *
- * @pseudocode
- * 1. If `win.__resolveStatButtonsReady` is a function, invoke it.
- * 2. Otherwise, create a resolved `win.statButtonsReadyPromise` so callers can await it.
- *
- * @param {Window} [win=window] - Window object to attach or call resolver on (testable).
- * @returns {void}
- */
-/**
  * Resolve any promises waiting for stat buttons to be ready.
  *
  * @pseudocode
@@ -65,7 +55,7 @@ export function disableStatButtons(buttons, container) {
  * 3. Otherwise, assign a resolved promise to `target.statButtonsReadyPromise`.
  * 4. If no target window is available (e.g., Node environments), exit early.
  *
- * @param {Window} [win] - Window object to use for global state when provided.
+ * @param {Window} [win] - Window object to use for global state. If not provided or undefined, attempts to use global window if available.
  * @returns {void}
  */
 export function resolveStatButtonsReady(win) {

--- a/tests/helpers/classicBattle/statButtons.resolve.node.test.js
+++ b/tests/helpers/classicBattle/statButtons.resolve.node.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { resolveStatButtonsReady } from "../../../src/helpers/classicBattle/statButtons.js";
 
 describe("resolveStatButtonsReady in non-browser environments", () => {
@@ -6,16 +6,36 @@ describe("resolveStatButtonsReady in non-browser environments", () => {
     const hadWindow = Object.prototype.hasOwnProperty.call(globalThis, "window");
     const originalWindow = globalThis.window;
 
-    if (hadWindow) {
-      delete globalThis.window;
-    }
+    try {
+      if (hadWindow) {
+        delete globalThis.window;
+      }
 
-    expect(() => resolveStatButtonsReady()).not.toThrow();
-
-    if (hadWindow) {
-      globalThis.window = originalWindow;
-    } else {
-      delete globalThis.window;
+      expect(() => resolveStatButtonsReady()).not.toThrow();
+    } finally {
+      if (hadWindow) {
+        globalThis.window = originalWindow;
+      } else {
+        delete globalThis.window;
+      }
     }
+  });
+
+  it("works correctly with explicit window parameter", () => {
+    const mockWindow = {};
+    const mockResolver = vi.fn();
+
+    mockWindow.__resolveStatButtonsReady = mockResolver;
+    expect(() => resolveStatButtonsReady(mockWindow)).not.toThrow();
+    expect(mockResolver).toHaveBeenCalledOnce();
+
+    delete mockWindow.__resolveStatButtonsReady;
+    expect(() => resolveStatButtonsReady(mockWindow)).not.toThrow();
+    expect(mockWindow.statButtonsReadyPromise).toBeInstanceOf(Promise);
+  });
+
+  it("handles null and undefined parameters gracefully", () => {
+    expect(() => resolveStatButtonsReady(null)).not.toThrow();
+    expect(() => resolveStatButtonsReady(undefined)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- clarify `resolveStatButtonsReady` JSDoc to document guarded window resolution fallback
- expand the Node environment unit test to cover resolver invocation and explicit window handling

## Testing
- npx vitest run tests/helpers/classicBattle/statButtons.resolve.node.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc3facd0d08326a3eaab853d1d63a1