### PR TITLE
Add missing JSDoc for stat readiness helpers

### DIFF
--- a/src/helpers/classicBattle/statButtons.js
+++ b/src/helpers/classicBattle/statButtons.js
@@ -1,18 +1,16 @@
 import { isEnabled, enableFlag } from "../featureFlags.js";
 
 /**
- * Enable an array of stat buttons and mark the container as ready.
+ * Normalize assorted button collections into a clean array of elements.
  *
  * @pseudocode
- * 1. For each button:
- *    - Set `disabled = false` and `tabIndex = 0` so it is keyboard focusable.
- *    - Remove visual markers `disabled` and `selected`.
- *    - Remove any explicit `background-color` style applied inline.
- * 2. If a `container` element is provided, set `container.dataset.buttonsReady = 'true'`.
+ * 1. If `buttons` is falsy, return an empty array.
+ * 2. If `buttons` is already an array, filter out falsy entries and return it.
+ * 3. Otherwise convert `buttons` (e.g., NodeList) to an array and filter out falsy entries.
  *
- * @param {HTMLElement[]} buttons - Button elements to enable.
- * @param {HTMLElement} [container] - Optional containing element to mark ready.
- * @returns {void}
+ * @param {HTMLElement[] | NodeListOf<HTMLElement> | null | undefined} buttons -
+ *   Collection of button-like values to normalize.
+ * @returns {HTMLElement[]} An array of valid button elements.
  */
 function toButtonArray(buttons) {
   if (!buttons) return [];
@@ -31,6 +29,22 @@ function applyDisabledState(btn, disabled) {
   }
 }
 
+/**
+ * Enable stat buttons and flag the container as ready for interaction.
+ *
+ * @pseudocode
+ * 1. Normalize `buttons` into an array via `toButtonArray`.
+ * 2. For each button:
+ *    - Call `applyDisabledState(btn, false)` to re-enable focus/interaction.
+ *    - Remove the `selected` CSS class.
+ *    - Remove any inline `background-color` styles.
+ * 3. If a `container` is provided, set `container.dataset.buttonsReady = 'true'`.
+ *
+ * @param {HTMLElement[] | NodeListOf<HTMLElement> | null | undefined} buttons -
+ *   Buttons to re-enable.
+ * @param {HTMLElement} [container] - Optional container that tracks readiness state.
+ * @returns {void}
+ */
 export function enableStatButtons(buttons, container) {
   toButtonArray(buttons).forEach((btn) => {
     applyDisabledState(btn, false);

--- a/src/helpers/settingsPage.js
+++ b/src/helpers/settingsPage.js
@@ -52,26 +52,23 @@ import { renderFeatureFlags } from "./settings/renderFeatureFlags.js";
  * 1. Create `settingsReadyPromise` resolved when `settings:ready` is dispatched.
  * 2. Attach it to `window` so tests can await it.
  */
-/**
- * A promise that resolves when the Settings UI has finished rendering and
- * dispatched the `settings:ready` event.
- *
- * @summary This promise provides a reliable signal for external scripts or tests
- * to know when the Settings page's DOM is ready and its controls are initialized.
- * When no DOM is available (e.g., in a Node environment), the promise resolves
- * immediately to keep module imports side-effect free.
- *
- * @pseudocode
- * 1. A new `Promise` is created.
- * 2. A one-time event listener is attached to `document` for the `settings:ready` event.
- * 3. When the `settings:ready` event is dispatched (typically after `renderSettingsControls` completes), the promise resolves.
- * 4. This allows other parts of the application to `await` this promise to ensure the settings UI is fully loaded before interacting with it.
- *
- * @type {Promise<void>}
- * @param {(value?: void) => void} resolve - Internal resolver for readiness.
- */
 const hasDocument = typeof document !== "undefined";
 
+/**
+ * Promise that resolves once the Settings UI dispatches `settings:ready`.
+ *
+ * @summary Provides a synchronization point for scripts/tests awaiting the
+ * Settings page to finish rendering. Falls back to an already-resolved promise
+ * when no DOM is present, keeping server-side imports side-effect free.
+ *
+ * @pseudocode
+ * 1. Detect whether `document` is available via `hasDocument`.
+ * 2. If available, create a new `Promise` and attach a one-time `settings:ready`
+ *    listener that resolves it.
+ * 3. If not available, return `Promise.resolve()` so consumers can still await readiness.
+ *
+ * @returns {Promise<void>} Resolves once the settings interface signals readiness.
+ */
 export const settingsReadyPromise = hasDocument
   ? new Promise((resolve) => {
       document.addEventListener("settings:ready", resolve, { once: true });


### PR DESCRIPTION
## Summary
- add detailed JSDoc for `enableStatButtons`, including pseudocode and parameter typing
- clarify the `settingsReadyPromise` documentation with accurate pseudocode and summary details

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68e440a4d1ec83268501c7a8ee591828