### PR TITLE
Normalize override whitespace handling

### DIFF
--- a/scripts/generateEmbeddings.js
+++ b/scripts/generateEmbeddings.js
@@ -455,10 +455,8 @@ async function processJsonObjectEntries(
     const allowedText = String(allowed).trim();
     const prefix = `${keyPath}: `;
     let overrideText;
-    if (allowedText.startsWith(prefix)) {
-      overrideText = allowedText;
-    } else if (allowedText.startsWith(`${keyPath}:`)) {
-      const remainder = allowedText.slice(`${keyPath}:`.length).trimStart();
+    if (allowedText.startsWith(keyPath) && allowedText.charAt(keyPath.length) === ":") {
+      const remainder = allowedText.slice(keyPath.length + 1).trimStart();
       overrideText = `${prefix}${remainder}`;
     } else {
       overrideText = `${prefix}${allowedText}`;

--- a/tests/scripts/generateEmbeddings.test.js
+++ b/tests/scripts/generateEmbeddings.test.js
@@ -272,4 +272,40 @@ describe("JSON processing helpers", () => {
       "rules.rounds: Already 3"
     );
   });
+
+  it("handles overrides with multiple spaces after the key path", async () => {
+    const obj = { rules: { rounds: 3 } };
+    const processItem = vi.fn();
+    const extractAllowedValuesFn = vi.fn(() => "rules.rounds:   Multiple   spaces");
+
+    await processJsonObjectEntries(obj, {
+      baseName: "gameModes.json",
+      processItem,
+      extractAllowedValuesFn
+    });
+
+    expect(processItem).toHaveBeenCalledWith(
+      { "rules.rounds": "3" },
+      "rules.rounds",
+      "rules.rounds: Multiple   spaces"
+    );
+  });
+
+  it("trims leading and trailing whitespace in overrides", async () => {
+    const obj = { rules: { rounds: 3 } };
+    const processItem = vi.fn();
+    const extractAllowedValuesFn = vi.fn(() => "  rules.rounds: Trimmed content  ");
+
+    await processJsonObjectEntries(obj, {
+      baseName: "gameModes.json",
+      processItem,
+      extractAllowedValuesFn
+    });
+
+    expect(processItem).toHaveBeenCalledWith(
+      { "rules.rounds": "3" },
+      "rules.rounds",
+      "rules.rounds: Trimmed content"
+    );
+  });
 });


### PR DESCRIPTION
## Task Contract
- **Inputs:** `scripts/generateEmbeddings.js`, `tests/scripts/generateEmbeddings.test.js`, reviewer feedback about whitespace normalization.
- **Outputs:** Updated normalization logic and expanded regression tests for override handling.
- **Success Criteria:** Override text always uses a single space after the key-path colon while preserving internal spacing; tests cover the new scenarios.
- **Failure Modes:** Prefix detection fails for irregular whitespace or tests regress.

## Summary
- Normalize override prefix detection to collapse whitespace immediately after the key-path colon while preserving interior spacing.
- Extend the JSON processing helper tests to cover multiple-space prefixes and leading/trailing whitespace cases.

## Files Changed
- `scripts/generateEmbeddings.js`
- `tests/scripts/generateEmbeddings.test.js`

## Testing
- npx vitest run tests/scripts/generateEmbeddings.test.js

## Risk
- Low: localized string manipulation changes with targeted unit test coverage.


------
https://chatgpt.com/codex/tasks/task_e_68e448de5ae08326ab0c98ab05ab3e9f