### PR TITLE
Address review feedback on engine listener logging

### DIFF
--- a/src/helpers/battleEngineFacade.js
+++ b/src/helpers/battleEngineFacade.js
@@ -66,13 +66,13 @@ function notifyEngineCreated(engine) {
 
   const shouldLogErrors =
     (typeof process !== "undefined" && process?.env?.NODE_ENV !== "production") ||
-    (typeof window !== "undefined" && Boolean(window.__TEST__));
+    (typeof window !== "undefined" && window.__TEST__);
 
   for (const listener of engineCreatedListeners) {
     try {
       listener(engine);
     } catch (error) {
-      if (shouldLogErrors && typeof console !== "undefined" && typeof console.warn === "function") {
+      if (shouldLogErrors) {
         console.warn("Engine creation listener failed:", error);
       }
     }

--- a/tests/classicBattle/page-scaffold.test.js
+++ b/tests/classicBattle/page-scaffold.test.js
@@ -1111,19 +1111,23 @@ describe("Classic Battle page scaffold (behavioral)", () => {
     vi.resetModules();
   });
 
-  test("engine created listeners can unsubscribe", async () => {
+  test("onEngineCreated listeners can unsubscribe and stop receiving notifications", async () => {
+    const { withMutedConsole } = await import("../utils/console.js");
     const facade = await import("../../src/helpers/battleEngineFacade.js");
     const listener = vi.fn();
     const unsubscribe = facade.onEngineCreated(listener);
 
-    await facade.createBattleEngine({ forceCreate: true });
-    expect(listener).toHaveBeenCalledTimes(1);
+    await withMutedConsole(async () => {
+      const firstEngine = await facade.createBattleEngine({ forceCreate: true });
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(firstEngine);
 
-    listener.mockClear();
-    unsubscribe();
+      listener.mockClear();
+      unsubscribe();
 
-    await facade.createBattleEngine({ forceCreate: true });
-    expect(listener).not.toHaveBeenCalled();
+      await facade.createBattleEngine({ forceCreate: true });
+      expect(listener).not.toHaveBeenCalled();
+    });
   });
 
   test("initializes scoreboard regions and default content", async () => {


### PR DESCRIPTION
## Summary
- simplify the engine creation logging condition and streamline the warn call
- wrap the unsubscribe test with withMutedConsole and assert the listener receives the engine
- rename the listener unsubscribe test for clearer intent

## Testing
- npx vitest run tests/classicBattle/page-scaffold.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de36efe9a48326a45175f15a8b4b61