### PR TITLE
Address accessibility and layout feedback for battle classic surfaces

### DIFF
--- a/src/pages/battleClassic.html
+++ b/src/pages/battleClassic.html
@@ -80,11 +80,11 @@
 
           <section id="controls" aria-label="Stat selection and round controls">
             <div class="slot-surface controls-surface">
-              <section class="stat-selection stat-controls" aria-label="Choose a stat">
+              <div class="stat-selection stat-controls" role="group" aria-label="Choose a stat">
                 <div id="stat-buttons" data-testid="stat-buttons" data-buttons-ready="false"></div>
-              </section>
+              </div>
 
-              <section class="battle-controls controls" aria-label="Round controls">
+              <div class="battle-controls controls" role="group" aria-label="Round controls">
                 <button
                   id="home-button"
                   type="button"
@@ -117,7 +117,7 @@
                 >
                   Quit
                 </button>
-              </section>
+              </div>
             </div>
           </section>
 

--- a/src/styles/battleClassic.css
+++ b/src/styles/battleClassic.css
@@ -22,6 +22,9 @@
 }
 
 #battle-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   gap: var(--space-md);
 }
 
@@ -52,15 +55,15 @@
   align-items: center;
 }
 
-#battle-area #controls .slot-surface {
+.controls-surface {
   align-items: center;
 }
 
-#battle-area #controls .slot-surface > * {
+.controls-surface > * {
   width: 100%;
 }
 
-#battle-area #controls .stat-controls {
+.controls-surface .stat-controls {
   padding-top: 0;
   justify-content: center;
 }


### PR DESCRIPTION
## Summary
- replace nested landmark sections in the battle controls with grouped div containers to resolve redundant regions
- ensure the battle area wrapper is a flex column with centered cards so gap spacing works reliably across browsers
- reduce CSS specificity for the control surface helpers to simplify future overrides

## Testing
- Not Run

------
https://chatgpt.com/codex/tasks/task_e_68e43a184998832684997c1985259685