### PR TITLE
Keep random card trigger hidden after use

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -167,7 +167,6 @@ export function setupRandomCardButton(button, container) {
         enableInspector: inspectorEnabled
       });
     } finally {
-      button.classList.remove("hidden");
       button.disabled = false;
     }
   });


### PR DESCRIPTION
## Summary
- stop restoring the random card button's visibility after activation so it remains hidden as expected

## Testing
- npx vitest run tests/helpers/gameRandom.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc427bd19c8326b116b12ecd2abb63