### PR TITLE
Refactor engine bridge listener registration

### DIFF
--- a/src/helpers/classicBattle/engineBridge.js
+++ b/src/helpers/classicBattle/engineBridge.js
@@ -1,6 +1,6 @@
 import { emitBattleEvent } from "./battleEvents.js";
 import * as engineFacade from "../battleEngineFacade.js";
-import { STATS } from "../battleEngineFacade.js";
+import { STATS, onEngineCreated } from "../battleEngineFacade.js";
 import { updateScore } from "../setupScoreboard.js";
 
 const trackedEngines = typeof WeakSet === "function" ? new WeakSet() : new Set();
@@ -85,7 +85,6 @@ export function bridgeEngineEvents() {
     const onEngine = engineFacade.on;
     if (typeof onEngine !== "function") return;
     onEngine("roundEnded", handleRoundEnded);
-    roundEndedRegistered = true;
     onEngine("matchEnded", handleMatchEndedLegacy);
     onEngine("roundStarted", handleRoundStarted);
     onEngine("timerTick", handleTimerTick);
@@ -97,34 +96,10 @@ export function bridgeEngineEvents() {
   } catch {}
 }
 
-const originalCreateBattleEngine =
-  typeof engineFacade.createBattleEngine === "function" ? engineFacade.createBattleEngine : null;
-const originalOnEngine =
-  typeof engineFacade.on === "function" ? engineFacade.on : null;
-let roundEndedRegistered = false;
-
-if (originalOnEngine) {
-  engineFacade.on = function wrappedOn(event, handler) {
-    const result = originalOnEngine(event, handler);
-    if (event === "roundEnded") {
-      roundEndedRegistered = true;
-    } else if (event === "matchEnded" && !roundEndedRegistered) {
-      try {
-        originalOnEngine("roundEnded", handleRoundEnded);
-        roundEndedRegistered = true;
-      } catch {}
-    }
-    return result;
-  };
-}
-
-if (originalCreateBattleEngine) {
-  engineFacade.createBattleEngine = function wrappedCreateBattleEngine(...args) {
-    const engine = originalCreateBattleEngine(...args);
-    roundEndedRegistered = false;
+if (typeof onEngineCreated === "function") {
+  onEngineCreated(() => {
     try {
       bridgeEngineEvents();
     } catch {}
-    return engine;
-  };
+  });
 }

--- a/tests/classicBattle/engineBridge.test.js
+++ b/tests/classicBattle/engineBridge.test.js
@@ -30,7 +30,8 @@ describe("bridgeEngineEvents", () => {
       __esModule: true,
       on,
       requireEngine,
-      STATS: ["speed", "power"]
+      STATS: ["speed", "power"],
+      onEngineCreated: vi.fn(() => () => {})
     }));
 
     const { bridgeEngineEvents } = await import("../../src/helpers/classicBattle/engineBridge.js");


### PR DESCRIPTION
## Summary
- add an engine creation listener hook in the battle engine facade and notify it whenever createBattleEngine runs
- rework the classic battle engine bridge to subscribe via the new onEngineCreated helper instead of mutating imported facade exports
- update classic battle tests to mock onEngineCreated and mimic engine instances that trigger the bridge registration logic

## Testing
- npx vitest run tests/classicBattle/engineBridge.test.js
- npx vitest run tests/classicBattle/page-scaffold.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd83b56a4c832693345b7dcd7a7343