### PR TITLE
Restore stat controls padding override specificity in battle classic

### DIFF
--- a/src/styles/battleClassic.css
+++ b/src/styles/battleClassic.css
@@ -63,7 +63,7 @@
   width: 100%;
 }
 
-.controls-surface .stat-controls {
+#battle-area #controls .controls-surface .stat-controls {
   padding-top: 0;
   justify-content: center;
 }


### PR DESCRIPTION
## Summary
- restore the stat controls padding override with a selector that matches the base layout specificity so the zero top padding is applied again

## Testing
- Not Run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e43c9bc814832689a6bc378f7814a9