### PR TITLE
Emit ready event when classic battle dispatch fails

### DIFF
--- a/src/helpers/classicBattle/roundManager.js
+++ b/src/helpers/classicBattle/roundManager.js
@@ -967,6 +967,9 @@ async function handleNextRoundExpiration(controls, btn, options = {}) {
       { suppressInProduction: true }
     );
   }
+  if (!dispatched && !fallbackDispatched) {
+    emitBattleEvent("ready");
+  }
   finalizeReadyControls(controls, dispatched, { forceResolve: !dispatched });
   safeRound(
     "handleNextRoundExpiration.traceEnd",


### PR DESCRIPTION
## Summary
- emit a `ready` event from `handleNextRoundExpiration` when neither the primary nor fallback dispatchers handle the cooldown completion
- extend the classic battle test harness to spy on the battle event bus and assert the non-orchestrated flow restarts when dispatching declines
- override `runReadyDispatchStrategies` within the new test to simulate a missing machine while still exercising the real dispatch logic

## Testing
- `npx vitest run tests/helpers/classicBattle/scheduleNextRound.test.js`
- `npx playwright test playwright/battle-classic/long-run-hang-probe.spec.js` *(fails: stat button remained disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ce8ed05c83269997e8285285671b