### PR TITLE
Refine classic battle layout surfaces

### DIFF
--- a/src/pages/battleClassic.html
+++ b/src/pages/battleClassic.html
@@ -66,59 +66,67 @@
 
         <!-- Battle area container -->
         <div id="battle-area">
-          <!-- Battle cards section -->
-          <section class="battle-layout" aria-label="Cards">
-            <div id="player-card" aria-label="Your card"></div>
-            <div id="opponent-card" aria-label="Opponent card">
-              <div
-                id="mystery-card-placeholder"
-                class="card common-rarity"
-                aria-label="Mystery opponent card"
-              >
-                <svg viewBox="0 0 960 960" class="mystery-icon">
-                  <path
-                    d="M424-320q0-81 14.5-116.5T500-514q41-36 62.5-62.5T584-637q0-41-27.5-68T480-732q-51 0-77.5 31T365-638l-103-44q21-64 77-111t141-47q105 0 161.5 58.5T698-641q0 50-21.5 85.5T609-475q-49 47-59.5 71.5T539-320H424Zm56 240q-33 0-56.5-23.5T400-160q0-33 23.5-56.5T480-240q33 0 56.5 23.5T560-160q0 33-23.5 56.5T480-80Z"
-                  />
-                </svg>
+          <section id="player-slot" class="card-slot player-slot" aria-label="Your card">
+            <div class="battle-slot-surface">
+              <div id="player-card" aria-label="Your card"></div>
+            </div>
+          </section>
+
+          <section id="controls" aria-label="Battle controls">
+            <div class="battle-slot-surface controls-surface">
+              <div class="stat-controls" aria-label="Choose a stat">
+                <div id="stat-buttons" data-testid="stat-buttons" data-buttons-ready="false"></div>
+              </div>
+
+              <div class="battle-controls" aria-label="Round controls">
+                <button
+                  id="home-button"
+                  type="button"
+                  data-testid="home-link"
+                  class="battle-control-button secondary-button"
+                >
+                  Main Menu
+                </button>
+                <button
+                  id="next-button"
+                  data-testid="next-button"
+                  data-role="next-round"
+                  class="battle-control-button primary-button"
+                  disabled
+                >
+                  Next
+                </button>
+                <button
+                  id="replay-button"
+                  data-testid="replay-button"
+                  data-role="replay"
+                  class="battle-control-button secondary-button"
+                >
+                  Replay
+                </button>
+                <button id="quit-button" data-role="quit" class="battle-control-button secondary-button">
+                  Quit
+                </button>
               </div>
             </div>
           </section>
 
-          <!-- Stat selection section -->
-          <section class="stat-selection" aria-label="Choose a stat">
-            <div id="stat-buttons" data-testid="stat-buttons" data-buttons-ready="false"></div>
-          </section>
-
-          <!-- Controls section -->
-          <section class="battle-controls" aria-label="Round controls">
-            <button
-              id="home-button"
-              type="button"
-              data-testid="home-link"
-              class="battle-control-button secondary-button"
-            >
-              Main Menu
-            </button>
-            <button
-              id="next-button"
-              data-testid="next-button"
-              data-role="next-round"
-              class="battle-control-button primary-button"
-              disabled
-            >
-              Next
-            </button>
-            <button
-              id="replay-button"
-              data-testid="replay-button"
-              data-role="replay"
-              class="battle-control-button secondary-button"
-            >
-              Replay
-            </button>
-            <button id="quit-button" data-role="quit" class="battle-control-button secondary-button">
-              Quit
-            </button>
+          <section id="opponent-slot" class="card-slot opponent-slot" aria-label="Opponent card">
+            <div class="battle-slot-surface">
+              <div id="opponent-card" aria-label="Opponent card">
+                <div
+                  id="mystery-card-placeholder"
+                  class="card common-rarity"
+                  aria-label="Mystery opponent card"
+                >
+                  <svg viewBox="0 0 960 960" class="mystery-icon">
+                    <path
+                      d="M424-320q0-81 14.5-116.5T500-514q41-36 62.5-62.5T584-637q0-41-27.5-68T480-732q-51 0-77.5 31T365-638l-103-44q21-64 77-111t141-47q105 0 161.5 58.5T698-641q0 50-21.5 85.5T609-475q-49 47-59.5 71.5T539-320H424Zm56 240q-33 0-56.5-23.5T400-160q0-33 23.5-56.5T480-240q33 0 56.5 23.5T560-160q0 33-23.5 56.5T480-80Z"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
           </section>
         </div>
       </main>

--- a/src/styles/battleClassic.css
+++ b/src/styles/battleClassic.css
@@ -8,6 +8,45 @@
   margin: 0 auto;
 }
 
+#battle-area {
+  gap: var(--space-md);
+  padding-inline: var(--space-md);
+  padding-bottom: var(--space-md);
+}
+
+.battle-slot-surface {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-base);
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  width: 100%;
+}
+
+.card-slot .battle-slot-surface {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.controls-surface {
+  align-items: stretch;
+  text-align: center;
+}
+
+.controls-surface .stat-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.controls-surface .battle-controls {
+  width: 100%;
+}
+
 /* Battle status within header */
 .battle-status-header {
   grid-column: 1 / -1;
@@ -28,26 +67,6 @@
   margin: 0;
   font-weight: 500;
   font-size: var(--font-small);
-}
-
-.battle-layout {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-md);
-  margin: var(--space-lg) 0;
-}
-
-@media (max-width: 720px) {
-  .battle-layout {
-    grid-template-columns: 1fr;
-  }
-}
-
-.stat-selection {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin: var(--space-lg) 0;
 }
 
 #stat-buttons {
@@ -75,11 +94,10 @@
   align-items: stretch;
   justify-content: center;
   flex-wrap: wrap;
-  margin-top: var(--space-lg);
-  padding: var(--space-sm);
-  border-radius: var(--radius-lg);
-  background-color: var(--color-surface);
-  box-shadow: var(--shadow-base);
+  margin: 0;
+  padding: 0;
+  background: none;
+  box-shadow: none;
 }
 
 .battle-controls .battle-control-button {


### PR DESCRIPTION
## Summary
- restore the classic battle area markup to the player, controls, and opponent slots expected by shared grid styles
- wrap each slot with material-inspired surface styling and center the stat controls while preserving 16px gutters across breakpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2eddacc548326bffee7fc029f8c79