### PR TITLE
Ensure random card button reappears after generation

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -168,6 +168,7 @@ export function setupRandomCardButton(button, container) {
       });
     } finally {
       button.disabled = false;
+      button.classList.remove("hidden");
     }
   });
 }


### PR DESCRIPTION
## Summary
- restore the random card button's visibility after generation completes by removing the hidden class in the finally block

## Testing
- `npx vitest run tests/unit/game.setupRandomCardButton.test.js`

## Task Contract
- **Inputs:** src/game.js, visibility handling requirements for the random card button
- **Outputs:** updated click handler that always restores button state
- **Success:** button is re-enabled and visible after random card generation; targeted unit test passes
- **Errors:** regressions in random card generation flow or failing tests

## Files Changed
- src/game.js

## Verification Summary
- Confirmed vitest unit coverage for setupRandomCardButton

## Risk
- Low risk: limited to UI state restoration for the random card button

------
https://chatgpt.com/codex/tasks/task_e_68dce955c01c83269449c6f066049073