### PR TITLE
Improve stat button observer cleanup and guards

### DIFF
--- a/src/helpers/battle/battleUI.js
+++ b/src/helpers/battle/battleUI.js
@@ -136,7 +136,12 @@ function trace(tag, extra) {
 export function enableStatButtons() {
   trace("enableStatButtons:begin");
   getStatButtons().forEach((btn) => {
-    if (!btn) return;
+    if (
+      !btn ||
+      (typeof btn !== "object" && typeof btn !== "function")
+    ) {
+      return;
+    }
     try {
       btn.disabled = false;
       if (Number.isFinite(btn.tabIndex)) {
@@ -165,7 +170,12 @@ export function enableStatButtons() {
 export function disableStatButtons() {
   trace("disableStatButtons:begin");
   getStatButtons().forEach((btn) => {
-    if (!btn) return;
+    if (
+      !btn ||
+      (typeof btn !== "object" && typeof btn !== "function")
+    ) {
+      return;
+    }
     try {
       btn.disabled = true;
       if (Number.isFinite(btn.tabIndex)) {

--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -90,7 +90,14 @@ function queryStatButtons() {
 
 function ensureStatButtonObservers() {
   if (collectStatButtons._observerAttached) {
-    return;
+    const root = collectStatButtons._observerRoot;
+    if (root && root.isConnected === false) {
+      collectStatButtons.invalidateCache();
+    } else if (!root) {
+      collectStatButtons._observerAttached = false;
+    } else {
+      return;
+    }
   }
   if (typeof MutationObserver !== "function") {
     collectStatButtons._observerAttached = true;
@@ -113,20 +120,17 @@ function ensureStatButtonObservers() {
 
 collectStatButtons.invalidateCache = function invalidateCache() {
   collectStatButtons._cachedButtons = undefined;
-  const observerRoot = collectStatButtons._observerRoot;
-  if (observerRoot && observerRoot.isConnected === false) {
-    if (
-      collectStatButtons._observer &&
-      typeof collectStatButtons._observer.disconnect === "function"
-    ) {
-      try {
-        collectStatButtons._observer.disconnect();
-      } catch {}
-    }
-    collectStatButtons._observer = undefined;
-    collectStatButtons._observerRoot = undefined;
-    collectStatButtons._observerAttached = false;
+
+  const observer = collectStatButtons._observer;
+  if (observer && typeof observer.disconnect === "function") {
+    try {
+      observer.disconnect();
+    } catch {}
   }
+
+  collectStatButtons._observer = undefined;
+  collectStatButtons._observerRoot = undefined;
+  collectStatButtons._observerAttached = false;
 };
 
 function clearStatButtonSelections(store) {


### PR DESCRIPTION
## Summary
- broaden stat button guards to skip non-object entries before toggling state
- reset stat button observer tracking when the root node is missing or disconnected
- always disconnect mutation observers during cache invalidation to prevent leaks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e15e160c8c8326bf67534f1c6079c2