### PR TITLE
Address review feedback for battle controls styling

### DIFF
--- a/src/pages/battleClassic.html
+++ b/src/pages/battleClassic.html
@@ -90,7 +90,7 @@
           </section>
 
           <!-- Controls section -->
-          <section class="battle-controls" aria-label="Round controls">
+          <section class="battle-controls controls" aria-label="Round controls">
             <button
               id="home-button"
               type="button"
@@ -116,7 +116,11 @@
             >
               Replay
             </button>
-            <button id="quit-button" data-role="quit" class="battle-control-button secondary-button">
+            <button
+              id="quit-button"
+              data-role="quit"
+              class="battle-control-button secondary-button"
+            >
               Quit
             </button>
           </section>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -11,6 +11,7 @@
   --color-background: #ffffff; /* Light mode background */
   --color-text: #000000; /* Light mode text */
   --color-text-inverted: #ffffff;
+  --color-border: rgba(0, 0, 0, 0.1);
   --link-color: var(--color-secondary);
 
   --button-bg: var(--color-primary);
@@ -84,6 +85,7 @@
   --link-color: #3399ff;
   --button-disabled-bg: #555555;
   --button-disabled-pattern: none;
+  --color-border: rgba(255, 255, 255, 0.24);
 }
 
 /* High contrast mode variable overrides */
@@ -105,6 +107,7 @@
   --toggle-on-bg: #8cff6b; /* Toggle on state background */
   --color-slider-dot: #8cff6b;
   --color-slider-active: #8cff6b;
+  --color-border: #8cff6b;
 }
 
 *,

--- a/src/styles/battleClassic.css
+++ b/src/styles/battleClassic.css
@@ -87,9 +87,17 @@
   min-width: 140px;
   max-width: 220px;
   min-height: var(--touch-target-size, 48px);
+  --button-bg: var(--color-surface);
+  --button-hover-bg: var(--color-tertiary);
+  --button-active-bg: var(--color-tertiary);
+  --button-text-color: var(--color-text);
 }
 
 .battle-controls .primary-button {
+  --button-bg: var(--color-primary);
+  --button-hover-bg: var(--color-primary);
+  --button-active-bg: var(--color-primary);
+  --button-text-color: var(--color-text-inverted);
   color: var(--color-text-inverted);
 }
 
@@ -105,14 +113,10 @@
   transform: translateY(-1px);
 }
 
-.battle-controls .primary-button:disabled {
-  box-shadow: none;
-}
-
 .battle-controls .secondary-button {
   background-color: var(--color-surface);
   color: var(--color-text);
-  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.1));
+  border: 1px solid var(--color-border);
   box-shadow: none;
 }
 
@@ -123,7 +127,7 @@
   box-shadow: var(--shadow-base);
 }
 
-/* Responsive adjustments */
+/* Responsive adjustments for battle control buttons */
 @media (max-width: 480px) {
   .battle-content {
     padding: var(--space-sm);


### PR DESCRIPTION
## Summary
- restore the legacy `controls` hook on the Classic Battle control section and normalize button markup formatting
- tune the battle controls styles to rely on button design tokens and tighten selector specificity
- define the shared `--color-border` design token for light, dark, and retro themes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ed90e6688326b9ba36abe7eeaab1