### PR TITLE
Align Classic Battle layout with global grid spacing

### DIFF
--- a/src/styles/battleClassic.css
+++ b/src/styles/battleClassic.css
@@ -1,11 +1,5 @@
 /* Battle Classic specific styles */
 
-/* Allow the Classic Battle header to stay in flow so it doesn't overlap stat buttons */
-.home-screen {
-  padding-top: var(--space-sm);
-  padding-top: calc(env(safe-area-inset-top) + var(--space-sm));
-}
-
 .home-screen > .header {
   position: sticky;
   top: 0;
@@ -22,10 +16,12 @@
 }
 
 #battle-area {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  justify-items: center;
+  align-items: flex-start;
   gap: var(--space-md);
+  padding-top: var(--header-height);
 }
 
 #battle-area > .card-slot,
@@ -217,6 +213,14 @@
 @media (max-width: 480px) {
   .battle-content {
     padding: var(--space-sm);
+  }
+
+  #battle-area {
+    grid-template-columns: 1fr;
+  }
+
+  #battle-area > #controls {
+    grid-column: 1;
   }
 
   #battle-area > .card-slot,


### PR DESCRIPTION
## Summary
- remove the Classic Battle home screen padding override so the global header spacing is respected
- switch the Classic Battle battle area to the shared three-column grid with header offset
- update the small-screen breakpoint to stack the battle area columns while preserving existing slot styling

## Testing
- npm run check:jsdoc
- npm run check:rag *(fails: local RAG model files missing, non-blocking pre-commit warning)*

------
https://chatgpt.com/codex/tasks/task_e_68e5561a4338832688946093da3674a1