### PR TITLE
Address review feedback on header height and focus outline

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -38,12 +38,10 @@
   --space-large: var(--space-lg);
 
   /* Navbar heights adjusted for mobile Safari */
-  --header-height: 8vh;
   --header-height: clamp(56px, 8vh, 64px);
   --footer-height: 8vh;
 
   @supports (height: 1dvh) {
-    --header-height: 8dvh;
     --header-height: clamp(56px, 8dvh, 64px);
     --footer-height: 8dvh;
   }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -124,10 +124,10 @@ body {
 }
 
 .logo-container a:focus-visible {
-  outline: 2px solid var(--color-text-inverted);
-  outline-offset: 2px;
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.6);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-text-inverted) 60%, transparent);
+  outline: 3px solid var(--color-text-inverted);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 5px rgba(0, 0, 0, 0.55);
+  box-shadow: 0 0 0 5px color-mix(in srgb, #000000 65%, var(--color-text-inverted));
 }
 
 .logo {


### PR DESCRIPTION
## Summary
- remove redundant header height tokens so the clamp-based value is the single source of truth
- boost the header logo focus ring contrast with a thicker outline and dark halo for better accessibility

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2d855c84c8326b2906681bcd6bcde