### PR TITLE
Guard settings ready promise for non-DOM environments

### DIFF
--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -58,6 +58,8 @@ import { renderFeatureFlags } from "./settings/renderFeatureFlags.js";
  *
  * @summary This promise provides a reliable signal for external scripts or tests
  * to know when the Settings page's DOM is ready and its controls are initialized.
+ * When no DOM is available (e.g., in a Node environment), the promise resolves
+ * immediately to keep module imports side-effect free.
  *
  * @pseudocode
  * 1. A new `Promise` is created.
@@ -68,9 +70,13 @@ import { renderFeatureFlags } from "./settings/renderFeatureFlags.js";
  * @type {Promise<void>}
  * @param {(value?: void) => void} resolve - Internal resolver for readiness.
  */
-export const settingsReadyPromise = new Promise((resolve) => {
-  document.addEventListener("settings:ready", resolve, { once: true });
-});
+const hasDocument = typeof document !== "undefined";
+
+export const settingsReadyPromise = hasDocument
+  ? new Promise((resolve) => {
+      document.addEventListener("settings:ready", resolve, { once: true });
+    })
+  : Promise.resolve();
 
 // Expose readiness for tests to await in browser environments.
 if (typeof window !== "undefined") {

--- a/tests/helpers/settingsPage.node.test.js
+++ b/tests/helpers/settingsPage.node.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from "vitest";
+
+describe("settingsPage module - environment compatibility", () => {
+  it("resolves readiness promise immediately when DOM is unavailable", async () => {
+    vi.resetModules();
+    vi.stubGlobal("document", undefined);
+    vi.stubGlobal("window", undefined);
+
+    try {
+      const { settingsReadyPromise } = await import(
+        "../../src/helpers/settingsPage.js"
+      );
+
+      await expect(settingsReadyPromise).resolves.toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+      vi.resetModules();
+    }
+  });
+});


### PR DESCRIPTION
## Task Contract
- **Inputs:** `src/helpers/settingsPage.js`, existing settings helper tests, new smoke test for Node-style import.
- **Outputs:** DOM-guarded readiness promise implementation and automated test coverage for Node environments.
- **Success Criteria:** Module imports without a DOM resolve a fallback promise while browser behavior remains unchanged; helper unit tests pass.
- **Failure Modes:** Document guard omitted or misconfigured, regressions in existing settings tests, or new smoke test failing.

## Files Changed
- `src/helpers/settingsPage.js` — Guard the readiness promise with a DOM existence check and document the Node fallback behavior.
- `tests/helpers/settingsPage.node.test.js` — Add a smoke test confirming the helper can be imported when `document` is undefined.

## Verification Summary
- **eslint:** not run (not requested)
- **vitest:** `npx vitest run tests/helpers/settingsPage.test.js tests/helpers/settingsPage.node.test.js` (12 passed, 0 failed)
- **playwright:** not run (not requested)
- **jsdoc:** not run (pre-commit hook warning only)

## Risk & Follow-Up
- **Risk Level:** Low — changes are limited to a guarded promise and an isolated test.
- **Follow-Up Work:** None.


------
https://chatgpt.com/codex/tasks/task_e_68e01f85854c832689ac2e4211717b71