### PR TITLE
Add browser coverage for settings readiness promise

### DIFF
--- a/tests/helpers/settingsPage.browser.test.js
+++ b/tests/helpers/settingsPage.browser.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const modulePath = "../../src/helpers/settingsPage.js";
+
+vi.mock("../../src/helpers/domReady.js", () => ({
+  onDomReady: vi.fn()
+}));
+
+describe("settingsReadyPromise in browser-like environments", () => {
+  afterEach(() => {
+    vi.resetModules();
+    if ("settingsReadyPromise" in window) {
+      delete window.settingsReadyPromise;
+    }
+  });
+
+  it("waits for the settings:ready event before resolving", async () => {
+    const { settingsReadyPromise } = await import(modulePath);
+
+    let state = "pending";
+    const trackedPromise = settingsReadyPromise.then(() => {
+      state = "resolved";
+    });
+
+    // Allow any synchronous microtasks to flush to detect premature resolution.
+    await Promise.resolve();
+    expect(state).toBe("pending");
+
+    document.dispatchEvent(new Event("settings:ready"));
+
+    await expect(trackedPromise).resolves.toBeUndefined();
+    expect(state).toBe("resolved");
+  });
+
+  it("exposes the readiness promise on window for tests", async () => {
+    const { settingsReadyPromise } = await import(modulePath);
+
+    expect(window.settingsReadyPromise).toBe(settingsReadyPromise);
+  });
+});


### PR DESCRIPTION
## Task Contract
- **Inputs:** `src/helpers/settingsPage.js`, existing settings helper tests, new smoke test for Node-style import.
- **Outputs:** DOM-guarded readiness promise implementation and automated test coverage for Node environments.
- **Success Criteria:** Module imports without a DOM resolve a fallback promise while browser behavior remains unchanged; helper unit tests pass.
- **Failure Modes:** Document guard omitted or misconfigured, regressions in existing settings tests, or new smoke test failing.

## Files Changed
- `src/helpers/settingsPage.js` — Guard the readiness promise with a DOM existence check and document the Node fallback behavior.
- `tests/helpers/settingsPage.node.test.js` — Add a smoke test confirming the helper can be imported when `document` is undefined.
- `tests/helpers/settingsPage.browser.test.js` — Add coverage that the readiness promise waits for the `settings:ready` event and is exposed on `window` in DOM-enabled environments.

## Verification Summary
- **eslint:** not run (not requested)
- **vitest:** `npx vitest run tests/helpers/settingsPage.test.js tests/helpers/settingsPage.node.test.js tests/helpers/settingsPage.browser.test.js` (14 passed, 0 failed)
- **playwright:** not run (not requested)
- **jsdoc:** not run (pre-commit hook warning only)

## Risk & Follow-Up
- **Risk Level:** Low — changes are limited to guarded promise logic and isolated tests.
- **Follow-Up Work:** None.


------
https://chatgpt.com/codex/tasks/task_e_68e0219c6e5c8326a63a5e956a8ef984