### PR TITLE
Normalize fallback roundEnded mock score updates

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -1042,6 +1042,11 @@ export function _resetForTest(store) {
       if (typeof maybeMock === "function" && typeof maybeMock.mock === "object") {
         maybeMock("roundEnded", (detail) => {
           emitBattleEvent("roundResolved", detail);
+          try {
+            const player = Number(detail?.playerScore) || 0;
+            const opponent = Number(detail?.opponentScore) || 0;
+            emitBattleEvent("display.score.update", { player, opponent });
+          } catch {}
         });
         maybeMock("matchEnded", (detail) => {
           emitBattleEvent("matchOver", detail);


### PR DESCRIPTION
## Summary
- normalize the mock roundEnded handler used during test resets so it mirrors the production bridge
- emit display.score.update events from the fallback to keep scoreboard observers in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de8dcc9d8c8326a956a41ab2e50a26