### PR TITLE
Add logging and unsubscribe coverage for engine listener errors

### DIFF
--- a/src/helpers/battleEngineFacade.js
+++ b/src/helpers/battleEngineFacade.js
@@ -63,10 +63,19 @@ const engineCreatedListeners = new Set();
 
 function notifyEngineCreated(engine) {
   if (engineCreatedListeners.size === 0) return;
+
+  const shouldLogErrors =
+    (typeof process !== "undefined" && process?.env?.NODE_ENV !== "production") ||
+    (typeof window !== "undefined" && Boolean(window.__TEST__));
+
   for (const listener of engineCreatedListeners) {
     try {
       listener(engine);
-    } catch {}
+    } catch (error) {
+      if (shouldLogErrors && typeof console !== "undefined" && typeof console.warn === "function") {
+        console.warn("Engine creation listener failed:", error);
+      }
+    }
   }
 }
 

--- a/tests/classicBattle/page-scaffold.test.js
+++ b/tests/classicBattle/page-scaffold.test.js
@@ -1111,6 +1111,21 @@ describe("Classic Battle page scaffold (behavioral)", () => {
     vi.resetModules();
   });
 
+  test("engine created listeners can unsubscribe", async () => {
+    const facade = await import("../../src/helpers/battleEngineFacade.js");
+    const listener = vi.fn();
+    const unsubscribe = facade.onEngineCreated(listener);
+
+    await facade.createBattleEngine({ forceCreate: true });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    listener.mockClear();
+    unsubscribe();
+
+    await facade.createBattleEngine({ forceCreate: true });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
   test("initializes scoreboard regions and default content", async () => {
     window.__FF_OVERRIDES = { battleStateBadge: true, showRoundSelectModal: true };
     const { init } = await import("../../src/pages/battleClassic.init.js");


### PR DESCRIPTION
## Summary
- add development/test logging when an engine creation listener throws
- cover the unsubscribe path for onEngineCreated with a dedicated test

## Testing
- npx vitest run tests/classicBattle/page-scaffold.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ddb2fa4944832699ead781a634a728