### PR TITLE
Add helper for unhandled rejection timing in tests

### DIFF
--- a/tests/unit/cooldown.start.spec.js
+++ b/tests/unit/cooldown.start.spec.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as roundManager from "@/helpers/classicBattle/roundManager.js";
+import { waitForUnhandledRejectionProcessing } from "../utils/waitForUnhandledRejectionProcessing.js";
 
 describe("cooldown auto-advance wiring", () => {
   let bus;
@@ -111,7 +112,8 @@ describe("cooldown auto-advance wiring", () => {
     // Fast-forward timers to ensure expiry triggers
     await vi.runAllTimersAsync();
     await flushScheduler();
-    await new Promise((resolve) => process.nextTick(resolve));
+    // Allow the unhandled rejection handler registered in the test to run before assertions.
+    await waitForUnhandledRejectionProcessing();
     // Ready promise should be present
     expect(controls).toBeTruthy();
     expect(typeof controls.ready?.then).toBe("function");

--- a/tests/unit/game.setupRandomCardButton.test.js
+++ b/tests/unit/game.setupRandomCardButton.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { withMutedConsole } from "../utils/console.js";
+import { waitForUnhandledRejectionProcessing } from "../utils/waitForUnhandledRejectionProcessing.js";
 
 const createDeferred = () => {
   let resolve;
@@ -97,7 +98,8 @@ describe("setupRandomCardButton", () => {
       process.off("unhandledRejection", handleUnhandledRejection);
     }
 
-    await new Promise((resolve) => process.nextTick(resolve));
+    // Give Node.js a tick to surface the captured unhandled rejection before checking it.
+    await waitForUnhandledRejectionProcessing();
 
     expect(unhandledRejections).toEqual([error]);
   });

--- a/tests/utils/waitForUnhandledRejectionProcessing.js
+++ b/tests/utils/waitForUnhandledRejectionProcessing.js
@@ -1,0 +1,14 @@
+/**
+ * Waits for the Node.js event loop to emit any queued `unhandledRejection` events.
+ *
+ * @pseudocode
+ * 1. Create a promise that resolves on the next event loop tick via `process.nextTick`.
+ * 2. Await the promise to allow the `unhandledRejection` event to fire.
+ *
+ * @returns {Promise<void>} Resolves after the next event loop tick.
+ */
+export function waitForUnhandledRejectionProcessing() {
+  return new Promise((resolve) => {
+    process.nextTick(resolve);
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared helper to wait for unhandled rejection processing between assertions
- replace direct `process.nextTick` usage in the random card and cooldown tests and document the timing requirement

## Testing
- `npx vitest tests/unit/game.setupRandomCardButton.test.js --run` *(fails on existing expectations for button visibility)*

------
https://chatgpt.com/codex/tasks/task_e_68dc515b9ebc83268ce52b5788dd389e