### PR TITLE
Handle fallback scoreboard errors in round manager

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -1062,7 +1062,10 @@ export function _resetForTest(store) {
             const player = Number(detail?.playerScore) || 0;
             const opponent = Number(detail?.opponentScore) || 0;
             emitBattleEvent("display.score.update", { player, opponent });
-          } catch {}
+          } catch (error) {
+            // Scoreboard updates are opportunistic; swallow errors after recording usage.
+            void error;
+          }
         };
 
         maybeMock("roundEnded", emitFallbackRoundEvents);


### PR DESCRIPTION
## Summary
- add an explicit error handler when emitting fallback scoreboard updates so the block is non-empty and intentionally swallows errors

## Testing
- npx eslint src/helpers/classicBattle/roundManager.js

------
https://chatgpt.com/codex/tasks/task_e_68e01721b89483268ced27bb69a1a0fe