### PR TITLE
Add onEngineCreated stub to battle engine facade test mocks

### DIFF
--- a/tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js
+++ b/tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js
@@ -71,7 +71,8 @@ describe("skip handler clears fallback timer", () => {
         startRound: makeTimer,
         startCoolDown: makeTimer,
         stopTimer: vi.fn(),
-        STATS: ["a", "b"]
+        STATS: ["a", "b"],
+        onEngineCreated: vi.fn(() => () => {})
       };
     });
     const { mockCreateRoundTimer } = await import("../roundTimerMock.js");

--- a/tests/helpers/classicBattle/playerChoiceReset.test.js
+++ b/tests/helpers/classicBattle/playerChoiceReset.test.js
@@ -8,7 +8,8 @@ vi.doMock("../../../src/helpers/classicBattle/cardSelection.js", () => ({
 
 vi.doMock("../../../src/helpers/battleEngineFacade.js", () => ({
   getRoundsPlayed: vi.fn(() => 0),
-  _resetForTest: vi.fn()
+  _resetForTest: vi.fn(),
+  onEngineCreated: vi.fn(() => () => {})
 }));
 
 vi.doMock("../../../src/helpers/classicBattle/battleEvents.js", () => ({

--- a/tests/helpers/classicBattle/rebindEngineEvents.test.js
+++ b/tests/helpers/classicBattle/rebindEngineEvents.test.js
@@ -7,7 +7,8 @@ describe("_resetForTest", () => {
     const on = vi.fn();
     vi.doMock("../../../src/helpers/battleEngineFacade.js", () => ({
       createBattleEngine: vi.fn(),
-      on
+      on,
+      onEngineCreated: vi.fn(() => () => {})
     }));
     const { initClassicBattleTest } = await import("../initClassicBattleTest.js");
     await initClassicBattleTest({ afterMock: true });

--- a/tests/helpers/classicBattle/roundResolverOnce.test.js
+++ b/tests/helpers/classicBattle/roundResolverOnce.test.js
@@ -24,7 +24,8 @@ vi.mock("../../../src/helpers/battleEngineFacade.js", () => ({
   createBattleEngine: vi.fn(),
   stopTimer: vi.fn(),
   getRoundsPlayed: vi.fn(() => 0),
-  _resetForTest: vi.fn()
+  _resetForTest: vi.fn(),
+  onEngineCreated: vi.fn(() => () => {})
 }));
 vi.mock("../../../src/helpers/setupScoreboard.js", () => ({
   updateScore: vi.fn(),

--- a/tests/helpers/classicBattle/timerService.nextRound.test.js
+++ b/tests/helpers/classicBattle/timerService.nextRound.test.js
@@ -41,7 +41,8 @@ describe("timerService next round handling", () => {
       startCoolDown,
       stopTimer: vi.fn(),
       STATS: [],
-      requireEngine: () => ({ startCoolDown })
+      requireEngine: () => ({ startCoolDown }),
+      onEngineCreated: vi.fn(() => () => {})
     }));
     dispatchBattleEvent = vi.fn();
     vi.doMock("../../../src/helpers/classicBattle/eventDispatcher.js", () => ({


### PR DESCRIPTION
## Summary
- add `onEngineCreated` stubs to the classic battle engine facade mocks so they expose the full interface

## Testing
- npx vitest run tests/helpers/classicBattle/cooldown.skipHandlerReady.test.js tests/helpers/classicBattle/playerChoiceReset.test.js tests/helpers/classicBattle/rebindEngineEvents.test.js tests/helpers/classicBattle/roundResolverOnce.test.js tests/helpers/classicBattle/timerService.nextRound.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de90568890832688e15515310828e7