### PR TITLE
Style round message as title in Classic Battle header

### DIFF
--- a/src/pages/battleClassic.html
+++ b/src/pages/battleClassic.html
@@ -41,7 +41,13 @@
 
         <!-- Battle status elements within header for backward compatibility -->
         <div class="battle-status-header">
-          <p id="round-message" aria-live="polite" aria-atomic="true" role="status"></p>
+          <p
+            id="round-message"
+            class="round-message-title"
+            aria-live="polite"
+            aria-atomic="true"
+            role="status"
+          ></p>
           <p
             id="next-round-timer"
             data-testid="next-round-timer"

--- a/src/styles/battleClassic.css
+++ b/src/styles/battleClassic.css
@@ -13,11 +13,11 @@
   grid-column: 1 / -1;
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--space-xs);
+  gap: var(--space-sm);
   background-color: var(--color-surface);
   border-radius: var(--radius-md);
-  padding: var(--space-sm);
-  margin: var(--space-xs);
+  padding: var(--space-md);
+  margin: var(--space-lg);
   box-shadow: var(--shadow-base);
   text-align: center;
   color: var(--color-text);
@@ -26,8 +26,21 @@
 .battle-status-header p {
   min-height: 1.2em;
   margin: 0;
+}
+
+.battle-status-header #round-message.round-message-title {
+  font-size: var(--font-extra-large);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin-bottom: calc(var(--space-md) - var(--space-sm));
+}
+
+.battle-status-header #next-round-timer,
+.battle-status-header #round-counter,
+.battle-status-header #score-display,
+.battle-status-header #battle-state-badge {
+  font-size: var(--font-medium);
   font-weight: 500;
-  font-size: var(--font-small);
 }
 
 .battle-layout {
@@ -140,7 +153,8 @@
   }
 
   .battle-status-header {
-    margin: var(--space-xs) 0;
+    margin: var(--space-lg) var(--space-sm);
+    padding: var(--space-md);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated class to the battle round message so it can be styled as a title-level element
- restyle the Classic Battle status header to use the Material spacing tokens and larger typography for the round message while keeping counters at body size
- expand the status header margins and padding to align the card with the grid and preserve contrast

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2edd3aba4832695afe2a1ac90b576