### PR TITLE
Address review feedback on stat button handling

### DIFF
--- a/src/helpers/battle/battleUI.js
+++ b/src/helpers/battle/battleUI.js
@@ -138,7 +138,9 @@ export function enableStatButtons() {
   getStatButtons().forEach((btn) => {
     try {
       btn.disabled = false;
-      btn.tabIndex = 0;
+      if (typeof btn.tabIndex === "number") {
+        btn.tabIndex = 0;
+      }
       btn.classList.remove("disabled", "selected");
       btn.style.removeProperty("background-color");
     } catch {}

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -54,12 +54,16 @@ function collectStatButtons(store) {
       );
     } catch {}
   }
-  try {
-    if (typeof document?.querySelectorAll === "function") {
-      return Array.from(document.querySelectorAll("#stat-buttons button[data-stat]"));
-    }
-  } catch {}
-  return [];
+  if (!collectStatButtons._cachedButtons) {
+    try {
+      if (typeof document?.querySelectorAll === "function") {
+        collectStatButtons._cachedButtons = Array.from(
+          document.querySelectorAll("#stat-buttons button[data-stat]")
+        );
+      }
+    } catch {}
+  }
+  return collectStatButtons._cachedButtons || [];
 }
 
 function clearStatButtonSelections(store) {
@@ -532,8 +536,6 @@ export async function handleRoundResolvedEvent(event, deps = {}) {
     clearStatButtonSelections(store);
     try {
       disableStatButtons?.();
-    } catch {}
-    try {
       emitBattleEvent("statButtons:disable");
     } catch {}
   };


### PR DESCRIPTION
## Summary
- guard `tabIndex` reassignment in `enableStatButtons` so only elements with a numeric index are touched
- cache the DOM fallback in `collectStatButtons` to avoid repeated queries when store elements are unavailable
- keep the stat button disable event emission aligned with the disable call during round reset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10de184b48326ba5dd32f2a597884