### PR TITLE
Update local model hydration cache directory

### DIFF
--- a/scripts/prepareLocalModel.mjs
+++ b/scripts/prepareLocalModel.mjs
@@ -9,7 +9,7 @@
  *    - Copy files into destination, creating folders as needed.
  *    - Print success and exit.
  * 4. Else attempt to hydrate via @xenova/transformers (may download when network available):
- *    - Configure env.allowLocalModels and env.localModelPath to repo root.
+ *    - Configure env.allowLocalModels, env.cacheDir (src/models), and env.localModelPath (src).
  *    - Instantiate a quantized feature-extraction pipeline for Xenova/all-MiniLM-L6-v2.
  *    - If successful, copy/cache files into models/minilm.
  * 5. On failure, print actionable guidance for strict-offline environments.
@@ -83,10 +83,13 @@ export async function prepareLocalModel(options = {}) {
   // Attempt hydration via transformers (may fetch if not cached)
   try {
     const { pipeline, env } = await import("@xenova/transformers");
+    const cacheDir = path.join(destRoot, "models");
     env.allowLocalModels = true;
-    env.localModelPath = rootDir;
+    env.cacheDir = cacheDir;
+    env.localModelPath = destRoot;
     // Prepare dest directories to allow caching to land in-place
-    await ensureDir(path.join(destDir, "onnx"));
+    await ensureDir(cacheDir);
+    await ensureDir(path.join(cacheDir, "minilm", "onnx"));
     // Instantiating the pipeline may populate caches; we still ensure required files exist.
     await pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", { quantized: true });
   } catch (err) {


### PR DESCRIPTION
## Summary
- configure the transformers hydration path to use src/models as the cache and ensure directories exist before downloading
- extend prepareLocalModel tests to cover the hydration flow and validate the configured cache path

## Testing
- npx vitest run tests/scripts/prepareLocalModel.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e55a71e4688326905de91a9d76fed7