### PR TITLE
Restore battle classic battle-area grid surfaces

### DIFF
--- a/src/pages/battleClassic.html
+++ b/src/pages/battleClassic.html
@@ -72,63 +72,71 @@
 
         <!-- Battle area container -->
         <div id="battle-area">
-          <!-- Battle cards section -->
-          <section class="battle-layout" aria-label="Cards">
-            <div id="player-card" aria-label="Your card"></div>
-            <div id="opponent-card" aria-label="Opponent card">
-              <div
-                id="mystery-card-placeholder"
-                class="card common-rarity"
-                aria-label="Mystery opponent card"
-              >
-                <svg viewBox="0 0 960 960" class="mystery-icon">
-                  <path
-                    d="M424-320q0-81 14.5-116.5T500-514q41-36 62.5-62.5T584-637q0-41-27.5-68T480-732q-51 0-77.5 31T365-638l-103-44q21-64 77-111t141-47q105 0 161.5 58.5T698-641q0 50-21.5 85.5T609-475q-49 47-59.5 71.5T539-320H424Zm56 240q-33 0-56.5-23.5T400-160q0-33 23.5-56.5T480-240q33 0 56.5 23.5T560-160q0 33-23.5 56.5T480-80Z"
-                  />
-                </svg>
-              </div>
+          <section class="card-slot player-slot" aria-label="Your card">
+            <div class="slot-surface">
+              <div id="player-card" aria-label="Your card"></div>
             </div>
           </section>
 
-          <!-- Stat selection section -->
-          <section class="stat-selection" aria-label="Choose a stat">
-            <div id="stat-buttons" data-testid="stat-buttons" data-buttons-ready="false"></div>
+          <section id="controls" aria-label="Stat selection and round controls">
+            <div class="slot-surface controls-surface">
+              <section class="stat-selection stat-controls" aria-label="Choose a stat">
+                <div id="stat-buttons" data-testid="stat-buttons" data-buttons-ready="false"></div>
+              </section>
+
+              <section class="battle-controls controls" aria-label="Round controls">
+                <button
+                  id="home-button"
+                  type="button"
+                  data-testid="home-link"
+                  class="battle-control-button secondary-button"
+                >
+                  Main Menu
+                </button>
+                <button
+                  id="next-button"
+                  data-testid="next-button"
+                  data-role="next-round"
+                  class="battle-control-button primary-button"
+                  disabled
+                >
+                  Next
+                </button>
+                <button
+                  id="replay-button"
+                  data-testid="replay-button"
+                  data-role="replay"
+                  class="battle-control-button secondary-button"
+                >
+                  Replay
+                </button>
+                <button
+                  id="quit-button"
+                  data-role="quit"
+                  class="battle-control-button secondary-button"
+                >
+                  Quit
+                </button>
+              </section>
+            </div>
           </section>
 
-          <!-- Controls section -->
-          <section class="battle-controls controls" aria-label="Round controls">
-            <button
-              id="home-button"
-              type="button"
-              data-testid="home-link"
-              class="battle-control-button secondary-button"
-            >
-              Main Menu
-            </button>
-            <button
-              id="next-button"
-              data-testid="next-button"
-              data-role="next-round"
-              class="battle-control-button primary-button"
-              disabled
-            >
-              Next
-            </button>
-            <button
-              id="replay-button"
-              data-testid="replay-button"
-              data-role="replay"
-              class="battle-control-button secondary-button"
-            >
-              Replay
-            </button>
-            <button
-              id="quit-button"
-              data-role="quit"
-              class="battle-control-button secondary-button"
-            >
-              Quit
-            </button>
+          <section class="card-slot opponent-slot" aria-label="Opponent card">
+            <div class="slot-surface">
+              <div id="opponent-card" aria-label="Opponent card">
+                <div
+                  id="mystery-card-placeholder"
+                  class="card common-rarity"
+                  aria-label="Mystery opponent card"
+                >
+                  <svg viewBox="0 0 960 960" class="mystery-icon">
+                    <path
+                      d="M424-320q0-81 14.5-116.5T500-514q41-36 62.5-62.5T584-637q0-41-27.5-68T480-732q-51 0-77.5 31T365-638l-103-44q21-64 77-111t141-47q105 0 161.5 58.5T698-641q0 50-21.5 85.5T609-475q-49 47-59.5 71.5T539-320H424Zm56 240q-33 0-56.5-23.5T400-160q0-33 23.5-56.5T480-240q33 0 56.5 23.5T560-160q0 33-23.5 56.5T480-80Z"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
           </section>
         </div>
       </main>

--- a/src/styles/battleClassic.css
+++ b/src/styles/battleClassic.css
@@ -21,6 +21,50 @@
   margin: 0 auto;
 }
 
+#battle-area {
+  gap: var(--space-md);
+}
+
+#battle-area > .card-slot,
+#battle-area > #controls {
+  width: 100%;
+  max-width: 420px;
+}
+
+#battle-area .card-slot {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+#battle-area .slot-surface {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-base);
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  width: 100%;
+}
+
+#battle-area .card-slot .slot-surface {
+  align-items: center;
+}
+
+#battle-area #controls .slot-surface {
+  align-items: center;
+}
+
+#battle-area #controls .slot-surface > * {
+  width: 100%;
+}
+
+#battle-area #controls .stat-controls {
+  padding-top: 0;
+  justify-content: center;
+}
+
 /* Battle status within header */
 .battle-status-header {
   grid-column: 1 / -1;
@@ -56,24 +100,12 @@
   font-weight: 500;
 }
 
-.battle-layout {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-md);
-  margin: var(--space-lg) 0;
-}
-
-@media (max-width: 720px) {
-  .battle-layout {
-    grid-template-columns: 1fr;
-  }
-}
-
 .stat-selection {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: var(--space-lg) 0;
+  margin: 0;
+  gap: var(--space-sm);
 }
 
 #stat-buttons {
@@ -101,11 +133,10 @@
   align-items: stretch;
   justify-content: center;
   flex-wrap: wrap;
-  margin-top: var(--space-lg);
-  padding: var(--space-sm);
-  border-radius: var(--radius-lg);
-  background-color: var(--color-surface);
-  box-shadow: var(--shadow-base);
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  box-shadow: none;
 }
 
 .battle-controls .battle-control-button {
@@ -179,6 +210,11 @@
 @media (max-width: 480px) {
   .battle-content {
     padding: var(--space-sm);
+  }
+
+  #battle-area > .card-slot,
+  #battle-area > #controls {
+    width: 100%;
   }
 
   .battle-controls {


### PR DESCRIPTION
## Summary
- restore the battle classic page battle-area markup to use the shared player, controls, and opponent slots
- add surface wrappers and spacing tweaks so each slot renders as a material-style card with 16px gutters on desktop and mobile

## Testing
- Not Run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e43517f3208326a902675ef6ef753a