### PR TITLE
Handle non-finite classic battle cooldown durations

### DIFF
--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -596,7 +596,8 @@ export async function handleRoundResolvedEvent(event, deps = {}) {
             cooldownResult = computeCooldown();
           } catch {}
           const resolvedSeconds = parseSecondsFromResult(cooldownResult);
-          const secs = Math.max(3, resolvedSeconds);
+          const safeSeconds = Number.isFinite(resolvedSeconds) ? resolvedSeconds : 3;
+          const secs = Math.max(3, safeSeconds);
           const attachRendererOptions =
             deps.attachCooldownRendererOptions &&
             typeof deps.attachCooldownRendererOptions === "object"


### PR DESCRIPTION
## Summary
- ensure round cooldown seconds fallback to the minimum when the computed value is non-finite
- extend the round UI handler spec to cover undefined/NaN cooldown outputs and verify timers use the minimum delay

## Testing
- npx vitest run tests/helpers/classicBattle/roundUI.handlers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e01f8121e883268b6e582a1f0bfc9e