### PR TITLE
Ensure stat buttons sync disabled class

### DIFF
--- a/src/helpers/classicBattle/statButtons.js
+++ b/src/helpers/classicBattle/statButtons.js
@@ -14,11 +14,27 @@ import { isEnabled, enableFlag } from "../featureFlags.js";
  * @param {HTMLElement} [container] - Optional containing element to mark ready.
  * @returns {void}
  */
+function toButtonArray(buttons) {
+  if (!buttons) return [];
+  if (Array.isArray(buttons)) return buttons.filter(Boolean);
+  return Array.from(buttons).filter(Boolean);
+}
+
+function applyDisabledState(btn, disabled) {
+  if (!btn) return;
+  btn.disabled = disabled;
+  btn.tabIndex = disabled ? -1 : 0;
+  if (disabled) {
+    btn.classList.add("disabled");
+  } else {
+    btn.classList.remove("disabled");
+  }
+}
+
 export function enableStatButtons(buttons, container) {
-  buttons.forEach((btn) => {
-    btn.disabled = false;
-    btn.tabIndex = 0;
-    btn.classList.remove("disabled", "selected");
+  toButtonArray(buttons).forEach((btn) => {
+    applyDisabledState(btn, false);
+    btn.classList.remove("selected");
     btn.style.removeProperty("background-color");
   });
   if (container) container.dataset.buttonsReady = "true";
@@ -38,10 +54,8 @@ export function enableStatButtons(buttons, container) {
  * @returns {void}
  */
 export function disableStatButtons(buttons, container) {
-  buttons.forEach((btn) => {
-    btn.disabled = true;
-    btn.tabIndex = -1;
-    btn.classList.add("disabled");
+  toButtonArray(buttons).forEach((btn) => {
+    applyDisabledState(btn, true);
   });
   if (container) container.dataset.buttonsReady = "false";
 }

--- a/src/pages/battleClassic.init.js
+++ b/src/pages/battleClassic.init.js
@@ -1215,6 +1215,14 @@ function handleRoundCounterFallback(visibleRound) {
 async function handleStatButtonClick(store, stat, btn) {
   console.debug("battleClassic: stat button click handler invoked");
   if (!btn || btn.disabled) return;
+  const container = document.getElementById("stat-buttons");
+  const buttons = container
+    ? Array.from(container.querySelectorAll("button[data-stat]"))
+    : [];
+  if (buttons.length > 0) {
+    disableStatButtons(buttons, container);
+  }
+
   const delayOverride = prepareUiBeforeSelection();
   const { playerVal, opponentVal } = resolveStatValues(store, stat);
   let result;
@@ -1231,10 +1239,11 @@ async function handleStatButtonClick(store, stat, btn) {
   }
 
   // Disable stat buttons after selection to prevent multiple clicks
-  const container = document.getElementById("stat-buttons");
-  if (container) {
-    const buttons = container.querySelectorAll("button[data-stat]");
-    disableStatButtons(buttons, container);
+  if (buttons.length === 0 && container) {
+    const fallbackButtons = Array.from(container.querySelectorAll("button[data-stat]"));
+    if (fallbackButtons.length > 0) {
+      disableStatButtons(fallbackButtons, container);
+    }
   }
 
   if (result) {

--- a/tests/helpers/classicBattle/statButtons.state.test.js
+++ b/tests/helpers/classicBattle/statButtons.state.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  enableStatButtons,
+  disableStatButtons
+} from "../../../src/helpers/classicBattle/statButtons.js";
+
+describe("classicBattle statButtons state helpers", () => {
+  let container;
+  let buttons;
+
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<div id="stat-buttons"><button data-stat="strength"></button><button data-stat="speed" class="selected"></button></div>';
+    container = document.getElementById("stat-buttons");
+    buttons = container.querySelectorAll("button[data-stat]");
+  });
+
+  it("disables buttons with matching class state", () => {
+    disableStatButtons(buttons, container);
+
+    buttons.forEach((button) => {
+      expect(button.disabled).toBe(true);
+      expect(button.tabIndex).toBe(-1);
+      expect(button.classList.contains("disabled")).toBe(true);
+    });
+    expect(container?.dataset.buttonsReady).toBe("false");
+  });
+
+  it("enables buttons and removes disabled class", () => {
+    disableStatButtons(buttons, container);
+    enableStatButtons(buttons, container);
+
+    buttons.forEach((button) => {
+      expect(button.disabled).toBe(false);
+      expect(button.tabIndex).toBe(0);
+      expect(button.classList.contains("disabled")).toBe(false);
+    });
+    expect(container?.dataset.buttonsReady).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary
- disable classic battle stat buttons immediately on selection so the DOM reflects the disabled class before async work
- centralize stat button enable/disable handling to keep the `.disabled` class aligned with the `disabled` attribute
- add coverage to confirm stat buttons toggle both the attribute and class states consistently

## Testing
- npx vitest run tests/helpers/classicBattle/statButtons.state.test.js
- npx playwright test playwright/battle-classic/keyboard-navigation.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e223c5acb883269b7598f5044d5c31