### PR TITLE
Delay stat button enablement until next round

### DIFF
--- a/src/helpers/battle/battleUI.js
+++ b/src/helpers/battle/battleUI.js
@@ -119,12 +119,28 @@ function trace(tag, extra) {
     );
   } catch {}
 }
+
+/**
+ * Explicitly enable all stat buttons by clearing disabled state and class.
+ * Safe to call multiple times; only touches known attributes/classes.
+ *
+ * @pseudocode
+ * 1. For each stat button:
+ *    - Set `disabled = false`.
+ *    - Set `tabIndex = 0` to return the button to the tab order.
+ *    - Remove the `disabled` and `selected` classes.
+ *    - Clear any inline `background-color` style.
+ *
+ * @returns {void}
+ */
 export function enableStatButtons() {
   trace("enableStatButtons:begin");
   getStatButtons().forEach((btn) => {
     try {
       btn.disabled = false;
-      btn.classList.remove("disabled");
+      btn.tabIndex = 0;
+      btn.classList.remove("disabled", "selected");
+      btn.style.removeProperty("background-color");
     } catch {}
   });
   trace("enableStatButtons:end");
@@ -132,12 +148,23 @@ export function enableStatButtons() {
 
 /**
  * Explicitly disable all stat buttons and add disabled class.
+ *
+ * @pseudocode
+ * 1. For each stat button:
+ *    - Set `disabled = true`.
+ *    - Set `tabIndex = -1` to remove it from the tab order.
+ *    - Add the `disabled` class when missing.
+ *
+ * @returns {void}
  */
 export function disableStatButtons() {
   trace("disableStatButtons:begin");
   getStatButtons().forEach((btn) => {
     try {
       btn.disabled = true;
+      if (typeof btn.tabIndex === "number") {
+        btn.tabIndex = -1;
+      }
       if (!btn.classList.contains("disabled")) btn.classList.add("disabled");
     } catch {}
   });


### PR DESCRIPTION
## Summary
- prevent the round resolved handler from clearing the stat button disabled state before the next round begins, keeping cooldown interactions inaccessible
- mirror the battleUI stat button helpers with the shared statButtons implementation so tab order and visual classes stay consistent

## Testing
- npx playwright test playwright/battle-classic/keyboard-navigation.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e0cf0df8d8832698fd3da76aff39ab