### PR TITLE
Fix stat button reset after round resolution

### DIFF
--- a/src/helpers/classicBattle/roundUI.js
+++ b/src/helpers/classicBattle/roundUI.js
@@ -551,7 +551,7 @@ export function handleStatSelectedEvent(event, deps = {}) {
  * 2. Surface the outcome message and update the score using the injected scoreboard API.
  * 3. When the match ends, clear the round counter, show the summary modal, and emit `matchOver`.
  * 4. Otherwise, compute the next-round cooldown and, if not orchestrated, configure and start the timer with injected helpers.
- * 5. Clear stat button visuals without re-enabling them and refresh the debug panel.
+ * 5. Clear stat button visuals, reset their interactive state, and refresh the debug panel.
  * @returns {Promise<void>}
  */
 export async function handleRoundResolvedEvent(event, deps = {}) {
@@ -602,8 +602,7 @@ export async function handleRoundResolvedEvent(event, deps = {}) {
   const runReset = () => {
     clearStatButtonSelections(store);
     try {
-      disableStatButtons?.();
-      emitBattleEvent("statButtons:disable");
+      resetStatButtons?.();
     } catch {}
   };
   let didReset = false;


### PR DESCRIPTION
## Summary
- stop `handleRoundResolvedEvent` from emitting a `statButtons:disable` event and instead reuse the shared `resetStatButtons` helper during the round reset
- refresh the handler documentation to note that stat buttons are reset and kept interactive after each round

## Testing
- `npx vitest run tests/helpers/classicBattle/roundResolved.statButton.test.js`
- `npx vitest run tests/helpers/classicBattle/statSelection.test.js`
- `npx vitest run tests/helpers/classicBattle/statButtons.disableAfterSelection.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e183a76c688326b697a040f42b7ebb