### PR TITLE
Address review comments for stat button caching (follow-up)

### DIFF
--- a/src/helpers/battle/battleUI.js
+++ b/src/helpers/battle/battleUI.js
@@ -136,11 +136,12 @@ function trace(tag, extra) {
 export function enableStatButtons() {
   trace("enableStatButtons:begin");
   getStatButtons().forEach((btn) => {
+    if (!btn) return;
     try {
       btn.disabled = false;
-      if (Number.isFinite(btn?.tabIndex)) {
+      if (Number.isFinite(btn.tabIndex)) {
         btn.tabIndex = 0;
-      } else if (typeof btn?.setAttribute === "function") {
+      } else if (typeof btn.setAttribute === "function") {
         btn.setAttribute("tabindex", "0");
       }
       btn.classList.remove("disabled", "selected");
@@ -164,11 +165,12 @@ export function enableStatButtons() {
 export function disableStatButtons() {
   trace("disableStatButtons:begin");
   getStatButtons().forEach((btn) => {
+    if (!btn) return;
     try {
       btn.disabled = true;
-      if (Number.isFinite(btn?.tabIndex)) {
+      if (Number.isFinite(btn.tabIndex)) {
         btn.tabIndex = -1;
-      } else if (typeof btn?.setAttribute === "function") {
+      } else if (typeof btn.setAttribute === "function") {
         btn.setAttribute("tabindex", "-1");
       }
       if (!btn.classList.contains("disabled")) btn.classList.add("disabled");


### PR DESCRIPTION
## Summary
- add defensive null guards before updating stat buttons and remove optional chaining fallbacks
- simplify cached button validation to drop stale entries while retaining connected references
- retain mutation observers across invalidations while cleaning up when the host node is removed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e15bee7cd88326a04cdfdb916b2b64