### PR TITLE
Ensure CLI snackbar colors align with terminal theme

### DIFF
--- a/src/pages/battleCLI.css
+++ b/src/pages/battleCLI.css
@@ -9,6 +9,11 @@
   --cli-accent: #9bdcff;
   --cli-warning: #ffcc00;
   --cli-focus: #ffd166;
+  --color-primary: #9bdcff;
+  --color-tertiary: #101820;
+  --color-text: #dce6ef;
+  --color-text-inverted: #050505;
+  --radius-lg: 4px;
 }
 
 :focus {
@@ -156,6 +161,12 @@ body {
   gap: 8px;
   align-items: center;
   flex-wrap: wrap;
+}
+.cli-root #snackbar-container .snackbar {
+  background: var(--color-tertiary);
+  color: var(--color-text);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-lg);
 }
 /* Terminal-style separators with enhanced visual hierarchy */
 .ascii-sep {


### PR DESCRIPTION
## Summary
- define CLI snackbar color and radius tokens in the CLI theme root so shared styles resolve
- add a CLI override to force snackbar background, text, and border contrast against the footer strip

## Testing
- not run (manual verification required for CLI battle snackbar states)


------
https://chatgpt.com/codex/tasks/task_e_68e55a90521c8326b8c64417e72329f8