### PR TITLE
Address snackbar fallback review feedback follow-up

### DIFF
--- a/src/helpers/showSnackbar.js
+++ b/src/helpers/showSnackbar.js
@@ -31,13 +31,31 @@ function getSafeRequestAnimationFrame(scheduler) {
   if (scheduler && typeof scheduler.requestAnimationFrame === "function") {
     return scheduler.requestAnimationFrame.bind(scheduler);
   }
-  if (typeof globalThis !== "undefined" && typeof globalThis.requestAnimationFrame === "function") {
-    return globalThis.requestAnimationFrame.bind(globalThis);
+  if (typeof globalThis !== "undefined") {
+    try {
+      if (typeof globalThis.requestAnimationFrame === "function") {
+        return globalThis.requestAnimationFrame.bind(globalThis);
+      }
+    } catch {}
+    try {
+      if (typeof globalThis.setTimeout === "function") {
+        return (callback) => {
+          try {
+            return globalThis.setTimeout(callback, 0);
+          } catch {
+            return undefined;
+          }
+        };
+      }
+    } catch {}
   }
-  if (typeof globalThis !== "undefined" && typeof globalThis.setTimeout === "function") {
-    return (callback) => globalThis.setTimeout(callback, 0);
-  }
-  return (callback) => setTimeout(callback, 0);
+  return (callback) => {
+    try {
+      return setTimeout(callback, 0);
+    } catch {
+      return undefined;
+    }
+  };
 }
 
 function resetState() {

--- a/tests/helpers/showSnackbar.test.js
+++ b/tests/helpers/showSnackbar.test.js
@@ -58,7 +58,8 @@ describe("showSnackbar", () => {
     const originalRaf = globalThis.requestAnimationFrame;
     const schedulerWithoutRaf = {
       setTimeout: (...args) => globalThis.setTimeout(...args),
-      clearTimeout: (...args) => globalThis.clearTimeout(...args)
+      clearTimeout: (...args) => globalThis.clearTimeout(...args),
+      requestAnimationFrame: undefined
     };
 
     setScheduler(schedulerWithoutRaf);


### PR DESCRIPTION
## Summary
- keep the defensive requestAnimationFrame helper but wrap the final setTimeout fallback in try/catch for maximum safety
- clarify the missing requestAnimationFrame scenario in the snackbar fallback test by explicitly setting the mock property to undefined

## Testing
- npx vitest run tests/helpers/showSnackbar.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc4236c7908326a21abfa85c4739c7