### PR TITLE
Handle logging errors in round manager catch blocks

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -267,7 +267,12 @@ export async function startRound(store, onRoundStart) {
       suppressInProduction: true
     });
   }
-  try { if (typeof console !== "undefined" && !process?.env?.VITEST) console.debug(`classicBattle.trace emit:roundStarted t=${Date.now()} round=${roundNumber}`); } catch {}
+  try {
+    if (typeof console !== "undefined" && !process?.env?.VITEST)
+      console.debug(`classicBattle.trace emit:roundStarted t=${Date.now()} round=${roundNumber}`);
+  } catch {
+    /* ignore logging errors to preserve round start flow */
+  }
   emitBattleEvent("roundStarted", { store, roundNumber });
   // Synchronise centralized store
   try {
@@ -370,7 +375,14 @@ export function startCooldown(_store, scheduler, overrides = {}) {
     });
   }
   const cooldownSeconds = computeNextRoundCooldown();
-  try { if (typeof console !== "undefined" && !process?.env?.VITEST) console.debug(`classicBattle.trace schedule:nextRound t=${Date.now()} secs=${cooldownSeconds}`); } catch {}
+  try {
+    if (typeof console !== "undefined" && !process?.env?.VITEST)
+      console.debug(
+        `classicBattle.trace schedule:nextRound t=${Date.now()} secs=${cooldownSeconds}`
+      );
+  } catch {
+    /* ignore logging errors so cooldown scheduling proceeds */
+  }
   appendReadyTrace("cooldownDurationResolved", { seconds: cooldownSeconds });
   safeRound(
     "startCooldown.emitCountdownStarted",


### PR DESCRIPTION
## Task Contract
- **Input**: ESLint reports for empty catch blocks in `src/helpers/classicBattle/roundManager.js`.
- **Output**: Update catch blocks to satisfy linting without altering runtime behaviour.
- **Success Criteria**: `npx eslint . --fix --cache` completes cleanly.
- **Failure Modes**: Logging safeguards could interfere with battle round flow if misapplied.

## Summary
- Expand the debug logging guards in the round manager to avoid empty catch blocks.
- Ignore logging failures explicitly so round scheduling continues unaffected.

## Files Changed
- src/helpers/classicBattle/roundManager.js

## Testing
- npx eslint . --fix --cache

## Risk
- Low: adjusts defensive logging without impacting core logic.

------
https://chatgpt.com/codex/tasks/task_e_68dd680f23588326bb2db3fcbf364094