### PR TITLE
Refine battle control button state feedback

### DIFF
--- a/src/styles/battleClassic.css
+++ b/src/styles/battleClassic.css
@@ -101,22 +101,29 @@
   max-width: 220px;
   min-height: var(--touch-target-size, 48px);
   --button-bg: var(--color-surface);
-  --button-hover-bg: var(--color-tertiary);
-  --button-active-bg: var(--color-tertiary);
+  --button-hover-bg: color-mix(in srgb, var(--color-surface) 92%, var(--color-text) 8%);
+  --button-active-bg: color-mix(in srgb, var(--color-surface) 88%, var(--color-text) 12%);
   --button-text-color: var(--color-text);
+  --button-disabled-bg: color-mix(in srgb, var(--color-surface) 84%, var(--color-text) 16%);
 }
 
 .battle-controls .primary-button {
   --button-bg: var(--color-primary);
-  --button-hover-bg: var(--color-primary);
-  --button-active-bg: var(--color-primary);
+  --button-hover-bg: color-mix(in srgb, var(--color-primary) 92%, var(--color-text-inverted) 8%);
+  --button-active-bg: color-mix(in srgb, var(--color-primary) 86%, var(--color-text-inverted) 14%);
   --button-text-color: var(--color-text-inverted);
+  --button-disabled-bg: color-mix(in srgb, var(--color-primary) 45%, var(--color-surface) 55%);
   color: var(--color-text-inverted);
 }
 
 .battle-controls .primary-button:not(:disabled) {
   background-color: var(--color-primary);
   box-shadow: var(--shadow-hover);
+}
+
+.battle-controls .battle-control-button:disabled {
+  box-shadow: none;
+  opacity: 0.72;
 }
 
 .battle-controls .primary-button:not(:disabled):hover,


### PR DESCRIPTION
## Summary
- differentiate hover, active, and disabled state tokens for battle control buttons to improve feedback across themes
- restore explicit disabled styling for battle control buttons so the primary action loses its shadow when inactive

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e42df0bd788326a6cb4b9e09a57464