### PR TITLE
Rename unhandled rejection helper for clarity

### DIFF
--- a/tests/unit/cooldown.start.spec.js
+++ b/tests/unit/cooldown.start.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as roundManager from "@/helpers/classicBattle/roundManager.js";
-import { waitForUnhandledRejectionProcessing } from "../utils/waitForUnhandledRejectionProcessing.js";
+import { flushUnhandledRejections } from "../utils/flushUnhandledRejections.js";
 
 describe("cooldown auto-advance wiring", () => {
   let bus;
@@ -113,7 +113,7 @@ describe("cooldown auto-advance wiring", () => {
     await vi.runAllTimersAsync();
     await flushScheduler();
     // Allow the unhandled rejection handler registered in the test to run before assertions.
-    await waitForUnhandledRejectionProcessing();
+    await flushUnhandledRejections();
     // Ready promise should be present
     expect(controls).toBeTruthy();
     expect(typeof controls.ready?.then).toBe("function");

--- a/tests/unit/game.setupRandomCardButton.test.js
+++ b/tests/unit/game.setupRandomCardButton.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { withMutedConsole } from "../utils/console.js";
-import { waitForUnhandledRejectionProcessing } from "../utils/waitForUnhandledRejectionProcessing.js";
+import { flushUnhandledRejections } from "../utils/flushUnhandledRejections.js";
 
 const createDeferred = () => {
   let resolve;
@@ -98,8 +98,8 @@ describe("setupRandomCardButton", () => {
       process.off("unhandledRejection", handleUnhandledRejection);
     }
 
-    // Give Node.js a tick to surface the captured unhandled rejection before checking it.
-    await waitForUnhandledRejectionProcessing();
+    // Give Node.js a nextTick (not just a microtask flush) to surface the captured unhandled rejection.
+    await flushUnhandledRejections();
 
     expect(unhandledRejections).toEqual([error]);
   });

--- a/tests/utils/flushUnhandledRejections.js
+++ b/tests/utils/flushUnhandledRejections.js
@@ -1,13 +1,17 @@
 /**
  * Waits for the Node.js event loop to emit any queued `unhandledRejection` events.
  *
+ * Although similar to {@link flushMicrotasks}, unhandled rejections are surfaced on
+ * the `nextTick` queue rather than the microtask queue. Separating the helper
+ * makes this distinction explicit so callers choose the correct timing primitive.
+ *
  * @pseudocode
  * 1. Create a promise that resolves on the next event loop tick via `process.nextTick`.
  * 2. Await the promise to allow the `unhandledRejection` event to fire.
  *
  * @returns {Promise<void>} Resolves after the next event loop tick.
  */
-export function waitForUnhandledRejectionProcessing() {
+export function flushUnhandledRejections() {
   return new Promise((resolve) => {
     process.nextTick(resolve);
   });


### PR DESCRIPTION
## Summary
- rename the unhandled rejection helper to `flushUnhandledRejections` and document how it differs from `flushMicrotasks`
- update cooldown and random card button tests to import the renamed helper and reference the nextTick timing requirement

## Testing
- `npx vitest tests/unit/game.setupRandomCardButton.test.js --run` *(fails: existing expectations for button visibility remain unchanged)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc5ed0d248326846b04723321ca00