### PR TITLE
Ensure JSON override text includes key path prefix

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -452,7 +452,18 @@ async function processJsonObjectEntries(
   for (const [keyPath, value] of flat) {
     const allowed = extractAllowedValuesFn(baseName, { [keyPath]: value });
     if (!allowed) continue;
-    await processItem({ [keyPath]: value }, keyPath, allowed);
+    const allowedText = String(allowed).trim();
+    const prefix = `${keyPath}: `;
+    let overrideText;
+    if (allowedText.startsWith(prefix)) {
+      overrideText = allowedText;
+    } else if (allowedText.startsWith(`${keyPath}:`)) {
+      const remainder = allowedText.slice(`${keyPath}:`.length).trimStart();
+      overrideText = `${prefix}${remainder}`;
+    } else {
+      overrideText = `${prefix}${allowedText}`;
+    }
+    await processItem({ [keyPath]: value }, keyPath, overrideText);
   }
 }
 

--- a/tests/scripts/generateEmbeddings.test.js
+++ b/tests/scripts/generateEmbeddings.test.js
@@ -236,4 +236,40 @@ describe("JSON processing helpers", () => {
       "rules.rounds: Rounds: 3"
     );
   });
+
+  it("avoids duplicating the key path when override already includes it", async () => {
+    const obj = { rules: { rounds: 3 } };
+    const processItem = vi.fn();
+    const extractAllowedValuesFn = vi.fn(() => "rules.rounds: Already 3");
+
+    await processJsonObjectEntries(obj, {
+      baseName: "gameModes.json",
+      processItem,
+      extractAllowedValuesFn
+    });
+
+    expect(processItem).toHaveBeenCalledWith(
+      { "rules.rounds": "3" },
+      "rules.rounds",
+      "rules.rounds: Already 3"
+    );
+  });
+
+  it("normalizes overrides missing a space after the key path", async () => {
+    const obj = { rules: { rounds: 3 } };
+    const processItem = vi.fn();
+    const extractAllowedValuesFn = vi.fn(() => "rules.rounds:Already 3");
+
+    await processJsonObjectEntries(obj, {
+      baseName: "gameModes.json",
+      processItem,
+      extractAllowedValuesFn
+    });
+
+    expect(processItem).toHaveBeenCalledWith(
+      { "rules.rounds": "3" },
+      "rules.rounds",
+      "rules.rounds: Already 3"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- ensure JSON object overrides always include the flattened key path prefix
- normalize overrides that already include the key path and add regression tests

## Testing
- npx vitest run tests/scripts/generateEmbeddings.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e445f8a2a88326a14de05bbea2b0dd