### PR TITLE
Address review feedback on engine bridge listeners

### DIFF
--- a/src/helpers/classicBattle/engineBridge.js
+++ b/src/helpers/classicBattle/engineBridge.js
@@ -2,7 +2,49 @@ import { emitBattleEvent } from "./battleEvents.js";
 import * as engineFacade from "../battleEngineFacade.js";
 import { STATS } from "../battleEngineFacade.js";
 
-const trackedEngines = typeof WeakSet === "function" ? new WeakSet() : new Set();
+const trackedEngines = typeof WeakSet === "function" ? new WeakSet() : null;
+const engineMarker =
+  typeof Symbol === "function"
+    ? Symbol("classicBattle.engineBridge.registered")
+    : "__classicBattleEngineBridgeRegistered__";
+
+function markEngineTracked(engine) {
+  if (!engine || typeof engine !== "object") {
+    return;
+  }
+
+  if (trackedEngines) {
+    trackedEngines.add(engine);
+    return;
+  }
+
+  if (engine[engineMarker]) {
+    return;
+  }
+
+  try {
+    Object.defineProperty(engine, engineMarker, {
+      configurable: true,
+      enumerable: false,
+      value: true,
+      writable: false
+    });
+  } catch {
+    engine[engineMarker] = true;
+  }
+}
+
+function isEngineTracked(engine) {
+  if (!engine || typeof engine !== "object") {
+    return false;
+  }
+
+  if (trackedEngines) {
+    return trackedEngines.has(engine);
+  }
+
+  return Boolean(engine[engineMarker]);
+}
 
 function getTrackableEngine() {
   if (typeof engineFacade.requireEngine !== "function") {
@@ -12,7 +54,12 @@ function getTrackableEngine() {
   try {
     const engine = engineFacade.requireEngine();
     return engine && typeof engine === "object" ? engine : null;
-  } catch {
+  } catch (error) {
+    const isProduction =
+      typeof process !== "undefined" && process.env?.NODE_ENV === "production";
+    if (!isProduction && typeof console?.warn === "function") {
+      console.warn("[engineBridge] Failed to resolve engine instance", error);
+    }
     return null;
   }
 }
@@ -24,10 +71,6 @@ function handleRoundEnded(detail) {
     const opponent = Number(detail?.opponentScore) || 0;
     emitBattleEvent("display.score.update", { player, opponent });
   } catch {}
-}
-
-function handleMatchEndedLegacy(detail) {
-  emitBattleEvent("matchOver", detail);
 }
 
 function handleRoundStarted(detail) {
@@ -44,6 +87,10 @@ function handleTimerTick(detail) {
   } else if (detail?.phase === "cooldown") {
     emitBattleEvent("cooldown.timer.tick", { remainingMs: Math.max(0, remaining) * 1000 });
   }
+}
+
+function handleMatchEndedLegacy(detail) {
+  emitBattleEvent("matchOver", detail);
 }
 
 function handleMatchEndedPrd(detail) {
@@ -64,6 +111,11 @@ function handleMatchEndedPrd(detail) {
   });
 }
 
+function handleMatchEnded(detail) {
+  handleMatchEndedLegacy(detail);
+  handleMatchEndedPrd(detail);
+}
+
 /**
  * Bridge events emitted by the battle engine to classic-battle `emitBattleEvent` names.
  *
@@ -77,21 +129,20 @@ function handleMatchEndedPrd(detail) {
  * 3. For each engine event, emit corresponding `emitBattleEvent` with normalized detail.
  */
 export function bridgeEngineEvents() {
-  try {
-    const engine = getTrackableEngine();
-    if (engine && trackedEngines.has(engine)) {
-      return;
-    }
-    const onEngine = engineFacade.on;
-    if (typeof onEngine !== "function") return;
-    onEngine("roundEnded", handleRoundEnded);
-    onEngine("matchEnded", handleMatchEndedLegacy);
-    onEngine("roundStarted", handleRoundStarted);
-    onEngine("timerTick", handleTimerTick);
-    onEngine("matchEnded", handleMatchEndedPrd);
+  const engine = getTrackableEngine();
+  if (isEngineTracked(engine)) {
+    return;
+  }
 
-    if (engine) {
-      trackedEngines.add(engine);
-    }
-  } catch {}
+  const onEngine = engineFacade.on;
+  if (typeof onEngine !== "function") {
+    return;
+  }
+
+  onEngine("roundEnded", handleRoundEnded);
+  onEngine("matchEnded", handleMatchEnded);
+  onEngine("roundStarted", handleRoundStarted);
+  onEngine("timerTick", handleTimerTick);
+
+  markEngineTracked(engine);
 }

--- a/tests/classicBattle/engineBridge.test.js
+++ b/tests/classicBattle/engineBridge.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 const createListenersMap = () => {
   const listeners = new Map();
@@ -14,40 +14,58 @@ const createListenersMap = () => {
   return { listeners, on, emit };
 };
 
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  vi.unstubAllGlobals();
+});
+
+async function setupBridge({ engines = [{ id: "engine" }], stats = ["speed", "power"], weakSet = true } = {}) {
+  vi.resetModules();
+
+  if (!weakSet) {
+    vi.stubGlobal("WeakSet", undefined);
+  }
+
+  const { listeners, on, emit } = createListenersMap();
+
+  let engineCall = 0;
+  const requireEngine = vi.fn(() => {
+    const index = Math.min(engineCall, engines.length - 1);
+    engineCall += 1;
+    return engines[index];
+  });
+
+  vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
+    __esModule: true,
+    emitBattleEvent: vi.fn()
+  }));
+
+  vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
+    __esModule: true,
+    on,
+    requireEngine,
+    STATS: stats
+  }));
+
+  const { bridgeEngineEvents } = await import("../../src/helpers/classicBattle/engineBridge.js");
+  const { emitBattleEvent } = await import("../../src/helpers/classicBattle/battleEvents.js");
+
+  return { bridgeEngineEvents, emitBattleEvent, listeners, on, emit, requireEngine };
+}
+
 describe("bridgeEngineEvents", () => {
   test("attaches one listener set per engine instance", async () => {
-    vi.resetModules();
-    const { listeners, on, emit } = createListenersMap();
-    const engine = { id: "engine" };
-    const requireEngine = vi.fn(() => engine);
-
-    vi.doMock("../../src/helpers/classicBattle/battleEvents.js", () => ({
-      __esModule: true,
-      emitBattleEvent: vi.fn()
-    }));
-
-    vi.doMock("../../src/helpers/battleEngineFacade.js", () => ({
-      __esModule: true,
-      on,
-      requireEngine,
-      STATS: ["speed", "power"]
-    }));
-
-    const { bridgeEngineEvents } = await import(
-      "../../src/helpers/classicBattle/engineBridge.js"
-    );
-    const { emitBattleEvent } = await import(
-      "../../src/helpers/classicBattle/battleEvents.js"
-    );
+    const { bridgeEngineEvents, emitBattleEvent, listeners, on, emit } = await setupBridge();
 
     bridgeEngineEvents();
     bridgeEngineEvents();
 
-    expect(on).toHaveBeenCalledTimes(5);
+    expect(on).toHaveBeenCalledTimes(4);
     expect(listeners.get("roundEnded")).toHaveLength(1);
     expect(listeners.get("roundStarted")).toHaveLength(1);
     expect(listeners.get("timerTick")).toHaveLength(1);
-    expect(listeners.get("matchEnded")).toHaveLength(2);
+    expect(listeners.get("matchEnded")).toHaveLength(1);
 
     const roundDetail = { playerScore: 3, opponentScore: 1 };
     emitBattleEvent.mockClear();
@@ -88,5 +106,44 @@ describe("bridgeEngineEvents", () => {
         { winner: "player", scores: { player: 4, opponent: 2 }, reason: "matchWinPlayer" }
       ]
     ]);
+  });
+
+  test("registers listeners again when the engine instance changes", async () => {
+    const engineA = { id: "engine-a" };
+    const engineB = { id: "engine-b" };
+    const { bridgeEngineEvents, listeners, on } = await setupBridge({ engines: [engineA, engineB] });
+
+    bridgeEngineEvents();
+    bridgeEngineEvents();
+    bridgeEngineEvents();
+
+    expect(on).toHaveBeenCalledTimes(8);
+    expect(listeners.get("roundEnded")).toHaveLength(2);
+    expect(listeners.get("matchEnded")).toHaveLength(2);
+    expect(listeners.get("roundStarted")).toHaveLength(2);
+    expect(listeners.get("timerTick")).toHaveLength(2);
+  });
+
+  test("avoids duplicate registration when WeakSet is unavailable", async () => {
+    const engine = { id: "engine" };
+    const { bridgeEngineEvents, listeners, on, requireEngine } = await setupBridge({
+      engines: [engine],
+      weakSet: false
+    });
+
+    bridgeEngineEvents();
+    bridgeEngineEvents();
+
+    expect(on).toHaveBeenCalledTimes(4);
+    expect(listeners.get("roundEnded")).toHaveLength(1);
+    expect(listeners.get("matchEnded")).toHaveLength(1);
+
+    const symbolMarkers = Object.getOwnPropertySymbols(engine).filter(
+      (symbol) => engine[symbol] === true
+    );
+    const stringMarkers = Object.keys(engine).filter((key) => engine[key] === true);
+
+    expect(symbolMarkers.length + stringMarkers.length).toBeGreaterThan(0);
+    expect(requireEngine).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- guard engine tracking against missing WeakSet by using a symbol marker and logging resolve failures
- collapse duplicate matchEnded listeners while maintaining legacy and PRD emissions
- broaden engine bridge tests to cover multiple engines and WeakSet fallback behaviour

## Testing
- npx vitest run tests/classicBattle/engineBridge.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc402fd0b48326ad2603b4a4f38740