### PR TITLE
Update random card button pseudocode to match hidden state

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -148,7 +148,7 @@ export function setupHideCardButton(button) {
  *    a. Hide and disable `button`, then clear `container`.
  *    b. Determine motion preference with `shouldReduceMotionSync`.
  *    c. Call `generateRandomCard` using the preference.
- *    d. Ensure `button` is revealed and re-enabled after generation finishes or fails.
+ *    d. Ensure `button` is re-enabled after generation finishes or fails, while it remains hidden.
  *
  * @param {HTMLElement} button - Button to trigger card generation.
  * @param {HTMLElement} container - Element to display the card.


### PR DESCRIPTION
## Summary
- update the setupRandomCardButton JSDoc pseudocode to clarify the button stays hidden after use

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4f9eb58083269ae410e7cc0f2611