### PR TITLE
Address review feedback on Classic Battle round title spacing

### DIFF
--- a/src/styles/battleClassic.css
+++ b/src/styles/battleClassic.css
@@ -32,7 +32,7 @@
   font-size: var(--font-extra-large);
   font-weight: 700;
   letter-spacing: 0.02em;
-  margin-bottom: calc(var(--space-md) - var(--space-sm));
+  margin-bottom: var(--space-xs);
 }
 
 .battle-status-header #next-round-timer,


### PR DESCRIPTION
## Summary
- replace the round message title margin calculation with the `--space-xs` token for predictable spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e42ce402408326b885995cea87ddee