### PR TITLE
Address stat button guard regression

### DIFF
--- a/src/helpers/battle/battleUI.js
+++ b/src/helpers/battle/battleUI.js
@@ -222,6 +222,9 @@ export function resetStatButtons(
   } catch {}
   const { onFrame, cancel } = scheduler;
   getStatButtons().forEach((btn) => {
+    if (!btn) {
+      return;
+    }
     btn.classList.remove("selected");
     btn.style.removeProperty("background-color");
     // Ensure disabled class is consistent with disabled attribute

--- a/tests/helpers/classicBattle.test.js
+++ b/tests/helpers/classicBattle.test.js
@@ -1,9 +1,11 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   resetStatButtons,
   showResult,
   getStatButtons,
-  getRoundMessageEl
+  getRoundMessageEl,
+  enableStatButtons,
+  disableStatButtons
 } from "../../src/helpers/battle/battleUI.js";
 
 const syncScheduler = {
@@ -52,6 +54,54 @@ describe("battleUI helpers", () => {
     const el = getRoundMessageEl();
     expect(el.textContent).toBe("Second");
     expect(el.classList.contains("fading")).toBe(true);
+  });
+
+  it("enableStatButtons skips falsy button references", () => {
+    const button = document.createElement("button");
+    button.disabled = true;
+    button.tabIndex = -1;
+    button.classList.add("disabled");
+    const querySpy = vi
+      .spyOn(document, "querySelectorAll")
+      .mockImplementation(() => [button, null]);
+
+    enableStatButtons();
+
+    expect(button.disabled).toBe(false);
+    expect(button.tabIndex).toBe(0);
+    expect(button.classList.contains("disabled")).toBe(false);
+    querySpy.mockRestore();
+  });
+
+  it("disableStatButtons skips falsy button references", () => {
+    const button = document.createElement("button");
+    button.disabled = false;
+    button.classList.remove("disabled");
+    const querySpy = vi
+      .spyOn(document, "querySelectorAll")
+      .mockImplementation(() => [button, undefined]);
+
+    disableStatButtons();
+
+    expect(button.disabled).toBe(true);
+    expect(button.classList.contains("disabled")).toBe(true);
+    querySpy.mockRestore();
+  });
+
+  it("resetStatButtons tolerates falsy button references", () => {
+    const button = document.createElement("button");
+    button.classList.add("selected");
+    button.style.backgroundColor = "red";
+    const querySpy = vi
+      .spyOn(document, "querySelectorAll")
+      .mockImplementation(() => [button, null]);
+
+    resetStatButtons(syncScheduler);
+
+    expect(button.classList.contains("selected")).toBe(false);
+    expect(button.disabled).toBe(false);
+    expect(button.style.backgroundColor).toBe("");
+    querySpy.mockRestore();
   });
 
   it("DOM helper functions return elements", () => {


### PR DESCRIPTION
## Summary
- restore the simple null guard for stat button iteration to avoid excluding valid elements
- add a matching guard in `resetStatButtons` to keep the helpers consistent
- add unit coverage to ensure battle UI helpers tolerate falsy button entries

## Testing
- npx vitest run tests/helpers/classicBattle.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e18311d7208326bd93d36fdf782622