### PR TITLE
Address review feedback for fallback opponent selection

### DIFF
--- a/src/helpers/classicBattle/cardSelection.js
+++ b/src/helpers/classicBattle/cardSelection.js
@@ -206,7 +206,7 @@ export async function selectOpponentJudoka({
       selection = pickRandom();
       attempts += 1;
     }
-    if (selection?.id === playerJudoka.id) {
+    if (selection?.id === playerJudoka.id || !selection) {
       forcedFallback = true;
       selection = null;
     }
@@ -217,7 +217,7 @@ export async function selectOpponentJudoka({
   if (typeof fallbackProvider === "function") {
     try {
       const fallback = await fallbackProvider();
-      if (typeof qaLogger === "function") {
+      if (fallback && typeof qaLogger === "function") {
         try {
           qaLogger(
             forcedFallback

--- a/tests/helpers/classicBattle/cardSelection.test.js
+++ b/tests/helpers/classicBattle/cardSelection.test.js
@@ -78,6 +78,7 @@ describe.sequential("classicBattle card selection", () => {
   it("falls back when only the player judoka is available", async () => {
     const qaLogger = vi.fn();
     const fallbackProvider = vi.fn().mockResolvedValue({ id: 99 });
+    const randomJudokaMock = vi.fn(() => ({ id: 1 }));
     const { selectOpponentJudoka, _resetForTest } = await import(
       "../../../src/helpers/classicBattle/cardSelection.js"
     );
@@ -86,13 +87,39 @@ describe.sequential("classicBattle card selection", () => {
     const result = await selectOpponentJudoka({
       availableJudoka: [{ id: 1 }],
       playerJudoka: { id: 1 },
-      randomJudoka: vi.fn(() => ({ id: 1 })),
+      randomJudoka: randomJudokaMock,
       fallbackProvider,
       qaLogger
     });
 
     expect(result).toEqual({ id: 99 });
     expect(fallbackProvider).toHaveBeenCalledTimes(1);
+    expect(randomJudokaMock).toHaveBeenCalledTimes(6);
+    expect(qaLogger).toHaveBeenCalledWith(
+      "Using fallback judoka after retry exhaustion"
+    );
+  });
+
+  it("falls back when random selection returns null", async () => {
+    const qaLogger = vi.fn();
+    const fallbackProvider = vi.fn().mockResolvedValue({ id: 101 });
+    const randomJudokaMock = vi.fn(() => null);
+    const { selectOpponentJudoka, _resetForTest } = await import(
+      "../../../src/helpers/classicBattle/cardSelection.js"
+    );
+    _resetForTest();
+
+    const result = await selectOpponentJudoka({
+      availableJudoka: [{ id: 1 }],
+      playerJudoka: { id: 1 },
+      randomJudoka: randomJudokaMock,
+      fallbackProvider,
+      qaLogger
+    });
+
+    expect(result).toEqual({ id: 101 });
+    expect(fallbackProvider).toHaveBeenCalledTimes(1);
+    expect(randomJudokaMock).toHaveBeenCalledTimes(1);
     expect(qaLogger).toHaveBeenCalledWith(
       "Using fallback judoka after retry exhaustion"
     );


### PR DESCRIPTION
## Summary
- treat null selections the same as duplicate player picks when deciding to force fallback
- only emit QA logging when the fallback provider returns a judoka
- extend the fallback regression test to assert retry attempts and cover null random selections

## Testing
- not run (npm tooling unavailable in container)

## Risk
- Low; changes are confined to fallback selection logic and its unit tests.

## Files Changed
- src/helpers/classicBattle/cardSelection.js
- tests/helpers/classicBattle/cardSelection.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc3f71241c832684a7922e2ca5eaeb