### PR TITLE
Address review feedback for random card button tests

### DIFF
--- a/tests/unit/game.setupRandomCardButton.test.js
+++ b/tests/unit/game.setupRandomCardButton.test.js
@@ -97,6 +97,8 @@ describe("setupRandomCardButton", () => {
       process.off("unhandledRejection", handleUnhandledRejection);
     }
 
+    await new Promise((resolve) => process.nextTick(resolve));
+
     expect(unhandledRejections).toEqual([error]);
   });
 


### PR DESCRIPTION
## Summary
- wait for the next tick before asserting captured unhandled rejections

## Testing
- `npx vitest tests/unit/game.setupRandomCardButton.test.js --run`


------
https://chatgpt.com/codex/tasks/task_e_68dc4f128d148326a66e68de8c43ffed