### PR TITLE
Address review feedback for cooldown minimum enforcement

### DIFF
--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -596,8 +596,7 @@ export async function handleRoundResolvedEvent(event, deps = {}) {
             cooldownResult = computeCooldown();
           } catch {}
           const resolvedSeconds = parseSecondsFromResult(cooldownResult);
-          const safeSeconds = Number.isFinite(resolvedSeconds) ? resolvedSeconds : 3;
-          const secs = Math.max(3, safeSeconds);
+          const secs = Math.max(3, Number.isFinite(resolvedSeconds) ? resolvedSeconds : 3);
           const attachRendererOptions =
             deps.attachCooldownRendererOptions &&
             typeof deps.attachCooldownRendererOptions === "object"

--- a/tests/helpers/classicBattle/roundUI.handlers.test.js
+++ b/tests/helpers/classicBattle/roundUI.handlers.test.js
@@ -290,6 +290,7 @@ describe("round UI handlers", () => {
       );
 
       expect(createRoundTimer).toHaveBeenCalledTimes(1);
+      expect(computeNextRoundCooldownMock).toHaveBeenCalledTimes(1);
       const timer = createRoundTimer.mock.results[0]?.value;
       expect(timer?.start).toHaveBeenCalledWith(3);
       const attachCall = attachCooldownRenderer.mock.calls[0];


### PR DESCRIPTION
## Summary
- streamline round cooldown minimum enforcement to avoid redundant fallback handling
- ensure the non-finite cooldown test asserts the cooldown computation mock is invoked

## Testing
- npx vitest run tests/helpers/classicBattle/roundUI.handlers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e021e42b3883268a8d8a6ddcddb866