### PR TITLE
Fix Classic Battle header spacing regression

### DIFF
--- a/src/styles/battleClassic.css
+++ b/src/styles/battleClassic.css
@@ -1,7 +1,7 @@
 /* Battle Classic specific styles */
 
 .home-screen > .header {
-  position: sticky;
+  position: fixed;
   top: 0;
   top: env(safe-area-inset-top);
 }
@@ -16,12 +16,13 @@
 }
 
 #battle-area {
+  /* Three-column grid: left card | controls | right card */
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   justify-items: center;
   align-items: flex-start;
   gap: var(--space-md);
-  padding-top: var(--header-height);
+  padding-top: var(--space-lg);
 }
 
 #battle-area > .card-slot,


### PR DESCRIPTION
## Summary
- revert the Classic Battle header to fixed positioning so the page no longer double-reserves header space
- reduce the battle grid's top padding and document the three-column structure for maintainability

## Testing
- npm run check:jsdoc
- npm run check:rag *(fails: local RAG model files missing, non-blocking pre-commit warning)*

------
https://chatgpt.com/codex/tasks/task_e_68e55a5956dc8326a002edde90ea6376