### PR TITLE
Address review feedback for fallback cache reset

### DIFF
--- a/src/helpers/judokaUtils.js
+++ b/src/helpers/judokaUtils.js
@@ -70,8 +70,12 @@ export async function getFallbackJudoka() {
  * 1. Set the module-scoped `cachedFallback` reference back to `null`.
  * 2. Allow future calls to `getFallbackJudoka` to perform a fresh fetch.
  *
+ * @since 2024-05-21
+ *
  * @returns {void} Nothing.
  */
 export function resetFallbackCache() {
-  cachedFallback = null;
+  if (cachedFallback !== null) {
+    cachedFallback = null;
+  }
 }

--- a/tests/helpers/judokaUtils.test.js
+++ b/tests/helpers/judokaUtils.test.js
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { withMutedConsole } from "../utils/console.js";
+import { resetFallbackCache } from "../../src/helpers/judokaUtils.js";
 
-const mockFetchJson = vi.fn();
+const mockFetchJson = vi.hoisted(() => vi.fn());
 
 vi.mock("../../src/helpers/dataUtils.js", () => ({
   fetchJson: mockFetchJson
@@ -12,12 +13,7 @@ afterEach(async () => {
   vi.clearAllMocks();
   mockFetchJson.mockReset();
 
-  const { resetFallbackCache } = await import(
-    "../../src/helpers/judokaUtils.js"
-  );
-  if (resetFallbackCache) {
-    resetFallbackCache();
-  }
+  resetFallbackCache();
 });
 
 /**


### PR DESCRIPTION
## Summary
- export a resetFallbackCache helper so tests can clear the module-scoped cached fallback judoka data
- reset the fallback cache in the judoka utils test teardown to ensure isolation between scenarios using a static import
- clarify the muted console restoration variable name during console error capture and document resetFallbackCache with a @since tag

## Testing
- `npx vitest run tests/helpers/judokaUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68dc4121d38883268f49f1b787ffd758